### PR TITLE
fix: suppress false idle chime while user is typing

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -27,6 +27,7 @@ type Agent struct {
 	displayName string
 	status      Status
 	lastOutput  time.Time
+	lastInput   time.Time
 	exitErr     error
 
 	done         chan struct{}
@@ -188,7 +189,7 @@ func (a *Agent) statusLoop() {
 			return
 		case <-ticker.C:
 			a.mu.Lock()
-			if a.status == StatusActive && time.Since(a.lastOutput) > idleTimeout {
+			if a.status == StatusActive && time.Since(a.lastOutput) > idleTimeout && time.Since(a.lastInput) > idleTimeout {
 				a.status = StatusIdle
 			} else if a.status == StatusIdle && time.Since(a.lastOutput) <= idleTimeout {
 				a.status = StatusActive
@@ -210,11 +211,17 @@ func (a *Agent) RenderRegion(startRow, endRow int) string {
 
 // SendKey forwards a key event to the VT terminal.
 func (a *Agent) SendKey(key xvt.KeyPressEvent) {
+	a.mu.Lock()
+	a.lastInput = time.Now()
+	a.mu.Unlock()
 	a.terminal.SendKey(key)
 }
 
 // SendText forwards text input to the VT terminal.
 func (a *Agent) SendText(text string) {
+	a.mu.Lock()
+	a.lastInput = time.Now()
+	a.mu.Unlock()
 	a.terminal.SendText(text)
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -182,6 +182,66 @@ func TestConfig_BypassPermissionsField(t *testing.T) {
 	}
 }
 
+func TestIdleSuppressedWhileTyping(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-idle-typing", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		// cat reads stdin forever, producing initial output then waiting.
+		return exec.Command("bash", "-c", "echo ready; cat")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for initial output to set status to Active.
+	time.Sleep(500 * time.Millisecond)
+	if s := a.Status(); s != StatusActive {
+		t.Fatalf("expected Active after output, got %s", s)
+	}
+
+	// Simulate user typing every 500ms for 5 seconds (well past the 3s idle timeout).
+	for i := 0; i < 10; i++ {
+		a.SendText("x")
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Agent should still be Active because user input keeps it non-idle.
+	if s := a.Status(); s != StatusActive {
+		t.Errorf("expected Active while typing, got %s", s)
+	}
+}
+
+func TestIdleTransitionWithoutInput(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-idle-no-input", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		// Produce output then go quiet — no user input at all.
+		return exec.Command("bash", "-c", "echo ready; sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for initial output.
+	time.Sleep(500 * time.Millisecond)
+	if s := a.Status(); s != StatusActive {
+		t.Fatalf("expected Active after output, got %s", s)
+	}
+
+	// Wait past idle timeout (3s) + statusLoop tick (500ms) margin.
+	time.Sleep(4 * time.Second)
+
+	if s := a.Status(); s != StatusIdle {
+		t.Errorf("expected Idle after timeout with no input, got %s", s)
+	}
+}
+
 func TestShutdownCleansAll(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo)


### PR DESCRIPTION
## Summary

- Track user input timestamps (`lastInput`) alongside PTY output in the Agent struct
- `SendKey()` and `SendText()` now record `lastInput = time.Now()` under the existing mutex
- Active→Idle transition requires **both** output and input to be quiet past `idleTimeout` (3s)
- Idle→Active transition remains output-only (user typing alone doesn't re-activate)
- Zero-value `lastInput` (no typing ever) behaves identically to the old code

Fixes false idle chimes that fired when users were actively typing into Claude's prompt — Claude produces no PTY output while waiting for input, so the old output-only check triggered after 3s of "silence."

## Test plan

- `TestIdleSuppressedWhileTyping` — sends text every 500ms for 5s, verifies agent stays Active past idle timeout
- `TestIdleTransitionWithoutInput` — regression: no user input, agent transitions to Idle after timeout as before
- All tests pass with `go test -race ./internal/agent/...`
- `go vet ./...` clean