### PR TITLE
feat: add diff summary panel in left sidebar

### DIFF
--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -113,6 +114,116 @@ func ParseDiffFiles(rawDiff string) []DiffFile {
 	}
 
 	return files
+}
+
+// FileStat holds per-file diff statistics.
+type FileStat struct {
+	Path       string // file path
+	Status     string // "A", "M", or "D"
+	Insertions int
+	Deletions  int
+}
+
+// GetPerFileDiffStats returns per-file insertion/deletion counts and statuses,
+// including uncommitted working tree changes. It also returns aggregate DiffStats.
+// It diffs the worktree's current state (committed + uncommitted) against the base
+// branch in a single pass to avoid double-counting.
+func GetPerFileDiffStats(repoPath string, wt *WorktreeInfo) ([]FileStat, *DiffStats, error) {
+	// Run from the worktree directory so that both committed and uncommitted
+	// changes are captured in a single diff against the base branch.
+	numstatOut, err := runGit(wt.Path, "diff", "--numstat", "--diff-filter=AMD", wt.BaseBranch)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting per-file numstat: %w", err)
+	}
+
+	nameStatusOut, err := runGit(wt.Path, "diff", "--name-status", "--diff-filter=AMD", wt.BaseBranch)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting per-file name-status: %w", err)
+	}
+
+	fileMap := make(map[string]*FileStat)
+	parseNumstat(numstatOut, fileMap)
+	parseNameStatus(nameStatusOut, fileMap)
+
+	// Build result slice and aggregate stats.
+	var result []FileStat
+	agg := &DiffStats{}
+	for _, fs := range fileMap {
+		result = append(result, *fs)
+		agg.Files++
+		agg.Insertions += fs.Insertions
+		agg.Deletions += fs.Deletions
+	}
+
+	// Sort by path for stable display order.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Path < result[j].Path
+	})
+
+	return result, agg, nil
+}
+
+// parseNumstat parses `git diff --numstat` output and merges into fileMap.
+// For existing entries, insertions and deletions are added (merged).
+func parseNumstat(output string, fileMap map[string]*FileStat) {
+	for _, line := range strings.Split(output, "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		path := fields[2]
+		ins := 0
+		del := 0
+		if fields[0] != "-" {
+			if n, err := strconv.Atoi(fields[0]); err == nil {
+				ins = n
+			}
+		}
+		if fields[1] != "-" {
+			if n, err := strconv.Atoi(fields[1]); err == nil {
+				del = n
+			}
+		}
+
+		if existing, ok := fileMap[path]; ok {
+			existing.Insertions += ins
+			existing.Deletions += del
+		} else {
+			fileMap[path] = &FileStat{
+				Path:       path,
+				Insertions: ins,
+				Deletions:  del,
+			}
+		}
+	}
+}
+
+// parseNameStatus parses `git diff --name-status` output and sets statuses in fileMap.
+// Later calls overwrite earlier statuses (uncommitted status takes precedence).
+func parseNameStatus(output string, fileMap map[string]*FileStat) {
+	for _, line := range strings.Split(output, "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		status := fields[0]
+		path := fields[1]
+
+		if existing, ok := fileMap[path]; ok {
+			existing.Status = status
+		} else {
+			fileMap[path] = &FileStat{
+				Path:   path,
+				Status: status,
+			}
+		}
+	}
 }
 
 // MergeWorktree merges the worktree branch into the base branch using --no-ff.

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,6 +1,9 @@
 package git_test
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/devenjarvis/baton/internal/git"
@@ -107,5 +110,229 @@ Binary files a/image.png and b/image.png differ
 		if len(line) > 0 && (line[0] == '+' || line[0] == '-') {
 			t.Errorf("binary file should not have +/- lines, got %q", line)
 		}
+	}
+}
+
+// gitInDir runs a git command in dir, failing the test on error.
+func gitInDir(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func TestGetPerFileDiffStats_AddedModifiedDeleted(t *testing.T) {
+	repo := initTestRepo(t)
+
+	// Create a file that will be deleted later.
+	if err := os.WriteFile(filepath.Join(repo, "to-delete.txt"), []byte("delete me\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitInDir(t, repo, "add", "to-delete.txt")
+	gitInDir(t, repo, "commit", "-m", "add file to delete")
+
+	wt, err := git.CreateWorktree(repo, "stats-agent")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	// Add a new file.
+	if err := os.WriteFile(filepath.Join(wt.Path, "new.txt"), []byte("line1\nline2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitInDir(t, wt.Path, "add", "new.txt")
+
+	// Modify existing file.
+	if err := os.WriteFile(filepath.Join(wt.Path, "README"), []byte("init\nupdated\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitInDir(t, wt.Path, "add", "README")
+
+	// Delete a file.
+	if err := os.Remove(filepath.Join(wt.Path, "to-delete.txt")); err != nil {
+		t.Fatal(err)
+	}
+	gitInDir(t, wt.Path, "add", "to-delete.txt")
+
+	gitInDir(t, wt.Path, "commit", "-m", "add, modify, delete")
+
+	fileStats, aggStats, err := git.GetPerFileDiffStats(repo, wt)
+	if err != nil {
+		t.Fatalf("GetPerFileDiffStats: %v", err)
+	}
+
+	// Build a map for easy lookup.
+	byPath := make(map[string]git.FileStat)
+	for _, fs := range fileStats {
+		byPath[fs.Path] = fs
+	}
+
+	// Check added file.
+	if fs, ok := byPath["new.txt"]; !ok {
+		t.Error("expected new.txt in results")
+	} else {
+		if fs.Status != "A" {
+			t.Errorf("new.txt: expected status A, got %q", fs.Status)
+		}
+		if fs.Insertions != 2 {
+			t.Errorf("new.txt: expected 2 insertions, got %d", fs.Insertions)
+		}
+		if fs.Deletions != 0 {
+			t.Errorf("new.txt: expected 0 deletions, got %d", fs.Deletions)
+		}
+	}
+
+	// Check modified file.
+	if fs, ok := byPath["README"]; !ok {
+		t.Error("expected README in results")
+	} else {
+		if fs.Status != "M" {
+			t.Errorf("README: expected status M, got %q", fs.Status)
+		}
+		if fs.Insertions < 1 {
+			t.Errorf("README: expected at least 1 insertion, got %d", fs.Insertions)
+		}
+	}
+
+	// Check deleted file.
+	if fs, ok := byPath["to-delete.txt"]; !ok {
+		t.Error("expected to-delete.txt in results")
+	} else {
+		if fs.Status != "D" {
+			t.Errorf("to-delete.txt: expected status D, got %q", fs.Status)
+		}
+		if fs.Deletions != 1 {
+			t.Errorf("to-delete.txt: expected 1 deletion, got %d", fs.Deletions)
+		}
+	}
+
+	// Check aggregate stats.
+	if aggStats.Files != 3 {
+		t.Errorf("expected 3 files, got %d", aggStats.Files)
+	}
+	if aggStats.Insertions < 3 {
+		t.Errorf("expected at least 3 insertions, got %d", aggStats.Insertions)
+	}
+	if aggStats.Deletions < 1 {
+		t.Errorf("expected at least 1 deletion, got %d", aggStats.Deletions)
+	}
+}
+
+func TestGetPerFileDiffStats_BinaryFile(t *testing.T) {
+	repo := initTestRepo(t)
+
+	wt, err := git.CreateWorktree(repo, "bin-agent")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	// Write a binary file (contains null bytes).
+	binaryContent := []byte{0x89, 0x50, 0x4e, 0x47, 0x00, 0x00, 0x00}
+	if err := os.WriteFile(filepath.Join(wt.Path, "image.png"), binaryContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitInDir(t, wt.Path, "add", "image.png")
+	gitInDir(t, wt.Path, "commit", "-m", "add binary file")
+
+	fileStats, aggStats, err := git.GetPerFileDiffStats(repo, wt)
+	if err != nil {
+		t.Fatalf("GetPerFileDiffStats: %v", err)
+	}
+
+	if len(fileStats) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(fileStats))
+	}
+
+	fs := fileStats[0]
+	if fs.Path != "image.png" {
+		t.Errorf("expected path image.png, got %q", fs.Path)
+	}
+	if fs.Insertions != 0 {
+		t.Errorf("binary file: expected 0 insertions, got %d", fs.Insertions)
+	}
+	if fs.Deletions != 0 {
+		t.Errorf("binary file: expected 0 deletions, got %d", fs.Deletions)
+	}
+
+	if aggStats.Files != 1 {
+		t.Errorf("expected 1 file in aggregate, got %d", aggStats.Files)
+	}
+}
+
+func TestGetPerFileDiffStats_UncommittedChanges(t *testing.T) {
+	repo := initTestRepo(t)
+
+	wt, err := git.CreateWorktree(repo, "wip-agent")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	// Make a committed change.
+	if err := os.WriteFile(filepath.Join(wt.Path, "committed.txt"), []byte("line1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitInDir(t, wt.Path, "add", "committed.txt")
+	gitInDir(t, wt.Path, "commit", "-m", "add committed file")
+
+	// Make an uncommitted change (new file, staged but not committed).
+	if err := os.WriteFile(filepath.Join(wt.Path, "uncommitted.txt"), []byte("wip\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitInDir(t, wt.Path, "add", "uncommitted.txt")
+
+	// Make an uncommitted modification to the committed file (unstaged).
+	if err := os.WriteFile(filepath.Join(wt.Path, "committed.txt"), []byte("line1\nline2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fileStats, _, err := git.GetPerFileDiffStats(repo, wt)
+	if err != nil {
+		t.Fatalf("GetPerFileDiffStats: %v", err)
+	}
+
+	byPath := make(map[string]git.FileStat)
+	for _, fs := range fileStats {
+		byPath[fs.Path] = fs
+	}
+
+	// committed.txt should show merged committed + uncommitted stats.
+	if fs, ok := byPath["committed.txt"]; !ok {
+		t.Error("expected committed.txt in results")
+	} else {
+		if fs.Insertions < 2 {
+			t.Errorf("committed.txt: expected at least 2 insertions (committed + uncommitted), got %d", fs.Insertions)
+		}
+	}
+
+	// uncommitted.txt should appear from working tree diff.
+	if _, ok := byPath["uncommitted.txt"]; !ok {
+		t.Error("expected uncommitted.txt in results from working tree changes")
+	}
+}
+
+func TestGetPerFileDiffStats_NoChanges(t *testing.T) {
+	repo := initTestRepo(t)
+
+	wt, err := git.CreateWorktree(repo, "empty-agent")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	fileStats, aggStats, err := git.GetPerFileDiffStats(repo, wt)
+	if err != nil {
+		t.Fatalf("GetPerFileDiffStats: %v", err)
+	}
+
+	if len(fileStats) != 0 {
+		t.Errorf("expected 0 file stats, got %d", len(fileStats))
+	}
+	if aggStats.Files != 0 {
+		t.Errorf("expected 0 files, got %d", aggStats.Files)
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -39,10 +39,22 @@ type splashResizeMsg struct {
 	agentID string
 }
 
+// diffStatsMsg carries the result of an async diff stats refresh.
+type diffStatsMsg struct {
+	sessionID string
+	stats     *diffSummaryData
+}
+
 // initAppMsg carries the result of app initialization.
 type initAppMsg struct {
 	cfg *config.Config
 	err error
+}
+
+// diffStatsEntry holds cached diff stats for a single session.
+type diffStatsEntry struct {
+	stats       *diffSummaryData
+	lastRefresh time.Time
 }
 
 // App is the root Bubble Tea model.
@@ -65,6 +77,9 @@ type App struct {
 
 	lastKnownStatus map[string]agent.Status
 	audioPlayer     *audio.Player
+
+	diffStatsCache    map[string]*diffStatsEntry // keyed by session ID
+	diffRefreshInFlight bool
 }
 
 func NewApp() App {
@@ -73,6 +88,7 @@ func NewApp() App {
 		dashboard:       newDashboardModel(),
 		managers:        make(map[string]*agent.Manager),
 		lastKnownStatus: make(map[string]agent.Status),
+		diffStatsCache:  make(map[string]*diffStatsEntry),
 	}
 }
 
@@ -164,7 +180,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		a.refreshAgentList()
 		// Auto-rename agents that just went idle for the first time,
-		// and detect Active->Idle transitions for audio notification.
+		// and detect Active->Idle transitions for audio notification and diff refresh.
+		idleTransition := false
 		for _, item := range a.dashboard.items {
 			if item.kind != listItemAgent || item.agent == nil {
 				continue
@@ -178,6 +195,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if a.audioPlayer != nil {
 						a.audioPlayer.Play()
 					}
+					idleTransition = true
 				}
 			}
 			a.lastKnownStatus[ag.ID] = currentStatus
@@ -197,7 +215,18 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.err = ""
 			}
 		}
-		return a, tickCmd()
+		// Clean stale diff cache entries periodically.
+		a.cleanDiffStatsCache()
+		// Refresh diff stats periodically or on idle transition.
+		var diffCmd tea.Cmd
+		if sess := a.dashboard.selectedSession(); sess != nil {
+			entry := a.diffStatsCache[sess.ID]
+			stale := entry == nil || time.Since(entry.lastRefresh) > 5*time.Second
+			if (stale || idleTransition) && !a.diffRefreshInFlight {
+				diffCmd = a.refreshDiffStatsCmd()
+			}
+		}
+		return a, tea.Batch(tickCmd(), diffCmd)
 
 	case agentEventMsg:
 		// Refresh list on any agent event — all repos are visible in the dashboard.
@@ -233,6 +262,19 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return splashResizeMsg{agentID: msg.agentID}
 		})
 		return a, delayedResize
+
+	case diffStatsMsg:
+		a.diffRefreshInFlight = false
+		// Always update cache timestamp to prevent tight retry loops on persistent errors.
+		a.diffStatsCache[msg.sessionID] = &diffStatsEntry{
+			stats:       msg.stats,
+			lastRefresh: time.Now(),
+		}
+		// Update dashboard with current session's stats.
+		if sess := a.dashboard.selectedSession(); sess != nil && sess.ID == msg.sessionID {
+			a.dashboard.diffStats = msg.stats
+		}
+		return a, nil
 
 	case splashResizeMsg:
 		// Guard: only resize if we're still on the dashboard and the agent
@@ -468,13 +510,16 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if mgr == nil {
 				return a, nil
 			}
+			sessID := item.session.ID
 			for _, ag := range item.session.Agents() {
 				delete(a.lastKnownStatus, ag.ID)
 			}
-			if err := mgr.KillSession(item.session.ID); err != nil {
+			if err := mgr.KillSession(sessID); err != nil {
 				a.setError(err.Error())
 			}
+			delete(a.diffStatsCache, sessID)
 			a.refreshAgentList()
+			a.updateDashboardDiffStats()
 			return a, nil
 
 		case "m":
@@ -566,6 +611,17 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if a.dashboard.selected != prevSelected || a.dashboard.panelFocus != prevPanelFocus {
 		a.resizeSelectedForDashboard()
 	}
+	// On selection change, update diff stats from cache (or trigger refresh).
+	if a.dashboard.selected != prevSelected {
+		a.updateDashboardDiffStats()
+		if sess := a.dashboard.selectedSession(); sess != nil {
+			entry := a.diffStatsCache[sess.ID]
+			if (entry == nil || time.Since(entry.lastRefresh) > 5*time.Second) && !a.diffRefreshInFlight {
+				diffCmd := a.refreshDiffStatsCmd()
+				return a, tea.Batch(cmd, diffCmd)
+			}
+		}
+	}
 	return a, cmd
 }
 
@@ -625,6 +681,7 @@ func (a App) updateMerge(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Collect agent IDs before KillSession clears the agents map.
 		sess := a.dashboard.selectedSession()
 		if sess != nil {
+			sessID := sess.ID
 			for _, ag := range sess.Agents() {
 				delete(a.lastKnownStatus, ag.ID)
 			}
@@ -632,10 +689,12 @@ func (a App) updateMerge(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if item != nil {
 				mgr := a.managers[item.repoPath]
 				if mgr != nil {
-					_ = mgr.KillSession(sess.ID)
+					_ = mgr.KillSession(sessID)
 				}
 			}
+			delete(a.diffStatsCache, sessID)
 			a.refreshAgentList()
+			a.updateDashboardDiffStats()
 		}
 		a.view = ViewDashboard
 		return a, nil
@@ -844,6 +903,77 @@ func slugify(s string) string {
 		}
 	}
 	return slug
+}
+
+// refreshDiffStatsCmd returns a Cmd that fetches diff stats for the currently selected session.
+func (a *App) refreshDiffStatsCmd() tea.Cmd {
+	sess := a.dashboard.selectedSession()
+	if sess == nil {
+		return nil
+	}
+	repoPath := a.dashboard.selectedRepoPath()
+	if repoPath == "" {
+		return nil
+	}
+	a.diffRefreshInFlight = true
+	sessionID := sess.ID
+	wt := sess.Worktree
+	return func() tea.Msg {
+		fileStats, agg, err := git.GetPerFileDiffStats(repoPath, wt)
+		if err != nil {
+			return diffStatsMsg{sessionID: sessionID, stats: nil}
+		}
+		// Convert git.FileStat to diffFileStat.
+		var files []diffFileStat
+		for _, fs := range fileStats {
+			files = append(files, diffFileStat{
+				Path:       fs.Path,
+				Status:     fs.Status,
+				Insertions: fs.Insertions,
+				Deletions:  fs.Deletions,
+			})
+		}
+		return diffStatsMsg{
+			sessionID: sessionID,
+			stats: &diffSummaryData{
+				Files: files,
+				Aggregate: diffAggregateStats{
+					Files:      agg.Files,
+					Insertions: agg.Insertions,
+					Deletions:  agg.Deletions,
+				},
+			},
+		}
+	}
+}
+
+// updateDashboardDiffStats passes cached diff stats to the dashboard for the current selection.
+func (a *App) updateDashboardDiffStats() {
+	sess := a.dashboard.selectedSession()
+	if sess == nil {
+		a.dashboard.diffStats = nil
+		return
+	}
+	if entry, ok := a.diffStatsCache[sess.ID]; ok {
+		a.dashboard.diffStats = entry.stats
+	} else {
+		a.dashboard.diffStats = nil
+	}
+}
+
+// cleanDiffStatsCache removes entries for sessions that no longer exist.
+func (a *App) cleanDiffStatsCache() {
+	activeSessions := make(map[string]bool)
+	for _, mgr := range a.managers {
+		for _, sess := range mgr.ListSessions() {
+			activeSessions[sess.ID] = true
+		}
+	}
+	for id := range a.diffStatsCache {
+		if !activeSessions[id] {
+			delete(a.diffStatsCache, id)
+		}
+	}
 }
 
 // ensureGitignore adds .baton/ to .gitignore in the given path if not already present.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -29,6 +30,25 @@ type listItem struct {
 	agent    *agent.Agent    // set for agent items
 }
 
+// diffSummaryData holds cached diff stats for rendering in the dashboard.
+type diffSummaryData struct {
+	Files     []diffFileStat
+	Aggregate diffAggregateStats
+}
+
+type diffFileStat struct {
+	Path       string
+	Status     string // "A", "M", or "D"
+	Insertions int
+	Deletions  int
+}
+
+type diffAggregateStats struct {
+	Files      int
+	Insertions int
+	Deletions  int
+}
+
 // dashboardModel shows the hierarchical repo/session/agent list and terminal preview.
 type dashboardModel struct {
 	items        []listItem
@@ -37,6 +57,7 @@ type dashboardModel struct {
 	height       int
 	panelFocus   panelFocus
 	scrollOffset int
+	diffStats    *diffSummaryData // nil when no session selected or no data
 }
 
 func newDashboardModel() dashboardModel {
@@ -298,6 +319,26 @@ func (d dashboardModel) renderList(width int) string {
 		}
 	}
 
+	// If we have diff stats, render the diff summary at the bottom.
+	if d.diffStats != nil {
+		contentH := d.contentHeight()
+		agentListHeight := len(lines)
+		maxDiffHeight := contentH / 3
+		availHeight := contentH - agentListHeight
+		if availHeight > maxDiffHeight {
+			availHeight = maxDiffHeight
+		}
+		if availHeight >= 2 { // need at least separator + one line
+			diffLines := d.renderDiffSummary(width, availHeight)
+			// Pad blank lines between agent list and diff summary.
+			padding := contentH - agentListHeight - len(diffLines)
+			for i := 0; i < padding; i++ {
+				lines = append(lines, "")
+			}
+			lines = append(lines, diffLines...)
+		}
+	}
+
 	return strings.Join(lines, "\n")
 }
 
@@ -435,6 +476,92 @@ func (d dashboardModel) agentItems() []*agent.Agent {
 		}
 	}
 	return result
+}
+
+// renderDiffSummary renders the CHANGES section for the diff summary panel.
+// It returns a slice of lines that fit within the given height.
+func (d dashboardModel) renderDiffSummary(width, maxHeight int) []string {
+	stats := d.diffStats
+
+	// Build the header line: "── CHANGES ── 3 files +47 -12"
+	agg := stats.Aggregate
+	headerStats := fmt.Sprintf(" %d files ", agg.Files)
+	headerStats += StyleSuccess.Render(fmt.Sprintf("+%d", agg.Insertions))
+	headerStats += " "
+	headerStats += StyleError.Render(fmt.Sprintf("-%d", agg.Deletions))
+
+	sepWidth := width - 2
+	if sepWidth < 0 {
+		sepWidth = 0
+	}
+	headerLabel := "── CHANGES ──"
+	padLen := sepWidth - len(headerLabel) - len(fmt.Sprintf(" %d files +%d -%d", agg.Files, agg.Insertions, agg.Deletions))
+	if padLen < 0 {
+		padLen = 0
+	}
+	header := StyleSubtle.Render(headerLabel) + headerStats + StyleSubtle.Render(strings.Repeat("─", padLen))
+
+	var lines []string
+	lines = append(lines, header)
+
+	if len(stats.Files) == 0 {
+		lines = append(lines, StyleSubtle.Render("  No changes"))
+		return lines
+	}
+
+	// Determine how many file rows we can show.
+	availRows := maxHeight - 1 // subtract header
+	fileCount := len(stats.Files)
+	showMore := false
+	visibleFiles := fileCount
+	if fileCount > availRows {
+		visibleFiles = availRows - 1 // leave room for "+N more" indicator
+		showMore = true
+	}
+
+	statusStyle := func(status string) lipgloss.Style {
+		switch status {
+		case "A":
+			return lipgloss.NewStyle().Foreground(ColorSuccess)
+		case "D":
+			return lipgloss.NewStyle().Foreground(ColorError)
+		default: // "M"
+			return lipgloss.NewStyle().Foreground(ColorSecondary)
+		}
+	}
+
+	for i := 0; i < visibleFiles; i++ {
+		f := stats.Files[i]
+		styledStatus := statusStyle(f.Status).Render(f.Status)
+		ins := StyleSuccess.Render(fmt.Sprintf("+%d", f.Insertions))
+		del := StyleError.Render(fmt.Sprintf("-%d", f.Deletions))
+		statsText := fmt.Sprintf(" %s %s", ins, del)
+		// Visible length of stats: " +N -N"
+		statsLen := 2 + len(fmt.Sprintf("+%d", f.Insertions)) + 1 + len(fmt.Sprintf("-%d", f.Deletions))
+
+		name := filepath.Base(f.Path)
+		// "  S name    +N -N" — 4 chars prefix ("  S "), stats at end
+		maxNameLen := width - 4 - statsLen
+		if maxNameLen < 1 {
+			maxNameLen = 1
+		}
+		if len(name) > maxNameLen {
+			name = name[:maxNameLen-1] + "…"
+		}
+		padName := maxNameLen - len(name)
+		if padName < 0 {
+			padName = 0
+		}
+		line := fmt.Sprintf("  %s %s%s%s", styledStatus, name, strings.Repeat(" ", padName), statsText)
+		lines = append(lines, line)
+	}
+
+	if showMore {
+		remaining := fileCount - visibleFiles
+		lines = append(lines, StyleSubtle.Render(fmt.Sprintf("  +%d more files", remaining)))
+	}
+
+	return lines
 }
 
 // humanizeElapsed formats a duration for display.


### PR DESCRIPTION
## Summary
- Add `GetPerFileDiffStats` to the git package — returns per-file insertion/deletion counts and A/M/D status by diffing the worktree's current state against the base branch in a single pass
- Add a `diffStatsCache` to the TUI app with 5-second periodic refresh, immediate refresh on Active→Idle transitions, and a `refreshInFlight` guard to prevent stacking git calls
- Render a "CHANGES" section below the agent list in the left panel with colored status letters, filenames, and +/- stats (capped at 1/3 panel height with "+N more" overflow)
- Wire cache updates into selection changes, session kills, and merge completions with stale-entry cleanup

## Test plan
- [x] `go test -race ./internal/git/...` — 4 new tests pass (added/modified/deleted, binary, uncommitted, empty)
- [x] `go test -race ./...` — all existing tests pass
- [x] `go build -o baton .` — builds cleanly
- [ ] Manual: create a session, let an agent make changes, verify diff summary appears and updates in left panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)