### PR TITLE
perf: parallelize startup/shutdown across agents and sessions

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -168,7 +168,7 @@ func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
 		}
 	}
 
-	wt, err := git.CreateWorktree(m.repoPath, name, settings.BranchPrefix, settings.WorktreeDir, startPoint)
+	wt, err := git.CreateWorktree(m.repoPath, name, settings.BranchPrefix, settings.WorktreeDir, baseBranch, startPoint)
 	if err != nil {
 		return nil, fmt.Errorf("creating worktree: %w", err)
 	}
@@ -402,10 +402,16 @@ func (m *Manager) Shutdown() {
 	}
 	m.mu.RUnlock()
 
+	var wg sync.WaitGroup
+	wg.Add(len(sessions))
 	for _, s := range sessions {
-		s.KillAll()
-		s.Cleanup(m.repoPath)
+		go func() {
+			defer wg.Done()
+			s.KillAll()
+			s.Cleanup(m.repoPath)
+		}()
 	}
+	wg.Wait()
 
 	m.watchers.Wait()
 
@@ -469,9 +475,15 @@ func (m *Manager) Detach() *state.BatonState {
 	}
 
 	// Kill all agents but do NOT call Cleanup (preserve worktrees).
+	var wg sync.WaitGroup
+	wg.Add(len(sessions))
 	for _, s := range sessions {
-		s.KillAll()
+		go func() {
+			defer wg.Done()
+			s.KillAll()
+		}()
 	}
+	wg.Wait()
 
 	m.watchers.Wait()
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -258,10 +258,16 @@ func (s *Session) KillAll() {
 	}
 	s.mu.RUnlock()
 
+	var wg sync.WaitGroup
+	wg.Add(len(agents))
 	for _, a := range agents {
-		a.Kill()
-		<-a.Done()
+		go func() {
+			defer wg.Done()
+			a.Kill()
+			<-a.Done()
+		}()
 	}
+	wg.Wait()
 
 	s.mu.Lock()
 	s.agents = make(map[string]*Agent)

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -137,7 +137,7 @@ func TestGetPerFileDiffStats_AddedModifiedDeleted(t *testing.T) {
 	gitInDir(t, repo, "add", "to-delete.txt")
 	gitInDir(t, repo, "commit", "-m", "add file to delete")
 
-	wt, err := git.CreateWorktree(repo, "stats-agent", "", "")
+	wt, err := git.CreateWorktree(repo, "stats-agent", "", "", "")
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestGetPerFileDiffStats_AddedModifiedDeleted(t *testing.T) {
 func TestGetPerFileDiffStats_BinaryFile(t *testing.T) {
 	repo := initTestRepo(t)
 
-	wt, err := git.CreateWorktree(repo, "bin-agent", "", "")
+	wt, err := git.CreateWorktree(repo, "bin-agent", "", "", "")
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestGetPerFileDiffStats_BinaryFile(t *testing.T) {
 func TestGetPerFileDiffStats_UncommittedChanges(t *testing.T) {
 	repo := initTestRepo(t)
 
-	wt, err := git.CreateWorktree(repo, "wip-agent", "", "")
+	wt, err := git.CreateWorktree(repo, "wip-agent", "", "", "")
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestGetPerFileDiffStats_UncommittedChanges(t *testing.T) {
 func TestGetPerFileDiffStats_NoChanges(t *testing.T) {
 	repo := initTestRepo(t)
 
-	wt, err := git.CreateWorktree(repo, "empty-agent", "", "")
+	wt, err := git.CreateWorktree(repo, "empty-agent", "", "", "")
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -78,7 +78,7 @@ func TestBaseBranch(t *testing.T) {
 func TestCreateWorktree(t *testing.T) {
 	repo := initTestRepo(t)
 
-	wt, err := git.CreateWorktree(repo, "agent1", "", "")
+	wt, err := git.CreateWorktree(repo, "agent1", "", "", "")
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
@@ -113,11 +113,11 @@ func TestCreateWorktree(t *testing.T) {
 func TestListWorktrees(t *testing.T) {
 	repo := initTestRepo(t)
 
-	_, err := git.CreateWorktree(repo, "agent1", "", "")
+	_, err := git.CreateWorktree(repo, "agent1", "", "", "")
 	if err != nil {
 		t.Fatalf("CreateWorktree agent1: %v", err)
 	}
-	_, err = git.CreateWorktree(repo, "agent2", "", "")
+	_, err = git.CreateWorktree(repo, "agent2", "", "", "")
 	if err != nil {
 		t.Fatalf("CreateWorktree agent2: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestListWorktrees(t *testing.T) {
 func TestDiffAndMerge(t *testing.T) {
 	repo := initTestRepo(t)
 
-	wt, err := git.CreateWorktree(repo, "agent1", "", "")
+	wt, err := git.CreateWorktree(repo, "agent1", "", "", "")
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
@@ -206,7 +206,7 @@ func TestDiffAndMerge(t *testing.T) {
 func TestRemoveWorktree(t *testing.T) {
 	repo := initTestRepo(t)
 
-	wt, err := git.CreateWorktree(repo, "agent1", "", "")
+	wt, err := git.CreateWorktree(repo, "agent1", "", "", "")
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
@@ -382,7 +382,7 @@ func TestCreateWorktreeWithStartPoint(t *testing.T) {
 	}
 
 	// Create worktree from origin/main (not local main).
-	wt, err := git.CreateWorktree(work, "start-point-agent", "", "", "origin/main")
+	wt, err := git.CreateWorktree(work, "start-point-agent", "", "", "", "origin/main")
 	if err != nil {
 		t.Fatalf("CreateWorktree with startPoint: %v", err)
 	}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -73,7 +73,7 @@ func UpdateBaseBranch(repoPath, branch string) error {
 // strings to use defaults ("baton/" and ".baton/worktrees").
 // An optional startPoint specifies the commit to branch from; if omitted,
 // the worktree branches from the current HEAD.
-func CreateWorktree(repoPath, agentName, branchPrefix, worktreeDir string, startPoint ...string) (*WorktreeInfo, error) {
+func CreateWorktree(repoPath, agentName, branchPrefix, worktreeDir, baseBranch string, startPoint ...string) (*WorktreeInfo, error) {
 	if branchPrefix == "" {
 		branchPrefix = "baton/"
 	}
@@ -81,9 +81,12 @@ func CreateWorktree(repoPath, agentName, branchPrefix, worktreeDir string, start
 		worktreeDir = ".baton/worktrees"
 	}
 
-	base, err := BaseBranch(repoPath)
-	if err != nil {
-		return nil, fmt.Errorf("getting base branch: %w", err)
+	if baseBranch == "" {
+		var err error
+		baseBranch, err = BaseBranch(repoPath)
+		if err != nil {
+			return nil, fmt.Errorf("getting base branch: %w", err)
+		}
 	}
 
 	branch := branchPrefix + agentName
@@ -107,7 +110,7 @@ func CreateWorktree(repoPath, agentName, branchPrefix, worktreeDir string, start
 		Name:       agentName,
 		Path:       absPath,
 		Branch:     branch,
-		BaseBranch: base,
+		BaseBranch: baseBranch,
 	}, nil
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -55,6 +56,11 @@ type diffStatsMsg struct {
 type initAppMsg struct {
 	cfg *config.Config
 	err error
+}
+
+// resumeDoneMsg signals that background session resume has completed.
+type resumeDoneMsg struct {
+	repoPaths []string // repos whose state files should be cleaned up
 }
 
 // diffStatsEntry holds cached diff stats for a single session.
@@ -213,7 +219,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, listenEvents(mgr))
 			}
 		}
-		// Auto-resume saved sessions for each repo.
+		// Build resume work to run in the background so the TUI renders immediately.
+		type resumeItem struct {
+			repoPath    string
+			mgr         *agent.Manager
+			resumeCfg   agent.Config
+			sessions    []state.SessionState
+		}
+		var resumeItems []resumeItem
 		for _, repo := range msg.cfg.Repos {
 			bs, err := state.Load(repo.Path)
 			if err != nil || bs == nil {
@@ -224,20 +237,37 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				continue
 			}
 			resolved := a.resolvedCache[repo.Path]
-			resumeCfg := agent.Config{
-				Rows:              24,
-				Cols:              80,
-				BypassPermissions: resolved.BypassPermissions,
-				AgentProgram:      resolved.AgentProgram,
-			}
-			for _, ss := range bs.Sessions {
-				if err := mgr.ResumeSession(ss, resumeCfg); err != nil {
-					// Skip sessions whose worktrees are missing — don't crash.
-					continue
+			resumeItems = append(resumeItems, resumeItem{
+				repoPath: repo.Path,
+				mgr:      mgr,
+				resumeCfg: agent.Config{
+					Rows:              24,
+					Cols:              80,
+					BypassPermissions: resolved.BypassPermissions,
+					AgentProgram:      resolved.AgentProgram,
+				},
+				sessions: bs.Sessions,
+			})
+		}
+		if len(resumeItems) > 0 {
+			cmds = append(cmds, func() tea.Msg {
+				var wg sync.WaitGroup
+				for _, ri := range resumeItems {
+					for _, ss := range ri.sessions {
+						wg.Add(1)
+						go func(mgr *agent.Manager, ss state.SessionState, cfg agent.Config) {
+							defer wg.Done()
+							_ = mgr.ResumeSession(ss, cfg)
+						}(ri.mgr, ss, ri.resumeCfg)
+					}
 				}
-			}
-			// Clean up state file after successful resume.
-			_ = state.Remove(repo.Path)
+				wg.Wait()
+				repoPaths := make([]string, len(resumeItems))
+				for i, ri := range resumeItems {
+					repoPaths[i] = ri.repoPath
+				}
+				return resumeDoneMsg{repoPaths: repoPaths}
+			})
 		}
 		// Always start on the dashboard — single repo or many.
 		a.view = ViewDashboard
@@ -382,6 +412,13 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.prCache[msg.sessionID] = &prCacheEntry{pr: msg.pr}
 			a.updateDashboardPRCache()
 		}
+		return a, nil
+
+	case resumeDoneMsg:
+		for _, repoPath := range msg.repoPaths {
+			_ = state.Remove(repoPath)
+		}
+		a.refreshAgentList()
 		return a, nil
 
 	case fixChecksMsg:


### PR DESCRIPTION
## Summary
- **Parallel agent kills:** `Session.KillAll()` now kills agents concurrently via goroutines + WaitGroup, reducing shutdown from N×3s to ~3s per session
- **Parallel session shutdown:** `Manager.Shutdown()` and `Manager.Detach()` fan-out session kills in parallel, reducing M-session shutdown from M×3s to ~3s total
- **Async session resume:** Moved session-resume loop into a background `tea.Cmd` so the TUI renders immediately on startup; agents appear as `EventCreated` events arrive through the existing event listener
- **Eliminate redundant `BaseBranch()`:** `CreateWorktree()` now accepts a `baseBranch` parameter to skip a redundant `git rev-parse` subprocess when the caller already knows the base branch

## Test plan
- [x] `go test -race ./internal/agent/...` — passes with race detector (concurrent kill paths exercised)
- [x] `go test -race ./internal/git/...` — passes (CreateWorktree signature change, "" fallback works)
- [x] `go test -race ./internal/tui/...` — passes (async resume compiles and vets clean)
- [x] `go build -o baton .` — compiles successfully
- [ ] Manual: launch baton, create 2+ sessions, quit with `q`, relaunch — TUI should render immediately while agents resume in background
- [ ] Manual: with 3+ agents running, press `q` twice — should exit within ~3-4 seconds (not 9+)