### PR TITLE
feat: replace Escape with Ctrl+E for exiting focus terminal

### DIFF
--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -11,14 +11,14 @@ import (
 )
 
 // createAgent presses 'n' and executes the async create cmd, returning the updated app.
-// If the terminal panel is already focused it presses Esc first so the 'n' key isn't
+// If the terminal panel is already focused it presses Ctrl+E first so the 'n' key isn't
 // forwarded to the agent.
 func createAgent(t *testing.T, app App) App {
 	t.Helper()
 
 	// Return to list focus if terminal has focus so 'n' is handled by the app.
 	if app.dashboard.panelFocus == focusTerminal {
-		model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+		model, _ := app.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
 		app = model.(App)
 	}
 
@@ -130,7 +130,7 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 		t.Fatalf("Expected 1 agent, got %d", mgr.AgentCount())
 	}
 
-	// Create second agent (createAgent presses Esc first to exit focusTerminal)
+	// Create second agent (createAgent presses Ctrl+E first to exit focusTerminal)
 	t.Log("=== Creating agent 2 ===")
 	app = createAgent(t, app)
 	t.Logf("After agent2: view=%v, err=%q, agents=%d, dashboard=%d",
@@ -207,11 +207,11 @@ func TestPanelFocusSwitching(t *testing.T) {
 		t.Fatalf("Expected focusTerminal after creation, got %v", app.dashboard.panelFocus)
 	}
 
-	// Esc returns to focusList.
-	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	// Ctrl+E returns to focusList.
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
 	app = model.(App)
 	if app.dashboard.panelFocus != focusList {
-		t.Fatalf("Expected focusList after esc, got %v", app.dashboard.panelFocus)
+		t.Fatalf("Expected focusList after ctrl+e, got %v", app.dashboard.panelFocus)
 	}
 
 	// Right arrow enters focusTerminal.
@@ -393,11 +393,11 @@ func TestMouseClickPreviewEntersFocus(t *testing.T) {
 		t.Fatal("Expected at least one agent")
 	}
 
-	// After creation the terminal is auto-focused; press Esc to return to list.
-	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	// After creation the terminal is auto-focused; press Ctrl+E to return to list.
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
 	app = model.(App)
 	if app.dashboard.panelFocus != focusList {
-		t.Fatalf("Expected focusList after esc, got %v", app.dashboard.panelFocus)
+		t.Fatalf("Expected focusList after ctrl+e, got %v", app.dashboard.panelFocus)
 	}
 
 	// Click the preview panel (X >= 32) — should enter focusTerminal.
@@ -407,11 +407,11 @@ func TestMouseClickPreviewEntersFocus(t *testing.T) {
 		t.Fatalf("Expected focusTerminal after preview click, got %v", app.dashboard.panelFocus)
 	}
 
-	// Esc returns to focusList.
-	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	// Ctrl+E returns to focusList.
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
 	app = model.(App)
 	if app.dashboard.panelFocus != focusList {
-		t.Fatalf("Expected focusList after esc, got %v", app.dashboard.panelFocus)
+		t.Fatalf("Expected focusList after ctrl+e, got %v", app.dashboard.panelFocus)
 	}
 }
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -47,7 +47,7 @@ func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 		if d.panelFocus == focusTerminal {
 			ag := d.selectedAgent()
 			switch msg.String() {
-			case "esc":
+			case "ctrl+e":
 				d.panelFocus = focusList
 				d.scrollOffset = 0
 			case "enter":
@@ -106,7 +106,7 @@ func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 				d.selected--
 				d.scrollOffset = 0
 			}
-		case "right":
+		case "right", "enter":
 			if d.selectedAgent() != nil {
 				d.panelFocus = focusTerminal
 			}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -14,7 +14,7 @@ type keyHint struct {
 var (
 	dashboardHints = []keyHint{
 		{"j/k", "navigate"},
-		{"→", "interact"},
+		{"⏎/→", "interact"},
 		{"n", "new agent"},
 		{"a", "add repo"},
 		{"d", "diff/remove"},
@@ -27,7 +27,7 @@ var (
 		{"enter", "send"},
 		{"pgup/pgdn", "scroll"},
 		{"home", "live"},
-		{"esc", "back"},
+		{"ctrl+e", "back"},
 	}
 
 	diffHints = []keyHint{


### PR DESCRIPTION
## Summary
- **Escape passthrough**: Escape in focus terminal mode now forwards to the agent instead of exiting, allowing users to interrupt Claude Code thinking/generation
- **Ctrl+E to exit**: Replaces Escape as the key to return from focus terminal to the dashboard list
- **Enter to focus**: Enter now works alongside right-arrow to enter focus terminal mode from the list
- **Status bar updated**: Hints reflect the new keybindings (`ctrl+e` for back, `⏎/→` for interact)

## Test plan
- `go test -race ./...` — all tests pass (updated to use Ctrl+E)
- Manual: launch baton, enter focus terminal, press Ctrl+E → returns to list
- Manual: in focus terminal, press Escape → forwarded to agent (interrupts thinking)
- Manual: in list view, press Enter on an agent → enters focus terminal
- Manual: verify status bar shows updated hint text

🤖 Generated with [Claude Code](https://claude.com/claude-code)