### PR TITLE
feat: open session on existing branch/PR

### DIFF
--- a/internal/agent/detach_resume_test.go
+++ b/internal/agent/detach_resume_test.go
@@ -350,6 +350,70 @@ func TestForceQuitCleansEverything(t *testing.T) {
 	}
 }
 
+func TestDetachResumePreservesOwnsBranch(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	// Create a branch to attach to.
+	cmd := exec.Command("git", "branch", "feature/test-detach")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("creating branch: %v\n%s", err, out)
+	}
+
+	mgr1 := NewManager(repo, defaultTestSettings())
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+
+	// Create an attached session (ownsBranch=false).
+	sess, _, err := mgr1.CreateSessionOnBranchWithCommand("feature/test-detach", "main", cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wtPath := sess.Worktree.Path
+
+	bs := mgr1.Detach()
+	if bs == nil {
+		t.Fatal("expected non-nil BatonState")
+	}
+
+	// OwnsBranch should be false in saved state.
+	if bs.Sessions[0].OwnsBranch {
+		t.Error("expected OwnsBranch=false for attached session")
+	}
+
+	// Resume and verify.
+	mgr2 := NewManager(repo, defaultTestSettings())
+	defer mgr2.Shutdown()
+
+	if err := mgr2.ResumeSession(bs.Sessions[0], Config{Rows: 24, Cols: 80}); err != nil {
+		t.Fatal(err)
+	}
+
+	resumedSess := mgr2.GetSession(sess.ID)
+	if resumedSess == nil {
+		t.Fatal("resumed session not found")
+	}
+	if resumedSess.Worktree.Path != wtPath {
+		t.Errorf("expected worktree path %s, got %s", wtPath, resumedSess.Worktree.Path)
+	}
+
+	// Kill the resumed session — branch should be preserved (ownsBranch=false).
+	if err := mgr2.KillSession(sess.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	branchCmd := exec.Command("git", "branch", "--list", "feature/test-detach")
+	branchCmd.Dir = repo
+	out, err := branchCmd.Output()
+	if err != nil {
+		t.Fatalf("git branch --list: %v", err)
+	}
+	if !strings.Contains(string(out), "feature/test-detach") {
+		t.Error("branch should be preserved after killing resumed attached session")
+	}
+}
+
 func TestParseSessionNum(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -132,6 +132,122 @@ func (m *Manager) CreateSessionWithCommand(cfg Config, cmd func(name string) *ex
 	return sess, a, nil
 }
 
+// CreateSessionOnBranch starts a new session on an existing branch using the default claude command.
+func (m *Manager) CreateSessionOnBranch(branch, baseBranch string, cfg Config) (*Session, *Agent, error) {
+	sess, err := m.createSessionOnBranchWorktree(branch, baseBranch, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a, err := sess.AddAgentDefault(cfg)
+	if err != nil {
+		_ = sess.Cleanup(m.repoPath)
+		m.mu.Lock()
+		delete(m.sessions, sess.ID)
+		m.mu.Unlock()
+		return nil, nil, err
+	}
+
+	m.emit(Event{Type: EventCreated, AgentID: a.ID, SessionID: sess.ID, Status: StatusStarting})
+
+	m.watchers.Add(1)
+	go func() {
+		defer m.watchers.Done()
+		m.watchAgent(a, sess.ID)
+	}()
+
+	return sess, a, nil
+}
+
+// CreateSessionOnBranchWithCommand starts a new session on an existing branch using a custom command.
+func (m *Manager) CreateSessionOnBranchWithCommand(branch, baseBranch string, cfg Config, cmd func(name string) *exec.Cmd) (*Session, *Agent, error) {
+	sess, err := m.createSessionOnBranchWorktree(branch, baseBranch, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	a, err := sess.AddAgent(cfg, cmd(cfg.Name))
+	if err != nil {
+		_ = sess.Cleanup(m.repoPath)
+		m.mu.Lock()
+		delete(m.sessions, sess.ID)
+		m.mu.Unlock()
+		return nil, nil, err
+	}
+
+	m.emit(Event{Type: EventCreated, AgentID: a.ID, SessionID: sess.ID, Status: StatusStarting})
+
+	m.watchers.Add(1)
+	go func() {
+		defer m.watchers.Done()
+		m.watchAgent(a, sess.ID)
+	}()
+
+	return sess, a, nil
+}
+
+// createSessionOnBranchWorktree creates a session attached to an existing branch.
+// The session does NOT own the branch — cleanup removes the worktree but preserves it.
+// If baseBranch is non-empty, it overrides the default base on the returned WorktreeInfo.
+func (m *Manager) createSessionOnBranchWorktree(branch, baseBranch string, cfg Config) (*Session, error) {
+	m.mu.Lock()
+	existing := make([]string, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		existing = append(existing, s.Name)
+	}
+	name := slugifyBranchName(branch, existing)
+	m.nextID++
+	id := fmt.Sprintf("session-%d", m.nextID)
+	settings := m.settings
+	m.mu.Unlock()
+
+	cfg.RepoPath = m.repoPath
+	if cfg.AgentProgram == "" {
+		cfg.AgentProgram = settings.AgentProgram
+	}
+
+	wt, err := git.AttachWorktree(m.repoPath, name, settings.WorktreeDir, branch)
+	if err != nil {
+		return nil, fmt.Errorf("attaching worktree: %w", err)
+	}
+
+	// Override base branch if caller provided one (e.g. from PR data).
+	if baseBranch != "" {
+		wt.BaseBranch = baseBranch
+	}
+
+	sess := newSession(id, name, wt)
+	// ownsBranch stays false — we didn't create this branch.
+
+	m.mu.Lock()
+	m.sessions[id] = sess
+	m.mu.Unlock()
+
+	return sess, nil
+}
+
+// slugifyBranchName derives a session name from a branch name.
+// Takes the last path segment (e.g. "feature/add-auth" → "add-auth"), slugifies it,
+// and falls back to RandomName if the result is empty or collides.
+func slugifyBranchName(branch string, existing []string) string {
+	parts := strings.Split(branch, "/")
+	last := parts[len(parts)-1]
+	name := slugify(last)
+
+	if name == "" {
+		return RandomName(existing)
+	}
+
+	// Check for collision.
+	for _, e := range existing {
+		if e == name {
+			return RandomName(existing)
+		}
+	}
+
+	return name
+}
+
 // createSessionWorktree creates a session with its worktree, adds it to the map.
 func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
 	// Generate session name.
@@ -174,6 +290,7 @@ func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
 	}
 
 	sess := newSession(id, name, wt)
+	sess.ownsBranch = true
 
 	m.mu.Lock()
 	m.sessions[id] = sess
@@ -454,6 +571,7 @@ func (m *Manager) Detach() *state.BatonState {
 			WorktreePath: s.Worktree.Path,
 			Branch:       s.Worktree.Branch,
 			BaseBranch:   s.Worktree.BaseBranch,
+			OwnsBranch:   s.ownsBranch,
 		}
 		for _, a := range s.Agents() {
 			as := state.AgentState{
@@ -509,6 +627,7 @@ func (m *Manager) ResumeSession(ss state.SessionState, cfg Config) error {
 	}
 
 	sess := newSession(ss.ID, ss.Name, wt)
+	sess.ownsBranch = ss.OwnsBranch
 	if ss.DisplayName != "" && ss.DisplayName != ss.Name {
 		sess.SetDisplayName(ss.DisplayName)
 	}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -21,6 +21,7 @@ type Session struct {
 	agents       map[string]*Agent
 	nextAgentNum int
 	displayName  string
+	ownsBranch   bool // true if this session created the branch (cleanup should delete it)
 }
 
 // newSession creates a session with the given worktree.
@@ -268,9 +269,10 @@ func (s *Session) KillAll() {
 	s.mu.Unlock()
 }
 
-// Cleanup removes the session's worktree and branch.
+// Cleanup removes the session's worktree. If the session owns its branch
+// (created it), the branch is also deleted. Attached sessions preserve the branch.
 func (s *Session) Cleanup(repoPath string) error {
-	return git.RemoveWorktree(repoPath, s.Worktree, true)
+	return git.RemoveWorktree(repoPath, s.Worktree, s.ownsBranch)
 }
 
 // existingNames returns the session name and all current agent names.

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -422,6 +423,164 @@ func TestSessionStatusExcludesShell(t *testing.T) {
 	st := sess.Status()
 	if st != StatusDone {
 		t.Fatalf("expected session status Done (shell excluded), got %s", st)
+	}
+}
+
+func TestCreateSessionOnBranch(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	// Create a branch to attach to.
+	cmd := exec.Command("git", "branch", "feature/add-auth")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("creating branch: %v\n%s", err, out)
+	}
+
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionOnBranchWithCommand("feature/add-auth", "main", cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Session name should be derived from branch.
+	if sess.Name != "add-auth" {
+		t.Errorf("expected session name 'add-auth', got %q", sess.Name)
+	}
+
+	// Agent should be created.
+	if ag == nil {
+		t.Fatal("agent should not be nil")
+	}
+
+	// Worktree should exist.
+	if _, err := os.Stat(sess.Worktree.Path); os.IsNotExist(err) {
+		t.Error("worktree should exist")
+	}
+
+	// Branch should be the one we specified.
+	if sess.Worktree.Branch != "feature/add-auth" {
+		t.Errorf("expected branch 'feature/add-auth', got %q", sess.Worktree.Branch)
+	}
+
+	// Base branch should be overridden to "main".
+	if sess.Worktree.BaseBranch != "main" {
+		t.Errorf("expected base branch 'main', got %q", sess.Worktree.BaseBranch)
+	}
+}
+
+func TestCreateSessionOnBranchPreservesBranch(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	// Create and switch to a branch.
+	for _, args := range [][]string{
+		{"git", "branch", "feature/keep-me"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionOnBranchWithCommand("feature/keep-me", "", cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessID := sess.ID
+
+	// Kill the session — should clean up worktree but NOT delete the branch.
+	if err := mgr.KillSession(sessID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Branch should still exist.
+	cmd := exec.Command("git", "branch", "--list", "feature/keep-me")
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git branch --list: %v", err)
+	}
+	if !strings.Contains(string(out), "feature/keep-me") {
+		t.Error("branch should be preserved after killing attached session")
+	}
+}
+
+func TestCreateSessionOwnsBranchDeletesOnCleanup(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	branch := sess.Worktree.Branch
+	sessID := sess.ID
+
+	if err := mgr.KillSession(sessID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Branch should be deleted (normal session owns its branch).
+	cmd := exec.Command("git", "branch", "--list", branch)
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git branch --list: %v", err)
+	}
+	if strings.Contains(string(out), branch) {
+		t.Errorf("branch %s should be deleted after killing session that owns it", branch)
+	}
+}
+
+func TestSlugifyBranchName(t *testing.T) {
+	tests := []struct {
+		branch   string
+		wantName string // expected name, or "" to indicate RandomName fallback
+	}{
+		{"feature/add-auth", "add-auth"},
+		{"bugfix/fix-login-issue", "fix-login-issue"},
+		{"main", "main"},
+		{"some/nested/deep/branch", "branch"},
+	}
+
+	for _, tt := range tests {
+		name := slugifyBranchName(tt.branch, nil)
+		if tt.wantName != "" && name != tt.wantName {
+			t.Errorf("slugifyBranchName(%q) = %q, want %q", tt.branch, name, tt.wantName)
+		}
+		if name == "" {
+			t.Errorf("slugifyBranchName(%q) returned empty string", tt.branch)
+		}
+	}
+}
+
+func TestSlugifyBranchNameCollisionFallback(t *testing.T) {
+	existing := []string{"add-auth"}
+	name := slugifyBranchName("feature/add-auth", existing)
+
+	// Should fall back to a random name due to collision.
+	if name == "add-auth" {
+		t.Error("expected fallback to random name on collision, got 'add-auth'")
+	}
+	if name == "" {
+		t.Error("name should not be empty")
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -342,6 +342,222 @@ func TestUpdateBaseBranch_NoRemote(t *testing.T) {
 	}
 }
 
+func TestAttachWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+
+	// Create a branch to attach to.
+	cmd := exec.Command("git", "branch", "feature-x")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git branch feature-x: %v\n%s", err, out)
+	}
+
+	wt, err := git.AttachWorktree(repo, "my-agent", "", "feature-x")
+	if err != nil {
+		t.Fatalf("AttachWorktree: %v", err)
+	}
+
+	// Worktree directory should exist.
+	if _, err := os.Stat(wt.Path); os.IsNotExist(err) {
+		t.Errorf("worktree path %s does not exist", wt.Path)
+	}
+
+	// Name should be the agent name we passed.
+	if wt.Name != "my-agent" {
+		t.Errorf("expected Name 'my-agent', got %q", wt.Name)
+	}
+
+	// Branch should be the actual branch name, not prefixed.
+	if wt.Branch != "feature-x" {
+		t.Errorf("expected Branch 'feature-x', got %q", wt.Branch)
+	}
+
+	// BaseBranch should be main (current HEAD of repo).
+	if wt.BaseBranch != "main" {
+		t.Errorf("expected BaseBranch 'main', got %q", wt.BaseBranch)
+	}
+
+	// The worktree should be on the correct branch.
+	cmd = exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = wt.Path
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD in worktree: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "feature-x" {
+		t.Errorf("worktree HEAD should be feature-x, got %q", strings.TrimSpace(string(out)))
+	}
+}
+
+func TestAttachWorktreeRemoteBranch(t *testing.T) {
+	work, bare := initTestRepoWithRemote(t)
+
+	// Create a branch on origin only via a second clone.
+	tmp := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "clone", bare, "."},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "config", "commit.gpgsign", "false"},
+		{"git", "checkout", "-b", "remote-feature"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = tmp
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup tmp %v failed: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "remote-feat.txt"), []byte("remote feature\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "add remote feature"},
+		{"git", "push", "origin", "remote-feature"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = tmp
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("push tmp %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	// Verify the local clone does NOT have this branch locally.
+	cmd := exec.Command("git", "rev-parse", "--verify", "remote-feature")
+	cmd.Dir = work
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected remote-feature to not exist locally before attach")
+	}
+
+	// AttachWorktree should auto-fetch and create the local tracking branch.
+	wt, err := git.AttachWorktree(work, "remote-agent", "", "remote-feature")
+	if err != nil {
+		t.Fatalf("AttachWorktree remote branch: %v", err)
+	}
+
+	// The worktree should contain the remote-only file.
+	if _, err := os.Stat(filepath.Join(wt.Path, "remote-feat.txt")); os.IsNotExist(err) {
+		t.Error("expected remote-feat.txt in worktree attached to remote branch")
+	}
+
+	if wt.Branch != "remote-feature" {
+		t.Errorf("expected Branch 'remote-feature', got %q", wt.Branch)
+	}
+}
+
+func TestAttachWorktreeNonexistent(t *testing.T) {
+	repo := initTestRepo(t)
+
+	_, err := git.AttachWorktree(repo, "bad-agent", "", "no-such-branch")
+	if err == nil {
+		t.Fatal("expected error attaching to nonexistent branch, got nil")
+	}
+}
+
+func TestListLocalBranches(t *testing.T) {
+	repo := initTestRepo(t)
+
+	// Create some extra branches.
+	for _, branch := range []string{"feature-a", "feature-b", "bugfix-1"} {
+		cmd := exec.Command("git", "branch", branch)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git branch %s: %v\n%s", branch, err, out)
+		}
+	}
+
+	branches, err := git.ListLocalBranches(repo)
+	if err != nil {
+		t.Fatalf("ListLocalBranches: %v", err)
+	}
+
+	expected := map[string]bool{"main": true, "feature-a": true, "feature-b": true, "bugfix-1": true}
+	got := make(map[string]bool)
+	for _, b := range branches {
+		got[b] = true
+	}
+
+	for name := range expected {
+		if !got[name] {
+			t.Errorf("expected branch %q in list, got %v", name, branches)
+		}
+	}
+
+	// Should not contain HEAD.
+	for _, b := range branches {
+		if b == "HEAD" {
+			t.Error("ListLocalBranches should not include HEAD")
+		}
+	}
+}
+
+func TestListRemoteBranches(t *testing.T) {
+	work, bare := initTestRepoWithRemote(t)
+
+	// Create and push additional branches via a second clone.
+	tmp := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "clone", bare, "."},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = tmp
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup tmp %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	for _, branch := range []string{"remote-a", "remote-b"} {
+		for _, args := range [][]string{
+			{"git", "checkout", "-b", branch},
+			{"git", "push", "origin", branch},
+			{"git", "checkout", "main"},
+		} {
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = tmp
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("push branch %s %v failed: %v\n%s", branch, args, err, out)
+			}
+		}
+	}
+
+	// Fetch in the working clone so it sees the remote branches.
+	cmd := exec.Command("git", "fetch", "origin")
+	cmd.Dir = work
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("fetch origin: %v\n%s", err, out)
+	}
+
+	branches, err := git.ListRemoteBranches(work)
+	if err != nil {
+		t.Fatalf("ListRemoteBranches: %v", err)
+	}
+
+	got := make(map[string]bool)
+	for _, b := range branches {
+		got[b] = true
+	}
+
+	// Should have main, remote-a, remote-b (all without origin/ prefix).
+	for _, name := range []string{"main", "remote-a", "remote-b"} {
+		if !got[name] {
+			t.Errorf("expected branch %q in remote list, got %v", name, branches)
+		}
+	}
+
+	// Should NOT have HEAD or any origin/ prefix.
+	for _, b := range branches {
+		if b == "HEAD" {
+			t.Error("ListRemoteBranches should not include HEAD")
+		}
+		if strings.HasPrefix(b, "origin/") {
+			t.Errorf("ListRemoteBranches should strip origin/ prefix, got %q", b)
+		}
+	}
+}
+
 func TestCreateWorktreeWithStartPoint(t *testing.T) {
 	work, bare := initTestRepoWithRemote(t)
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -111,6 +111,95 @@ func CreateWorktree(repoPath, agentName, branchPrefix, worktreeDir string, start
 	}, nil
 }
 
+// AttachWorktree creates a new git worktree that checks out an existing branch.
+// Unlike CreateWorktree, it does NOT create a new branch (no -b flag).
+// For remote-only branches, it fetches from origin first so git can
+// auto-create the local tracking branch.
+// worktreeDir defaults to ".baton/worktrees" if empty.
+func AttachWorktree(repoPath, name, worktreeDir, branch string) (*WorktreeInfo, error) {
+	if worktreeDir == "" {
+		worktreeDir = ".baton/worktrees"
+	}
+
+	// Check if the branch exists locally.
+	_, localErr := runGit(repoPath, "rev-parse", "--verify", branch)
+
+	if localErr != nil {
+		// Local branch doesn't exist — try fetching from origin.
+		// This handles the case where the remote knows about the branch
+		// but we haven't fetched it yet.
+		if _, err := runGit(repoPath, "fetch", "origin", branch); err != nil {
+			// Fetch failed — branch doesn't exist on origin either.
+			return nil, fmt.Errorf("branch %q not found locally or on origin", branch)
+		}
+	}
+
+	base, err := BaseBranch(repoPath)
+	if err != nil {
+		return nil, fmt.Errorf("getting base branch: %w", err)
+	}
+
+	wtPath := filepath.Join(repoPath, worktreeDir, name)
+
+	if _, err := runGit(repoPath, "worktree", "add", wtPath, branch); err != nil {
+		return nil, fmt.Errorf("attaching worktree: %w", err)
+	}
+
+	absPath, err := filepath.Abs(wtPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &WorktreeInfo{
+		Name:       name,
+		Path:       absPath,
+		Branch:     branch,
+		BaseBranch: base,
+	}, nil
+}
+
+// ListLocalBranches returns the names of all local branches in the repo.
+func ListLocalBranches(repoPath string) ([]string, error) {
+	out, err := runGit(repoPath, "branch", "--format", "%(refname:short)")
+	if err != nil {
+		return nil, fmt.Errorf("listing local branches: %w", err)
+	}
+
+	var branches []string
+	for _, line := range strings.Split(out, "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || name == "HEAD" {
+			continue
+		}
+		branches = append(branches, name)
+	}
+	return branches, nil
+}
+
+// ListRemoteBranches returns the names of all remote branches, with the
+// "origin/" prefix stripped and HEAD entries filtered out.
+func ListRemoteBranches(repoPath string) ([]string, error) {
+	out, err := runGit(repoPath, "branch", "-r", "--format", "%(refname:short)")
+	if err != nil {
+		return nil, fmt.Errorf("listing remote branches: %w", err)
+	}
+
+	var branches []string
+	for _, line := range strings.Split(out, "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		// Strip origin/ prefix.
+		short := strings.TrimPrefix(name, "origin/")
+		if short == "HEAD" {
+			continue
+		}
+		branches = append(branches, short)
+	}
+	return branches, nil
+}
+
 // RemoveWorktree removes a worktree and optionally deletes its branch.
 func RemoveWorktree(repoPath string, wt *WorktreeInfo, deleteBranch bool) error {
 	if _, err := runGit(repoPath, "worktree", "remove", "--force", wt.Path); err != nil {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -45,7 +45,7 @@ func (c *Client) GetPR(ctx context.Context, owner, repo, branch string) (*PRStat
 	return prToState(prs[0]), nil
 }
 
-// ListPRs returns all open pull requests for the given repository.
+// ListPRs returns open pull requests for the given repository (up to 100).
 func (c *Client) ListPRs(ctx context.Context, owner, repo string) ([]*PRState, error) {
 	prs, _, err := c.gh.PullRequests.List(ctx, owner, repo, &gh.PullRequestListOptions{
 		State: "open",

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -45,6 +45,25 @@ func (c *Client) GetPR(ctx context.Context, owner, repo, branch string) (*PRStat
 	return prToState(prs[0]), nil
 }
 
+// ListPRs returns all open pull requests for the given repository.
+func (c *Client) ListPRs(ctx context.Context, owner, repo string) ([]*PRState, error) {
+	prs, _, err := c.gh.PullRequests.List(ctx, owner, repo, &gh.PullRequestListOptions{
+		State: "open",
+		ListOptions: gh.ListOptions{
+			PerPage: 100,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing PRs: %w", err)
+	}
+
+	states := make([]*PRState, len(prs))
+	for i, pr := range prs {
+		states[i] = prToState(pr)
+	}
+	return states, nil
+}
+
 // CreatePR creates a new pull request and returns its state.
 func (c *Client) CreatePR(ctx context.Context, owner, repo, head, base, title, body string) (*PRState, error) {
 	pr, _, err := c.gh.PullRequests.Create(ctx, owner, repo, &gh.NewPullRequest{
@@ -152,11 +171,13 @@ func prToState(pr *gh.PullRequest) *PRState {
 	}
 
 	return &PRState{
-		Number:    pr.GetNumber(),
-		Title:     pr.GetTitle(),
-		URL:       pr.GetHTMLURL(),
-		State:     state,
-		Mergeable: mergeable,
-		Draft:     pr.GetDraft(),
+		Number:     pr.GetNumber(),
+		Title:      pr.GetTitle(),
+		URL:        pr.GetHTMLURL(),
+		State:      state,
+		Mergeable:  mergeable,
+		Draft:      pr.GetDraft(),
+		HeadBranch: pr.GetHead().GetRef(),
+		BaseBranch: pr.GetBase().GetRef(),
 	}
 }

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -2,12 +2,14 @@ package github
 
 // PRState holds the state of a GitHub pull request.
 type PRState struct {
-	Number    int
-	Title     string
-	URL       string
-	State     string // "open", "closed", "merged"
-	Mergeable bool
-	Draft     bool
+	Number     int
+	Title      string
+	URL        string
+	State      string // "open", "closed", "merged"
+	Mergeable  bool
+	Draft      bool
+	HeadBranch string // branch the PR is from
+	BaseBranch string // branch the PR targets
 }
 
 // CheckStatus holds the combined check/CI status for a git ref.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -23,6 +23,7 @@ type SessionState struct {
 	WorktreePath string       `json:"worktreePath"`
 	Branch       string       `json:"branch"`
 	BaseBranch   string       `json:"baseBranch"`
+	OwnsBranch   bool         `json:"ownsBranch"`
 	Agents       []AgentState `json:"agents"`
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -68,7 +68,8 @@ type App struct {
 	managers   map[string]*agent.Manager
 	activeRepo string
 	cfg        *config.Config
-	repoBrowser fileBrowserModel
+	repoBrowser   fileBrowserModel
+	branchPicker  branchPickerModel
 
 	// Settings
 	globalSettings *config.GlobalSettings
@@ -166,6 +167,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.diff.height = msg.Height - 1
 		a.repoBrowser.width = msg.Width
 		a.repoBrowser.height = msg.Height - 1
+		a.branchPicker.width = msg.Width
+		a.branchPicker.height = msg.Height - 1
 
 		// Resize agent terminals to match their current display container.
 		if a.view == ViewDashboard {
@@ -415,6 +418,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.updateFileBrowser(msg)
 	case ViewGlobalConfig:
 		return a.updateGlobalConfig(msg)
+	case ViewBranchPicker:
+		return a.updateBranchPicker(msg)
 	}
 
 	return a, nil
@@ -627,6 +632,31 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.repoBrowser.height = a.height - 1
 			a.view = ViewFileBrowser
 			return a, nil
+
+		case "o":
+			// Open branch picker to create session on existing branch/PR.
+			repoPath := a.dashboard.selectedRepoPath()
+			if repoPath == "" {
+				repoPath = a.activeRepo
+			}
+			if repoPath == "" {
+				a.setError("No repo available")
+				return a, nil
+			}
+			// Build set of branches that already have active sessions.
+			mgr := a.managers[repoPath]
+			activeBranches := make(map[string]bool)
+			if mgr != nil {
+				for _, sess := range mgr.ListSessions() {
+					activeBranches[sess.Worktree.Branch] = true
+				}
+			}
+			a.branchPicker = newBranchPickerModel()
+			a.branchPicker.width = a.width
+			a.branchPicker.height = a.height - 1
+			a.activeRepo = repoPath
+			a.view = ViewBranchPicker
+			return a, loadBranchPickerData(repoPath, a.ghClient, activeBranches)
 
 		case "t":
 			// Open or focus a shell terminal in the selected session.
@@ -1012,6 +1042,54 @@ func (a App) updateFileBrowser(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return a, cmd
 }
 
+func (a App) updateBranchPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case branchPickerSelectMsg:
+		a.view = ViewDashboard
+		item := msg.item
+
+		repoPath := a.activeRepo
+		mgr := a.managers[repoPath]
+		if mgr == nil {
+			a.setError("No manager for repo")
+			return a, nil
+		}
+
+		previewW := a.dashboard.previewTermWidth()
+		previewH := a.dashboard.previewTermHeight()
+		if previewW <= 0 || previewH <= 0 {
+			a.setError("Terminal size not yet known; try again")
+			return a, nil
+		}
+
+		resolved := a.resolvedCache[repoPath]
+		cfg := agent.Config{
+			Rows:              previewH,
+			Cols:              previewW,
+			BypassPermissions: resolved.BypassPermissions,
+			AgentProgram:      resolved.AgentProgram,
+		}
+
+		branch := item.branch
+		baseBranch := item.baseBranch
+		return a, func() tea.Msg {
+			sess, ag, err := mgr.CreateSessionOnBranch(branch, baseBranch, cfg)
+			if err != nil {
+				return createResultMsg{err: err}
+			}
+			return createResultMsg{sessionID: sess.ID, agentID: ag.ID}
+		}
+
+	case branchPickerCancelMsg:
+		a.view = ViewDashboard
+		return a, nil
+	}
+
+	var cmd tea.Cmd
+	a.branchPicker, cmd = a.branchPicker.Update(msg)
+	return a, cmd
+}
+
 func (a App) updateDiff(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg.(type) {
 	case diffCloseMsg:
@@ -1342,6 +1420,10 @@ func (a App) View() tea.View {
 		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)
 	case ViewGlobalConfig:
 		content = a.globalConfig.View()
+	case ViewBranchPicker:
+		body := a.branchPicker.View()
+		statusbar := renderStatusBar(branchPickerHints, a.width)
+		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)
 	}
 
 	// Show quit confirmation.

--- a/internal/tui/branchpicker.go
+++ b/internal/tui/branchpicker.go
@@ -1,0 +1,387 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/devenjarvis/baton/internal/git"
+	"github.com/devenjarvis/baton/internal/github"
+)
+
+// branchPickerItem represents a single entry in the branch picker.
+type branchPickerItem struct {
+	kind       string // "pr", "local", "remote"
+	branch     string
+	baseBranch string // only for PRs
+	prNumber   int    // only for PRs
+	prTitle    string // only for PRs
+}
+
+// branchPickerDataMsg carries the async-loaded picker data.
+type branchPickerDataMsg struct {
+	prs      []branchPickerItem
+	local    []branchPickerItem
+	remote   []branchPickerItem
+	err      error
+}
+
+// branchPickerSelectMsg is emitted when the user picks an item.
+type branchPickerSelectMsg struct {
+	item branchPickerItem
+}
+
+// branchPickerCancelMsg is emitted when the user cancels.
+type branchPickerCancelMsg struct{}
+
+// branchPickerModel is a sub-component for selecting a branch or PR to open.
+type branchPickerModel struct {
+	items    []branchPickerItem
+	filtered []int // indices into items
+	selected int   // index into filtered
+	filter   string
+	loading  bool
+	loadErr  string
+
+	width  int
+	height int
+}
+
+// newBranchPickerModel creates a new branch picker in loading state.
+func newBranchPickerModel() branchPickerModel {
+	return branchPickerModel{
+		loading: true,
+	}
+}
+
+// loadBranchPickerData returns a tea.Cmd that loads PRs and branches concurrently.
+func loadBranchPickerData(repoPath string, ghClient *github.Client, activeBranches map[string]bool) tea.Cmd {
+	return func() tea.Msg {
+		// Detect the repo's current HEAD branch (e.g. "main") to exclude it from the list.
+		headBranch, _ := git.BaseBranch(repoPath)
+		var prs []branchPickerItem
+		var local []branchPickerItem
+		var remote []branchPickerItem
+		var prErr error
+
+		// Load PRs if GitHub client is available.
+		if ghClient != nil {
+			rawURL, err := git.GetRemoteURL(repoPath)
+			if err == nil {
+				owner, repo, err := github.ParseRemoteURL(rawURL)
+				if err == nil {
+					ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+					defer cancel()
+					prList, err := ghClient.ListPRs(ctx, owner, repo)
+					if err != nil {
+						prErr = err
+					} else {
+						for _, pr := range prList {
+							if activeBranches[pr.HeadBranch] {
+								continue
+							}
+							prs = append(prs, branchPickerItem{
+								kind:       "pr",
+								branch:     pr.HeadBranch,
+								baseBranch: pr.BaseBranch,
+								prNumber:   pr.Number,
+								prTitle:    pr.Title,
+							})
+						}
+					}
+				}
+			}
+		}
+
+		// Load local branches.
+		localBranches, err := git.ListLocalBranches(repoPath)
+		if err == nil {
+			for _, b := range localBranches {
+				if activeBranches[b] || b == headBranch {
+					continue
+				}
+				local = append(local, branchPickerItem{
+					kind:   "local",
+					branch: b,
+				})
+			}
+		}
+
+		// Load remote branches.
+		remoteBranches, err := git.ListRemoteBranches(repoPath)
+		if err == nil {
+			for _, b := range remoteBranches {
+				if activeBranches[b] || b == headBranch {
+					continue
+				}
+				// Skip remote branches that are also local (avoid duplicates).
+				isLocal := false
+				for _, lb := range localBranches {
+					if lb == b {
+						isLocal = true
+						break
+					}
+				}
+				// Also skip branches that appear as PR head branches.
+				isPR := false
+				for _, pr := range prs {
+					if pr.branch == b {
+						isPR = true
+						break
+					}
+				}
+				if !isLocal && !isPR {
+					remote = append(remote, branchPickerItem{
+						kind:   "remote",
+						branch: b,
+					})
+				}
+			}
+		}
+
+		// If PR loading failed but we got branches, just return what we have.
+		if len(local) == 0 && len(remote) == 0 && prErr != nil {
+			return branchPickerDataMsg{err: prErr}
+		}
+
+		return branchPickerDataMsg{
+			prs:    prs,
+			local:  local,
+			remote: remote,
+		}
+	}
+}
+
+// Update handles key events for the branch picker.
+func (m branchPickerModel) Update(msg tea.Msg) (branchPickerModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case branchPickerDataMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.loadErr = msg.err.Error()
+			return m, nil
+		}
+		// Combine items: PRs first, then local, then remote.
+		m.items = nil
+		m.items = append(m.items, msg.prs...)
+		m.items = append(m.items, msg.local...)
+		m.items = append(m.items, msg.remote...)
+		m.applyFilter()
+		return m, nil
+
+	case tea.KeyPressMsg:
+		key := msg.String()
+		switch key {
+		case "esc":
+			return m, func() tea.Msg { return branchPickerCancelMsg{} }
+		case "up", "k":
+			if m.selected > 0 {
+				m.selected--
+			}
+		case "down", "j":
+			if m.selected < len(m.filtered)-1 {
+				m.selected++
+			}
+		case "enter":
+			if len(m.filtered) > 0 && m.selected < len(m.filtered) {
+				item := m.items[m.filtered[m.selected]]
+				return m, func() tea.Msg { return branchPickerSelectMsg{item: item} }
+			}
+		case "backspace":
+			if len(m.filter) > 0 {
+				m.filter = m.filter[:len(m.filter)-1]
+				m.applyFilter()
+			}
+		default:
+			// Single printable character → add to filter.
+			if len(key) == 1 && key[0] >= ' ' && key[0] <= '~' {
+				m.filter += key
+				m.applyFilter()
+			}
+		}
+	}
+	return m, nil
+}
+
+// applyFilter updates the filtered indices based on the current filter string.
+func (m *branchPickerModel) applyFilter() {
+	m.filtered = nil
+	lower := strings.ToLower(m.filter)
+	for i, item := range m.items {
+		if lower == "" {
+			m.filtered = append(m.filtered, i)
+			continue
+		}
+		if strings.Contains(strings.ToLower(item.branch), lower) {
+			m.filtered = append(m.filtered, i)
+			continue
+		}
+		if item.prTitle != "" && strings.Contains(strings.ToLower(item.prTitle), lower) {
+			m.filtered = append(m.filtered, i)
+		}
+	}
+	if m.selected >= len(m.filtered) {
+		m.selected = max(0, len(m.filtered)-1)
+	}
+}
+
+// View renders the branch picker as a two-panel overlay.
+func (m branchPickerModel) View() string {
+	leftWidth := m.width / 3
+	if leftWidth < 25 {
+		leftWidth = 25
+	}
+	rightWidth := m.width - leftWidth - 1
+	if rightWidth < 0 {
+		rightWidth = 0
+	}
+
+	left := m.renderList(leftWidth)
+	right := m.renderDetails(rightWidth)
+
+	leftStyle := lipgloss.NewStyle().
+		Width(leftWidth).
+		Height(m.height).
+		Border(lipgloss.NormalBorder(), false, true, false, false).
+		BorderForeground(ColorMuted)
+
+	rightStyle := lipgloss.NewStyle().
+		Width(rightWidth).
+		Height(m.height)
+
+	return lipgloss.JoinHorizontal(lipgloss.Top,
+		leftStyle.Render(left),
+		rightStyle.Render(right),
+	)
+}
+
+// renderList renders the left panel with the grouped branch list.
+func (m branchPickerModel) renderList(width int) string {
+	title := StyleTitle.Render("OPEN BRANCH")
+	sepWidth := width - 2
+	if sepWidth < 0 {
+		sepWidth = 0
+	}
+	separator := StyleSubtle.Render(strings.Repeat("─", sepWidth))
+
+	var lines []string
+	lines = append(lines, title, separator)
+
+	// Filter indicator.
+	if m.filter != "" {
+		lines = append(lines, StyleSubtle.Render("filter: ")+m.filter)
+	}
+	lines = append(lines, "")
+
+	if m.loading {
+		lines = append(lines, StyleSubtle.Render("  Loading..."))
+		return strings.Join(lines, "\n")
+	}
+
+	if m.loadErr != "" {
+		lines = append(lines, StyleWarning.Render("  Error: "+m.loadErr))
+		return strings.Join(lines, "\n")
+	}
+
+	if len(m.filtered) == 0 {
+		if m.filter != "" {
+			lines = append(lines, StyleSubtle.Render("  No matches"))
+		} else {
+			lines = append(lines, StyleSubtle.Render("  No branches available"))
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	// Group items by kind for display.
+	lastKind := ""
+	for fi, idx := range m.filtered {
+		item := m.items[idx]
+
+		// Section headers.
+		if item.kind != lastKind {
+			if lastKind != "" {
+				lines = append(lines, "")
+			}
+			switch item.kind {
+			case "pr":
+				lines = append(lines, StyleTitle.Render("Pull Requests"))
+			case "local":
+				lines = append(lines, StyleTitle.Render("Local Branches"))
+			case "remote":
+				lines = append(lines, StyleTitle.Render("Remote Branches"))
+			}
+			lastKind = item.kind
+		}
+
+		prefix := "  "
+		if fi == m.selected {
+			prefix = StyleActive.Render("▸ ")
+		}
+
+		label := item.branch
+		if item.kind == "pr" {
+			label = fmt.Sprintf("#%d %s", item.prNumber, item.branch)
+		}
+		maxLen := width - 4
+		if len(label) > maxLen && maxLen > 3 {
+			label = label[:maxLen-1] + "…"
+		}
+		lines = append(lines, prefix+label)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderDetails renders the right panel with details about the selected item.
+func (m branchPickerModel) renderDetails(width int) string {
+	title := StyleTitle.Render("DETAILS")
+	sepWidth := width - 1
+	if sepWidth < 0 {
+		sepWidth = 0
+	}
+	separator := StyleSubtle.Render(strings.Repeat("─", sepWidth))
+
+	var lines []string
+	lines = append(lines, title, separator)
+
+	if m.loading {
+		lines = append(lines, "", StyleSubtle.Render("Loading branch data..."))
+		return strings.Join(lines, "\n")
+	}
+
+	if len(m.filtered) == 0 || m.selected >= len(m.filtered) {
+		lines = append(lines, "", StyleSubtle.Render("No item selected"))
+		return strings.Join(lines, "\n")
+	}
+
+	item := m.items[m.filtered[m.selected]]
+	lines = append(lines, "")
+
+	switch item.kind {
+	case "pr":
+		lines = append(lines, StyleTitle.Render(fmt.Sprintf("PR #%d", item.prNumber)))
+		lines = append(lines, "")
+		lines = append(lines, StyleSubtle.Render("Title: ")+item.prTitle)
+		lines = append(lines, StyleSubtle.Render("Branch: ")+item.branch)
+		lines = append(lines, StyleSubtle.Render("Base: ")+item.baseBranch)
+		lines = append(lines, "")
+		lines = append(lines, StyleSubtle.Render("Press enter to open session on this PR's branch"))
+	case "local":
+		lines = append(lines, StyleTitle.Render(item.branch))
+		lines = append(lines, "")
+		lines = append(lines, StyleSuccess.Render("local branch"))
+		lines = append(lines, "")
+		lines = append(lines, StyleSubtle.Render("Press enter to open session on this branch"))
+	case "remote":
+		lines = append(lines, StyleTitle.Render(item.branch))
+		lines = append(lines, "")
+		lines = append(lines, StyleSubtle.Render("remote branch (will be fetched)"))
+		lines = append(lines, "")
+		lines = append(lines, StyleSubtle.Render("Press enter to open session on this branch"))
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -4,11 +4,12 @@ package tui
 type ViewMode int
 
 const (
-	ViewDashboard    ViewMode = iota
+	ViewDashboard     ViewMode = iota
 	ViewDiff
-	ViewMerge        // overlay
-	ViewFileBrowser  // overlay: browse filesystem to add a repo
-	ViewGlobalConfig // overlay: edit global settings
+	ViewMerge         // overlay
+	ViewFileBrowser   // overlay: browse filesystem to add a repo
+	ViewGlobalConfig  // overlay: edit global settings
+	ViewBranchPicker  // overlay: pick branch/PR to open session on
 )
 
 // panelFocus tracks which dashboard panel has keyboard focus.

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -20,6 +20,7 @@ var (
 		{"t", "shell"},
 		{"s", "settings"},
 		{"a", "add repo"},
+		{"o", "open branch"},
 		{"d", "diff/remove"},
 		{"x", "kill agent"},
 		{"X", "kill session"},
@@ -72,6 +73,14 @@ var (
 		{"enter", "edit/toggle"},
 		{"ctrl+s", "save"},
 		{"esc", "back"},
+	}
+
+	branchPickerHints = []keyHint{
+		{"j/k", "navigate"},
+		{"enter", "select"},
+		{"type", "filter"},
+		{"backspace", "clear filter"},
+		{"esc", "cancel"},
 	}
 )
 


### PR DESCRIPTION
## Summary

- Add ability to open a baton session on an existing branch or PR via the `o` key in the dashboard
- New branch picker overlay shows open PRs, local branches, and remote branches with substring filtering
- Sessions on existing branches preserve the branch on cleanup (vs. sessions that create their own branches which delete on cleanup)
- Git layer: `AttachWorktree`, `ListLocalBranches`, `ListRemoteBranches`
- GitHub layer: `ListPRs`, `HeadBranch`/`BaseBranch` fields on `PRState`
- Agent layer: `CreateSessionOnBranch`, `ownsBranch` flag persisted through detach/resume
- 13 files changed, ~1,170 insertions

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` no warnings
- [x] `go test -race ./...` all tests pass
- [ ] Manual: launch baton on a repo with open PRs, press `o`, verify picker shows PRs/local/remote branches
- [ ] Manual: type to filter, verify list narrows
- [ ] Manual: select a PR, verify session created on PR's branch with correct base
- [ ] Manual: kill the session, verify worktree removed but branch preserved
- [ ] Manual: detach with open-branch session, relaunch, verify session resumes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)