### PR TITLE
fix: resize VT on mouse click-to-focus to fix layout jumble

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -368,6 +368,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// X==31 is the list panel's right border and is intentionally ignored.
 				if a.dashboard.panelFocus == focusList && a.dashboard.selectedAgent() != nil {
 					a.dashboard.panelFocus = focusTerminal
+					a.resizeSelectedForDashboard()
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Clicking the preview (right) panel to enter `focusTerminal` mode caused layout corruption because the mouse click handler returned early without calling `resizeSelectedForDashboard()`
- The keyboard path (`right` arrow) worked correctly because a change-detection block at lines 381–383 triggers the resize when `panelFocus` changes
- Fix adds a single `resizeSelectedForDashboard()` call immediately after `panelFocus = focusTerminal` in the mouse handler, making the click path symmetrical with the keyboard path and the left-panel click path

## Test plan

- `go build -o baton .` — compiles cleanly
- `go test -race ./...` — all tests pass
- Launch baton with an active agent, click the preview panel — terminal content renders correctly inside the border (no layout jumble)
- Press `esc` to return to list focus, then press `right` — keyboard path still works correctly