### PR TITLE
fix: use longer idle timeout while composing

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -28,6 +28,7 @@ type Agent struct {
 	status      Status
 	lastOutput  time.Time
 	lastInput   time.Time
+	composing   bool
 	exitErr     error
 
 	done         chan struct{}
@@ -189,8 +190,13 @@ func (a *Agent) statusLoop() {
 			return
 		case <-ticker.C:
 			a.mu.Lock()
-			if a.status == StatusActive && time.Since(a.lastOutput) > idleTimeout && time.Since(a.lastInput) > idleTimeout {
+			timeout := idleTimeout
+			if a.composing {
+				timeout = composingIdleTimeout
+			}
+			if a.status == StatusActive && time.Since(a.lastOutput) > timeout && time.Since(a.lastInput) > timeout {
 				a.status = StatusIdle
+				a.composing = false
 			} else if a.status == StatusIdle && time.Since(a.lastOutput) <= idleTimeout {
 				a.status = StatusActive
 			}
@@ -213,6 +219,11 @@ func (a *Agent) RenderRegion(startRow, endRow int) string {
 func (a *Agent) SendKey(key xvt.KeyPressEvent) {
 	a.mu.Lock()
 	a.lastInput = time.Now()
+	if key.Code == xvt.KeyEnter {
+		a.composing = false
+	} else {
+		a.composing = true
+	}
 	a.mu.Unlock()
 	a.terminal.SendKey(key)
 }
@@ -221,6 +232,7 @@ func (a *Agent) SendKey(key xvt.KeyPressEvent) {
 func (a *Agent) SendText(text string) {
 	a.mu.Lock()
 	a.lastInput = time.Now()
+	a.composing = true
 	a.mu.Unlock()
 	a.terminal.SendText(text)
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	xvt "github.com/charmbracelet/x/vt"
 )
 
 // setupTestRepo creates a temporary git repo with an initial commit.
@@ -240,6 +242,102 @@ func TestIdleTransitionWithoutInput(t *testing.T) {
 	if s := a.Status(); s != StatusIdle {
 		t.Errorf("expected Idle after timeout with no input, got %s", s)
 	}
+}
+
+func TestIdleWhileComposingUsesLongerTimeout(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-composing-idle", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo ready; cat")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for initial output to become Active.
+	time.Sleep(500 * time.Millisecond)
+	if s := a.Status(); s != StatusActive {
+		t.Fatalf("expected Active after output, got %s", s)
+	}
+
+	// Type some text (sets composing = true), then stop typing.
+	a.SendText("hello")
+
+	// Wait 5s — past the normal 3s idle timeout but within composing 30s timeout.
+	time.Sleep(5 * time.Second)
+
+	if s := a.Status(); s != StatusActive {
+		t.Errorf("expected Active while composing (5s pause), got %s", s)
+	}
+}
+
+func TestIdleAfterEnterUsesNormalTimeout(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-enter-idle", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo ready; cat")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for initial output.
+	time.Sleep(500 * time.Millisecond)
+	if s := a.Status(); s != StatusActive {
+		t.Fatalf("expected Active after output, got %s", s)
+	}
+
+	// Type text then press Enter (clears composing).
+	a.SendText("hello")
+	a.SendKey(xvt.KeyPressEvent{Code: xvt.KeyEnter})
+
+	// Wait past normal 3s idle timeout + tick margin.
+	// cat echoes input back, resetting lastOutput, so allow extra margin.
+	time.Sleep(5 * time.Second)
+
+	if s := a.Status(); s != StatusIdle {
+		t.Errorf("expected Idle after Enter + 4s, got %s", s)
+	}
+}
+
+func TestComposingClearedOnEnter(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-composing-clear", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo ready; cat")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	// SendText sets composing = true.
+	a.SendText("hello")
+	a.mu.RLock()
+	if !a.composing {
+		a.mu.RUnlock()
+		t.Fatal("expected composing to be true after SendText")
+	}
+	a.mu.RUnlock()
+
+	// SendKey(Enter) clears composing.
+	a.SendKey(xvt.KeyPressEvent{Code: xvt.KeyEnter})
+	a.mu.RLock()
+	if a.composing {
+		a.mu.RUnlock()
+		t.Fatal("expected composing to be false after Enter")
+	}
+	a.mu.RUnlock()
 }
 
 func TestShutdownCleansAll(t *testing.T) {

--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -49,3 +49,4 @@ func (s Status) Symbol() string {
 }
 
 const idleTimeout = 3 * time.Second
+const composingIdleTimeout = 30 * time.Second


### PR DESCRIPTION
## Summary
- Adds a `composing` flag to Agent that tracks when the user is actively typing a prompt
- Uses 30s idle timeout while composing vs the normal 3s, preventing false idle chimes during natural thinking pauses
- `composing` is set on any key/text input, cleared on Enter or when the agent transitions to Idle
- Entirely contained in `internal/agent/` — no TUI or audio changes

## Test plan
- [x] `TestIdleWhileComposingUsesLongerTimeout` — type text, stop, wait 5s, assert still Active
- [x] `TestIdleAfterEnterUsesNormalTimeout` — type text, send Enter, wait 5s, assert Idle
- [x] `TestComposingClearedOnEnter` — SendText then SendKey(Enter), verify composing is false
- [x] All existing tests pass with `go test -race ./...`
- [x] `go vet ./...` clean
- [ ] Manual: launch baton, focus agent, type partial prompt, pause >5s — no chime. Press Enter, wait for agent finish — chime fires after ~3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)