### PR TITLE
feat: agent-centric session management

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -36,6 +36,9 @@ func newSession(id, name string, wt *git.WorktreeInfo) *Session {
 // AddAgent creates and starts a new agent within this session using the session's worktree.
 func (s *Session) AddAgent(cfg Config, cmd *exec.Cmd) (*Agent, error) {
 	s.mu.Lock()
+	if cfg.Name == "" {
+		cfg.Name = RandomName(s.existingNames())
+	}
 	s.nextAgentNum++
 	num := s.nextAgentNum
 	id := fmt.Sprintf("%s-agent-%d", s.ID, num)
@@ -56,6 +59,9 @@ func (s *Session) AddAgent(cfg Config, cmd *exec.Cmd) (*Agent, error) {
 // AddAgentDefault creates and starts a new agent using the default claude command.
 func (s *Session) AddAgentDefault(cfg Config) (*Agent, error) {
 	s.mu.Lock()
+	if cfg.Name == "" {
+		cfg.Name = RandomName(s.existingNames())
+	}
 	s.nextAgentNum++
 	num := s.nextAgentNum
 	id := fmt.Sprintf("%s-agent-%d", s.ID, num)
@@ -193,6 +199,17 @@ func (s *Session) KillAll() {
 // Cleanup removes the session's worktree and branch.
 func (s *Session) Cleanup(repoPath string) error {
 	return git.RemoveWorktree(repoPath, s.Worktree, true)
+}
+
+// existingNames returns the session name and all current agent names.
+// Must be called with s.mu held.
+func (s *Session) existingNames() []string {
+	names := make([]string, 0, len(s.agents)+1)
+	names = append(names, s.Name)
+	for _, a := range s.agents {
+		names = append(names, a.Name)
+	}
+	return names
 }
 
 // Elapsed returns how long the session has been running.

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -228,3 +228,54 @@ func TestSessionAgentsSorted(t *testing.T) {
 		t.Errorf("expected second agent %s, got %s", ag2.ID, agents[1].ID)
 	}
 }
+
+func TestAddAgentDefaultAssignsUniqueName(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag1, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Agent should get a random name distinct from session name.
+	if ag1.Name == "" {
+		t.Fatal("agent 1 should have a non-empty name")
+	}
+	if ag1.Name == sess.Name {
+		t.Errorf("agent name %q should differ from session name %q", ag1.Name, sess.Name)
+	}
+
+	// Add a second agent — should also get a unique name.
+	ag2, err := mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ag2.Name == "" {
+		t.Fatal("agent 2 should have a non-empty name")
+	}
+	if ag2.Name == ag1.Name {
+		t.Errorf("agent 2 name %q should differ from agent 1 name %q", ag2.Name, ag1.Name)
+	}
+	if ag2.Name == sess.Name {
+		t.Errorf("agent 2 name %q should differ from session name %q", ag2.Name, sess.Name)
+	}
+
+	// Explicit names should be preserved.
+	ag3, err := mgr.AddAgentWithCommand(sess.ID, Config{Name: "custom-name", Task: "test", Rows: 24, Cols: 80}, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ag3.Name != "custom-name" {
+		t.Errorf("explicit name should be preserved, got %q", ag3.Name)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -442,31 +442,37 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 
 		case "x":
+			// Kill the selected agent.
 			item := a.dashboard.selectedItem()
-			if item == nil {
+			if item == nil || item.kind != listItemAgent || item.agent == nil || item.session == nil {
 				return a, nil
 			}
 			mgr := a.managers[item.repoPath]
 			if mgr == nil {
 				return a, nil
 			}
-			if item.kind == listItemAgent && item.session != nil {
-				// Kill just this agent.
-				if err := mgr.KillAgent(item.session.ID, item.agent.ID); err != nil {
-					a.setError(err.Error())
-				}
-			} else if item.kind == listItemSession && item.session != nil {
-				// Kill entire session.
-				if err := mgr.KillSession(item.session.ID); err != nil {
-					a.setError(err.Error())
-				}
+			if err := mgr.KillAgent(item.session.ID, item.agent.ID); err != nil {
+				a.setError(err.Error())
 			}
-			if item.kind == listItemSession && item.session != nil {
-				for _, ag := range item.session.Agents() {
-					delete(a.lastKnownStatus, ag.ID)
-				}
-			} else if item.agent != nil {
-				delete(a.lastKnownStatus, item.agent.ID)
+			delete(a.lastKnownStatus, item.agent.ID)
+			a.refreshAgentList()
+			return a, nil
+
+		case "X":
+			// Kill the entire parent session of the selected agent.
+			item := a.dashboard.selectedItem()
+			if item == nil || item.session == nil {
+				return a, nil
+			}
+			mgr := a.managers[item.repoPath]
+			if mgr == nil {
+				return a, nil
+			}
+			for _, ag := range item.session.Agents() {
+				delete(a.lastKnownStatus, ag.ID)
+			}
+			if err := mgr.KillSession(item.session.ID); err != nil {
+				a.setError(err.Error())
 			}
 			a.refreshAgentList()
 			return a, nil
@@ -514,6 +520,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				itemIndex := msg.Y - dashboardTopY - 2
 				if itemIndex >= 0 && itemIndex < len(a.dashboard.items) {
 					a.dashboard.selected = itemIndex
+					a.dashboard.clampToAgent()
 					a.dashboard.panelFocus = focusList
 					a.dashboard.scrollOffset = 0
 					a.resizeSelectedForDashboard()
@@ -615,17 +622,18 @@ func (a App) updateMerge(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		// Merge succeeded — clean up the entire session.
+		// Collect agent IDs before KillSession clears the agents map.
 		sess := a.dashboard.selectedSession()
 		if sess != nil {
+			for _, ag := range sess.Agents() {
+				delete(a.lastKnownStatus, ag.ID)
+			}
 			item := a.dashboard.selectedItem()
 			if item != nil {
 				mgr := a.managers[item.repoPath]
 				if mgr != nil {
 					_ = mgr.KillSession(sess.ID)
 				}
-			}
-			for _, ag := range sess.Agents() {
-				delete(a.lastKnownStatus, ag.ID)
 			}
 			a.refreshAgentList()
 		}
@@ -696,7 +704,8 @@ func (a *App) refreshAgentList() {
 				}
 			}
 			a.dashboard.items = items
-		}
+			a.dashboard.clampToAgent()
+			}
 		return
 	}
 
@@ -737,6 +746,7 @@ func (a *App) refreshAgentList() {
 		a.dashboard.selected = len(items) - 1
 	}
 	a.dashboard.items = items
+	a.dashboard.clampToAgent()
 }
 
 func (a App) View() tea.View {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -651,3 +651,106 @@ func TestErrorPersistsAcrossTicks(t *testing.T) {
 		t.Fatalf("Error should be cleared after 30 ticks, got %q", app.err)
 	}
 }
+
+func TestNavigationSkipsSessionRows(t *testing.T) {
+	sess := &agent.Session{Name: "test-session"}
+	ag1 := &agent.Agent{Name: "agent-1"}
+	ag2 := &agent.Agent{Name: "agent-2"}
+
+	d := newDashboardModel()
+	d.width = 120
+	d.height = 39
+	d.items = []listItem{
+		{kind: listItemRepo, repoPath: "/fake/repo", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/fake/repo", session: sess},
+		{kind: listItemAgent, repoPath: "/fake/repo", session: sess, agent: ag1},
+		{kind: listItemSession, repoPath: "/fake/repo", session: sess},
+		{kind: listItemAgent, repoPath: "/fake/repo", session: sess, agent: ag2},
+	}
+	d.selected = 0 // repo row
+
+	// j from repo should skip session at index 1, land on agent at index 2.
+	d, _ = d.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	if d.selected != 2 {
+		t.Fatalf("Expected selected=2 (agent), got %d", d.selected)
+	}
+
+	// j from agent at 2 should skip session at 3, land on agent at 4.
+	d, _ = d.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	if d.selected != 4 {
+		t.Fatalf("Expected selected=4 (agent), got %d", d.selected)
+	}
+
+	// k from agent at 4 should skip session at 3, land on agent at 2.
+	d, _ = d.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if d.selected != 2 {
+		t.Fatalf("Expected selected=2 (agent), got %d", d.selected)
+	}
+
+	// k from agent at 2 should skip session at 1, land on repo at 0.
+	d, _ = d.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if d.selected != 0 {
+		t.Fatalf("Expected selected=0 (repo), got %d", d.selected)
+	}
+}
+
+func TestMouseClickSessionSnapsToAgent(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-snap-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir)
+	defer mgr.Shutdown()
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+
+	// Create a session with an agent.
+	app = createAgent(t, app)
+	if app.err != "" {
+		t.Fatalf("Error creating session: %s", app.err)
+	}
+
+	// Return to list focus.
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
+	app = model.(App)
+
+	// Find the session row index.
+	sessionIdx := -1
+	for i, item := range app.dashboard.items {
+		if item.kind == listItemSession {
+			sessionIdx = i
+			break
+		}
+	}
+	if sessionIdx < 0 {
+		t.Fatal("No session row found in dashboard items")
+	}
+
+	// Click the session header row (Y = 2 header rows + sessionIdx).
+	model, _ = app.Update(tea.MouseClickMsg{Button: tea.MouseLeft, X: 5, Y: 2 + sessionIdx})
+	app = model.(App)
+
+	// Should snap from session to the nearest agent.
+	if app.dashboard.items[app.dashboard.selected].kind == listItemSession {
+		t.Fatalf("Expected selection to snap away from session row, but selected=%d is a session", app.dashboard.selected)
+	}
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -99,14 +99,20 @@ func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 		// focusList mode
 		switch msg.String() {
 		case "j", "down":
-			if d.selected < len(d.items)-1 {
-				d.selected++
-				d.scrollOffset = 0
+			for next := d.selected + 1; next < len(d.items); next++ {
+				if d.items[next].kind != listItemSession {
+					d.selected = next
+					d.scrollOffset = 0
+					break
+				}
 			}
 		case "k", "up":
-			if d.selected > 0 {
-				d.selected--
-				d.scrollOffset = 0
+			for next := d.selected - 1; next >= 0; next-- {
+				if d.items[next].kind != listItemSession {
+					d.selected = next
+					d.scrollOffset = 0
+					break
+				}
 			}
 		case "right", "enter":
 			if d.selectedAgent() != nil {
@@ -167,7 +173,7 @@ func (d dashboardModel) previewTermWidth() int {
 
 // previewTermHeight returns the terminal row count for the preview panel.
 func (d dashboardModel) previewTermHeight() int {
-	h := d.contentHeight() - 3 // title + task info + blank line
+	h := d.contentHeight() - 4 // title + session info + task info + blank line
 	if d.panelFocus == focusTerminal {
 		h -= 2 // NormalBorder consumes 1 row top and bottom
 	}
@@ -184,7 +190,7 @@ func (d dashboardModel) emptyView() string {
 }
 
 func (d dashboardModel) renderList(width int) string {
-	title := StyleTitle.Render("SESSIONS")
+	title := StyleTitle.Render("AGENTS")
 	sepWidth := width - 2
 	if sepWidth < 0 {
 		sepWidth = 0
@@ -218,46 +224,31 @@ func (d dashboardModel) renderList(width int) string {
 			lines = append(lines, prefix+repoStyle.Render(name))
 
 		case listItemSession:
-			// Session row — indented under its repo.
+			// Session separator header — not selectable.
 			sess := item.session
 			status := sess.Status()
 			symbol := status.Symbol()
-			elapsed := humanizeElapsed(sess.Elapsed())
-			count := fmt.Sprintf("[%d]", sess.AgentCount())
+			count := fmt.Sprintf("%d agents", sess.AgentCount())
 
-			var style lipgloss.Style
+			var symbolStyle lipgloss.Style
 			switch status {
 			case agent.StatusActive:
-				style = lipgloss.NewStyle().Foreground(ColorSecondary)
+				symbolStyle = lipgloss.NewStyle().Foreground(ColorSecondary)
 			case agent.StatusDone:
-				style = lipgloss.NewStyle().Foreground(ColorSuccess)
+				symbolStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
 			case agent.StatusError:
-				style = lipgloss.NewStyle().Foreground(ColorError)
-			case agent.StatusIdle:
-				style = lipgloss.NewStyle().Foreground(ColorMuted)
+				symbolStyle = lipgloss.NewStyle().Foreground(ColorError)
 			default:
-				style = lipgloss.NewStyle().Foreground(ColorWarning)
+				symbolStyle = lipgloss.NewStyle().Foreground(ColorMuted)
 			}
 
-			nameWidth := width - 20 // space for indent, symbol, count badge, elapsed, padding
-			name := sess.Name
-			if len(name) > nameWidth {
-				name = name[:nameWidth-1] + "…"
+			label := fmt.Sprintf(" %s %s (%s) ", symbolStyle.Render(symbol), sess.Name, count)
+			labelLen := len(symbol) + 1 + len(sess.Name) + len(count) + 5 // approximate visible length
+			padLen := width - 4 - labelLen
+			if padLen < 0 {
+				padLen = 0
 			}
-
-			sessionPrefix := "    "
-			if isSelected {
-				sessionPrefix = "  " + StyleActive.Render("▸ ")
-			}
-
-			line := fmt.Sprintf("%s%s %-*s %s %5s",
-				sessionPrefix,
-				style.Render(symbol),
-				nameWidth,
-				name,
-				StyleSubtle.Render(count),
-				elapsed,
-			)
+			line := StyleSubtle.Render("  ──") + label + StyleSubtle.Render(strings.Repeat("─", padLen))
 			lines = append(lines, line)
 
 		case listItemAgent:
@@ -321,23 +312,18 @@ func (d dashboardModel) renderPreview(width int) string {
 		return lipgloss.JoinVertical(lipgloss.Left, title, pathLine, "", hint)
 	}
 
-	if item.kind == listItemSession {
-		// Show session info in the preview panel when a session row is selected.
-		sess := item.session
-		title := StyleTitle.Render(" " + sess.Name + " ")
-		pathLine := StyleSubtle.Render(" Worktree: " + sess.Worktree.Path)
-		statusLine := StyleSubtle.Render(fmt.Sprintf(" Agents: %d  Status: %s", sess.AgentCount(), sess.Status()))
-		hint := StyleSubtle.Render(" Press c to add an agent")
-		return lipgloss.JoinVertical(lipgloss.Left, title, pathLine, statusLine, "", hint)
-	}
-
-	// Agent selected — show terminal preview.
+	// Agent selected — show terminal preview with session context.
 	ag := item.agent
 	titleText := " " + ag.GetDisplayName() + " "
 	if d.scrollOffset > 0 {
 		titleText = fmt.Sprintf(" %s [↑%d] ", ag.GetDisplayName(), d.scrollOffset)
 	}
 	title := StyleTitle.Render(titleText)
+
+	sessionInfo := ""
+	if item.session != nil {
+		sessionInfo = StyleSubtle.Render(fmt.Sprintf(" Session: %s  Worktree: %s", item.session.Name, item.session.Worktree.Path))
+	}
 	taskInfo := StyleSubtle.Render(" Task: " + ag.Task)
 
 	var render string
@@ -362,6 +348,7 @@ func (d dashboardModel) renderPreview(width int) string {
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		title,
+		sessionInfo,
 		taskInfo,
 		"",
 		render,
@@ -402,6 +389,37 @@ func (d dashboardModel) selectedRepoPath() string {
 		return ""
 	}
 	return item.repoPath
+}
+
+// clampToAgent adjusts selected to the nearest non-session row.
+// Searches forward first, then backward. Falls through to repo rows if no agents exist.
+func (d *dashboardModel) clampToAgent() {
+	if len(d.items) == 0 {
+		return
+	}
+	if d.selected >= len(d.items) {
+		d.selected = len(d.items) - 1
+	}
+	if d.selected < 0 {
+		d.selected = 0
+	}
+	if d.items[d.selected].kind != listItemSession {
+		return
+	}
+	// Search forward for an agent or repo.
+	for i := d.selected + 1; i < len(d.items); i++ {
+		if d.items[i].kind != listItemSession {
+			d.selected = i
+			return
+		}
+	}
+	// Search backward.
+	for i := d.selected - 1; i >= 0; i-- {
+		if d.items[i].kind != listItemSession {
+			d.selected = i
+			return
+		}
+	}
 }
 
 // agentItems returns all agent items from the list (for resize operations).

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -19,7 +19,8 @@ var (
 		{"c", "add agent"},
 		{"a", "add repo"},
 		{"d", "diff/remove"},
-		{"x", "kill"},
+		{"x", "kill agent"},
+		{"X", "kill session"},
 		{"m", "merge"},
 		{"q", "quit"},
 	}


### PR DESCRIPTION
## Summary

- **Agent naming**: Each agent gets a unique random adjective-noun name at creation (e.g. "swift-otter"), distinct from its session name and sibling agents. Explicit names are preserved.
- **Session headers**: Sessions become thin non-selectable separator rows (`── ● dark-ferret (2 agents) ──`) instead of navigable items. List title changed from "SESSIONS" to "AGENTS".
- **Navigation**: j/k skips session rows, landing only on agents and repos. `clampToAgent()` ensures selection never rests on a session after list refresh or mouse click.
- **Kill split**: `x` kills the selected agent only; `X` (shift-x) kills the entire parent session (all agents + worktree cleanup).
- **Agent preview**: Shows session name and worktree path in the preview header for context.
- **Mouse click**: Clicking a session header snaps to the nearest agent row.
- **Status bar**: Updated hints to reflect `x` = "kill agent" and `X` = "kill session".
- **Bug fix**: Fixed ordering in `mergeCompleteMsg` handler to collect agent IDs before `KillSession` clears the agents map.

## Test plan

- [x] `go build -o baton .` — compiles cleanly
- [x] `go test -race ./...` — all tests pass
- [x] `go vet ./...` — no issues
- [x] New test: `TestAddAgentDefaultAssignsUniqueName` — agents get unique names, explicit names preserved
- [x] New test: `TestNavigationSkipsSessionRows` — j/k skips session rows, lands on agents/repos
- [x] New test: `TestMouseClickSessionSnapsToAgent` — clicking session header selects nearest agent
- [ ] Manual: Launch baton, create session with 2+ agents, verify unique names in sidebar
- [ ] Manual: Verify j/k skips session headers, x/X kill agent/session respectively
- [ ] Manual: Verify clicking session header snaps to nearest agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)