### PR TITLE
fix: suppress false idle chime on agent startup

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -272,6 +272,13 @@ func (a *Agent) GetDisplayName() string {
 	return a.Name
 }
 
+// HasReceivedInput reports whether the user has sent any input to this agent.
+func (a *Agent) HasReceivedInput() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return !a.lastInput.IsZero()
+}
+
 // HasDisplayName reports whether a display name has been explicitly set.
 func (a *Agent) HasDisplayName() bool {
 	a.mu.RLock()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -174,7 +174,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Check for Active->Idle transition.
 			if prev, ok := a.lastKnownStatus[ag.ID]; ok {
-				if prev == agent.StatusActive && currentStatus == agent.StatusIdle {
+				if prev == agent.StatusActive && currentStatus == agent.StatusIdle && ag.HasReceivedInput() {
 					if a.audioPlayer != nil {
 						a.audioPlayer.Play()
 					}


### PR DESCRIPTION
## Summary
- Add `HasReceivedInput()` accessor to Agent that returns true after the user has sent any key or text input
- Gate the Active→Idle chime in the TUI on `HasReceivedInput()` so it only fires for agents that have actually received work

Previously, when an agent started up, Claude Code would output its startup UI (marking the agent Active), then wait for input. After 3 seconds of silence it would transition to Idle, triggering a false chime alert.

## Test plan
- `go test -race ./...` — all tests pass
- Manual: open baton, create agent, wait >3s without typing — no chime
- Manual: type a prompt, wait for agent to finish — chime plays on idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)