### PR TITLE
feat: multi-agent sessions with shared worktrees

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,25 +1,24 @@
 package agent
 
 import (
-	"fmt"
 	"os/exec"
 	"sync"
 	"time"
 
-	"github.com/devenjarvis/baton/internal/git"
 	bpty "github.com/devenjarvis/baton/internal/pty"
 	"github.com/devenjarvis/baton/internal/vt"
 
 	xvt "github.com/charmbracelet/x/vt"
 )
 
-// Agent ties together a PTY, VT terminal, and git worktree into a managed unit.
+// Agent ties together a PTY and VT terminal into a managed unit.
+// Agents do not own worktrees — sessions do.
 type Agent struct {
-	ID        string
-	Name      string
-	Task      string
-	Worktree  *git.WorktreeInfo
-	CreatedAt time.Time
+	ID           string
+	Name         string
+	Task         string
+	WorktreePath string // reference only; session owns the worktree
+	CreatedAt    time.Time
 
 	pty      *bpty.PTY
 	terminal *vt.Terminal
@@ -45,13 +44,9 @@ type Config struct {
 	BypassPermissions bool
 }
 
-// newAgent creates and starts an agent. Called by Manager.
-func newAgent(id string, cfg Config) (*Agent, error) {
-	wt, err := git.CreateWorktree(cfg.RepoPath, cfg.Name)
-	if err != nil {
-		return nil, fmt.Errorf("creating worktree: %w", err)
-	}
-
+// newAgent creates and starts an agent with the default claude command.
+// The worktreePath is provided by the session — agents do not create worktrees.
+func newAgent(id string, cfg Config, worktreePath string) (*Agent, error) {
 	term := vt.New(cfg.Cols, cfg.Rows)
 
 	var cmd *exec.Cmd
@@ -68,25 +63,23 @@ func newAgent(id string, cfg Config) (*Agent, error) {
 			cmd = exec.Command("claude")
 		}
 	}
-	cmd.Dir = wt.Path
+	cmd.Dir = worktreePath
 	cmd.Env = append(cmd.Environ(), "TERM=xterm-256color")
 
 	p := &bpty.PTY{}
 	if err := p.Start(cmd, uint16(cfg.Rows), uint16(cfg.Cols)); err != nil {
-		// Clean up worktree on failure.
-		_ = git.RemoveWorktree(cfg.RepoPath, wt, true)
-		return nil, fmt.Errorf("starting PTY: %w", err)
+		return nil, err
 	}
 
 	a := &Agent{
-		ID:        id,
-		Name:      cfg.Name,
-		Task:      cfg.Task,
-		Worktree:  wt,
-		CreatedAt: time.Now(),
-		pty:       p,
-		terminal:  term,
-		status:    StatusStarting,
+		ID:           id,
+		Name:         cfg.Name,
+		Task:         cfg.Task,
+		WorktreePath: worktreePath,
+		CreatedAt:    time.Now(),
+		pty:          p,
+		terminal:     term,
+		status:       StatusStarting,
 		done:          make(chan struct{}),
 		stop:          make(chan struct{}),
 		writeLoopDone: make(chan struct{}),
@@ -100,33 +93,27 @@ func newAgent(id string, cfg Config) (*Agent, error) {
 }
 
 // newAgentWithCommand creates an agent using a custom command instead of claude.
-// Used for testing.
-func newAgentWithCommand(id string, cfg Config, cmd *exec.Cmd) (*Agent, error) {
-	wt, err := git.CreateWorktree(cfg.RepoPath, cfg.Name)
-	if err != nil {
-		return nil, fmt.Errorf("creating worktree: %w", err)
-	}
-
+// Used for testing. The worktreePath is provided by the session.
+func newAgentWithCommand(id string, cfg Config, worktreePath string, cmd *exec.Cmd) (*Agent, error) {
 	term := vt.New(cfg.Cols, cfg.Rows)
 
-	cmd.Dir = wt.Path
+	cmd.Dir = worktreePath
 	cmd.Env = append(cmd.Environ(), "TERM=xterm-256color")
 
 	p := &bpty.PTY{}
 	if err := p.Start(cmd, uint16(cfg.Rows), uint16(cfg.Cols)); err != nil {
-		_ = git.RemoveWorktree(cfg.RepoPath, wt, true)
-		return nil, fmt.Errorf("starting PTY: %w", err)
+		return nil, err
 	}
 
 	a := &Agent{
-		ID:        id,
-		Name:      cfg.Name,
-		Task:      cfg.Task,
-		Worktree:  wt,
-		CreatedAt: time.Now(),
-		pty:       p,
-		terminal:  term,
-		status:    StatusStarting,
+		ID:           id,
+		Name:         cfg.Name,
+		Task:         cfg.Task,
+		WorktreePath: worktreePath,
+		CreatedAt:    time.Now(),
+		pty:          p,
+		terminal:     term,
+		status:       StatusStarting,
 		done:          make(chan struct{}),
 		stop:          make(chan struct{}),
 		writeLoopDone: make(chan struct{}),
@@ -300,7 +287,3 @@ func (a *Agent) Kill() {
 	<-a.writeLoopDone
 }
 
-// Cleanup removes the agent's worktree and branch.
-func (a *Agent) Cleanup(repoPath string) error {
-	return git.RemoveWorktree(repoPath, a.Worktree, true)
-}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -103,32 +103,30 @@ func TestAgentStatusTransitions(t *testing.T) {
 	}
 }
 
-func TestMultipleAgentsUniqueWorktrees(t *testing.T) {
+func TestMultipleSessionsUniqueWorktrees(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo)
 	defer mgr.Shutdown()
 
-	agents := make([]*Agent, 3)
-	names := []string{"alpha", "beta", "gamma"}
-
-	for i, name := range names {
-		cfg := Config{Name: name, Task: "test", Rows: 24, Cols: 80}
-		a, err := mgr.CreateWithCommand(cfg, func(n string) *exec.Cmd {
+	sessions := make([]*Session, 3)
+	for i := 0; i < 3; i++ {
+		cfg := Config{Task: "test", Rows: 24, Cols: 80}
+		sess, _, err := mgr.CreateSessionWithCommand(cfg, func(n string) *exec.Cmd {
 			return exec.Command("bash", "-c", "sleep 2")
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		agents[i] = a
+		sessions[i] = sess
 	}
 
 	// Check unique worktree paths.
 	paths := make(map[string]bool)
-	for _, a := range agents {
-		if paths[a.Worktree.Path] {
-			t.Errorf("duplicate worktree path: %s", a.Worktree.Path)
+	for _, s := range sessions {
+		if paths[s.Worktree.Path] {
+			t.Errorf("duplicate worktree path: %s", s.Worktree.Path)
 		}
-		paths[a.Worktree.Path] = true
+		paths[s.Worktree.Path] = true
 	}
 
 	if mgr.AgentCount() != 3 {
@@ -142,16 +140,16 @@ func TestKillAndCleanup(t *testing.T) {
 	defer mgr.Shutdown()
 
 	cfg := Config{Name: "test-kill", Task: "test", Rows: 24, Cols: 80}
-	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
 		return exec.Command("bash", "-c", "sleep 60")
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	wtPath := a.Worktree.Path
+	wtPath := sess.Worktree.Path
 
-	if err := mgr.Kill(a.ID); err != nil {
+	if err := mgr.KillSession(sess.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -189,8 +187,8 @@ func TestShutdownCleansAll(t *testing.T) {
 	mgr := NewManager(repo)
 
 	for i := 0; i < 3; i++ {
-		cfg := Config{Name: "shut-" + string(rune('a'+i)), Task: "test", Rows: 24, Cols: 80}
-		_, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		cfg := Config{Task: "test", Rows: 24, Cols: 80}
+		_, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
 			return exec.Command("bash", "-c", "sleep 60")
 		})
 		if err != nil {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"regexp"
 	"sync"
+
+	"github.com/devenjarvis/baton/internal/git"
 )
 
 var validName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
@@ -22,18 +24,19 @@ const (
 
 // Event represents something that happened to an agent.
 type Event struct {
-	Type    EventType
-	AgentID string
-	Status  Status
+	Type      EventType
+	AgentID   string
+	SessionID string
+	Status    Status
 }
 
-// Manager manages the lifecycle of all agents.
+// Manager manages the lifecycle of all sessions and their agents.
 type Manager struct {
 	repoPath string
 
-	mu     sync.RWMutex
-	agents map[string]*Agent
-	nextID int
+	mu       sync.RWMutex
+	sessions map[string]*Session
+	nextID   int
 
 	events   chan Event
 	done     chan struct{}
@@ -44,136 +47,259 @@ type Manager struct {
 func NewManager(repoPath string) *Manager {
 	return &Manager{
 		repoPath: repoPath,
-		agents:   make(map[string]*Agent),
+		sessions: make(map[string]*Session),
 		events:   make(chan Event, 64),
 		done:     make(chan struct{}),
 	}
 }
 
-// Create starts a new agent with the given config.
-func (m *Manager) Create(cfg Config) (*Agent, error) {
-	// Auto-generate a name if none provided.
-	if cfg.Name == "" {
+// CreateSession starts a new session with its first agent using the default claude command.
+func (m *Manager) CreateSession(cfg Config) (*Session, *Agent, error) {
+	sess, err := m.createSessionWorktree(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a, err := sess.AddAgentDefault(cfg)
+	if err != nil {
+		// Clean up worktree on failure.
+		_ = sess.Cleanup(m.repoPath)
 		m.mu.Lock()
-		existing := make([]string, 0, len(m.agents))
-		for _, a := range m.agents {
-			existing = append(existing, a.Name)
-		}
-		cfg.Name = RandomName(existing)
+		delete(m.sessions, sess.ID)
 		m.mu.Unlock()
+		return nil, nil, err
 	}
 
-	if !validName.MatchString(cfg.Name) {
-		return nil, fmt.Errorf("invalid agent name %q: must match [a-zA-Z0-9][a-zA-Z0-9_-]*", cfg.Name)
+	m.emit(Event{Type: EventCreated, AgentID: a.ID, SessionID: sess.ID, Status: StatusStarting})
+
+	m.watchers.Add(1)
+	go func() {
+		defer m.watchers.Done()
+		m.watchAgent(a, sess.ID)
+	}()
+
+	return sess, a, nil
+}
+
+// CreateSessionWithCommand starts a new session with its first agent using a custom command.
+func (m *Manager) CreateSessionWithCommand(cfg Config, cmd func(name string) *exec.Cmd) (*Session, *Agent, error) {
+	sess, err := m.createSessionWorktree(cfg)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	// Check name uniqueness.
+	a, err := sess.AddAgent(cfg, cmd(cfg.Name))
+	if err != nil {
+		_ = sess.Cleanup(m.repoPath)
+		m.mu.Lock()
+		delete(m.sessions, sess.ID)
+		m.mu.Unlock()
+		return nil, nil, err
+	}
+
+	m.emit(Event{Type: EventCreated, AgentID: a.ID, SessionID: sess.ID, Status: StatusStarting})
+
+	m.watchers.Add(1)
+	go func() {
+		defer m.watchers.Done()
+		m.watchAgent(a, sess.ID)
+	}()
+
+	return sess, a, nil
+}
+
+// createSessionWorktree creates a session with its worktree, adds it to the map.
+func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
+	// Generate session name.
+	m.mu.Lock()
+	existing := make([]string, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		existing = append(existing, s.Name)
+	}
+	name := RandomName(existing)
+	m.nextID++
+	id := fmt.Sprintf("session-%d", m.nextID)
+	m.mu.Unlock()
+
+	cfg.RepoPath = m.repoPath
+
+	wt, err := git.CreateWorktree(m.repoPath, name)
+	if err != nil {
+		return nil, fmt.Errorf("creating worktree: %w", err)
+	}
+
+	sess := newSession(id, name, wt)
+
+	m.mu.Lock()
+	m.sessions[id] = sess
+	m.mu.Unlock()
+
+	return sess, nil
+}
+
+// AddAgent adds an agent to an existing session using the default claude command.
+func (m *Manager) AddAgent(sessionID string, cfg Config) (*Agent, error) {
 	m.mu.RLock()
-	for _, a := range m.agents {
-		if a.Name == cfg.Name {
-			m.mu.RUnlock()
-			return nil, fmt.Errorf("agent %q already exists", cfg.Name)
-		}
-	}
+	sess := m.sessions[sessionID]
 	m.mu.RUnlock()
 
+	if sess == nil {
+		return nil, fmt.Errorf("session %s not found", sessionID)
+	}
+
 	cfg.RepoPath = m.repoPath
 
-	m.mu.Lock()
-	m.nextID++
-	id := fmt.Sprintf("agent-%d", m.nextID)
-	m.mu.Unlock()
-
-	a, err := newAgent(id, cfg)
+	a, err := sess.AddAgentDefault(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	m.mu.Lock()
-	m.agents[id] = a
-	m.mu.Unlock()
+	m.emit(Event{Type: EventCreated, AgentID: a.ID, SessionID: sessionID, Status: StatusStarting})
 
-	m.emit(Event{Type: EventCreated, AgentID: id, Status: StatusStarting})
-
-	// Watch for status changes and completion.
 	m.watchers.Add(1)
 	go func() {
 		defer m.watchers.Done()
-		m.watchAgent(a)
+		m.watchAgent(a, sessionID)
 	}()
 
 	return a, nil
 }
 
-// CreateWithCommand starts a new agent with a custom command (for testing).
+// AddAgentWithCommand adds an agent to an existing session using a custom command.
+func (m *Manager) AddAgentWithCommand(sessionID string, cfg Config, cmd func(name string) *exec.Cmd) (*Agent, error) {
+	m.mu.RLock()
+	sess := m.sessions[sessionID]
+	m.mu.RUnlock()
+
+	if sess == nil {
+		return nil, fmt.Errorf("session %s not found", sessionID)
+	}
+
+	cfg.RepoPath = m.repoPath
+
+	a, err := sess.AddAgent(cfg, cmd(cfg.Name))
+	if err != nil {
+		return nil, err
+	}
+
+	m.emit(Event{Type: EventCreated, AgentID: a.ID, SessionID: sessionID, Status: StatusStarting})
+
+	m.watchers.Add(1)
+	go func() {
+		defer m.watchers.Done()
+		m.watchAgent(a, sessionID)
+	}()
+
+	return a, nil
+}
+
+// Create starts a new session with its first agent (backward-compatible wrapper).
+func (m *Manager) Create(cfg Config) (*Agent, error) {
+	_, a, err := m.CreateSession(cfg)
+	return a, err
+}
+
+// CreateWithCommand starts a new session with a custom command (backward-compatible wrapper).
 func (m *Manager) CreateWithCommand(cfg Config, cmd func(name string) *exec.Cmd) (*Agent, error) {
-	cfg.RepoPath = m.repoPath
-
-	m.mu.Lock()
-	m.nextID++
-	id := fmt.Sprintf("agent-%d", m.nextID)
-	m.mu.Unlock()
-
-	a, err := newAgentWithCommand(id, cfg, cmd(cfg.Name))
-	if err != nil {
-		return nil, err
-	}
-
-	m.mu.Lock()
-	m.agents[id] = a
-	m.mu.Unlock()
-
-	m.emit(Event{Type: EventCreated, AgentID: id, Status: StatusStarting})
-
-	m.watchers.Add(1)
-	go func() {
-		defer m.watchers.Done()
-		m.watchAgent(a)
-	}()
-
-	return a, nil
+	_, a, err := m.CreateSessionWithCommand(cfg, cmd)
+	return a, err
 }
 
-// Get returns an agent by ID.
-func (m *Manager) Get(id string) *Agent {
+// GetSession returns a session by ID, or nil if not found.
+func (m *Manager) GetSession(id string) *Session {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.agents[id]
+	return m.sessions[id]
 }
 
-// List returns all agents.
-func (m *Manager) List() []*Agent {
+// ListSessions returns all sessions.
+func (m *Manager) ListSessions() []*Session {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	result := make([]*Agent, 0, len(m.agents))
-	for _, a := range m.agents {
-		result = append(result, a)
+	result := make([]*Session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		result = append(result, s)
 	}
 	return result
 }
 
-// Kill terminates an agent and cleans up its resources.
-func (m *Manager) Kill(id string) error {
+// Get returns an agent by ID (searches all sessions).
+func (m *Manager) Get(id string) *Agent {
 	m.mu.RLock()
-	a := m.agents[id]
+	defer m.mu.RUnlock()
+	for _, s := range m.sessions {
+		if a := s.GetAgent(id); a != nil {
+			return a
+		}
+	}
+	return nil
+}
+
+// List returns all agents across all sessions.
+func (m *Manager) List() []*Agent {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*Agent
+	for _, s := range m.sessions {
+		result = append(result, s.Agents()...)
+	}
+	return result
+}
+
+// KillAgent kills a single agent within a session. Does not remove the session.
+func (m *Manager) KillAgent(sessionID, agentID string) error {
+	m.mu.RLock()
+	sess := m.sessions[sessionID]
 	m.mu.RUnlock()
 
-	if a == nil {
-		return fmt.Errorf("agent %s not found", id)
+	if sess == nil {
+		return fmt.Errorf("session %s not found", sessionID)
 	}
 
-	a.Kill()
-	<-a.Done()
+	if sess.GetAgent(agentID) == nil {
+		return fmt.Errorf("agent %s not found in session %s", agentID, sessionID)
+	}
 
-	if err := a.Cleanup(m.repoPath); err != nil {
-		return fmt.Errorf("cleanup agent %s: %w", id, err)
+	sess.KillAgent(agentID)
+	return nil
+}
+
+// KillSession kills all agents in a session, removes the worktree, and deletes the session.
+func (m *Manager) KillSession(sessionID string) error {
+	m.mu.RLock()
+	sess := m.sessions[sessionID]
+	m.mu.RUnlock()
+
+	if sess == nil {
+		return fmt.Errorf("session %s not found", sessionID)
+	}
+
+	sess.KillAll()
+
+	if err := sess.Cleanup(m.repoPath); err != nil {
+		return fmt.Errorf("cleanup session %s: %w", sessionID, err)
 	}
 
 	m.mu.Lock()
-	delete(m.agents, id)
+	delete(m.sessions, sessionID)
 	m.mu.Unlock()
 
 	return nil
+}
+
+// Kill terminates an agent and cleans up its session (backward-compatible).
+// Finds the session containing the agent and kills the entire session.
+func (m *Manager) Kill(id string) error {
+	m.mu.RLock()
+	for _, sess := range m.sessions {
+		if a := sess.GetAgent(id); a != nil {
+			sessID := sess.ID
+			m.mu.RUnlock()
+			return m.KillSession(sessID)
+		}
+	}
+	m.mu.RUnlock()
+	return fmt.Errorf("agent %s not found", id)
 }
 
 // Events returns a channel that emits agent lifecycle events.
@@ -181,39 +307,40 @@ func (m *Manager) Events() <-chan Event {
 	return m.events
 }
 
-// Shutdown kills all agents and cleans up.
+// Shutdown kills all sessions and cleans up.
 func (m *Manager) Shutdown() {
-	// Signal all watcher goroutines to stop first.
 	close(m.done)
 
 	m.mu.RLock()
-	agents := make([]*Agent, 0, len(m.agents))
-	for _, a := range m.agents {
-		agents = append(agents, a)
+	sessions := make([]*Session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		sessions = append(sessions, s)
 	}
 	m.mu.RUnlock()
 
-	for _, a := range agents {
-		a.Kill()
-		<-a.Done()
-		a.Cleanup(m.repoPath)
+	for _, s := range sessions {
+		s.KillAll()
+		s.Cleanup(m.repoPath)
 	}
 
-	// Wait for all watcher goroutines to finish before closing the channel.
 	m.watchers.Wait()
 
 	m.mu.Lock()
-	m.agents = make(map[string]*Agent)
+	m.sessions = make(map[string]*Session)
 	m.mu.Unlock()
 
 	close(m.events)
 }
 
-// AgentCount returns the number of active agents.
+// AgentCount returns the total number of agents across all sessions.
 func (m *Manager) AgentCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return len(m.agents)
+	count := 0
+	for _, s := range m.sessions {
+		count += s.AgentCount()
+	}
+	return count
 }
 
 // RepoPath returns the manager's repo path.
@@ -221,11 +348,11 @@ func (m *Manager) RepoPath() string {
 	return m.repoPath
 }
 
-func (m *Manager) watchAgent(a *Agent) {
+func (m *Manager) watchAgent(a *Agent, sessionID string) {
 	select {
 	case <-a.Done():
 		status := a.Status()
-		m.emit(Event{Type: EventDone, AgentID: a.ID, Status: status})
+		m.emit(Event{Type: EventDone, AgentID: a.ID, SessionID: sessionID, Status: status})
 	case <-m.done:
 	}
 }
@@ -234,6 +361,5 @@ func (m *Manager) emit(e Event) {
 	select {
 	case m.events <- e:
 	default:
-		// Drop event if channel is full — non-blocking.
 	}
 }

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -1,0 +1,201 @@
+package agent
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/devenjarvis/baton/internal/git"
+)
+
+// Session owns a git worktree and holds one or more agents that share it.
+type Session struct {
+	ID        string
+	Name      string
+	Worktree  *git.WorktreeInfo
+	CreatedAt time.Time
+
+	mu           sync.RWMutex
+	agents       map[string]*Agent
+	nextAgentNum int
+}
+
+// newSession creates a session with the given worktree.
+func newSession(id, name string, wt *git.WorktreeInfo) *Session {
+	return &Session{
+		ID:        id,
+		Name:      name,
+		Worktree:  wt,
+		CreatedAt: time.Now(),
+		agents:    make(map[string]*Agent),
+	}
+}
+
+// AddAgent creates and starts a new agent within this session using the session's worktree.
+func (s *Session) AddAgent(cfg Config, cmd *exec.Cmd) (*Agent, error) {
+	s.mu.Lock()
+	s.nextAgentNum++
+	num := s.nextAgentNum
+	id := fmt.Sprintf("%s-agent-%d", s.ID, num)
+	s.mu.Unlock()
+
+	a, err := newAgentWithCommand(id, cfg, s.Worktree.Path, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.agents[id] = a
+	s.mu.Unlock()
+
+	return a, nil
+}
+
+// AddAgentDefault creates and starts a new agent using the default claude command.
+func (s *Session) AddAgentDefault(cfg Config) (*Agent, error) {
+	s.mu.Lock()
+	s.nextAgentNum++
+	num := s.nextAgentNum
+	id := fmt.Sprintf("%s-agent-%d", s.ID, num)
+	s.mu.Unlock()
+
+	a, err := newAgent(id, cfg, s.Worktree.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.agents[id] = a
+	s.mu.Unlock()
+
+	return a, nil
+}
+
+// GetAgent returns an agent by ID, or nil if not found.
+func (s *Session) GetAgent(id string) *Agent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.agents[id]
+}
+
+// Agents returns all agents sorted by CreatedAt.
+func (s *Session) Agents() []*Agent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]*Agent, 0, len(s.agents))
+	for _, a := range s.agents {
+		result = append(result, a)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].CreatedAt.Before(result[j].CreatedAt)
+	})
+	return result
+}
+
+// Status returns a composite status across all agents in the session.
+// Priority: any Active→Active, any Starting→Starting, any Idle→Idle,
+// any Error→Error, all Done→Done, no agents→Idle.
+func (s *Session) Status() Status {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(s.agents) == 0 {
+		return StatusIdle
+	}
+
+	hasStarting := false
+	hasIdle := false
+	hasError := false
+	allDone := true
+
+	for _, a := range s.agents {
+		st := a.Status()
+		switch st {
+		case StatusActive:
+			return StatusActive
+		case StatusStarting:
+			hasStarting = true
+			allDone = false
+		case StatusIdle:
+			hasIdle = true
+			allDone = false
+		case StatusError:
+			hasError = true
+			allDone = false
+		case StatusDone:
+			// continue
+		default:
+			allDone = false
+		}
+	}
+
+	if hasStarting {
+		return StatusStarting
+	}
+	if hasIdle {
+		return StatusIdle
+	}
+	if hasError {
+		return StatusError
+	}
+	if allDone {
+		return StatusDone
+	}
+	return StatusIdle
+}
+
+// AgentCount returns the number of agents in this session.
+func (s *Session) AgentCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.agents)
+}
+
+// KillAgent kills a single agent but does not remove the session.
+func (s *Session) KillAgent(id string) {
+	s.mu.RLock()
+	a := s.agents[id]
+	s.mu.RUnlock()
+
+	if a == nil {
+		return
+	}
+
+	a.Kill()
+	<-a.Done()
+
+	s.mu.Lock()
+	delete(s.agents, id)
+	s.mu.Unlock()
+}
+
+// KillAll kills all agents in this session.
+func (s *Session) KillAll() {
+	s.mu.RLock()
+	agents := make([]*Agent, 0, len(s.agents))
+	for _, a := range s.agents {
+		agents = append(agents, a)
+	}
+	s.mu.RUnlock()
+
+	for _, a := range agents {
+		a.Kill()
+		<-a.Done()
+	}
+
+	s.mu.Lock()
+	s.agents = make(map[string]*Agent)
+	s.mu.Unlock()
+}
+
+// Cleanup removes the session's worktree and branch.
+func (s *Session) Cleanup(repoPath string) error {
+	return git.RemoveWorktree(repoPath, s.Worktree, true)
+}
+
+// Elapsed returns how long the session has been running.
+func (s *Session) Elapsed() time.Duration {
+	return time.Since(s.CreatedAt)
+}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1,0 +1,230 @@
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestSessionCreation(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 2")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sess.Name == "" {
+		t.Error("session name should not be empty")
+	}
+	if sess.Worktree == nil {
+		t.Fatal("session worktree should not be nil")
+	}
+	if ag == nil {
+		t.Fatal("first agent should not be nil")
+	}
+	if sess.AgentCount() != 1 {
+		t.Errorf("expected 1 agent, got %d", sess.AgentCount())
+	}
+}
+
+func TestMultipleAgentsShareWorktree(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag1, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ag2, err := mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both agents should share the same worktree path.
+	if ag1.WorktreePath != ag2.WorktreePath {
+		t.Errorf("agents should share worktree path: %s != %s", ag1.WorktreePath, ag2.WorktreePath)
+	}
+	if ag1.WorktreePath != sess.Worktree.Path {
+		t.Errorf("agent worktree path should match session: %s != %s", ag1.WorktreePath, sess.Worktree.Path)
+	}
+	if sess.AgentCount() != 2 {
+		t.Errorf("expected 2 agents, got %d", sess.AgentCount())
+	}
+	if mgr.AgentCount() != 2 {
+		t.Errorf("expected 2 total agents, got %d", mgr.AgentCount())
+	}
+}
+
+func TestKillAgentSessionSurvives(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag1, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Kill just the first agent.
+	if err := mgr.KillAgent(sess.ID, ag1.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Session should still exist with one agent.
+	if mgr.GetSession(sess.ID) == nil {
+		t.Error("session should still exist after killing one agent")
+	}
+	if sess.AgentCount() != 1 {
+		t.Errorf("expected 1 agent remaining, got %d", sess.AgentCount())
+	}
+	if mgr.AgentCount() != 1 {
+		t.Errorf("expected 1 total agent, got %d", mgr.AgentCount())
+	}
+
+	// Worktree should still exist.
+	if _, err := os.Stat(sess.Worktree.Path); os.IsNotExist(err) {
+		t.Error("worktree should still exist after killing one agent")
+	}
+}
+
+func TestKillSessionCleansAll(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath := sess.Worktree.Path
+	sessID := sess.ID
+
+	if err := mgr.KillSession(sessID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Session should be gone.
+	if mgr.GetSession(sessID) != nil {
+		t.Error("session should be removed after KillSession")
+	}
+	// Worktree should be gone.
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Error("worktree should be removed after KillSession")
+	}
+	if mgr.AgentCount() != 0 {
+		t.Errorf("expected 0 agents, got %d", mgr.AgentCount())
+	}
+}
+
+func TestSessionCompositeStatus(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	// Create a session with an agent that exits quickly.
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo hi; sleep 0.3")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Initially should be starting or active.
+	s := sess.Status()
+	if s != StatusStarting && s != StatusActive {
+		t.Errorf("expected Starting or Active initially, got %s", s)
+	}
+
+	// Add a second agent that runs longer.
+	_, err = mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo world; sleep 2")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait briefly for output.
+	time.Sleep(200 * time.Millisecond)
+	s = sess.Status()
+	if s != StatusActive && s != StatusStarting {
+		t.Errorf("expected Active or Starting with running agents, got %s", s)
+	}
+
+	// Wait for the first agent to finish but the second is still running.
+	time.Sleep(500 * time.Millisecond)
+	// Session should still be active since agent 2 is still running.
+	s = sess.Status()
+	if s != StatusActive && s != StatusIdle {
+		t.Errorf("expected Active or Idle (agent2 still running), got %s", s)
+	}
+}
+
+func TestSessionAgentsSorted(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag1, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(10 * time.Millisecond) // ensure different CreatedAt
+
+	ag2, err := mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	agents := sess.Agents()
+	if len(agents) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(agents))
+	}
+	if agents[0].ID != ag1.ID {
+		t.Errorf("expected first agent %s, got %s", ag1.ID, agents[0].ID)
+	}
+	if agents[1].ID != ag2.ID {
+		t.Errorf("expected second agent %s, got %s", ag2.ID, agents[1].ID)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -27,8 +27,9 @@ type agentEventMsg struct {
 
 // createResultMsg carries the result of async agent creation.
 type createResultMsg struct {
-	agentID string
-	err     error
+	sessionID string
+	agentID   string
+	err       error
 }
 
 // initAppMsg carries the result of app initialization.
@@ -273,8 +274,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch msg.String() {
 		case "n":
-			// Create an agent in the repo of the currently selected item.
-			// Fall back to activeRepo for tests and pre-init states.
+			// Create a new session in the repo of the currently selected item.
 			repoPath := a.dashboard.selectedRepoPath()
 			if repoPath == "" {
 				repoPath = a.activeRepo
@@ -303,11 +303,50 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				BypassPermissions: bypassPerms,
 			}
 			return a, func() tea.Msg {
-				ag, err := mgr.Create(cfg)
+				sess, ag, err := mgr.CreateSession(cfg)
 				if err != nil {
 					return createResultMsg{err: err}
 				}
-				return createResultMsg{agentID: ag.ID}
+				return createResultMsg{sessionID: sess.ID, agentID: ag.ID}
+			}
+
+		case "c":
+			// Add an agent to the selected session.
+			sess := a.dashboard.selectedSession()
+			if sess == nil {
+				a.setError("No session selected")
+				return a, nil
+			}
+			repoPath := a.dashboard.selectedRepoPath()
+			if repoPath == "" {
+				repoPath = a.activeRepo
+			}
+			mgr := a.managers[repoPath]
+			if mgr == nil {
+				return a, nil
+			}
+			previewW := a.dashboard.previewTermWidth()
+			previewH := a.dashboard.previewTermHeight()
+			if previewW <= 0 || previewH <= 0 {
+				a.setError("Terminal size not yet known; try again")
+				return a, nil
+			}
+			bypassPerms := true
+			if a.cfg != nil {
+				bypassPerms = a.cfg.GetBypassPermissions()
+			}
+			cfg := agent.Config{
+				Rows:              previewH,
+				Cols:              previewW,
+				BypassPermissions: bypassPerms,
+			}
+			sessionID := sess.ID
+			return a, func() tea.Msg {
+				ag, err := mgr.AddAgent(sessionID, cfg)
+				if err != nil {
+					return createResultMsg{err: err}
+				}
+				return createResultMsg{sessionID: sessionID, agentID: ag.ID}
 			}
 
 		case "a":
@@ -323,9 +362,13 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if item == nil {
 				return a, nil
 			}
-			if item.kind == listItemAgent {
-				// Diff the selected agent's worktree.
-				rawDiff, err := git.Diff(item.repoPath, item.agent.Worktree)
+			if item.kind == listItemSession || item.kind == listItemAgent {
+				// Diff the session's worktree.
+				sess := item.session
+				if sess == nil {
+					return a, nil
+				}
+				rawDiff, err := git.Diff(item.repoPath, sess.Worktree)
 				if err != nil {
 					a.setError(err.Error())
 					return a, nil
@@ -336,7 +379,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				files := git.ParseDiffFiles(rawDiff)
 				a.view = ViewDiff
-				a.diff = newDiffModel(item.agent.ID, files, a.width, a.height-1)
+				a.diff = newDiffModel(sess.Name, files, a.width, a.height-1)
 				return a, nil
 			}
 			// Repo header selected — remove the repo.
@@ -351,12 +394,21 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "x":
 			item := a.dashboard.selectedItem()
-			if item == nil || item.kind != listItemAgent {
+			if item == nil {
 				return a, nil
 			}
 			mgr := a.managers[item.repoPath]
-			if mgr != nil {
-				if err := mgr.Kill(item.agent.ID); err != nil {
+			if mgr == nil {
+				return a, nil
+			}
+			if item.kind == listItemAgent && item.session != nil {
+				// Kill just this agent.
+				if err := mgr.KillAgent(item.session.ID, item.agent.ID); err != nil {
+					a.setError(err.Error())
+				}
+			} else if item.kind == listItemSession && item.session != nil {
+				// Kill entire session.
+				if err := mgr.KillSession(item.session.ID); err != nil {
 					a.setError(err.Error())
 				}
 			}
@@ -365,17 +417,24 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case "m":
 			item := a.dashboard.selectedItem()
-			if item == nil || item.kind != listItemAgent {
+			if item == nil {
 				return a, nil
 			}
-			ag := item.agent
-			if ag.Status() != agent.StatusDone && ag.Status() != agent.StatusIdle {
-				a.setError("Agent must be done or idle to merge")
+			sess := a.dashboard.selectedSession()
+			if sess == nil {
 				return a, nil
+			}
+			// Check that all agents in the session are done or idle.
+			for _, ag := range sess.Agents() {
+				st := ag.Status()
+				if st != agent.StatusDone && st != agent.StatusIdle {
+					a.setError("All agents in session must be done or idle to merge")
+					return a, nil
+				}
 			}
 			a.activeRepo = item.repoPath
 			a.view = ViewMerge
-			a.merge = newMergeModel(ag.Name, ag.Worktree.Branch, ag.Worktree.BaseBranch)
+			a.merge = newMergeModel(sess.Name, sess.Worktree.Branch, sess.Worktree.BaseBranch)
 			a.merge.width = a.width
 			a.merge.height = a.height
 			return a, nil
@@ -481,15 +540,17 @@ func (a App) updateMerge(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.view = ViewDashboard
 		return a, nil
 	case mergeConfirmMsg:
-		ag := a.dashboard.selectedAgent()
-		if ag == nil {
+		sess := a.dashboard.selectedSession()
+		if sess == nil {
 			a.view = ViewDashboard
 			return a, nil
 		}
 		activeRepo := a.activeRepo
+		wt := sess.Worktree
+		sessName := sess.Name
 		return a, func() tea.Msg {
-			message := "Merge baton/" + ag.Name + " into " + ag.Worktree.BaseBranch
-			err := git.MergeWorktree(activeRepo, ag.Worktree, message)
+			message := "Merge baton/" + sessName + " into " + wt.BaseBranch
+			err := git.MergeWorktree(activeRepo, wt, message)
 			return mergeCompleteMsg{err: err}
 		}
 	case mergeCompleteMsg:
@@ -497,12 +558,15 @@ func (a App) updateMerge(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.merge.errMsg = msg.err.Error()
 			return a, nil
 		}
-		// Merge succeeded — clean up the agent.
-		item := a.dashboard.selectedItem()
-		if item != nil && item.kind == listItemAgent {
-			mgr := a.managers[item.repoPath]
-			if mgr != nil {
-				_ = mgr.Kill(item.agent.ID)
+		// Merge succeeded — clean up the entire session.
+		sess := a.dashboard.selectedSession()
+		if sess != nil {
+			item := a.dashboard.selectedItem()
+			if item != nil {
+				mgr := a.managers[item.repoPath]
+				if mgr != nil {
+					_ = mgr.KillSession(sess.ID)
+				}
 			}
 			a.refreshAgentList()
 		}
@@ -552,24 +616,32 @@ func (a *App) refreshAgentList() {
 	if a.cfg == nil {
 		// Fallback used in tests that set up managers directly without cfg.
 		if mgr := a.managers[a.activeRepo]; mgr != nil {
-			agents := mgr.List()
-			sort.Slice(agents, func(i, j int) bool {
-				return agents[i].CreatedAt.Before(agents[j].CreatedAt)
-			})
 			var items []listItem
-			for _, ag := range agents {
+			sessions := mgr.ListSessions()
+			sort.Slice(sessions, func(i, j int) bool {
+				return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
+			})
+			for _, sess := range sessions {
 				items = append(items, listItem{
-					kind:     listItemAgent,
+					kind:     listItemSession,
 					repoPath: a.activeRepo,
-					agent:    ag,
+					session:  sess,
 				})
+				for _, ag := range sess.Agents() {
+					items = append(items, listItem{
+						kind:     listItemAgent,
+						repoPath: a.activeRepo,
+						session:  sess,
+						agent:    ag,
+					})
+				}
 			}
 			a.dashboard.items = items
 		}
 		return
 	}
 
-	// Build hierarchical list: one repo header per registered repo, agents below.
+	// Build hierarchical list: repo > session > agent.
 	var items []listItem
 	for _, repo := range a.cfg.Repos {
 		items = append(items, listItem{
@@ -579,16 +651,24 @@ func (a *App) refreshAgentList() {
 		})
 		mgr := a.managers[repo.Path]
 		if mgr != nil {
-			agents := mgr.List()
-			sort.Slice(agents, func(i, j int) bool {
-				return agents[i].CreatedAt.Before(agents[j].CreatedAt)
+			sessions := mgr.ListSessions()
+			sort.Slice(sessions, func(i, j int) bool {
+				return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
 			})
-			for _, ag := range agents {
+			for _, sess := range sessions {
 				items = append(items, listItem{
-					kind:     listItemAgent,
+					kind:     listItemSession,
 					repoPath: repo.Path,
-					agent:    ag,
+					session:  sess,
 				})
+				for _, ag := range sess.Agents() {
+					items = append(items, listItem{
+						kind:     listItemAgent,
+						repoPath: repo.Path,
+						session:  sess,
+						agent:    ag,
+					})
+				}
 			}
 		}
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -36,6 +36,30 @@ func createAgent(t *testing.T, app App) App {
 	return app
 }
 
+// addAgentToSession presses 'c' and executes the async add cmd, returning the updated app.
+func addAgentToSession(t *testing.T, app App) App {
+	t.Helper()
+
+	// Return to list focus if terminal has focus so 'c' is handled by the app.
+	if app.dashboard.panelFocus == focusTerminal {
+		model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+		app = model.(App)
+	}
+
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	app = model.(App)
+
+	if cmd == nil {
+		t.Fatal("Expected cmd from 'c', got nil")
+	}
+
+	msg := cmd()
+	model, _ = app.Update(msg)
+	app = model.(App)
+
+	return app
+}
+
 func TestCreateAgentViaN(t *testing.T) {
 	dir, err := os.MkdirTemp("", "baton-tui-*")
 	if err != nil {
@@ -86,6 +110,11 @@ func TestCreateAgentViaN(t *testing.T) {
 	if app.dashboard.panelFocus != focusTerminal {
 		t.Errorf("Expected focusTerminal after creation, got %v", app.dashboard.panelFocus)
 	}
+	// Session should be present.
+	sessions := mgr.ListSessions()
+	if len(sessions) != 1 {
+		t.Errorf("Expected 1 session, got %d", len(sessions))
+	}
 }
 
 func TestCreateMultipleAgentsViaTUI(t *testing.T) {
@@ -117,27 +146,27 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 	app.managers[dir] = mgr
 	app.activeRepo = dir
 
-	// Create first agent
-	t.Log("=== Creating agent 1 ===")
+	// Create first session+agent
+	t.Log("=== Creating session 1 ===")
 	app = createAgent(t, app)
-	t.Logf("After agent1: view=%v, err=%q, agents=%d, dashboard=%d",
+	t.Logf("After session1: view=%v, err=%q, agents=%d, dashboard=%d",
 		app.view, app.err, mgr.AgentCount(), len(app.dashboard.agentItems()))
 
 	if app.err != "" {
-		t.Fatalf("Agent 1 error: %s", app.err)
+		t.Fatalf("Session 1 error: %s", app.err)
 	}
 	if mgr.AgentCount() != 1 {
 		t.Fatalf("Expected 1 agent, got %d", mgr.AgentCount())
 	}
 
-	// Create second agent (createAgent presses Esc first to exit focusTerminal)
-	t.Log("=== Creating agent 2 ===")
+	// Create second session+agent
+	t.Log("=== Creating session 2 ===")
 	app = createAgent(t, app)
-	t.Logf("After agent2: view=%v, err=%q, agents=%d, dashboard=%d",
+	t.Logf("After session2: view=%v, err=%q, agents=%d, dashboard=%d",
 		app.view, app.err, mgr.AgentCount(), len(app.dashboard.agentItems()))
 
 	if app.err != "" {
-		t.Fatalf("Agent 2 error: %s", app.err)
+		t.Fatalf("Session 2 error: %s", app.err)
 	}
 	if mgr.AgentCount() != 2 {
 		t.Fatalf("Expected 2 agents, got %d", mgr.AgentCount())
@@ -146,14 +175,14 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 		t.Fatalf("Expected 2 dashboard agents, got %d", len(app.dashboard.agentItems()))
 	}
 
-	// Create third agent
-	t.Log("=== Creating agent 3 ===")
+	// Create third session+agent
+	t.Log("=== Creating session 3 ===")
 	app = createAgent(t, app)
-	t.Logf("After agent3: view=%v, err=%q, agents=%d, dashboard=%d",
+	t.Logf("After session3: view=%v, err=%q, agents=%d, dashboard=%d",
 		app.view, app.err, mgr.AgentCount(), len(app.dashboard.agentItems()))
 
 	if app.err != "" {
-		t.Fatalf("Agent 3 error: %s", app.err)
+		t.Fatalf("Session 3 error: %s", app.err)
 	}
 	if mgr.AgentCount() != 3 {
 		t.Fatalf("Expected 3 agents, got %d", mgr.AgentCount())
@@ -162,9 +191,77 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 		t.Fatalf("Expected 3 dashboard agents, got %d", len(app.dashboard.agentItems()))
 	}
 
-	t.Logf("SUCCESS: Created %d agents", len(app.dashboard.agentItems()))
-	for _, a := range app.dashboard.agentItems() {
-		t.Logf("  %s: status=%v", a.Name, a.Status())
+	// Should have 3 sessions.
+	sessions := mgr.ListSessions()
+	if len(sessions) != 3 {
+		t.Fatalf("Expected 3 sessions, got %d", len(sessions))
+	}
+
+	t.Logf("SUCCESS: Created %d sessions with %d agents", len(sessions), len(app.dashboard.agentItems()))
+}
+
+func TestAddAgentToSessionViaC(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-tui-addagent-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir)
+	defer mgr.Shutdown()
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+
+	// Create first session with 'n'.
+	app = createAgent(t, app)
+	if app.err != "" {
+		t.Fatalf("Error creating session: %s", app.err)
+	}
+	if mgr.AgentCount() != 1 {
+		t.Fatalf("Expected 1 agent, got %d", mgr.AgentCount())
+	}
+
+	sessions := mgr.ListSessions()
+	if len(sessions) != 1 {
+		t.Fatalf("Expected 1 session, got %d", len(sessions))
+	}
+
+	// Navigate to the session row or agent row (either works for 'c').
+	// The agent row should be selected already after creation + esc.
+
+	// Add second agent with 'c'.
+	app = addAgentToSession(t, app)
+	if app.err != "" {
+		t.Fatalf("Error adding agent: %s", app.err)
+	}
+
+	if mgr.AgentCount() != 2 {
+		t.Fatalf("Expected 2 agents, got %d", mgr.AgentCount())
+	}
+	// Should still be the same single session.
+	sessions = mgr.ListSessions()
+	if len(sessions) != 1 {
+		t.Fatalf("Expected still 1 session after 'c', got %d", len(sessions))
+	}
+	if sessions[0].AgentCount() != 2 {
+		t.Fatalf("Expected 2 agents in session, got %d", sessions[0].AgentCount())
 	}
 }
 
@@ -284,7 +381,7 @@ func TestMouseClickSelectsListItem(t *testing.T) {
 	app.dashboard.width = 120
 	app.dashboard.height = 39
 
-	// Directly populate the list with fake agent items (no real processes needed).
+	// Directly populate the list with fake items (no real processes needed).
 	app.dashboard.items = []listItem{
 		{kind: listItemAgent, repoPath: "/fake/repo"},
 		{kind: listItemAgent, repoPath: "/fake/repo"},
@@ -436,9 +533,8 @@ func TestMouseWheelScrollInFocusTerminal(t *testing.T) {
 	mgr := agent.NewManager(dir)
 	defer mgr.Shutdown()
 
-	// Create an agent with bash that writes 40 lines (more than the 24-row terminal height)
-	// so scrollback is populated before we test wheel scrolling.
-	ag, err := mgr.CreateWithCommand(agent.Config{
+	// Create a session with an agent that writes 40 lines.
+	sess, ag, err := mgr.CreateSessionWithCommand(agent.Config{
 		Name:     "wheel-test",
 		Task:     "test",
 		RepoPath: dir,
@@ -450,6 +546,7 @@ func TestMouseWheelScrollInFocusTerminal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	_ = sess // used for session creation
 
 	// Wait for bash output to be processed into scrollback.
 	time.Sleep(300 * time.Millisecond)
@@ -458,7 +555,7 @@ func TestMouseWheelScrollInFocusTerminal(t *testing.T) {
 		t.Fatal("Expected scrollback lines after bash output")
 	}
 
-	// Build an app with this agent directly in dashboard items — no TUI prompt needed.
+	// Build an app with this agent directly in dashboard items.
 	app := NewApp()
 	app.width = 120
 	app.height = 40
@@ -467,7 +564,7 @@ func TestMouseWheelScrollInFocusTerminal(t *testing.T) {
 	app.managers[dir] = mgr
 	app.activeRepo = dir
 	app.dashboard.items = []listItem{
-		{kind: listItemAgent, repoPath: dir, agent: ag},
+		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
 	}
 	app.dashboard.panelFocus = focusTerminal
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -11,23 +11,25 @@ import (
 	"github.com/devenjarvis/baton/internal/agent"
 )
 
-// listItemKind distinguishes repo headers from agent rows in the dashboard list.
+// listItemKind distinguishes repo headers, session rows, and agent rows in the dashboard list.
 type listItemKind int
 
 const (
-	listItemRepo  listItemKind = iota
-	listItemAgent listItemKind = iota
+	listItemRepo listItemKind = iota
+	listItemSession
+	listItemAgent
 )
 
 // listItem represents one row in the hierarchical dashboard list.
 type listItem struct {
 	kind     listItemKind
 	repoPath string
-	repoName string       // set for repo header items
-	agent    *agent.Agent // set for agent items
+	repoName string          // set for repo header items
+	session  *agent.Session  // set for session and agent items
+	agent    *agent.Agent    // set for agent items
 }
 
-// dashboardModel shows the hierarchical repo/agent list and terminal preview.
+// dashboardModel shows the hierarchical repo/session/agent list and terminal preview.
 type dashboardModel struct {
 	items        []listItem
 	selected     int
@@ -175,7 +177,7 @@ func (d dashboardModel) previewTermHeight() int {
 func (d dashboardModel) emptyView() string {
 	title := StyleTitle.Render("Baton")
 	subtitle := StyleSubtle.Render("No agents running")
-	hint := StyleSubtle.Render("Press n to create a new agent")
+	hint := StyleSubtle.Render("Press n to create a new session")
 
 	content := lipgloss.JoinVertical(lipgloss.Center, title, "", subtitle, "", hint)
 	return lipgloss.Place(d.width, d.contentHeight(), lipgloss.Center, lipgloss.Center, content)
@@ -215,8 +217,51 @@ func (d dashboardModel) renderList(width int) string {
 			}
 			lines = append(lines, prefix+repoStyle.Render(name))
 
+		case listItemSession:
+			// Session row — indented under its repo.
+			sess := item.session
+			status := sess.Status()
+			symbol := status.Symbol()
+			elapsed := humanizeElapsed(sess.Elapsed())
+			count := fmt.Sprintf("[%d]", sess.AgentCount())
+
+			var style lipgloss.Style
+			switch status {
+			case agent.StatusActive:
+				style = lipgloss.NewStyle().Foreground(ColorSecondary)
+			case agent.StatusDone:
+				style = lipgloss.NewStyle().Foreground(ColorSuccess)
+			case agent.StatusError:
+				style = lipgloss.NewStyle().Foreground(ColorError)
+			case agent.StatusIdle:
+				style = lipgloss.NewStyle().Foreground(ColorMuted)
+			default:
+				style = lipgloss.NewStyle().Foreground(ColorWarning)
+			}
+
+			nameWidth := width - 20 // space for indent, symbol, count badge, elapsed, padding
+			name := sess.Name
+			if len(name) > nameWidth {
+				name = name[:nameWidth-1] + "…"
+			}
+
+			sessionPrefix := "    "
+			if isSelected {
+				sessionPrefix = "  " + StyleActive.Render("▸ ")
+			}
+
+			line := fmt.Sprintf("%s%s %-*s %s %5s",
+				sessionPrefix,
+				style.Render(symbol),
+				nameWidth,
+				name,
+				StyleSubtle.Render(count),
+				elapsed,
+			)
+			lines = append(lines, line)
+
 		case listItemAgent:
-			// Agent row — indented under its repo.
+			// Agent row — indented under its session.
 			ag := item.agent
 			status := ag.Status()
 			symbol := status.Symbol()
@@ -236,15 +281,15 @@ func (d dashboardModel) renderList(width int) string {
 				style = lipgloss.NewStyle().Foreground(ColorWarning)
 			}
 
-			nameWidth := width - 16 // space for indent, symbol, elapsed, padding
+			nameWidth := width - 18 // space for indent, symbol, elapsed, padding
 			name := ag.GetDisplayName()
 			if len(name) > nameWidth {
 				name = name[:nameWidth-1] + "…"
 			}
 
-			agentPrefix := "    "
+			agentPrefix := "      "
 			if isSelected {
-				agentPrefix = "  " + StyleActive.Render("▸ ")
+				agentPrefix = "    " + StyleActive.Render("▸ ")
 			}
 
 			line := fmt.Sprintf("%s%s %-*s %5s",
@@ -272,8 +317,18 @@ func (d dashboardModel) renderPreview(width int) string {
 		// Show repo info in the preview panel when a repo header is selected.
 		title := StyleTitle.Render(" " + item.repoName + " ")
 		pathLine := StyleSubtle.Render(" " + item.repoPath)
-		hint := StyleSubtle.Render(" Press n to create an agent in this repo")
+		hint := StyleSubtle.Render(" Press n to create a session in this repo")
 		return lipgloss.JoinVertical(lipgloss.Left, title, pathLine, "", hint)
+	}
+
+	if item.kind == listItemSession {
+		// Show session info in the preview panel when a session row is selected.
+		sess := item.session
+		title := StyleTitle.Render(" " + sess.Name + " ")
+		pathLine := StyleSubtle.Render(" Worktree: " + sess.Worktree.Path)
+		statusLine := StyleSubtle.Render(fmt.Sprintf(" Agents: %d  Status: %s", sess.AgentCount(), sess.Status()))
+		hint := StyleSubtle.Render(" Press c to add an agent")
+		return lipgloss.JoinVertical(lipgloss.Left, title, pathLine, statusLine, "", hint)
 	}
 
 	// Agent selected — show terminal preview.
@@ -321,13 +376,23 @@ func (d dashboardModel) selectedItem() *listItem {
 	return &d.items[d.selected]
 }
 
-// selectedAgent returns the currently selected agent, or nil if a repo header is selected.
+// selectedAgent returns the currently selected agent, or nil if a repo/session header is selected.
 func (d dashboardModel) selectedAgent() *agent.Agent {
 	item := d.selectedItem()
 	if item == nil || item.kind != listItemAgent {
 		return nil
 	}
 	return item.agent
+}
+
+// selectedSession returns the session for the currently selected item.
+// Works for both session and agent items.
+func (d dashboardModel) selectedSession() *agent.Session {
+	item := d.selectedItem()
+	if item == nil {
+		return nil
+	}
+	return item.session
 }
 
 // selectedRepoPath returns the repo path of the currently selected item.

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -15,7 +15,8 @@ var (
 	dashboardHints = []keyHint{
 		{"j/k", "navigate"},
 		{"→", "interact"},
-		{"n", "new agent"},
+		{"n", "new session"},
+		{"c", "add agent"},
 		{"a", "add repo"},
 		{"d", "diff/remove"},
 		{"x", "kill"},


### PR DESCRIPTION
## Summary

- Introduces a **Session** layer between Manager and Agent — sessions own git worktrees and can hold multiple agents sharing the same worktree
- TUI gains a three-level hierarchy: **Repo > Session > Agent** with session rows showing composite status and agent count badges
- `n` creates a new session (with its first agent), `c` adds an agent to the selected session
- `d`, `m`, `x` are all session-aware — diff/merge operate on the session worktree, kill works at both agent and session level
- Backward-compatible `Create()`, `Kill()` wrappers kept on Manager to minimize churn

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -race ./...` — all tests pass
- [ ] Manual: launch baton, press `n` → session created with one agent, auto-focused
- [ ] Manual: press `esc`, press `c` → second agent added to same session
- [ ] Manual: verify both agents show under the session in the left panel
- [ ] Manual: press `d` on session or agent → shows combined worktree diff
- [ ] Manual: press `x` on one agent → only that agent killed, session remains
- [ ] Manual: press `x` on session → all agents killed, worktree cleaned
- [ ] Manual: create session, let agents work, press `m` → merge session worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)