### PR TITLE
fix: guard nil agent dereference when killing sessions

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -461,7 +461,13 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.setError(err.Error())
 				}
 			}
-			delete(a.lastKnownStatus, item.agent.ID)
+			if item.kind == listItemSession && item.session != nil {
+				for _, ag := range item.session.Agents() {
+					delete(a.lastKnownStatus, ag.ID)
+				}
+			} else if item.agent != nil {
+				delete(a.lastKnownStatus, item.agent.ID)
+			}
 			a.refreshAgentList()
 			return a, nil
 
@@ -618,7 +624,9 @@ func (a App) updateMerge(msg tea.Msg) (tea.Model, tea.Cmd) {
 					_ = mgr.KillSession(sess.ID)
 				}
 			}
-			delete(a.lastKnownStatus, item.agent.ID)
+			for _, ag := range sess.Agents() {
+				delete(a.lastKnownStatus, ag.ID)
+			}
 			a.refreshAgentList()
 		}
 		a.view = ViewDashboard


### PR DESCRIPTION
## Summary
- Fix panic (nil pointer dereference on `item.agent.ID`) when pressing "x" on a session header in the dashboard
- Fix same panic in the merge completion handler where status cleanup accessed `item.agent.ID` outside the nil guard
- For session-level operations, iterate `session.Agents()` to clean up `lastKnownStatus` entries instead of accessing the nil `item.agent`

## Test plan
- `go build -o baton .` — builds cleanly
- `go vet ./...` — no issues
- `go test -race ./...` — all tests pass
- Manual: launch a multi-agent session, select the session header, press "x" — should kill cleanly without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)