### PR TITLE
fix: plug goroutine/memory leak on natural agent exit

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -39,6 +39,7 @@ type Agent struct {
 
 	done         chan struct{}
 	stop         chan struct{}
+	stopOnce     sync.Once
 	writeLoopDone chan struct{}
 }
 
@@ -172,6 +173,11 @@ func (a *Agent) readLoop() {
 		a.status = StatusDone
 	}
 	a.mu.Unlock()
+
+	// Close terminal to unblock writeLoop's Read call and bridgeRead's pipe,
+	// mirroring what Kill() does for forced exits.
+	a.terminal.Close()
+	<-a.writeLoopDone
 
 	close(a.done)
 }
@@ -319,12 +325,17 @@ func (a *Agent) ExitErr() error {
 
 // Kill terminates the agent's process and waits for goroutines to exit.
 func (a *Agent) Kill() {
-	close(a.stop)
+	a.closeStop()
 	a.pty.Close()
 	// Close terminal to unblock writeLoop's Read call.
 	a.terminal.Close()
 	// Wait for writeLoop to finish before returning.
 	<-a.writeLoopDone
+}
+
+// closeStop safely closes the stop channel exactly once.
+func (a *Agent) closeStop() {
+	a.stopOnce.Do(func() { close(a.stop) })
 }
 
 // ClaudeSessionDir overrides the session directory for testing.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -340,6 +340,62 @@ func TestComposingClearedOnEnter(t *testing.T) {
 	a.mu.RUnlock()
 }
 
+func TestNaturalExitCleansUpGoroutines(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-natural-exit", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo done")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the agent to exit naturally.
+	select {
+	case <-a.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for agent to finish")
+	}
+
+	// writeLoopDone should already be closed (goroutine cleaned up).
+	select {
+	case <-a.writeLoopDone:
+	default:
+		t.Error("writeLoopDone should be closed after natural exit")
+	}
+
+	if s := a.Status(); s != StatusDone {
+		t.Errorf("expected Done, got %s", s)
+	}
+}
+
+func TestKillAfterNaturalExitDoesNotPanic(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-kill-after-exit", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo done")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for natural exit.
+	select {
+	case <-a.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for agent to finish")
+	}
+
+	// Kill on an already-exited agent must not panic.
+	a.Kill()
+}
+
 func TestShutdownCleansAll(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo)

--- a/internal/vt/bridge.go
+++ b/internal/vt/bridge.go
@@ -106,7 +106,9 @@ func (t *Terminal) Write(p []byte) (int, error) {
 				t.historyMu.Lock()
 				t.history = append(t.history, topLine)
 				if len(t.history) > maxHistoryLines {
-					t.history = t.history[len(t.history)-maxHistoryLines:]
+					trimmed := make([]string, maxHistoryLines)
+					copy(trimmed, t.history[len(t.history)-maxHistoryLines:])
+					t.history = trimmed
 				}
 				t.historyMu.Unlock()
 			}


### PR DESCRIPTION
## Summary
- Close terminal and wait for writeLoop in `readLoop()` when agent process exits naturally, mirroring `Kill()`'s cleanup — fixes `writeLoop` and `bridgeRead` goroutines leaking permanently (~30MB per session cycle)
- Protect `close(a.stop)` with `sync.Once` so calling `Kill()` on an already-exited agent doesn't panic
- Replace history slice reslicing with `make`/`copy` to break reference to old backing array, allowing GC of trimmed lines

## Test plan
- [x] `go test -race ./...` — all pass, no races
- [x] `go vet ./...` — clean
- [x] New test: `TestNaturalExitCleansUpGoroutines` — confirms `writeLoopDone` closes after natural exit
- [x] New test: `TestKillAfterNaturalExitDoesNotPanic` — exercises double-close safety
- [ ] Manual: start baton, create agent with short-lived command, confirm memory stabilizes after GC

🤖 Generated with [Claude Code](https://claude.com/claude-code)