### PR TITLE
feat: remap esc/shift+esc in terminal focus mode

### DIFF
--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -320,6 +320,20 @@ func TestPanelFocusSwitching(t *testing.T) {
 		t.Fatalf("Expected focusTerminal after →, got %v", app.dashboard.panelFocus)
 	}
 
+	// Esc returns to focusList.
+	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	app = model.(App)
+	if app.dashboard.panelFocus != focusList {
+		t.Fatalf("Expected focusList after esc, got %v", app.dashboard.panelFocus)
+	}
+
+	// Right arrow enters focusTerminal again.
+	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	app = model.(App)
+	if app.dashboard.panelFocus != focusTerminal {
+		t.Fatalf("Expected focusTerminal after →, got %v", app.dashboard.panelFocus)
+	}
+
 	// Enter stays in focusTerminal (it forwards the key to the agent).
 	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	app = model.(App)
@@ -373,6 +387,55 @@ func TestActionKeysBlockedInFocusTerminal(t *testing.T) {
 	}
 	if app.dashboard.panelFocus != focusTerminal {
 		t.Fatalf("Expected focusTerminal to persist after 'n', got %v", app.dashboard.panelFocus)
+	}
+}
+
+func TestShiftEscForwardsEscapeToAgent(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-shiftesc-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir)
+	defer mgr.Shutdown()
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+
+	app = createAgent(t, app)
+	if app.dashboard.panelFocus != focusTerminal {
+		t.Fatalf("Expected focusTerminal after creation, got %v", app.dashboard.panelFocus)
+	}
+
+	// Press shift+esc — should stay in focusTerminal (not exit).
+	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEscape, Mod: tea.ModShift})
+	app = model.(App)
+	if app.dashboard.panelFocus != focusTerminal {
+		t.Fatalf("Expected focusTerminal after shift+esc (should forward, not exit), got %v", app.dashboard.panelFocus)
+	}
+
+	// Press plain esc — should exit to focusList.
+	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	app = model.(App)
+	if app.dashboard.panelFocus != focusList {
+		t.Fatalf("Expected focusList after esc, got %v", app.dashboard.panelFocus)
 	}
 }
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -49,9 +49,13 @@ func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 		if d.panelFocus == focusTerminal {
 			ag := d.selectedAgent()
 			switch msg.String() {
-			case "ctrl+e":
+			case "ctrl+e", "esc":
 				d.panelFocus = focusList
 				d.scrollOffset = 0
+			case "shift+esc":
+				if ag != nil {
+					ag.SendKey(xvt.KeyPressEvent{Code: tea.KeyEscape})
+				}
 			case "enter":
 				if ag != nil {
 					ag.SendKey(xvt.KeyPressEvent(msg))

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -28,7 +28,8 @@ var (
 		{"enter", "send"},
 		{"pgup/pgdn", "scroll"},
 		{"home", "live"},
-		{"ctrl+e", "back"},
+		{"esc", "back"},
+		{"⇧esc", "interrupt"},
 	}
 
 	diffHints = []keyHint{


### PR DESCRIPTION
## Summary
- **Esc** now exits terminal focus mode (alongside existing ctrl+e), matching the user's instinct
- **Shift+esc** sends a plain escape key to the agent PTY for interruption
- Status bar hints updated to show `esc back` and `⇧esc interrupt`

## Test plan
- [x] `go build -o baton .` passes
- [x] `go test -race ./...` passes
- [x] `TestPanelFocusSwitching` covers esc-to-exit alongside ctrl+e
- [x] `TestShiftEscForwardsEscapeToAgent` verifies shift+esc stays in focus mode (forwards to agent) and plain esc exits
- [ ] Manual: launch baton, enter terminal focus, press esc (exits), re-enter, press shift+esc (sends interrupt to agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)