### PR TITLE
fix: eliminate scroll jank on agent focus switch

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -240,12 +240,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				continue
 			}
 			resolved := a.resolvedCache[repo.Path]
+			fixedW := a.dashboard.fixedTermWidth()
+			fixedH := a.dashboard.fixedTermHeight()
+			if fixedW <= 0 {
+				fixedW = 80
+			}
+			if fixedH <= 0 {
+				fixedH = 24
+			}
 			resumeItems = append(resumeItems, resumeItem{
 				repoPath: repo.Path,
 				mgr:      mgr,
 				resumeCfg: agent.Config{
-					Rows:              24,
-					Cols:              80,
+					Rows:              fixedH,
+					Cols:              fixedW,
 					BypassPermissions: resolved.BypassPermissions,
 					AgentProgram:      resolved.AgentProgram,
 				},
@@ -600,9 +608,9 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			}
 			a.activeRepo = repoPath
-			previewW := a.dashboard.previewTermWidth()
-			previewH := a.dashboard.previewTermHeight()
-			if previewW <= 0 || previewH <= 0 {
+			fixedW := a.dashboard.fixedTermWidth()
+			fixedH := a.dashboard.fixedTermHeight()
+			if fixedW <= 0 || fixedH <= 0 {
 				a.setError("Terminal size not yet known; try again")
 				return a, nil
 			}
@@ -612,8 +620,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			}
 			cfg := agent.Config{
-				Rows:              previewH,
-				Cols:              previewW,
+				Rows:              fixedH,
+				Cols:              fixedW,
 				BypassPermissions: resolved.BypassPermissions,
 				AgentProgram:      resolved.AgentProgram,
 			}
@@ -640,16 +648,16 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if mgr == nil {
 				return a, nil
 			}
-			previewW := a.dashboard.previewTermWidth()
-			previewH := a.dashboard.previewTermHeight()
-			if previewW <= 0 || previewH <= 0 {
+			fixedW := a.dashboard.fixedTermWidth()
+			fixedH := a.dashboard.fixedTermHeight()
+			if fixedW <= 0 || fixedH <= 0 {
 				a.setError("Terminal size not yet known; try again")
 				return a, nil
 			}
 			resolved := a.resolvedCache[repoPath]
 			cfg := agent.Config{
-				Rows:              previewH,
-				Cols:              previewW,
+				Rows:              fixedH,
+				Cols:              fixedW,
 				BypassPermissions: resolved.BypassPermissions,
 				AgentProgram:      resolved.AgentProgram,
 			}
@@ -708,7 +716,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if item.kind == listItemAgent && item.agent != nil && item.agent.IsShell && item.session == sess {
 						a.dashboard.selected = i
 						a.dashboard.panelFocus = focusTerminal
-						a.resizeSelectedForDashboard()
 						break
 					}
 				}
@@ -722,15 +729,15 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if mgr == nil {
 				return a, nil
 			}
-			previewW := a.dashboard.previewTermWidth()
-			previewH := a.dashboard.previewTermHeight()
-			if previewW <= 0 || previewH <= 0 {
+			fixedW := a.dashboard.fixedTermWidth()
+			fixedH := a.dashboard.fixedTermHeight()
+			if fixedW <= 0 || fixedH <= 0 {
 				a.setError("Terminal size not yet known; try again")
 				return a, nil
 			}
 			cfg := agent.Config{
-				Rows: previewH,
-				Cols: previewW,
+				Rows: fixedH,
+				Cols: fixedW,
 			}
 			sessionID := sess.ID
 			return a, func() tea.Msg {
@@ -1007,14 +1014,12 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.dashboard.clampToAgent()
 					a.dashboard.panelFocus = focusList
 					a.dashboard.scrollOffset = 0
-					a.resizeSelectedForDashboard()
 				}
 			} else if msg.X >= 32 {
 				// Preview panel click — enter focusTerminal if an agent is selected.
 				// X==31 is the list panel's right border and is intentionally ignored.
 				if a.dashboard.panelFocus == focusList && a.dashboard.selectedAgent() != nil {
 					a.dashboard.panelFocus = focusTerminal
-					a.resizeSelectedForDashboard()
 				}
 			}
 		}
@@ -1044,12 +1049,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	prevSelected := a.dashboard.selected
-	prevPanelFocus := a.dashboard.panelFocus
 	var cmd tea.Cmd
 	a.dashboard, cmd = a.dashboard.Update(msg)
-	if a.dashboard.selected != prevSelected || a.dashboard.panelFocus != prevPanelFocus {
-		a.resizeSelectedForDashboard()
-	}
 	// On selection change, update diff stats from cache (or trigger refresh).
 	if a.dashboard.selected != prevSelected {
 		a.updateDashboardDiffStats()
@@ -1092,17 +1093,17 @@ func (a App) updateBranchPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
-		previewW := a.dashboard.previewTermWidth()
-		previewH := a.dashboard.previewTermHeight()
-		if previewW <= 0 || previewH <= 0 {
+		fixedW := a.dashboard.fixedTermWidth()
+		fixedH := a.dashboard.fixedTermHeight()
+		if fixedW <= 0 || fixedH <= 0 {
 			a.setError("Terminal size not yet known; try again")
 			return a, nil
 		}
 
 		resolved := a.resolvedCache[repoPath]
 		cfg := agent.Config{
-			Rows:              previewH,
-			Cols:              previewW,
+			Rows:              fixedH,
+			Cols:              fixedW,
 			BypassPermissions: resolved.BypassPermissions,
 			AgentProgram:      resolved.AgentProgram,
 		}
@@ -1317,8 +1318,8 @@ func (a *App) resizeSelectedForDashboard() {
 	if ag == nil {
 		return
 	}
-	w := a.dashboard.previewTermWidth()
-	h := a.dashboard.previewTermHeight()
+	w := a.dashboard.fixedTermWidth()
+	h := a.dashboard.fixedTermHeight()
 	if w > 0 && h > 0 {
 		ag.Resize(h, w)
 	}
@@ -1327,8 +1328,8 @@ func (a *App) resizeSelectedForDashboard() {
 // resizeAllForDashboard resizes every agent to the dashboard preview dimensions.
 // Called on WindowSizeMsg so all agents match the new terminal size.
 func (a *App) resizeAllForDashboard() {
-	w := a.dashboard.previewTermWidth()
-	h := a.dashboard.previewTermHeight()
+	w := a.dashboard.fixedTermWidth()
+	h := a.dashboard.fixedTermHeight()
 	if w <= 0 || h <= 0 {
 		return
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -206,6 +206,23 @@ func (d dashboardModel) contentHeight() int {
 	return d.height - 2 // statusbar + title
 }
 
+// fixedTermWidth returns the terminal column count that all agents should use.
+// This is always the focusTerminal width (deducting the border) regardless of
+// the current panelFocus, so that focus switches never trigger a resize.
+func (d dashboardModel) fixedTermWidth() int {
+	listWidth := 30
+	return d.width - listWidth - 1 - 2 // list border + focusTerminal border
+}
+
+// fixedTermHeight returns the terminal row count that all agents should use.
+// This is always the focusTerminal height (deducting the border) regardless of
+// the current panelFocus. It intentionally does NOT deduct the PR line —
+// accepting 1 row of clipping when PR is visible is better than per-session
+// resize churn.
+func (d dashboardModel) fixedTermHeight() int {
+	return d.contentHeight() - 4 - 2 // metadata rows + focusTerminal border
+}
+
 // previewTermWidth returns the terminal column count for the preview panel.
 func (d dashboardModel) previewTermWidth() int {
 	listWidth := 30


### PR DESCRIPTION
## Summary
- Add `fixedTermWidth()`/`fixedTermHeight()` helpers that always return focusTerminal dimensions regardless of current panel focus state
- Use fixed dimensions for all agent creation (new session, add agent, shell, branch picker, resume) and resize paths
- Remove `resizeSelectedForDashboard()` calls from focus/selection switch paths (j/k, enter, mouse clicks) since agents are already at correct size
- Retain resize calls only for new agent splash-clear and delayed SIGWINCH

## Test plan
- [x] `go build -o baton .` compiles cleanly
- [x] `go test -race ./...` passes (pre-existing `TestLoad_MigratesFromLegacyXDGPath` failure unrelated)
- [x] `go vet ./...` clean
- [ ] Manual: create 2+ sessions, switch between agents with j/k and enter/ctrl+e — no visible scroll artifact
- [ ] Manual: resize terminal window — all agents render correctly
- [ ] Manual: create new agent — splash clear + delayed resize still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)