### PR TITLE
fix: capture alt-screen scroll history so pgup works in Claude sessions

### DIFF
--- a/internal/vt/bridge.go
+++ b/internal/vt/bridge.go
@@ -74,6 +74,11 @@ func (t *Terminal) bridgeRead() {
 // the scroll region. If so, the write will cause the top line to scroll off,
 // and we capture it before it's lost. This works for both main-screen and
 // alternate-screen terminals.
+//
+// Write must not be called concurrently. The three SafeEmulator reads
+// (CursorPosition, Height, Render) and the subsequent Write each acquire the
+// emulator lock independently, which is safe because agent.readLoop is the
+// only caller and never calls Write from more than one goroutine.
 func (t *Terminal) Write(p []byte) (int, error) {
 	written := 0
 	remaining := p
@@ -179,26 +184,17 @@ func (t *Terminal) Height() int {
 }
 
 // ScrollbackLines returns scrolled-off lines as ANSI-encoded strings, oldest
-// first. Our history buffer (populated by scroll detection in Write) takes
-// priority over the VT emulator's main-screen scrollback, since apps using
-// alternate screen mode (like Claude Code) never populate the latter.
+// first. The history buffer is populated by Write's scroll detection and
+// captures scrollback for both main-screen and alternate-screen terminals.
+// Returns nil if no lines have scrolled off yet.
 func (t *Terminal) ScrollbackLines() []string {
 	t.historyMu.RLock()
-	if len(t.history) > 0 {
-		result := make([]string, len(t.history))
-		copy(result, t.history)
-		t.historyMu.RUnlock()
-		return result
+	defer t.historyMu.RUnlock()
+	if len(t.history) == 0 {
+		return nil
 	}
-	t.historyMu.RUnlock()
-
-	// Fallback: VT emulator's main-screen scrollback (for non-alt-screen terminals
-	// where our cursor detection may have missed lines written before baton started).
-	lines := t.emu.Scrollback().Lines()
-	result := make([]string, len(lines))
-	for i, l := range lines {
-		result[i] = l.Render()
-	}
+	result := make([]string, len(t.history))
+	copy(result, t.history)
 	return result
 }
 

--- a/internal/vt/bridge.go
+++ b/internal/vt/bridge.go
@@ -4,12 +4,15 @@
 package vt
 
 import (
+	"bytes"
 	"io"
 	"strings"
 	"sync"
 
 	xvt "github.com/charmbracelet/x/vt"
 )
+
+const maxHistoryLines = 5000
 
 // Terminal wraps a virtual terminal emulator, providing a simplified interface
 // for feeding PTY output and reading screen state.
@@ -23,6 +26,14 @@ type Terminal struct {
 	pw *io.PipeWriter
 
 	closeOnce sync.Once
+
+	// history captures lines that scrolled off the top of the screen.
+	// The x/vt emulator only exposes main-screen scrollback, so apps using
+	// alternate screen mode (like Claude Code) would otherwise lose history.
+	// We detect scroll events by checking if the cursor is at the bottom row
+	// before writing a newline, then capturing the top line before it's lost.
+	history   []string
+	historyMu sync.RWMutex
 }
 
 // New creates a new Terminal with the given dimensions.
@@ -55,9 +66,54 @@ func (t *Terminal) bridgeRead() {
 	}
 }
 
-// Write feeds raw PTY output into the emulator.
+// Write feeds raw PTY output into the emulator and captures any lines that
+// scroll off the top into the history buffer.
+//
+// The input is processed line-by-line (splitting on LF). Before writing each
+// LF-terminated chunk, we check whether the cursor is at the bottom row of
+// the scroll region. If so, the write will cause the top line to scroll off,
+// and we capture it before it's lost. This works for both main-screen and
+// alternate-screen terminals.
 func (t *Terminal) Write(p []byte) (int, error) {
-	return t.emu.Write(p)
+	written := 0
+	remaining := p
+	for len(remaining) > 0 {
+		// Split on the first LF to process one line boundary at a time.
+		idx := bytes.IndexByte(remaining, '\n')
+		var chunk []byte
+		if idx < 0 {
+			chunk = remaining
+			remaining = nil
+		} else {
+			chunk = remaining[:idx+1]
+			remaining = remaining[idx+1:]
+		}
+
+		// If the cursor is at the bottom row and this chunk includes a LF,
+		// the current top line is about to scroll off — capture it first.
+		// Note: this assumes a full-height scroll region (the default). Apps
+		// that set a DECSTBM sub-region would need the scroll region bottom
+		// instead of Height()-1, but SafeEmulator does not expose that.
+		if idx >= 0 {
+			pos := t.emu.CursorPosition()
+			if pos.Y >= t.emu.Height()-1 {
+				topLine := strings.SplitN(t.emu.Render(), "\n", 2)[0]
+				t.historyMu.Lock()
+				t.history = append(t.history, topLine)
+				if len(t.history) > maxHistoryLines {
+					t.history = t.history[len(t.history)-maxHistoryLines:]
+				}
+				t.historyMu.Unlock()
+			}
+		}
+
+		n, err := t.emu.Write(chunk)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+	return written, nil
 }
 
 // Render returns the full screen as an ANSI-encoded string.
@@ -122,9 +178,22 @@ func (t *Terminal) Height() int {
 	return t.emu.Height()
 }
 
-// ScrollbackLines returns the scrollback buffer contents as a slice of
-// ANSI-encoded strings, one per line, oldest first.
+// ScrollbackLines returns scrolled-off lines as ANSI-encoded strings, oldest
+// first. Our history buffer (populated by scroll detection in Write) takes
+// priority over the VT emulator's main-screen scrollback, since apps using
+// alternate screen mode (like Claude Code) never populate the latter.
 func (t *Terminal) ScrollbackLines() []string {
+	t.historyMu.RLock()
+	if len(t.history) > 0 {
+		result := make([]string, len(t.history))
+		copy(result, t.history)
+		t.historyMu.RUnlock()
+		return result
+	}
+	t.historyMu.RUnlock()
+
+	// Fallback: VT emulator's main-screen scrollback (for non-alt-screen terminals
+	// where our cursor detection may have missed lines written before baton started).
 	lines := t.emu.Scrollback().Lines()
 	result := make([]string, len(lines))
 	for i, l := range lines {

--- a/internal/vt/bridge_test.go
+++ b/internal/vt/bridge_test.go
@@ -146,6 +146,64 @@ func TestScrollbackLinesEmpty(t *testing.T) {
 	}
 }
 
+func TestScrollbackLinesAltScreen(t *testing.T) {
+	// 3-row terminal in alt screen mode: writing 4 lines forces the first line
+	// into our history buffer (alt screen scrollback isn't exposed by x/vt).
+	term := New(80, 3)
+	defer term.Close()
+
+	// Enter alternate screen mode.
+	term.Write([]byte("\x1b[?1049h"))
+
+	// Write 4 lines — the first will scroll off the 3-row alt screen.
+	term.Write([]byte("AltFirst\r\nAltSecond\r\nAltThird\r\nAltFourth"))
+
+	lines := term.ScrollbackLines()
+	if len(lines) == 0 {
+		t.Fatal("expected scrollback to be non-empty after scrolling in alt screen mode")
+	}
+	if !strings.Contains(lines[0], "AltFirst") {
+		t.Errorf("expected scrollback line 0 to contain 'AltFirst', got %q", lines[0])
+	}
+}
+
+func TestScrollbackLinesHistoryPreferred(t *testing.T) {
+	// Verify that our history buffer captures scrollback from both main-screen
+	// and alternate-screen mode. The x/vt emulator's built-in Scrollback() only
+	// covers the main screen, so alt-screen history would otherwise be lost.
+	term := New(80, 2)
+	defer term.Close()
+
+	// Scroll in main screen to populate VT scrollback AND our history buffer.
+	term.Write([]byte("MainFirst\r\nMainSecond\r\nMainThird"))
+
+	// Enter alt screen and scroll to populate history with alt-screen content.
+	term.Write([]byte("\x1b[?1049h"))
+	term.Write([]byte("AltFirst\r\nAltSecond\r\nAltThird"))
+
+	lines := term.ScrollbackLines()
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty scrollback")
+	}
+	// Both main-screen and alt-screen lines should appear in history.
+	hasMain := false
+	hasAlt := false
+	for _, line := range lines {
+		if strings.Contains(line, "MainFirst") {
+			hasMain = true
+		}
+		if strings.Contains(line, "AltFirst") {
+			hasAlt = true
+		}
+	}
+	if !hasMain {
+		t.Errorf("expected 'MainFirst' in scrollback history, got: %v", lines)
+	}
+	if !hasAlt {
+		t.Errorf("expected 'AltFirst' in scrollback history, got: %v", lines)
+	}
+}
+
 func TestCursorPosition(t *testing.T) {
 	term := New(80, 24)
 	defer term.Close()


### PR DESCRIPTION
## Summary

- **Root cause**: Claude Code runs in alternate screen mode (`\x1b[?1049h`). The x/vt library's `Scrollback()` only returns main-screen scrollback, so every line that scrolled off a Claude session was silently discarded — `ScrollbackLines()` always returned empty, `maxOffset` was always 0, and pgup was completely broken.
- **Fix**: `vt.Terminal.Write` now processes input line-by-line. Before each LF-terminated chunk, if the cursor is at the bottom row, the top line is captured into a history ring buffer before the scroll happens. This works for both main-screen and alternate-screen terminals.
- **Cleanup**: Removed dead `emu.Scrollback()` fallback in `ScrollbackLines()` (unreachable once any line scrolls); documented the single-writer concurrency invariant on `Terminal.Write`.

## Test plan

- `go test -race ./...` — all packages pass, race detector clean
- Two new tests in `internal/vt/bridge_test.go`:
  - `TestScrollbackLinesAltScreen`: enters alt screen, scrolls 4 lines through a 3-row terminal, asserts `ScrollbackLines()` returns the scrolled-off content
  - `TestScrollbackLinesHistoryPreferred`: verifies history captures scrollback from both main-screen and alt-screen mode in the same session
- Manual: run `./baton`, create a Claude agent, wait for the conversation to fill the screen, press `right` to focus the terminal, press `pgup` — scrolled-off conversation history should become visible