### PR TITLE
feat: add audible chime when agents go idle

### DIFF
--- a/internal/audio/chime.go
+++ b/internal/audio/chime.go
@@ -1,0 +1,93 @@
+package audio
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+)
+
+const (
+	sampleRate    = 44100
+	bitsPerSample = 16
+	numChannels   = 1
+	duration      = 0.2 // seconds
+	amplitude     = 0.3
+	fadeMs        = 5 // fade envelope in milliseconds
+	freq1         = 800.0
+	freq2         = 1200.0
+)
+
+// GenerateChime creates a short ascending two-tone WAV file in a temp directory.
+// The caller owns the returned file and is responsible for cleanup.
+func GenerateChime() (string, error) {
+	numSamples := int(sampleRate * duration)
+	fadeDuration := float64(fadeMs) / 1000.0
+	fadeSamples := int(float64(sampleRate) * fadeDuration)
+	half := numSamples / 2
+
+	dataSize := numSamples * numChannels * (bitsPerSample / 8)
+	fileSize := 44 + dataSize
+
+	buf := make([]byte, fileSize)
+
+	// RIFF header
+	copy(buf[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(fileSize-8))
+	copy(buf[8:12], "WAVE")
+
+	// fmt subchunk
+	copy(buf[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:20], 16) // subchunk size
+	binary.LittleEndian.PutUint16(buf[20:22], 1)  // PCM
+	binary.LittleEndian.PutUint16(buf[22:24], numChannels)
+	binary.LittleEndian.PutUint32(buf[24:28], sampleRate)
+	binary.LittleEndian.PutUint32(buf[28:32], sampleRate*numChannels*(bitsPerSample/8)) // byte rate
+	binary.LittleEndian.PutUint16(buf[32:34], numChannels*(bitsPerSample/8))            // block align
+	binary.LittleEndian.PutUint16(buf[34:36], bitsPerSample)
+
+	// data subchunk
+	copy(buf[36:40], "data")
+	binary.LittleEndian.PutUint32(buf[40:44], uint32(dataSize))
+
+	// Generate samples
+	for i := range numSamples {
+		t := float64(i) / sampleRate
+		freq := freq1
+		if i >= half {
+			freq = freq2
+		}
+		sample := amplitude * math.Sin(2*math.Pi*freq*t)
+
+		// Fade envelope
+		var env float64 = 1.0
+		if i < fadeSamples {
+			env = float64(i) / float64(fadeSamples)
+		} else if i >= numSamples-fadeSamples {
+			env = float64(numSamples-1-i) / float64(fadeSamples)
+		}
+		sample *= env
+
+		// Convert to 16-bit PCM
+		val := int16(sample * 32767)
+		offset := 44 + i*2
+		binary.LittleEndian.PutUint16(buf[offset:offset+2], uint16(val))
+	}
+
+	f, err := os.CreateTemp("", "baton-chime-*.wav")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+
+	if _, err := f.Write(buf); err != nil {
+		f.Close()
+		os.Remove(path)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(path)
+		return "", err
+	}
+
+	return path, nil
+}

--- a/internal/audio/chime_test.go
+++ b/internal/audio/chime_test.go
@@ -1,0 +1,85 @@
+package audio
+
+import (
+	"encoding/binary"
+	"os"
+	"testing"
+)
+
+func TestGenerateChime_WAVHeader(t *testing.T) {
+	path, err := GenerateChime()
+	if err != nil {
+		t.Fatalf("GenerateChime() error: %v", err)
+	}
+	defer os.Remove(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading chime file: %v", err)
+	}
+
+	if len(data) < 44 {
+		t.Fatalf("WAV file too short: %d bytes", len(data))
+	}
+
+	// RIFF header
+	if string(data[0:4]) != "RIFF" {
+		t.Errorf("expected RIFF, got %q", string(data[0:4]))
+	}
+
+	// WAVE format
+	if string(data[8:12]) != "WAVE" {
+		t.Errorf("expected WAVE, got %q", string(data[8:12]))
+	}
+
+	// fmt subchunk
+	if string(data[12:16]) != "fmt " {
+		t.Errorf("expected 'fmt ', got %q", string(data[12:16]))
+	}
+
+	// Audio format: PCM = 1
+	audioFormat := binary.LittleEndian.Uint16(data[20:22])
+	if audioFormat != 1 {
+		t.Errorf("expected PCM format (1), got %d", audioFormat)
+	}
+
+	// Channels: mono = 1
+	channels := binary.LittleEndian.Uint16(data[22:24])
+	if channels != 1 {
+		t.Errorf("expected 1 channel, got %d", channels)
+	}
+
+	// Sample rate: 44100
+	sampleRate := binary.LittleEndian.Uint32(data[24:28])
+	if sampleRate != 44100 {
+		t.Errorf("expected sample rate 44100, got %d", sampleRate)
+	}
+
+	// Bits per sample: 16
+	bitsPerSample := binary.LittleEndian.Uint16(data[34:36])
+	if bitsPerSample != 16 {
+		t.Errorf("expected 16 bits per sample, got %d", bitsPerSample)
+	}
+
+	// data subchunk
+	if string(data[36:40]) != "data" {
+		t.Errorf("expected 'data', got %q", string(data[36:40]))
+	}
+
+	// Data size should match remaining bytes
+	dataSize := binary.LittleEndian.Uint32(data[40:44])
+	if int(dataSize) != len(data)-44 {
+		t.Errorf("data size %d doesn't match actual %d", dataSize, len(data)-44)
+	}
+
+	// RIFF chunk size = file size - 8
+	chunkSize := binary.LittleEndian.Uint32(data[4:8])
+	if int(chunkSize) != len(data)-8 {
+		t.Errorf("RIFF chunk size %d doesn't match expected %d", chunkSize, len(data)-8)
+	}
+
+	// Sanity: ~200ms at 44100Hz mono 16-bit = ~17640 bytes of sample data
+	if dataSize < 15000 || dataSize > 20000 {
+		t.Errorf("unexpected data size %d (expected ~17640 for 200ms)", dataSize)
+	}
+}

--- a/internal/audio/player.go
+++ b/internal/audio/player.go
@@ -1,0 +1,55 @@
+package audio
+
+import (
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+const debounceDuration = 2 * time.Second
+
+// Player manages playback of a pre-generated chime sound.
+// All errors are silent — audio is best-effort.
+type Player struct {
+	chimePath  string
+	lastPlayed time.Time
+	mu         sync.Mutex
+}
+
+// NewPlayer generates a chime WAV file and returns a Player that can play it.
+func NewPlayer() (*Player, error) {
+	path, err := GenerateChime()
+	if err != nil {
+		return nil, err
+	}
+	return &Player{chimePath: path}, nil
+}
+
+// Play plays the chime sound if at least 2 seconds have elapsed since the last play.
+// Never blocks — playback runs in a goroutine. Errors are silently ignored.
+func (p *Player) Play() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if time.Since(p.lastPlayed) < debounceDuration {
+		return
+	}
+	p.lastPlayed = time.Now()
+
+	go func() {
+		_ = exec.Command("afplay", p.chimePath).Run()
+	}()
+}
+
+// LastPlayedTime returns the timestamp of the last successful Play call.
+func (p *Player) LastPlayedTime() time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastPlayed
+}
+
+// Close removes the temporary chime file.
+func (p *Player) Close() {
+	os.Remove(p.chimePath)
+}

--- a/internal/audio/player_test.go
+++ b/internal/audio/player_test.go
@@ -1,0 +1,64 @@
+package audio
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestNewPlayer(t *testing.T) {
+	p, err := NewPlayer()
+	if err != nil {
+		t.Fatalf("NewPlayer() error: %v", err)
+	}
+	defer p.Close()
+
+	if p.chimePath == "" {
+		t.Error("expected chimePath to be set")
+	}
+	if _, err := os.Stat(p.chimePath); err != nil {
+		t.Errorf("chime file should exist: %v", err)
+	}
+}
+
+func TestPlayer_Close_RemovesFile(t *testing.T) {
+	p, err := NewPlayer()
+	if err != nil {
+		t.Fatalf("NewPlayer() error: %v", err)
+	}
+	path := p.chimePath
+	p.Close()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected chime file to be removed after Close")
+	}
+}
+
+func TestPlayer_Debounce(t *testing.T) {
+	p, err := NewPlayer()
+	if err != nil {
+		t.Fatalf("NewPlayer() error: %v", err)
+	}
+	defer p.Close()
+
+	// Override chimePath to a nonexistent file so afplay fails silently
+	// (we only care about debounce logic, not actual playback).
+	p.chimePath = "/dev/null"
+
+	// First call should update lastPlayed.
+	p.Play()
+	first := p.LastPlayedTime()
+
+	if first.IsZero() {
+		t.Fatal("expected lastPlayed to be set after first Play()")
+	}
+
+	// Second call within debounce window should be suppressed.
+	time.Sleep(10 * time.Millisecond)
+	p.Play()
+	second := p.LastPlayedTime()
+
+	if !second.Equal(first) {
+		t.Errorf("expected debounce to suppress second Play(); lastPlayed changed from %v to %v", first, second)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/baton/internal/agent"
+	"github.com/devenjarvis/baton/internal/audio"
 	"github.com/devenjarvis/baton/internal/config"
 	"github.com/devenjarvis/baton/internal/git"
 )
@@ -54,13 +55,17 @@ type App struct {
 	err         string
 	errTicks    int // ticks remaining to show error
 	confirmQuit bool
+
+	lastKnownStatus map[string]agent.Status
+	audioPlayer     *audio.Player
 }
 
 func NewApp() App {
 	return App{
-		view:      ViewDashboard,
-		dashboard: newDashboardModel(),
-		managers:  make(map[string]*agent.Manager),
+		view:            ViewDashboard,
+		dashboard:       newDashboardModel(),
+		managers:        make(map[string]*agent.Manager),
+		lastKnownStatus: make(map[string]agent.Status),
 	}
 }
 
@@ -130,6 +135,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		a.cfg = msg.cfg
+		// Initialize audio player (best-effort — nil on failure).
+		if p, err := audio.NewPlayer(); err == nil {
+			a.audioPlayer = p
+		}
 		// Create a manager for every registered repo and start event listeners.
 		var cmds []tea.Cmd
 		for _, repo := range msg.cfg.Repos {
@@ -147,13 +156,26 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		a.refreshAgentList()
-		// Auto-rename agents that just went idle for the first time.
+		// Auto-rename agents that just went idle for the first time,
+		// and detect Active->Idle transitions for audio notification.
 		for _, item := range a.dashboard.items {
 			if item.kind != listItemAgent || item.agent == nil {
 				continue
 			}
 			ag := item.agent
-			if ag.Status() != agent.StatusIdle || ag.HasDisplayName() {
+			currentStatus := ag.Status()
+
+			// Check for Active->Idle transition.
+			if prev, ok := a.lastKnownStatus[ag.ID]; ok {
+				if prev == agent.StatusActive && currentStatus == agent.StatusIdle {
+					if a.audioPlayer != nil {
+						a.audioPlayer.Play()
+					}
+				}
+			}
+			a.lastKnownStatus[ag.ID] = currentStatus
+
+			if currentStatus != agent.StatusIdle || ag.HasDisplayName() {
 				continue
 			}
 			name := extractAgentName(ag.Render())
@@ -266,6 +288,9 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			for _, mgr := range a.managers {
 				mgr.Shutdown()
 			}
+			if a.audioPlayer != nil {
+				a.audioPlayer.Close()
+			}
 			return a, tea.Quit
 		default:
 			a.confirmQuit = false
@@ -360,6 +385,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.setError(err.Error())
 				}
 			}
+			delete(a.lastKnownStatus, item.agent.ID)
 			a.refreshAgentList()
 			return a, nil
 
@@ -504,6 +530,7 @@ func (a App) updateMerge(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if mgr != nil {
 				_ = mgr.Kill(item.agent.ID)
 			}
+			delete(a.lastKnownStatus, item.agent.ID)
 			a.refreshAgentList()
 		}
 		a.view = ViewDashboard


### PR DESCRIPTION
## Summary

- Add `internal/audio` package with pure Go WAV generation and macOS `afplay` playback
- Generate a ~200ms ascending two-tone chime (800Hz→1200Hz) as 16-bit PCM mono @ 44100Hz
- `Player` struct wraps chime file with 2-second debounce and non-blocking goroutine playback
- TUI tracks `lastKnownStatus` per agent and plays chime on Active→Idle transition
- Zero new Go module dependencies — uses `math.Sin` + `encoding/binary` for WAV, `os/exec` for playback
- All audio errors are silent (best-effort)

## Test plan

- [x] `go build -o baton .` — compiles without errors
- [x] `go test -race ./internal/audio/...` — WAV header validation and debounce tests pass
- [x] `go test -race ./...` — no regressions across all packages
- [x] `go vet ./...` — clean
- [ ] Manual: launch baton, create an agent, wait for idle — chime plays once
- [ ] Manual: two agents idle within 2s — only one chime (debounce)

🤖 Generated with [Claude Code](https://claude.ai/code)