### PR TITLE
feat: auto-close sessions when all agents are gone

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -20,6 +20,7 @@ const (
 	EventOutput
 	EventDone
 	EventError
+	EventSessionClosed
 )
 
 // Event represents something that happened to an agent.
@@ -246,7 +247,8 @@ func (m *Manager) List() []*Agent {
 	return result
 }
 
-// KillAgent kills a single agent within a session. Does not remove the session.
+// KillAgent kills a single agent within a session. If the session becomes
+// empty after the kill, the session is automatically cleaned up and removed.
 func (m *Manager) KillAgent(sessionID, agentID string) error {
 	m.mu.RLock()
 	sess := m.sessions[sessionID]
@@ -261,6 +263,12 @@ func (m *Manager) KillAgent(sessionID, agentID string) error {
 	}
 
 	sess.KillAgent(agentID)
+
+	// Auto-close empty sessions.
+	if sess.AgentCount() == 0 {
+		m.closeSession(sessionID, sess)
+	}
+
 	return nil
 }
 
@@ -353,8 +361,32 @@ func (m *Manager) watchAgent(a *Agent, sessionID string) {
 	case <-a.Done():
 		status := a.Status()
 		m.emit(Event{Type: EventDone, AgentID: a.ID, SessionID: sessionID, Status: status})
+
+		// Auto-close session if all agents are done.
+		m.mu.RLock()
+		sess := m.sessions[sessionID]
+		m.mu.RUnlock()
+		if sess != nil && sess.Status() == StatusDone {
+			m.closeSession(sessionID, sess)
+		}
 	case <-m.done:
 	}
+}
+
+// closeSession cleans up and removes a session, emitting EventSessionClosed.
+// Safe to call concurrently — only the first caller performs cleanup.
+func (m *Manager) closeSession(sessionID string, sess *Session) {
+	m.mu.Lock()
+	if _, exists := m.sessions[sessionID]; !exists {
+		m.mu.Unlock()
+		return // already cleaned up by another goroutine
+	}
+	delete(m.sessions, sessionID)
+	m.mu.Unlock()
+
+	_ = sess.Cleanup(m.repoPath)
+
+	m.emit(Event{Type: EventSessionClosed, SessionID: sessionID})
 }
 
 func (m *Manager) emit(e Event) {

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -229,6 +229,108 @@ func TestSessionAgentsSorted(t *testing.T) {
 	}
 }
 
+func TestKillLastAgentAutoClosesSession(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag1, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ag2, err := mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath := sess.Worktree.Path
+	sessID := sess.ID
+
+	// Kill first agent — session should survive.
+	if err := mgr.KillAgent(sessID, ag1.ID); err != nil {
+		t.Fatal(err)
+	}
+	if mgr.GetSession(sessID) == nil {
+		t.Fatal("session should still exist after killing first agent")
+	}
+
+	// Kill second agent — session should auto-close.
+	if err := mgr.KillAgent(sessID, ag2.ID); err != nil {
+		t.Fatal(err)
+	}
+	if mgr.GetSession(sessID) != nil {
+		t.Error("session should be removed after killing last agent")
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Error("worktree should be removed after session auto-close")
+	}
+
+	// Verify EventSessionClosed was emitted.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case e := <-mgr.Events():
+			if e.Type == EventSessionClosed && e.SessionID == sessID {
+				return // success
+			}
+		case <-deadline:
+			t.Error("expected EventSessionClosed event")
+			return
+		}
+	}
+}
+
+func TestNaturalExitAutoClosesSession(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo done")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo done")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath := sess.Worktree.Path
+	sessID := sess.ID
+
+	// Wait for both agents to exit naturally and session to auto-close.
+	deadline := time.After(5 * time.Second)
+	gotSessionClosed := false
+	for !gotSessionClosed {
+		select {
+		case e := <-mgr.Events():
+			if e.Type == EventSessionClosed && e.SessionID == sessID {
+				gotSessionClosed = true
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for EventSessionClosed")
+		}
+	}
+
+	if mgr.GetSession(sessID) != nil {
+		t.Error("session should be removed after all agents exit naturally")
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Error("worktree should be removed after session auto-close")
+	}
+}
+
 func TestAddAgentDefaultAssignsUniqueName(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -200,6 +200,15 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, tickCmd()
 
 	case agentEventMsg:
+		// Clean up stale lastKnownStatus entries when a session auto-closes.
+		if msg.event.Type == agent.EventSessionClosed && msg.event.SessionID != "" {
+			prefix := msg.event.SessionID + "-agent-"
+			for id := range a.lastKnownStatus {
+				if strings.HasPrefix(id, prefix) {
+					delete(a.lastKnownStatus, id)
+				}
+			}
+		}
 		// Refresh list on any agent event — all repos are visible in the dashboard.
 		a.refreshAgentList()
 		if mgr := a.managers[msg.repoPath]; mgr != nil {


### PR DESCRIPTION
## Summary
- Sessions now auto-close when their last agent is killed via 'x' or when all agents exit naturally
- Adds `EventSessionClosed` event type so the TUI refreshes when a session is removed
- Cleans up `lastKnownStatus` entries for agents in auto-closed sessions to prevent stale state
- Uses check-and-delete under the manager write lock to prevent double-cleanup races

## Test plan
- [x] `go test -race ./...` passes
- [x] `TestKillLastAgentAutoClosesSession` — verifies session survives first agent kill, auto-closes on last
- [x] `TestNaturalExitAutoClosesSession` — verifies auto-close when both agents exit naturally
- [ ] Manual: launch baton, create session with 2 agents, press 'x' on each — session disappears after last kill
- [ ] Manual: create session with 1 agent, let it exit — session auto-closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)