### PR TITLE
feat: add session recovery with detach/resume

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -29,8 +29,9 @@ type Agent struct {
 
 	mu             sync.RWMutex
 	displayName    string
-	claudePid      int
-	hasClaudeName  bool
+	claudePid       int
+	claudeSessionID string
+	hasClaudeName   bool
 	status         Status
 	lastOutput  time.Time
 	lastInput   time.Time
@@ -105,6 +106,66 @@ func newAgent(id string, cfg Config, worktreePath string) (*Agent, error) {
 	go a.statusLoop()
 
 	return a, nil
+}
+
+// newResumedAgent creates and starts an agent that resumes a previous Claude session.
+// It uses `claude --resume <sessionId>` if claudeSessionID is provided, falls back to
+// `claude --continue` if empty, then plain `claude` as last resort.
+func newResumedAgent(id string, cfg Config, worktreePath string, claudeSessionID string) (*Agent, error) {
+	term := vt.New(cfg.Cols, cfg.Rows)
+
+	args := buildResumeArgs(cfg, claudeSessionID)
+	cmd := exec.Command("claude", args...)
+	cmd.Dir = worktreePath
+	cmd.Env = append(cmd.Environ(), "TERM=xterm-256color")
+
+	p := &bpty.PTY{}
+	if err := p.Start(cmd, uint16(cfg.Rows), uint16(cfg.Cols)); err != nil {
+		return nil, err
+	}
+
+	a := &Agent{
+		ID:              id,
+		Name:            cfg.Name,
+		Task:            cfg.Task,
+		WorktreePath:    worktreePath,
+		CreatedAt:       time.Now(),
+		pty:             p,
+		terminal:        term,
+		claudePid:       p.Pid(),
+		claudeSessionID: claudeSessionID,
+		status:          StatusStarting,
+		done:            make(chan struct{}),
+		stop:            make(chan struct{}),
+		writeLoopDone:   make(chan struct{}),
+	}
+
+	go a.readLoop()
+	go a.writeLoop()
+	go a.statusLoop()
+
+	return a, nil
+}
+
+// buildResumeArgs constructs claude CLI arguments for resuming a session.
+func buildResumeArgs(cfg Config, claudeSessionID string) []string {
+	var args []string
+
+	if cfg.BypassPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+
+	if claudeSessionID != "" {
+		args = append(args, "--resume", claudeSessionID)
+	} else {
+		args = append(args, "--continue")
+	}
+
+	if cfg.Task != "" {
+		args = append(args, cfg.Task)
+	}
+
+	return args
 }
 
 // newAgentWithCommand creates an agent using a custom command instead of claude.
@@ -366,12 +427,32 @@ func (a *Agent) PollClaudeSessionName() string {
 	}
 
 	var session struct {
-		Name string `json:"name"`
+		Name      string `json:"name"`
+		SessionID string `json:"sessionId"`
 	}
 	if err := json.Unmarshal(data, &session); err != nil {
 		return ""
 	}
+	if session.SessionID != "" {
+		a.mu.Lock()
+		a.claudeSessionID = session.SessionID
+		a.mu.Unlock()
+	}
 	return session.Name
+}
+
+// ClaudeSessionID returns the Claude session ID captured from the session file.
+func (a *Agent) ClaudeSessionID() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.claudeSessionID
+}
+
+// SetClaudeSessionID sets the Claude session ID.
+func (a *Agent) SetClaudeSessionID(id string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.claudeSessionID = id
 }
 
 // HasClaudeName reports whether the agent has been given a Claude session name.

--- a/internal/agent/detach_resume_test.go
+++ b/internal/agent/detach_resume_test.go
@@ -1,0 +1,370 @@
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devenjarvis/baton/internal/state"
+)
+
+func TestDetachSnapshotsState(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set a session ID on the agent to simulate polling.
+	ag.SetClaudeSessionID("test-session-uuid")
+	ag.SetDisplayName("my-task")
+	ag.SetClaudeName(true)
+
+	wtPath := sess.Worktree.Path
+	sessID := sess.ID
+
+	bs := mgr.Detach()
+	if bs == nil {
+		t.Fatal("expected non-nil BatonState from Detach")
+	}
+
+	// State should have the session.
+	if len(bs.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(bs.Sessions))
+	}
+
+	ss := bs.Sessions[0]
+	if ss.ID != sessID {
+		t.Errorf("expected session ID %s, got %s", sessID, ss.ID)
+	}
+	if ss.WorktreePath != wtPath {
+		t.Errorf("expected worktree path %s, got %s", wtPath, ss.WorktreePath)
+	}
+
+	// Agent state should be captured.
+	if len(ss.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(ss.Agents))
+	}
+	as := ss.Agents[0]
+	if as.ClaudeSessionID != "test-session-uuid" {
+		t.Errorf("expected session ID 'test-session-uuid', got %q", as.ClaudeSessionID)
+	}
+	if as.DisplayName != "my-task" {
+		t.Errorf("expected display name 'my-task', got %q", as.DisplayName)
+	}
+
+	// Worktree should still exist (not cleaned up).
+	if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+		t.Error("worktree should still exist after detach")
+	}
+
+	// Manager should have no sessions after detach.
+	if mgr.AgentCount() != 0 {
+		t.Errorf("expected 0 agents after detach, got %d", mgr.AgentCount())
+	}
+}
+
+func TestDetachEmptyReturnsNil(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+
+	bs := mgr.Detach()
+	if bs != nil {
+		t.Errorf("expected nil BatonState for empty manager, got %+v", bs)
+	}
+}
+
+func TestDetachSaveLoadRoundTrip(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ag.SetClaudeSessionID("uuid-abc")
+
+	_ = sess // used implicitly
+
+	bs := mgr.Detach()
+	if bs == nil {
+		t.Fatal("expected non-nil BatonState")
+	}
+
+	// Save to disk.
+	if err := state.Save(repo, bs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load from disk.
+	loaded, err := state.Load(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded == nil {
+		t.Fatal("expected loaded state, got nil")
+	}
+	if len(loaded.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(loaded.Sessions))
+	}
+	if loaded.Sessions[0].Agents[0].ClaudeSessionID != "uuid-abc" {
+		t.Errorf("expected session ID 'uuid-abc', got %q", loaded.Sessions[0].Agents[0].ClaudeSessionID)
+	}
+}
+
+func TestResumeSessionCreatesAgentWithResume(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	// First manager: create a session and detach.
+	mgr1 := NewManager(repo)
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr1.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ag.SetClaudeSessionID("resume-uuid-123")
+	ag.SetDisplayName("my-agent")
+	ag.SetClaudeName(true)
+
+	sessID := sess.ID
+	sessName := sess.Name
+	wtPath := sess.Worktree.Path
+	branch := sess.Worktree.Branch
+	baseBranch := sess.Worktree.BaseBranch
+
+	bs := mgr1.Detach()
+	if bs == nil {
+		t.Fatal("expected non-nil BatonState")
+	}
+
+	// Second manager: resume from saved state.
+	mgr2 := NewManager(repo)
+	defer mgr2.Shutdown()
+
+	resumeCfg := Config{Rows: 24, Cols: 80}
+	if err := mgr2.ResumeSession(bs.Sessions[0], resumeCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify session was recreated.
+	resumedSess := mgr2.GetSession(sessID)
+	if resumedSess == nil {
+		t.Fatal("resumed session not found")
+	}
+	if resumedSess.Name != sessName {
+		t.Errorf("expected session name %q, got %q", sessName, resumedSess.Name)
+	}
+	if resumedSess.Worktree.Path != wtPath {
+		t.Errorf("expected worktree path %q, got %q", wtPath, resumedSess.Worktree.Path)
+	}
+	if resumedSess.Worktree.Branch != branch {
+		t.Errorf("expected branch %q, got %q", branch, resumedSess.Worktree.Branch)
+	}
+	if resumedSess.Worktree.BaseBranch != baseBranch {
+		t.Errorf("expected base branch %q, got %q", baseBranch, resumedSess.Worktree.BaseBranch)
+	}
+
+	// Verify agent was created.
+	agents := resumedSess.Agents()
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(agents))
+	}
+	if agents[0].GetDisplayName() != "my-agent" {
+		t.Errorf("expected display name 'my-agent', got %q", agents[0].GetDisplayName())
+	}
+	if agents[0].ClaudeSessionID() != "resume-uuid-123" {
+		t.Errorf("expected claude session ID 'resume-uuid-123', got %q", agents[0].ClaudeSessionID())
+	}
+}
+
+func TestResumeSessionMissingWorktreeReturnsError(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	ss := state.SessionState{
+		ID:           "session-99",
+		Name:         "nonexistent",
+		WorktreePath: "/tmp/does-not-exist-" + time.Now().Format("20060102150405"),
+		Branch:       "baton/nonexistent",
+		BaseBranch:   "main",
+		Agents: []state.AgentState{
+			{ID: "session-99-agent-1", Name: "test"},
+		},
+	}
+
+	err := mgr.ResumeSession(ss, Config{Rows: 24, Cols: 80})
+	if err == nil {
+		t.Fatal("expected error for missing worktree")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %s", err)
+	}
+}
+
+func TestResumeNextIDNoCollision(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+	defer mgr.Shutdown()
+
+	// Create a session and detach from a first manager to get the worktree.
+	mgr1 := NewManager(repo)
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr1.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wtPath := sess.Worktree.Path
+	mgr1.Detach()
+
+	// Resume with a high session ID.
+	ss := state.SessionState{
+		ID:           "session-50",
+		Name:         sess.Name,
+		WorktreePath: wtPath,
+		Branch:       sess.Worktree.Branch,
+		BaseBranch:   sess.Worktree.BaseBranch,
+		Agents: []state.AgentState{
+			{ID: "session-50-agent-1", Name: "test"},
+		},
+	}
+
+	if err := mgr.ResumeSession(ss, Config{Rows: 24, Cols: 80}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new session — its ID should be > 50.
+	newSess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if newSess.ID == "session-50" {
+		t.Error("new session ID should not collide with resumed session")
+	}
+	// The nextID should have been bumped past 50, so the new session
+	// should have an ID > 50.
+	num := parseSessionNum(newSess.ID)
+	if num <= 50 {
+		t.Errorf("expected new session ID > 50, got %s (num=%d)", newSess.ID, num)
+	}
+}
+
+func TestBuildResumeArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      Config
+		sessID   string
+		wantArgs []string
+	}{
+		{
+			name:     "with session ID and bypass",
+			cfg:      Config{BypassPermissions: true, Task: "do stuff"},
+			sessID:   "uuid-123",
+			wantArgs: []string{"--dangerously-skip-permissions", "--resume", "uuid-123", "do stuff"},
+		},
+		{
+			name:     "empty session ID falls back to continue",
+			cfg:      Config{BypassPermissions: true},
+			sessID:   "",
+			wantArgs: []string{"--dangerously-skip-permissions", "--continue"},
+		},
+		{
+			name:     "no bypass no task",
+			cfg:      Config{},
+			sessID:   "uuid-456",
+			wantArgs: []string{"--resume", "uuid-456"},
+		},
+		{
+			name:     "continue with task",
+			cfg:      Config{Task: "hello"},
+			sessID:   "",
+			wantArgs: []string{"--continue", "hello"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildResumeArgs(tt.cfg, tt.sessID)
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("expected %d args, got %d: %v", len(tt.wantArgs), len(got), got)
+			}
+			for i, want := range tt.wantArgs {
+				if got[i] != want {
+					t.Errorf("arg[%d]: expected %q, got %q", i, want, got[i])
+				}
+			}
+		})
+	}
+}
+
+func TestForceQuitCleansEverything(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo)
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ag.SetClaudeSessionID("uuid-force")
+	wtPath := sess.Worktree.Path
+
+	// Simulate force quit: Shutdown + Remove state.
+	mgr.Shutdown()
+	_ = state.Remove(repo)
+
+	// Worktree should be gone (Shutdown calls Cleanup).
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Error("worktree should be removed after Shutdown")
+	}
+
+	// State file should not exist.
+	loaded, err := state.Load(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded != nil {
+		t.Error("expected no state file after force quit")
+	}
+}
+
+func TestParseSessionNum(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"session-1", 1},
+		{"session-50", 50},
+		{"session-0", 0},
+		{"invalid", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		got := parseSessionNum(tt.input)
+		if got != tt.want {
+			t.Errorf("parseSessionNum(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -2,11 +2,16 @@ package agent
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/devenjarvis/baton/internal/git"
+	"github.com/devenjarvis/baton/internal/state"
 )
 
 var validName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
@@ -354,6 +359,146 @@ func (m *Manager) AgentCount() int {
 // RepoPath returns the manager's repo path.
 func (m *Manager) RepoPath() string {
 	return m.repoPath
+}
+
+// Detach snapshots all sessions into a BatonState, kills all agents but preserves
+// worktrees, and shuts down the manager. Returns the state for persistence.
+func (m *Manager) Detach() *state.BatonState {
+	close(m.done)
+
+	m.mu.RLock()
+	sessions := make([]*Session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		sessions = append(sessions, s)
+	}
+	m.mu.RUnlock()
+
+	// Snapshot state before killing agents.
+	var sessionStates []state.SessionState
+	for _, s := range sessions {
+		ss := state.SessionState{
+			ID:           s.ID,
+			Name:         s.Name,
+			DisplayName:  s.GetDisplayName(),
+			WorktreePath: s.Worktree.Path,
+			Branch:       s.Worktree.Branch,
+			BaseBranch:   s.Worktree.BaseBranch,
+		}
+		for _, a := range s.Agents() {
+			as := state.AgentState{
+				ID:              a.ID,
+				Name:            a.Name,
+				DisplayName:     a.GetDisplayName(),
+				Task:            a.Task,
+				ClaudeSessionID: a.ClaudeSessionID(),
+			}
+			ss.Agents = append(ss.Agents, as)
+		}
+		sessionStates = append(sessionStates, ss)
+	}
+
+	// Kill all agents but do NOT call Cleanup (preserve worktrees).
+	for _, s := range sessions {
+		s.KillAll()
+	}
+
+	m.watchers.Wait()
+
+	m.mu.Lock()
+	m.sessions = make(map[string]*Session)
+	m.mu.Unlock()
+
+	close(m.events)
+
+	if len(sessionStates) == 0 {
+		return nil
+	}
+
+	return &state.BatonState{
+		Version:  1,
+		SavedAt:  time.Now(),
+		Sessions: sessionStates,
+	}
+}
+
+// ResumeSession recreates a session from saved state without creating a new worktree.
+// It verifies the worktree directory exists, constructs a Session from saved data,
+// and spawns agents with --resume flags.
+func (m *Manager) ResumeSession(ss state.SessionState, cfg Config) error {
+	// Verify worktree directory exists.
+	if _, err := os.Stat(ss.WorktreePath); err != nil {
+		return fmt.Errorf("worktree %s not found: %w", ss.WorktreePath, err)
+	}
+
+	wt := &git.WorktreeInfo{
+		Name:       ss.Name,
+		Path:       ss.WorktreePath,
+		Branch:     ss.Branch,
+		BaseBranch: ss.BaseBranch,
+	}
+
+	sess := newSession(ss.ID, ss.Name, wt)
+	if ss.DisplayName != "" && ss.DisplayName != ss.Name {
+		sess.SetDisplayName(ss.DisplayName)
+	}
+
+	m.mu.Lock()
+	m.sessions[ss.ID] = sess
+	// Parse session ID number to avoid collisions with nextID.
+	if num := parseSessionNum(ss.ID); num >= m.nextID {
+		m.nextID = num + 1
+	}
+	m.mu.Unlock()
+
+	for _, as := range ss.Agents {
+		agentCfg := Config{
+			Name:              as.Name,
+			Task:              as.Task,
+			Rows:              cfg.Rows,
+			Cols:              cfg.Cols,
+			RepoPath:          m.repoPath,
+			BypassPermissions: cfg.BypassPermissions,
+		}
+
+		a, err := sess.AddAgentResumed(agentCfg, as.ClaudeSessionID)
+		if err != nil {
+			// Clean up any agents already created in this session.
+			sess.KillAll()
+			m.mu.Lock()
+			delete(m.sessions, ss.ID)
+			m.mu.Unlock()
+			return fmt.Errorf("resuming agent %s: %w", as.Name, err)
+		}
+
+		// Restore display name from saved state.
+		if as.DisplayName != "" {
+			a.SetDisplayName(as.DisplayName)
+			a.SetClaudeName(true)
+		}
+
+		m.emit(Event{Type: EventCreated, AgentID: a.ID, SessionID: sess.ID, Status: StatusStarting})
+
+		m.watchers.Add(1)
+		go func() {
+			defer m.watchers.Done()
+			m.watchAgent(a, sess.ID)
+		}()
+	}
+
+	return nil
+}
+
+// parseSessionNum extracts the numeric ID from a session ID like "session-3".
+func parseSessionNum(id string) int {
+	parts := strings.SplitN(id, "-", 2)
+	if len(parts) != 2 {
+		return 0
+	}
+	n, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 func (m *Manager) watchAgent(a *Agent, sessionID string) {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -80,6 +80,29 @@ func (s *Session) AddAgentDefault(cfg Config) (*Agent, error) {
 	return a, nil
 }
 
+// AddAgentResumed creates and starts a new agent that resumes a previous Claude session.
+func (s *Session) AddAgentResumed(cfg Config, claudeSessionID string) (*Agent, error) {
+	s.mu.Lock()
+	if cfg.Name == "" {
+		cfg.Name = RandomName(s.existingNames())
+	}
+	s.nextAgentNum++
+	num := s.nextAgentNum
+	id := fmt.Sprintf("%s-agent-%d", s.ID, num)
+	s.mu.Unlock()
+
+	a, err := newResumedAgent(id, cfg, s.Worktree.Path, claudeSessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	s.agents[id] = a
+	s.mu.Unlock()
+
+	return a, nil
+}
+
 // GetAgent returns an agent by ID, or nil if not found.
 func (s *Session) GetAgent(id string) *Agent {
 	s.mu.RLock()

--- a/internal/agent/session_name_test.go
+++ b/internal/agent/session_name_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,6 +84,32 @@ func TestSlugify(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("slugify(%q) = %q, want %q", tc.input, got, tc.want)
 		}
+	}
+}
+
+func TestPollClaudeSessionName_CapturesSessionID(t *testing.T) {
+	dir := t.TempDir()
+	old := ClaudeSessionDir
+	ClaudeSessionDir = dir
+	defer func() { ClaudeSessionDir = old }()
+
+	pid := 12345
+	data, _ := json.Marshal(map[string]string{
+		"sessionId": "test-uuid-123",
+		"name":      "test-session",
+	})
+	os.WriteFile(filepath.Join(dir, fmt.Sprintf("%d.json", pid)), data, 0644)
+
+	a := &Agent{
+		claudePid: pid,
+	}
+
+	name := a.PollClaudeSessionName()
+	if name != "test-session" {
+		t.Errorf("expected name 'test-session', got %q", name)
+	}
+	if got := a.ClaudeSessionID(); got != "test-uuid-123" {
+		t.Errorf("expected session ID 'test-uuid-123', got %q", got)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,117 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// BatonState is the top-level persisted state for session recovery.
+type BatonState struct {
+	Version  int            `json:"version"`
+	SavedAt  time.Time      `json:"savedAt"`
+	Sessions []SessionState `json:"sessions"`
+}
+
+// SessionState captures the state of a single baton session (worktree).
+type SessionState struct {
+	ID           string       `json:"id"`
+	Name         string       `json:"name"`
+	DisplayName  string       `json:"displayName,omitempty"`
+	WorktreePath string       `json:"worktreePath"`
+	Branch       string       `json:"branch"`
+	BaseBranch   string       `json:"baseBranch"`
+	Agents       []AgentState `json:"agents"`
+}
+
+// AgentState captures the state of a single agent within a session.
+type AgentState struct {
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	DisplayName     string `json:"displayName,omitempty"`
+	Task            string `json:"task,omitempty"`
+	ClaudeSessionID string `json:"claudeSessionId,omitempty"`
+}
+
+// statePath returns the path to the state file for a given repo.
+func statePath(repoPath string) string {
+	return filepath.Join(repoPath, ".baton", "state.json")
+}
+
+// Save persists the BatonState to disk using atomic temp+rename.
+func Save(repoPath string, s *BatonState) error {
+	path := statePath(repoPath)
+	dir := filepath.Dir(path)
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("state: creating dir %s: %w", dir, err)
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("state: marshalling state: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, "state-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("state: creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	defer func() {
+		if err != nil {
+			os.Remove(tmpName)
+		}
+	}()
+
+	if _, writeErr := tmp.Write(data); writeErr != nil {
+		tmp.Close()
+		err = fmt.Errorf("state: writing temp file: %w", writeErr)
+		return err
+	}
+
+	if closeErr := tmp.Close(); closeErr != nil {
+		err = fmt.Errorf("state: closing temp file: %w", closeErr)
+		return err
+	}
+
+	if renameErr := os.Rename(tmpName, path); renameErr != nil {
+		err = fmt.Errorf("state: renaming temp file to %s: %w", path, renameErr)
+		return err
+	}
+
+	return nil
+}
+
+// Load reads the BatonState from disk. Returns (nil, nil) if the file does not exist.
+func Load(repoPath string) (*BatonState, error) {
+	path := statePath(repoPath)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("state: reading %s: %w", path, err)
+	}
+
+	var s BatonState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("state: unmarshalling state: %w", err)
+	}
+
+	return &s, nil
+}
+
+// Remove deletes the state file. It is idempotent: returns nil if the file does not exist.
+func Remove(repoPath string) error {
+	path := statePath(repoPath)
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("state: removing %s: %w", path, err)
+	}
+
+	return nil
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,202 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	saved := &BatonState{
+		Version: 1,
+		SavedAt: time.Now().Truncate(time.Second),
+		Sessions: []SessionState{
+			{
+				ID:           "sess-1",
+				Name:         "warm-xerus",
+				DisplayName:  "Warm Xerus",
+				WorktreePath: "/tmp/worktrees/warm-xerus",
+				Branch:       "baton/warm-xerus",
+				BaseBranch:   "main",
+				Agents: []AgentState{
+					{
+						ID:              "agent-1",
+						Name:            "agent-alpha",
+						DisplayName:     "Alpha",
+						Task:            "implement feature X",
+						ClaudeSessionID: "claude-abc123",
+					},
+					{
+						ID:   "agent-2",
+						Name: "agent-beta",
+					},
+				},
+			},
+			{
+				ID:           "sess-2",
+				Name:         "dark-drake",
+				WorktreePath: "/tmp/worktrees/dark-drake",
+				Branch:       "baton/dark-drake",
+				BaseBranch:   "main",
+				Agents:       []AgentState{},
+			},
+		},
+	}
+
+	if err := Save(dir, saved); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load returned nil")
+	}
+
+	if loaded.Version != saved.Version {
+		t.Errorf("Version: got %d, want %d", loaded.Version, saved.Version)
+	}
+	if !loaded.SavedAt.Equal(saved.SavedAt) {
+		t.Errorf("SavedAt: got %v, want %v", loaded.SavedAt, saved.SavedAt)
+	}
+	if len(loaded.Sessions) != len(saved.Sessions) {
+		t.Fatalf("Sessions count: got %d, want %d", len(loaded.Sessions), len(saved.Sessions))
+	}
+
+	s := loaded.Sessions[0]
+	if s.ID != "sess-1" {
+		t.Errorf("Session ID: got %q, want %q", s.ID, "sess-1")
+	}
+	if s.Name != "warm-xerus" {
+		t.Errorf("Session Name: got %q, want %q", s.Name, "warm-xerus")
+	}
+	if s.DisplayName != "Warm Xerus" {
+		t.Errorf("Session DisplayName: got %q, want %q", s.DisplayName, "Warm Xerus")
+	}
+	if s.WorktreePath != "/tmp/worktrees/warm-xerus" {
+		t.Errorf("WorktreePath: got %q", s.WorktreePath)
+	}
+	if s.Branch != "baton/warm-xerus" {
+		t.Errorf("Branch: got %q", s.Branch)
+	}
+	if s.BaseBranch != "main" {
+		t.Errorf("BaseBranch: got %q", s.BaseBranch)
+	}
+	if len(s.Agents) != 2 {
+		t.Fatalf("Agents count: got %d, want 2", len(s.Agents))
+	}
+
+	a := s.Agents[0]
+	if a.ID != "agent-1" {
+		t.Errorf("Agent ID: got %q", a.ID)
+	}
+	if a.Name != "agent-alpha" {
+		t.Errorf("Agent Name: got %q", a.Name)
+	}
+	if a.DisplayName != "Alpha" {
+		t.Errorf("Agent DisplayName: got %q", a.DisplayName)
+	}
+	if a.Task != "implement feature X" {
+		t.Errorf("Agent Task: got %q", a.Task)
+	}
+	if a.ClaudeSessionID != "claude-abc123" {
+		t.Errorf("Agent ClaudeSessionID: got %q", a.ClaudeSessionID)
+	}
+
+	// Check omitempty fields are absent for agent-2
+	a2 := s.Agents[1]
+	if a2.DisplayName != "" {
+		t.Errorf("Agent2 DisplayName should be empty, got %q", a2.DisplayName)
+	}
+	if a2.Task != "" {
+		t.Errorf("Agent2 Task should be empty, got %q", a2.Task)
+	}
+
+	// Check second session has empty display name (omitempty)
+	s2 := loaded.Sessions[1]
+	if s2.DisplayName != "" {
+		t.Errorf("Session2 DisplayName should be empty, got %q", s2.DisplayName)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load on missing file should not error, got: %v", err)
+	}
+	if loaded != nil {
+		t.Fatalf("Load on missing file should return nil, got: %+v", loaded)
+	}
+}
+
+func TestRemoveIdempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	saved := &BatonState{
+		Version:  1,
+		SavedAt:  time.Now().Truncate(time.Second),
+		Sessions: []SessionState{},
+	}
+	if err := Save(dir, saved); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// First remove should succeed
+	if err := Remove(dir); err != nil {
+		t.Fatalf("First Remove: %v", err)
+	}
+
+	// File should be gone
+	if _, err := os.Stat(statePath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("File should not exist after Remove")
+	}
+
+	// Second remove should also succeed (idempotent)
+	if err := Remove(dir); err != nil {
+		t.Fatalf("Second Remove: %v", err)
+	}
+}
+
+func TestSaveCreatesBatonDir(t *testing.T) {
+	dir := t.TempDir()
+	// Use a subdirectory that doesn't exist yet
+	repoPath := filepath.Join(dir, "newrepo")
+
+	saved := &BatonState{
+		Version:  1,
+		SavedAt:  time.Now().Truncate(time.Second),
+		Sessions: []SessionState{},
+	}
+
+	if err := Save(repoPath, saved); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify the .baton directory was created
+	info, err := os.Stat(filepath.Join(repoPath, ".baton"))
+	if err != nil {
+		t.Fatalf("Expected .baton dir to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal(".baton should be a directory")
+	}
+
+	// Verify the file exists and is loadable
+	loaded, err := Load(repoPath)
+	if err != nil {
+		t.Fatalf("Load after Save: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load returned nil after Save")
+	}
+	if loaded.Version != 1 {
+		t.Errorf("Version: got %d, want 1", loaded.Version)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devenjarvis/baton/internal/audio"
 	"github.com/devenjarvis/baton/internal/config"
 	"github.com/devenjarvis/baton/internal/git"
+	"github.com/devenjarvis/baton/internal/state"
 )
 
 // tickMsg triggers periodic re-renders.
@@ -170,6 +171,34 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				ensureGitignore(repo.Path)
 				cmds = append(cmds, listenEvents(mgr))
 			}
+		}
+		// Auto-resume saved sessions for each repo.
+		for _, repo := range msg.cfg.Repos {
+			bs, err := state.Load(repo.Path)
+			if err != nil || bs == nil {
+				continue
+			}
+			mgr := a.managers[repo.Path]
+			if mgr == nil {
+				continue
+			}
+			bypassPerms := true
+			if a.cfg != nil {
+				bypassPerms = a.cfg.GetBypassPermissions()
+			}
+			resumeCfg := agent.Config{
+				Rows:              24,
+				Cols:              80,
+				BypassPermissions: bypassPerms,
+			}
+			for _, ss := range bs.Sessions {
+				if err := mgr.ResumeSession(ss, resumeCfg); err != nil {
+					// Skip sessions whose worktrees are missing — don't crash.
+					continue
+				}
+			}
+			// Clean up state file after successful resume.
+			_ = state.Remove(repo.Path)
 		}
 		// Always start on the dashboard — single repo or many.
 		a.view = ViewDashboard
@@ -350,6 +379,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch msg.String() {
 		case "q", "ctrl+c":
+			// Detach path: save state and exit, preserving worktrees.
 			hasRunning := false
 			for _, mgr := range a.managers {
 				if mgr.AgentCount() > 0 {
@@ -361,8 +391,35 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.confirmQuit = true
 				return a, nil
 			}
+			// Detach all managers and save state.
+			for repoPath, mgr := range a.managers {
+				bs := mgr.Detach()
+				if bs != nil {
+					_ = state.Save(repoPath, bs)
+				} else {
+					_ = state.Remove(repoPath)
+				}
+			}
+			if a.audioPlayer != nil {
+				a.audioPlayer.Close()
+			}
+			return a, tea.Quit
+		case "Q":
+			// Force quit: full cleanup, remove state.
+			hasRunning := false
 			for _, mgr := range a.managers {
+				if mgr.AgentCount() > 0 {
+					hasRunning = true
+					break
+				}
+			}
+			if hasRunning && !a.confirmQuit {
+				a.confirmQuit = true
+				return a, nil
+			}
+			for repoPath, mgr := range a.managers {
 				mgr.Shutdown()
+				_ = state.Remove(repoPath)
 			}
 			if a.audioPlayer != nil {
 				a.audioPlayer.Close()
@@ -843,7 +900,7 @@ func (a App) View() tea.View {
 
 	// Show quit confirmation.
 	if a.confirmQuit {
-		confirmLine := StyleWarning.Render("Agents are running. Press q again to quit, or any key to cancel.")
+		confirmLine := StyleWarning.Render("Agents are running. q to detach (resume later), Q to quit and clean up, any key to cancel.")
 		content = lipgloss.JoinVertical(lipgloss.Left, confirmLine, content)
 	}
 

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -22,7 +22,8 @@ var (
 		{"x", "kill agent"},
 		{"X", "kill session"},
 		{"m", "merge"},
-		{"q", "quit"},
+		{"q", "detach"},
+		{"Q", "quit"},
 	}
 
 	focusTerminalHints = []keyHint{


### PR DESCRIPTION
## Summary
- **Detach on quit**: `q` saves session state (Claude session IDs, worktree info) to `.baton/state.json` and exits without cleaning up worktrees
- **Auto-resume on launch**: On startup, loads saved state and resumes all sessions using `claude --resume <sessionId>` (falls back to `--continue` if no session ID)
- **Force quit**: `Q` (shift-Q) does full cleanup — kills agents, removes worktrees, deletes state file

## Changes
- New `internal/state/` package for state persistence with atomic writes
- Extended `Agent` to capture Claude session IDs from `~/.claude/sessions/<PID>.json`
- Added `Manager.Detach()` and `Manager.ResumeSession()` for save/restore lifecycle
- Split TUI quit: `q`=detach, `Q`=force quit, with updated statusbar hints
- Auto-resume in `initAppMsg` handler with graceful handling of missing worktrees

## Test plan
- [x] `go build -o baton .` succeeds
- [x] `go test -race ./...` — all pass (10 new tests for detach/resume cycle)
- [x] `go vet ./...` — clean
- [ ] Manual: launch baton, create sessions, press `q` → verify `.baton/state.json` exists and worktrees remain → relaunch → verify auto-resume with Claude context intact → press `Q` → verify full cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)