### PR TITLE
feat: replace broken auto-rename with Claude session file polling

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,7 +1,11 @@
 package agent
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -23,9 +27,11 @@ type Agent struct {
 	pty      *bpty.PTY
 	terminal *vt.Terminal
 
-	mu          sync.RWMutex
-	displayName string
-	status      Status
+	mu             sync.RWMutex
+	displayName    string
+	claudePid      int
+	hasClaudeName  bool
+	status         Status
 	lastOutput  time.Time
 	lastInput   time.Time
 	composing   bool
@@ -73,6 +79,8 @@ func newAgent(id string, cfg Config, worktreePath string) (*Agent, error) {
 		return nil, err
 	}
 
+	claudePid := p.Pid()
+
 	a := &Agent{
 		ID:           id,
 		Name:         cfg.Name,
@@ -81,10 +89,15 @@ func newAgent(id string, cfg Config, worktreePath string) (*Agent, error) {
 		CreatedAt:    time.Now(),
 		pty:          p,
 		terminal:     term,
+		claudePid:    claudePid,
 		status:       StatusStarting,
 		done:          make(chan struct{}),
 		stop:          make(chan struct{}),
 		writeLoopDone: make(chan struct{}),
+	}
+
+	if cfg.Task != "" {
+		a.SetDisplayName(slugify(cfg.Task))
 	}
 
 	go a.readLoop()
@@ -115,6 +128,7 @@ func newAgentWithCommand(id string, cfg Config, worktreePath string, cmd *exec.C
 		CreatedAt:    time.Now(),
 		pty:          p,
 		terminal:     term,
+		claudePid:    p.Pid(),
 		status:       StatusStarting,
 		done:          make(chan struct{}),
 		stop:          make(chan struct{}),
@@ -304,5 +318,66 @@ func (a *Agent) Kill() {
 	a.terminal.Close()
 	// Wait for writeLoop to finish before returning.
 	<-a.writeLoopDone
+}
+
+// ClaudeSessionDir overrides the session directory for testing.
+// When empty, claudeSessionDir() uses the real home directory.
+var ClaudeSessionDir string
+
+func claudeSessionDir() string {
+	if ClaudeSessionDir != "" {
+		return ClaudeSessionDir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude", "sessions")
+}
+
+// PollClaudeSessionName reads the Claude session file for this agent's PID
+// and returns the "name" field if present. Returns "" on any error or if
+// the name field is not yet populated.
+func (a *Agent) PollClaudeSessionName() string {
+	a.mu.RLock()
+	pid := a.claudePid
+	a.mu.RUnlock()
+
+	if pid == 0 {
+		return ""
+	}
+
+	dir := claudeSessionDir()
+	if dir == "" {
+		return ""
+	}
+
+	path := filepath.Join(dir, fmt.Sprintf("%d.json", pid))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+
+	var session struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(data, &session); err != nil {
+		return ""
+	}
+	return session.Name
+}
+
+// HasClaudeName reports whether the agent has been given a Claude session name.
+func (a *Agent) HasClaudeName() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.hasClaudeName
+}
+
+// SetClaudeName sets whether the agent has been given a Claude session name.
+func (a *Agent) SetClaudeName(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.hasClaudeName = v
 }
 

--- a/internal/agent/names.go
+++ b/internal/agent/names.go
@@ -1,6 +1,10 @@
 package agent
 
-import "math/rand/v2"
+import (
+	"math/rand/v2"
+	"regexp"
+	"strings"
+)
 
 var adjectives = []string{
 	"brave", "calm", "dark", "eager", "fair",
@@ -39,4 +43,27 @@ func RandomName(existing []string) string {
 		}
 	}
 	return name
+}
+
+var nonAlnumRe = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// slugify lowercases s, collapses runs of non-alphanumeric characters to "-",
+// trims leading/trailing "-", and truncates to 40 characters.
+// Returns "" if the result is empty or doesn't start with [a-zA-Z0-9].
+func slugify(s string) string {
+	slug := nonAlnumRe.ReplaceAllString(strings.ToLower(s), "-")
+	slug = strings.Trim(slug, "-")
+	if len(slug) > 40 {
+		slug = slug[:40]
+		slug = strings.TrimRight(slug, "-")
+	}
+	if slug == "" {
+		return ""
+	}
+	if slug[0] < 'a' || slug[0] > 'z' {
+		if slug[0] < '0' || slug[0] > '9' {
+			return ""
+		}
+	}
+	return slug
 }

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -20,6 +20,7 @@ type Session struct {
 	mu           sync.RWMutex
 	agents       map[string]*Agent
 	nextAgentNum int
+	displayName  string
 }
 
 // newSession creates a session with the given worktree.
@@ -210,6 +211,30 @@ func (s *Session) existingNames() []string {
 		names = append(names, a.Name)
 	}
 	return names
+}
+
+// SetDisplayName sets a human-readable display name for the session.
+func (s *Session) SetDisplayName(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.displayName = name
+}
+
+// GetDisplayName returns the display name if set, otherwise falls back to Name.
+func (s *Session) GetDisplayName() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.displayName != "" {
+		return s.displayName
+	}
+	return s.Name
+}
+
+// HasDisplayName reports whether a display name has been set.
+func (s *Session) HasDisplayName() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.displayName != ""
 }
 
 // Elapsed returns how long the session has been running.

--- a/internal/agent/session_name_test.go
+++ b/internal/agent/session_name_test.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPollClaudeSessionName_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	old := ClaudeSessionDir
+	ClaudeSessionDir = dir
+	defer func() { ClaudeSessionDir = old }()
+
+	a := &Agent{claudePid: 99999}
+	if got := a.PollClaudeSessionName(); got != "" {
+		t.Errorf("expected empty string for missing file, got %q", got)
+	}
+}
+
+func TestPollClaudeSessionName_NoNameField(t *testing.T) {
+	dir := t.TempDir()
+	old := ClaudeSessionDir
+	ClaudeSessionDir = dir
+	defer func() { ClaudeSessionDir = old }()
+
+	// Write a JSON file without a "name" field.
+	data, _ := json.Marshal(map[string]any{"id": "abc123"})
+	if err := os.WriteFile(filepath.Join(dir, "12345.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &Agent{claudePid: 12345}
+	if got := a.PollClaudeSessionName(); got != "" {
+		t.Errorf("expected empty string for missing name field, got %q", got)
+	}
+}
+
+func TestPollClaudeSessionName_WithName(t *testing.T) {
+	dir := t.TempDir()
+	old := ClaudeSessionDir
+	ClaudeSessionDir = dir
+	defer func() { ClaudeSessionDir = old }()
+
+	data, _ := json.Marshal(map[string]any{"name": "fix-auth-bug", "id": "abc123"})
+	if err := os.WriteFile(filepath.Join(dir, "42.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &Agent{claudePid: 42}
+	got := a.PollClaudeSessionName()
+	if got != "fix-auth-bug" {
+		t.Errorf("expected %q, got %q", "fix-auth-bug", got)
+	}
+}
+
+func TestPollClaudeSessionName_ZeroPid(t *testing.T) {
+	a := &Agent{claudePid: 0}
+	if got := a.PollClaudeSessionName(); got != "" {
+		t.Errorf("expected empty string for zero PID, got %q", got)
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Hello World", "hello-world"},
+		{"fix: auth bug in login", "fix-auth-bug-in-login"},
+		{"  spaces  and  stuff  ", "spaces-and-stuff"},
+		{"UPPERCASE", "uppercase"},
+		{"a-b-c", "a-b-c"},
+		{"123-start", "123-start"},
+		{"", ""},
+		{"!@#$%", ""},
+		{"a very long string that exceeds the forty character limit for slugs yes", "a-very-long-string-that-exceeds-the-fort"},
+	}
+
+	for _, tc := range tests {
+		got := slugify(tc.input)
+		if got != tc.want {
+			t.Errorf("slugify(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestSessionGetDisplayName_Fallback(t *testing.T) {
+	s := &Session{
+		Name:   "eager-panda",
+		agents: make(map[string]*Agent),
+	}
+
+	// Should fall back to Name.
+	if got := s.GetDisplayName(); got != "eager-panda" {
+		t.Errorf("GetDisplayName() = %q, want %q", got, "eager-panda")
+	}
+
+	if s.HasDisplayName() {
+		t.Error("HasDisplayName() should be false before SetDisplayName")
+	}
+
+	s.SetDisplayName("fix-auth-bug")
+	if got := s.GetDisplayName(); got != "fix-auth-bug" {
+		t.Errorf("GetDisplayName() = %q, want %q", got, "fix-auth-bug")
+	}
+
+	if !s.HasDisplayName() {
+		t.Error("HasDisplayName() should be true after SetDisplayName")
+	}
+}

--- a/internal/pty/pty.go
+++ b/internal/pty/pty.go
@@ -81,6 +81,15 @@ func (p *PTY) Close() error {
 	return closeErr
 }
 
+// Pid returns the process ID of the spawned subprocess.
+// Returns 0 if the process has not been started yet.
+func (p *PTY) Pid() int {
+	if p.cmd != nil && p.cmd.Process != nil {
+		return p.cmd.Process.Pid
+	}
+	return 0
+}
+
 // Done returns a channel that fires when the subprocess exits.
 func (p *PTY) Done() <-chan struct{} {
 	return p.done

--- a/internal/pty/pty_test.go
+++ b/internal/pty/pty_test.go
@@ -83,6 +83,25 @@ func TestCatWriteReadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPid(t *testing.T) {
+	p := &pty.PTY{}
+	// Before Start, Pid should return 0.
+	if got := p.Pid(); got != 0 {
+		t.Errorf("expected Pid() == 0 before Start, got %d", got)
+	}
+
+	cmd := exec.Command("sleep", "5")
+	if err := p.Start(cmd, 24, 80); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer p.Close()
+
+	// After Start, Pid should be a positive integer.
+	if got := p.Pid(); got <= 0 {
+		t.Errorf("expected Pid() > 0 after Start, got %d", got)
+	}
+}
+
 func TestCloseAndDoneChannel(t *testing.T) {
 	p := &pty.PTY{}
 	cmd := exec.Command("sleep", "60")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -163,8 +162,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		a.refreshAgentList()
-		// Auto-rename agents that just went idle for the first time,
-		// and detect Active->Idle transitions for audio notification.
+		// Poll for Claude session names and detect Active->Idle transitions.
 		for _, item := range a.dashboard.items {
 			if item.kind != listItemAgent || item.agent == nil {
 				continue
@@ -182,14 +180,16 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			a.lastKnownStatus[ag.ID] = currentStatus
 
-			if currentStatus != agent.StatusIdle || ag.HasDisplayName() {
-				continue
+			// Poll Claude session file for auto-generated name.
+			if !ag.HasClaudeName() {
+				if name := ag.PollClaudeSessionName(); name != "" {
+					ag.SetDisplayName(name)
+					ag.SetClaudeName(true)
+					if item.session != nil && !item.session.HasDisplayName() {
+						item.session.SetDisplayName(name)
+					}
+				}
 			}
-			name := extractAgentName(ag.Render())
-			if name == "" {
-				name = ag.Name // fallback: use random name to prevent retrying
-			}
-			ag.SetDisplayName(name)
 		}
 		if a.errTicks > 0 {
 			a.errTicks--
@@ -428,7 +428,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				files := git.ParseDiffFiles(rawDiff)
 				a.view = ViewDiff
-				a.diff = newDiffModel(sess.Name, files, a.width, a.height-1)
+				a.diff = newDiffModel(sess.GetDisplayName(), files, a.width, a.height-1)
 				return a, nil
 			}
 			// Repo header selected — remove the repo.
@@ -791,59 +791,6 @@ func (a App) View() tea.View {
 		v.MouseMode = tea.MouseModeCellMotion
 	}
 	return v
-}
-
-var (
-	ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
-	nonAlnumRe   = regexp.MustCompile(`[^a-zA-Z0-9]+`)
-)
-
-// extractAgentName scans ANSI-rendered terminal output for the first Claude REPL
-// user-input line ("> " prefix after stripping escape codes) and returns a slug.
-// Returns "" if no suitable line is found.
-func extractAgentName(rendered string) string {
-	// Strip ANSI escape codes.
-	plain := ansiEscapeRe.ReplaceAllString(rendered, "")
-
-	// Find the first line starting with "> " (Claude REPL user input).
-	for _, line := range strings.Split(plain, "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "> ") {
-			continue
-		}
-		input := strings.TrimPrefix(line, "> ")
-		input = strings.TrimSpace(input)
-		if input == "" {
-			continue
-		}
-		slug := slugify(input)
-		if slug != "" {
-			return slug
-		}
-	}
-	return ""
-}
-
-// slugify lowercases s, collapses runs of non-alphanumeric characters to "-",
-// trims leading/trailing "-", and truncates to 40 characters.
-// Returns "" if the result is empty or doesn't start with [a-zA-Z0-9].
-func slugify(s string) string {
-	slug := nonAlnumRe.ReplaceAllString(strings.ToLower(s), "-")
-	slug = strings.Trim(slug, "-")
-	if len(slug) > 40 {
-		slug = slug[:40]
-		slug = strings.TrimRight(slug, "-")
-	}
-	if slug == "" {
-		return ""
-	}
-	// Must start with alphanumeric (validName constraint).
-	if slug[0] < 'a' || slug[0] > 'z' {
-		if slug[0] < '0' || slug[0] > '9' {
-			return ""
-		}
-	}
-	return slug
 }
 
 // ensureGitignore adds .baton/ to .gitignore in the given path if not already present.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -246,8 +246,8 @@ func (d dashboardModel) renderList(width int) string {
 				symbolStyle = lipgloss.NewStyle().Foreground(ColorMuted)
 			}
 
-			label := fmt.Sprintf(" %s %s (%s) ", symbolStyle.Render(symbol), sess.Name, count)
-			labelLen := len(symbol) + 1 + len(sess.Name) + len(count) + 5 // approximate visible length
+			label := fmt.Sprintf(" %s %s (%s) ", symbolStyle.Render(symbol), sess.GetDisplayName(), count)
+			labelLen := len(symbol) + 1 + len(sess.GetDisplayName()) + len(count) + 5 // approximate visible length
 			padLen := width - 4 - labelLen
 			if padLen < 0 {
 				padLen = 0
@@ -326,7 +326,7 @@ func (d dashboardModel) renderPreview(width int) string {
 
 	sessionInfo := ""
 	if item.session != nil {
-		sessionInfo = StyleSubtle.Render(fmt.Sprintf(" Session: %s  Worktree: %s", item.session.Name, item.session.Worktree.Path))
+		sessionInfo = StyleSubtle.Render(fmt.Sprintf(" Session: %s  Worktree: %s", item.session.GetDisplayName(), item.session.Worktree.Path))
 	}
 	taskInfo := StyleSubtle.Render(" Task: " + ag.Task)
 


### PR DESCRIPTION
## Summary
- Replace the broken auto-rename system that parsed raw terminal output with reliable Claude session file polling (`~/.claude/sessions/<pid>.json`)
- Add `Pid()` to PTY so agents can track their spawned Claude process PID
- Use slugified task description as interim display name until Claude's auto-generated name arrives
- Add display name support to Sessions (with fallback to random name)
- Clean up old terminal-parsing code (`extractAgentName`, `slugify`, `ansiEscapeRe`) from TUI

## Test plan
- [x] `go build ./...` compiles
- [x] `go vet ./...` passes
- [x] `go test -race ./...` — all tests pass including new tests for:
  - PTY `Pid()` before/after start
  - `PollClaudeSessionName` with missing file, no name field, valid name, zero PID
  - `slugify` with various inputs
  - Session `GetDisplayName` fallback behavior
- [ ] Manual: launch baton, create a session, send a few prompts, observe name updates
- [ ] Manual: create session with a pre-set task, verify slugified task appears as interim name
- [ ] Manual: verify session headers in sidebar update to match first agent's name

🤖 Generated with [Claude Code](https://claude.com/claude-code)