### PR TITLE
feat: add per-session shell terminal

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -21,6 +21,7 @@ type Agent struct {
 	ID           string
 	Name         string
 	Task         string
+	IsShell      bool   // true for shell agents (not Claude)
 	WorktreePath string // reference only; session owns the worktree
 	CreatedAt    time.Time
 
@@ -40,6 +41,7 @@ type Agent struct {
 	done         chan struct{}
 	stop         chan struct{}
 	writeLoopDone chan struct{}
+	killOnce     sync.Once
 }
 
 // Config holds parameters for creating a new agent.
@@ -138,6 +140,47 @@ func newAgentWithCommand(id string, cfg Config, worktreePath string, cmd *exec.C
 	go a.readLoop()
 	go a.writeLoop()
 	go a.statusLoop()
+
+	return a, nil
+}
+
+// newShellAgent creates an agent that spawns the user's shell instead of claude.
+// It reuses the same PTY+VT setup and readLoop/writeLoop but skips statusLoop —
+// shell agents stay StatusActive once output is received.
+func newShellAgent(id string, cfg Config, worktreePath string) (*Agent, error) {
+	term := vt.New(cfg.Cols, cfg.Rows)
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+	cmd := exec.Command(shell)
+	cmd.Dir = worktreePath
+	cmd.Env = append(cmd.Environ(), "TERM=xterm-256color")
+
+	p := &bpty.PTY{}
+	if err := p.Start(cmd, uint16(cfg.Rows), uint16(cfg.Cols)); err != nil {
+		return nil, err
+	}
+
+	a := &Agent{
+		ID:           id,
+		Name:         "shell",
+		IsShell:      true,
+		WorktreePath: worktreePath,
+		CreatedAt:    time.Now(),
+		pty:          p,
+		terminal:     term,
+		displayName:  "shell",
+		status:       StatusStarting,
+		done:         make(chan struct{}),
+		stop:         make(chan struct{}),
+		writeLoopDone: make(chan struct{}),
+	}
+
+	go a.readLoop()
+	go a.writeLoop()
+	// No statusLoop — shell agents don't transition to Idle.
 
 	return a, nil
 }
@@ -318,11 +361,14 @@ func (a *Agent) ExitErr() error {
 }
 
 // Kill terminates the agent's process and waits for goroutines to exit.
+// Safe to call multiple times — subsequent calls are no-ops.
 func (a *Agent) Kill() {
-	close(a.stop)
-	a.pty.Close()
-	// Close terminal to unblock writeLoop's Read call.
-	a.terminal.Close()
+	a.killOnce.Do(func() {
+		close(a.stop)
+		a.pty.Close()
+		// Close terminal to unblock writeLoop's Read call.
+		a.terminal.Close()
+	})
 	// Wait for writeLoop to finish before returning.
 	<-a.writeLoopDone
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -340,6 +340,49 @@ func TestComposingClearedOnEnter(t *testing.T) {
 	a.mu.RUnlock()
 }
 
+func TestNewShellAgent(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := Config{Rows: 24, Cols: 80}
+	a, err := newShellAgent("test-shell-1", cfg, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Kill()
+
+	// Verify IsShell flag.
+	if !a.IsShell {
+		t.Error("expected IsShell to be true")
+	}
+	if a.Name != "shell" {
+		t.Errorf("expected Name 'shell', got %q", a.Name)
+	}
+	if a.GetDisplayName() != "shell" {
+		t.Errorf("expected display name 'shell', got %q", a.GetDisplayName())
+	}
+
+	// Send a command to trigger output.
+	a.SendText("echo hello\n")
+	time.Sleep(500 * time.Millisecond)
+
+	// Should transition to Active on output.
+	if s := a.Status(); s != StatusActive {
+		t.Errorf("expected Active after shell output, got %s", s)
+	}
+
+	// Verify output appears in render.
+	render := a.Render()
+	if !strings.Contains(render, "hello") {
+		t.Errorf("expected render to contain 'hello', got: %q", render)
+	}
+
+	// Shell agents should NOT transition to Idle (no statusLoop).
+	time.Sleep(4 * time.Second)
+	if s := a.Status(); s == StatusIdle {
+		t.Error("shell agent should not transition to Idle (no statusLoop)")
+	}
+}
+
 func TestShutdownCleansAll(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -194,6 +194,34 @@ func (m *Manager) AddAgentWithCommand(sessionID string, cfg Config, cmd func(nam
 	return a, nil
 }
 
+// AddShell adds a shell agent to an existing session.
+func (m *Manager) AddShell(sessionID string, cfg Config) (*Agent, error) {
+	m.mu.RLock()
+	sess := m.sessions[sessionID]
+	m.mu.RUnlock()
+
+	if sess == nil {
+		return nil, fmt.Errorf("session %s not found", sessionID)
+	}
+
+	cfg.RepoPath = m.repoPath
+
+	a, err := sess.AddShell(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	m.emit(Event{Type: EventCreated, AgentID: a.ID, SessionID: sessionID, Status: StatusStarting})
+
+	m.watchers.Add(1)
+	go func() {
+		defer m.watchers.Done()
+		m.watchAgent(a, sessionID)
+	}()
+
+	return a, nil
+}
+
 // Create starts a new session with its first agent (backward-compatible wrapper).
 func (m *Manager) Create(cfg Config) (*Agent, error) {
 	_, a, err := m.CreateSession(cfg)
@@ -384,6 +412,7 @@ func (m *Manager) closeSession(sessionID string, sess *Session) {
 	delete(m.sessions, sessionID)
 	m.mu.Unlock()
 
+	sess.KillAll()
 	_ = sess.Cleanup(m.repoPath)
 
 	m.emit(Event{Type: EventSessionClosed, SessionID: sessionID})

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -80,6 +80,45 @@ func (s *Session) AddAgentDefault(cfg Config) (*Agent, error) {
 	return a, nil
 }
 
+// AddShell creates and starts a shell agent within this session.
+// Only one shell per session is allowed.
+func (s *Session) AddShell(cfg Config) (*Agent, error) {
+	s.mu.Lock()
+	for _, a := range s.agents {
+		if a.IsShell {
+			s.mu.Unlock()
+			return nil, fmt.Errorf("session %s already has a shell agent", s.ID)
+		}
+	}
+	s.nextAgentNum++
+	num := s.nextAgentNum
+	id := fmt.Sprintf("%s-agent-%d", s.ID, num)
+	s.mu.Unlock()
+
+	a, err := newShellAgent(id, cfg, s.Worktree.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.agents[id] = a
+	s.mu.Unlock()
+
+	return a, nil
+}
+
+// HasShell reports whether this session has a shell agent.
+func (s *Session) HasShell() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, a := range s.agents {
+		if a.IsShell {
+			return true
+		}
+	}
+	return false
+}
+
 // GetAgent returns an agent by ID, or nil if not found.
 func (s *Session) GetAgent(id string) *Agent {
 	s.mu.RLock()
@@ -116,8 +155,13 @@ func (s *Session) Status() Status {
 	hasIdle := false
 	hasError := false
 	allDone := true
+	nonShellCount := 0
 
 	for _, a := range s.agents {
+		if a.IsShell {
+			continue
+		}
+		nonShellCount++
 		st := a.Status()
 		switch st {
 		case StatusActive:
@@ -138,6 +182,9 @@ func (s *Session) Status() Status {
 		}
 	}
 
+	if nonShellCount == 0 {
+		return StatusIdle
+	}
 	if hasStarting {
 		return StatusStarting
 	}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"testing"
 	"time"
+
+	"github.com/devenjarvis/baton/internal/git"
 )
 
 func TestSessionCreation(t *testing.T) {
@@ -328,6 +330,98 @@ func TestNaturalExitAutoClosesSession(t *testing.T) {
 	}
 	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
 		t.Error("worktree should be removed after session auto-close")
+	}
+}
+
+func TestAddShellCreatesShellAgent(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shellCfg := Config{Rows: 24, Cols: 80}
+	shell, err := sess.AddShell(shellCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !shell.IsShell {
+		t.Error("shell agent should have IsShell == true")
+	}
+	if shell.Name != "shell" {
+		t.Errorf("expected shell agent name 'shell', got %q", shell.Name)
+	}
+	if !sess.HasShell() {
+		t.Error("HasShell() should return true after adding shell")
+	}
+}
+
+func TestAddShellEnforcesOnePerSession(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shellCfg := Config{Rows: 24, Cols: 80}
+	_, err = sess.AddShell(shellCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second shell should fail.
+	_, err = sess.AddShell(shellCfg)
+	if err == nil {
+		t.Error("expected error when adding second shell, got nil")
+	}
+}
+
+func TestSessionStatusExcludesShell(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	// Create session directly (no manager) to avoid auto-close interference.
+	wt := &git.WorktreeInfo{Path: repo, Branch: "main", BaseBranch: "main"}
+	sess := newSession("test-sess", "test", wt)
+
+	// Add a Claude agent that exits quickly.
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	ag, err := sess.AddAgent(cfg, exec.Command("bash", "-c", "echo done"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a shell (which will stay active).
+	shellCfg := Config{Rows: 24, Cols: 80}
+	shell, err := sess.AddShell(shellCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shell.Kill()
+
+	// Wait for the Claude agent to exit naturally.
+	select {
+	case <-ag.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Claude agent to exit")
+	}
+
+	// Session status should be Done — shell is excluded from the composite.
+	st := sess.Status()
+	if st != StatusDone {
+		t.Fatalf("expected session status Done (shell excluded), got %s", st)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -189,7 +189,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			// Check for Active->Idle transition.
 			if prev, ok := a.lastKnownStatus[ag.ID]; ok {
-				if prev == agent.StatusActive && currentStatus == agent.StatusIdle && ag.HasReceivedInput() {
+				if prev == agent.StatusActive && currentStatus == agent.StatusIdle && ag.HasReceivedInput() && !ag.IsShell {
 					if a.audioPlayer != nil {
 						a.audioPlayer.Play()
 					}
@@ -199,7 +199,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.lastKnownStatus[ag.ID] = currentStatus
 
 			// Poll Claude session file for auto-generated name.
-			if !ag.HasClaudeName() {
+			if !ag.IsShell && !ag.HasClaudeName() {
 				if name := ag.PollClaudeSessionName(); name != "" {
 					ag.SetDisplayName(name)
 					ag.SetClaudeName(true)
@@ -457,6 +457,52 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.view = ViewFileBrowser
 			return a, nil
 
+		case "t":
+			// Open or focus a shell terminal in the selected session.
+			sess := a.dashboard.selectedSession()
+			if sess == nil {
+				a.setError("No session selected")
+				return a, nil
+			}
+			if sess.HasShell() {
+				// Shell exists — select it and enter focusTerminal.
+				for i, item := range a.dashboard.items {
+					if item.kind == listItemAgent && item.agent != nil && item.agent.IsShell && item.session == sess {
+						a.dashboard.selected = i
+						a.dashboard.panelFocus = focusTerminal
+						a.resizeSelectedForDashboard()
+						break
+					}
+				}
+				return a, nil
+			}
+			repoPath := a.dashboard.selectedRepoPath()
+			if repoPath == "" {
+				repoPath = a.activeRepo
+			}
+			mgr := a.managers[repoPath]
+			if mgr == nil {
+				return a, nil
+			}
+			previewW := a.dashboard.previewTermWidth()
+			previewH := a.dashboard.previewTermHeight()
+			if previewW <= 0 || previewH <= 0 {
+				a.setError("Terminal size not yet known; try again")
+				return a, nil
+			}
+			cfg := agent.Config{
+				Rows: previewH,
+				Cols: previewW,
+			}
+			sessionID := sess.ID
+			return a, func() tea.Msg {
+				ag, err := mgr.AddShell(sessionID, cfg)
+				if err != nil {
+					return createResultMsg{err: err}
+				}
+				return createResultMsg{sessionID: sessionID, agentID: ag.ID}
+			}
+
 		case "d":
 			item := a.dashboard.selectedItem()
 			if item == nil {
@@ -540,8 +586,11 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if sess == nil {
 				return a, nil
 			}
-			// Check that all agents in the session are done or idle.
+			// Check that all non-shell agents in the session are done or idle.
 			for _, ag := range sess.Agents() {
+				if ag.IsShell {
+					continue
+				}
 				st := ag.Status()
 				if st != agent.StatusDone && st != agent.StatusIdle {
 					a.setError("All agents in session must be done or idle to merge")

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -283,18 +283,26 @@ func (d dashboardModel) renderList(width int) string {
 			symbol := status.Symbol()
 			elapsed := humanizeElapsed(ag.Elapsed())
 
+			if ag.IsShell {
+				symbol = "$"
+			}
+
 			var style lipgloss.Style
-			switch status {
-			case agent.StatusActive:
-				style = lipgloss.NewStyle().Foreground(ColorSecondary)
-			case agent.StatusDone:
-				style = lipgloss.NewStyle().Foreground(ColorSuccess)
-			case agent.StatusError:
-				style = lipgloss.NewStyle().Foreground(ColorError)
-			case agent.StatusIdle:
+			if ag.IsShell {
 				style = lipgloss.NewStyle().Foreground(ColorMuted)
-			default:
-				style = lipgloss.NewStyle().Foreground(ColorWarning)
+			} else {
+				switch status {
+				case agent.StatusActive:
+					style = lipgloss.NewStyle().Foreground(ColorSecondary)
+				case agent.StatusDone:
+					style = lipgloss.NewStyle().Foreground(ColorSuccess)
+				case agent.StatusError:
+					style = lipgloss.NewStyle().Foreground(ColorError)
+				case agent.StatusIdle:
+					style = lipgloss.NewStyle().Foreground(ColorMuted)
+				default:
+					style = lipgloss.NewStyle().Foreground(ColorWarning)
+				}
 			}
 
 			nameWidth := width - 18 // space for indent, symbol, elapsed, padding
@@ -369,7 +377,12 @@ func (d dashboardModel) renderPreview(width int) string {
 	if item.session != nil {
 		sessionInfo = StyleSubtle.Render(fmt.Sprintf(" Session: %s  Worktree: %s", item.session.GetDisplayName(), item.session.Worktree.Path))
 	}
-	taskInfo := StyleSubtle.Render(" Task: " + ag.Task)
+	var taskInfo string
+	if ag.IsShell {
+		taskInfo = StyleSubtle.Render(" Shell — " + ag.WorktreePath)
+	} else {
+		taskInfo = StyleSubtle.Render(" Task: " + ag.Task)
+	}
 
 	var render string
 	if d.scrollOffset > 0 {

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -17,6 +17,7 @@ var (
 		{"⏎/→", "interact"},
 		{"n", "new session"},
 		{"c", "add agent"},
+		{"t", "shell"},
 		{"a", "add repo"},
 		{"d", "diff/remove"},
 		{"x", "kill agent"},


### PR DESCRIPTION
## Summary
- Adds an in-TUI shell terminal per session (`t` key) that spawns `$SHELL` in the session's worktree directory
- Reuses existing PTY+VT infrastructure (readLoop/writeLoop) but skips Claude-specific statusLoop, name polling, and idle notifications
- One shell per session enforced; pressing `t` again focuses the existing shell
- Shell agents excluded from session composite status (don't block auto-close or merge)
- Visual distinction in sidebar (`$` symbol, muted color) and preview panel ("Shell — path")
- `Kill()` made idempotent via `sync.Once`; `closeSession` now kills all agents before cleanup

## Test plan
- [x] `go build -o baton .` compiles cleanly
- [x] `go test -race ./...` all tests pass with race detector
- [x] `go vet ./...` no static analysis issues
- [ ] Manual: create session (`n`), press `t` — shell opens in worktree
- [ ] Manual: `pwd` shows worktree path, `go test ./...` renders correctly
- [ ] Manual: `esc` back to list, `t` again — focuses existing shell (no duplicate)
- [ ] Manual: kill session (`X`) — shell cleaned up
- [ ] Manual: shell agent shows `$` icon in sidebar
- [ ] Manual: session auto-closes when Claude agents finish (shell doesn't block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)