### PR TITLE
Clean up session headers in dashboard

### DIFF
--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -253,8 +253,6 @@ func (d dashboardModel) renderList(width int) string {
 			sess := item.session
 			status := sess.Status()
 			symbol := status.Symbol()
-			count := fmt.Sprintf("%d agents", sess.AgentCount())
-
 			var symbolStyle lipgloss.Style
 			switch status {
 			case agent.StatusActive:
@@ -267,8 +265,18 @@ func (d dashboardModel) renderList(width int) string {
 				symbolStyle = lipgloss.NewStyle().Foreground(ColorMuted)
 			}
 
-			label := fmt.Sprintf(" %s %s (%s) ", symbolStyle.Render(symbol), sess.GetDisplayName(), count)
-			labelLen := len(symbol) + 1 + len(sess.GetDisplayName()) + len(count) + 5 // approximate visible length
+			displayName := sess.GetDisplayName()
+			// 4 for "  ──", 3 for " symbol ", 1 trailing space, plus some padding chars
+			maxNameLen := width - 10
+			if maxNameLen < 5 {
+				maxNameLen = 5
+			}
+			if len(displayName) > maxNameLen {
+				displayName = displayName[:maxNameLen-1] + "…"
+			}
+
+			label := fmt.Sprintf(" %s %s ", symbolStyle.Render(symbol), displayName)
+			labelLen := len(symbol) + 1 + len(displayName) + 2 // approximate visible length
 			padLen := width - 4 - labelLen
 			if padLen < 0 {
 				padLen = 0


### PR DESCRIPTION
## Summary
- Remove the `(X agents)` count suffix from session names in the left panel
- Truncate long session display names with `…` to prevent line wrapping

## Test plan
- `go test -race ./...` passes
- Visually verify session headers no longer show agent counts
- Verify long session names are truncated with ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)