### PR TITLE
feat: real-time GitHub PR and check status

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	gh "github.com/google/go-github/v69/github"
 )
@@ -119,6 +120,21 @@ func (c *Client) GetChecks(ctx context.Context, owner, repo, ref string) (*Check
 				DetailsURL: run.GetDetailsURL(),
 			})
 		}
+
+		cr := CheckRun{
+			Name:       run.GetName(),
+			Status:     run.GetStatus(),
+			Conclusion: conclusion,
+		}
+		if run.StartedAt != nil {
+			cr.StartedAt = run.StartedAt.Time
+			if run.CompletedAt != nil {
+				cr.Duration = run.CompletedAt.Sub(run.StartedAt.Time)
+			} else {
+				cr.Duration = time.Since(run.StartedAt.Time)
+			}
+		}
+		status.Runs = append(status.Runs, cr)
 	}
 
 	switch {
@@ -156,6 +172,60 @@ func (c *Client) GetFailedCheckLogs(ctx context.Context, owner, repo string, che
 		)
 	}
 	return b.String(), nil
+}
+
+// GetReviews returns the aggregated review status for a pull request.
+// It deduplicates by user, keeping only the latest review per reviewer.
+func (c *Client) GetReviews(ctx context.Context, owner, repo string, number int) (*ReviewStatus, error) {
+	var allReviews []*gh.PullRequestReview
+	opts := &gh.ListOptions{PerPage: 100}
+	for {
+		reviews, resp, err := c.gh.PullRequests.ListReviews(ctx, owner, repo, number, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing reviews: %w", err)
+		}
+		allReviews = append(allReviews, reviews...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	// Deduplicate: latest review per user wins.
+	latestByUser := make(map[int64]*gh.PullRequestReview)
+	for _, r := range allReviews {
+		uid := r.GetUser().GetID()
+		// COMMENTED state means review was started but not submitted — skip.
+		if r.GetState() == "COMMENTED" {
+			continue
+		}
+		if existing, ok := latestByUser[uid]; !ok || r.GetSubmittedAt().After(existing.GetSubmittedAt().Time) {
+			latestByUser[uid] = r
+		}
+	}
+
+	status := &ReviewStatus{}
+	for _, r := range latestByUser {
+		switch r.GetState() {
+		case "APPROVED":
+			status.Approved++
+		case "CHANGES_REQUESTED":
+			status.ChangesRequested++
+		default:
+			status.Pending++
+		}
+	}
+
+	switch {
+	case status.ChangesRequested > 0:
+		status.State = "changes_requested"
+	case status.Approved > 0 && status.Pending == 0:
+		status.State = "approved"
+	default:
+		status.State = "pending"
+	}
+
+	return status, nil
 }
 
 // prToState converts a GitHub API PullRequest to our PRState type.

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -1,5 +1,7 @@
 package github
 
+import "time"
+
 // PRState holds the state of a GitHub pull request.
 type PRState struct {
 	Number     int
@@ -20,6 +22,16 @@ type CheckStatus struct {
 	Failed       int
 	Pending      int
 	FailedChecks []FailedCheck
+	Runs         []CheckRun
+}
+
+// CheckRun holds details about a single check run.
+type CheckRun struct {
+	Name       string
+	Status     string // "queued", "in_progress", "completed"
+	Conclusion string // "success", "failure", "cancelled", "skipped", etc.
+	StartedAt  time.Time
+	Duration   time.Duration
 }
 
 // FailedCheck holds details about a single failed check run.
@@ -28,4 +40,12 @@ type FailedCheck struct {
 	Name       string
 	Conclusion string
 	DetailsURL string
+}
+
+// ReviewStatus holds the aggregated review status for a PR.
+type ReviewStatus struct {
+	State            string // "approved", "changes_requested", "pending"
+	Approved         int
+	Pending          int
+	ChangesRequested int
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -100,10 +100,10 @@ type App struct {
 	diffStatsCache      map[string]*diffStatsEntry // keyed by session ID
 	diffRefreshInFlight bool
 
-	ghClient       *github.Client
-	prCache        map[string]*prCacheEntry // keyed by session ID
-	prPollInFlight bool
-	prLastPoll     time.Time
+	ghClient        *github.Client
+	prCache         map[string]*prCacheEntry   // keyed by session ID
+	prPollStates    map[string]*prSessionState // keyed by session ID
+	prPollsInFlight int                        // count of concurrent in-flight polls
 }
 
 func NewApp() App {
@@ -116,6 +116,7 @@ func NewApp() App {
 		lastKnownStatus: make(map[string]agent.Status),
 		diffStatsCache:  make(map[string]*diffStatsEntry),
 		prCache:         make(map[string]*prCacheEntry),
+		prPollStates:    make(map[string]*prSessionState),
 	}
 }
 
@@ -337,13 +338,13 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				diffCmd = a.refreshDiffStatsCmd()
 			}
 		}
-		// Poll PR status every 30s for the selected session.
-		var prCmd tea.Cmd
-		if a.ghClient != nil && !a.prPollInFlight && time.Since(a.prLastPoll) > 30*time.Second {
-			a.prLastPoll = time.Now() // Update unconditionally to avoid 100ms re-checks.
-			prCmd = a.refreshPRStatusCmd()
+		// Adaptive per-session PR polling.
+		var prCmds []tea.Cmd
+		if a.ghClient != nil {
+			prCmds = a.pollAllSessions()
 		}
-		return a, tea.Batch(tickCmd(), diffCmd, prCmd)
+		allCmds := append([]tea.Cmd{tickCmd(), diffCmd}, prCmds...)
+		return a, tea.Batch(allCmds...)
 
 	case agentEventMsg:
 		// Clean up stale lastKnownStatus entries when a session auto-closes.
@@ -403,12 +404,43 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case prPollMsg:
-		a.prPollInFlight = false
+		a.prPollsInFlight--
+		if a.prPollsInFlight < 0 {
+			a.prPollsInFlight = 0
+		}
+		ps := a.prPollStates[msg.sessionID]
+		if ps != nil {
+			ps.inFlight = false
+		}
 		// Only update cache if we got data; preserve existing cache on errors.
 		if msg.pr != nil {
 			a.prCache[msg.sessionID] = &prCacheEntry{
-				pr:     msg.pr,
-				checks: msg.checks,
+				pr:      msg.pr,
+				checks:  msg.checks,
+				reviews: msg.reviews,
+			}
+			// Detect check state transitions and fire notifications.
+			if ps != nil && msg.checks != nil {
+				prevState := ps.lastCheckState
+				newState := msg.checks.State
+				if prevState == "pending" && (newState == "success" || newState == "failure") {
+					// Flash the session row.
+					ps.flashUntil = time.Now().Add(2 * time.Second)
+					if newState == "success" {
+						ps.flashColor = "success"
+					} else {
+						ps.flashColor = "error"
+					}
+					// Play audio notification, gated by the session's repo AudioEnabled setting
+					// (same gate as the idle-transition notification above).
+					if a.audioPlayer != nil {
+						repoPath := a.repoPathForSession(msg.sessionID)
+						if repoPath != "" && a.resolvedCache[repoPath].AudioEnabled {
+							a.audioPlayer.Play()
+						}
+					}
+				}
+				ps.lastCheckState = newState
 			}
 			a.updateDashboardPRCache()
 		}
@@ -1201,6 +1233,7 @@ func (a App) updateMerge(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			delete(a.diffStatsCache, sessID)
 			delete(a.prCache, sessID)
+			delete(a.prPollStates, sessID)
 			a.refreshAgentList()
 			a.updateDashboardDiffStats()
 			a.updateDashboardPRCache()
@@ -1540,9 +1573,26 @@ func (a *App) updateDashboardDiffStats() {
 	}
 }
 
-// updateDashboardPRCache passes the PR cache to the dashboard for rendering.
+// updateDashboardPRCache passes the PR cache and poll states to the dashboard for rendering.
 func (a *App) updateDashboardPRCache() {
 	a.dashboard.prCache = a.prCache
+	a.dashboard.prPollStates = a.prPollStates
+}
+
+// repoPathForSession returns the repo path containing the given session, or "" if not found.
+func (a *App) repoPathForSession(sessionID string) string {
+	for _, repo := range a.cfg.Repos {
+		mgr := a.managers[repo.Path]
+		if mgr == nil {
+			continue
+		}
+		for _, sess := range mgr.ListSessions() {
+			if sess.ID == sessionID {
+				return repo.Path
+			}
+		}
+	}
+	return ""
 }
 
 // cleanStaleCaches removes diff stats and PR cache entries for sessions that no longer exist.
@@ -1563,26 +1613,105 @@ func (a *App) cleanStaleCaches() {
 			delete(a.prCache, id)
 		}
 	}
+	for id := range a.prPollStates {
+		if !activeSessions[id] {
+			delete(a.prPollStates, id)
+		}
+	}
 }
 
-// refreshPRStatusCmd returns a Cmd that polls PR and check status for the selected session.
-func (a *App) refreshPRStatusCmd() tea.Cmd {
-	sess := a.dashboard.selectedSession()
-	if sess == nil {
-		return nil
+// pollAllSessions returns Cmds for sessions that are due for a PR status poll.
+// It respects adaptive intervals and limits concurrent in-flight polls.
+func (a *App) pollAllSessions() []tea.Cmd {
+	const (
+		maxConcurrent    = 3
+		shaCheckInterval = 2 * time.Second
+	)
+
+	var cmds []tea.Cmd
+	now := time.Now()
+
+outer:
+	for _, repo := range a.cfg.Repos {
+		mgr := a.managers[repo.Path]
+		if mgr == nil {
+			continue
+		}
+		for _, sess := range mgr.ListSessions() {
+			if a.prPollsInFlight >= maxConcurrent {
+				break outer
+			}
+
+			ps := a.prPollStates[sess.ID]
+			if ps == nil {
+				ps = &prSessionState{}
+				a.prPollStates[sess.ID] = ps
+			}
+			if ps.inFlight {
+				continue
+			}
+
+			// Determine adaptive polling interval.
+			interval := a.prPollInterval(sess.ID, ps)
+			if now.Sub(ps.lastPoll) < interval {
+				// Check for push detection: if no PR yet, see if the remote SHA changed.
+				// Throttle git rev-parse calls to at most once every shaCheckInterval per
+				// session to avoid blocking the Bubble Tea main goroutine on every tick.
+				if a.prCache[sess.ID] == nil || a.prCache[sess.ID].pr == nil {
+					if now.Sub(ps.lastSHACheck) < shaCheckInterval {
+						continue
+					}
+					ps.lastSHACheck = now
+					sha := getRemoteSHA(repo.Path, sess.Worktree.Branch)
+					if sha != "" && sha != ps.lastRemoteSHA {
+						ps.lastRemoteSHA = sha
+						// Push detected — fall through to schedule an immediate poll.
+					} else {
+						continue
+					}
+				} else {
+					continue
+				}
+			}
+
+			ps.lastPoll = now
+			ps.inFlight = true
+			a.prPollsInFlight++
+			cmds = append(cmds, a.refreshPRStatusForSession(sess.ID, sess.Worktree.Branch, repo.Path))
+		}
 	}
-	// Skip sessions where agents are still starting/active.
-	st := sess.Status()
-	if st == agent.StatusActive || st == agent.StatusStarting {
-		return nil
+	return cmds
+}
+
+// prPollInterval returns the adaptive polling interval for a session.
+func (a *App) prPollInterval(sessionID string, ps *prSessionState) time.Duration {
+	entry := a.prCache[sessionID]
+	// No PR found yet but branch may have been pushed.
+	if entry == nil || entry.pr == nil {
+		if ps.lastRemoteSHA != "" {
+			return 10 * time.Second // branch pushed, waiting for PR
+		}
+		return 30 * time.Second // stable, no activity
 	}
-	repoPath := a.dashboard.selectedRepoPath()
-	if repoPath == "" {
-		return nil
+	// PR exists — adapt based on check state.
+	if entry.checks != nil && entry.checks.State == "pending" {
+		return 5 * time.Second
 	}
-	a.prPollInFlight = true
-	sessionID := sess.ID
-	branch := sess.Worktree.Branch
+	return 30 * time.Second
+}
+
+// getRemoteSHA runs `git rev-parse origin/<branch>` to detect pushes.
+// Returns empty string on any error.
+func getRemoteSHA(repoPath, branch string) string {
+	out, err := exec.Command("git", "-C", repoPath, "rev-parse", "origin/"+branch).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// refreshPRStatusForSession returns a Cmd that polls PR, check, and review status for a single session.
+func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath string) tea.Cmd {
 	ghClient := a.ghClient
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1599,14 +1728,17 @@ func (a *App) refreshPRStatusCmd() tea.Cmd {
 
 		pr, _ := ghClient.GetPR(ctx, owner, repo, branch)
 		var checks *github.CheckStatus
+		var reviews *github.ReviewStatus
 		if pr != nil {
 			checks, _ = ghClient.GetChecks(ctx, owner, repo, branch)
+			reviews, _ = ghClient.GetReviews(ctx, owner, repo, pr.Number)
 		}
 
 		return prPollMsg{
 			sessionID: sessionID,
 			pr:        pr,
 			checks:    checks,
+			reviews:   reviews,
 		}
 	}
 }

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	xvt "github.com/charmbracelet/x/vt"
 	"github.com/devenjarvis/baton/internal/agent"
+	"github.com/devenjarvis/baton/internal/github"
 )
 
 // listItemKind distinguishes repo headers, session rows, and agent rows in the dashboard list.
@@ -57,8 +59,9 @@ type dashboardModel struct {
 	height       int
 	panelFocus   panelFocus
 	scrollOffset int
-	diffStats    *diffSummaryData         // nil when no session selected or no data
-	prCache      map[string]*prCacheEntry // keyed by session ID, passed from App
+	diffStats    *diffSummaryData           // nil when no session selected or no data
+	prCache      map[string]*prCacheEntry   // keyed by session ID, passed from App
+	prPollStates map[string]*prSessionState // keyed by session ID, passed from App
 
 	// Repo config form shown in the right panel when focusConfig is active.
 	repoConfigForm *configForm
@@ -314,11 +317,14 @@ func (d dashboardModel) renderList(width int) string {
 			var prSuffix string
 			var prSuffixLen int
 			if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
-				prSuffix = " " + prIndicator(entry.pr, entry.checks)
-				// Approximate visible length: space + #N + space + symbol
+				prSuffix = " " + prIndicator(entry)
+				// Approximate visible length: space + #N + space + symbol + optional " Ready"
 				prSuffixLen = 1 + len(fmt.Sprintf("#%d", entry.pr.Number))
 				if entry.checks != nil {
 					prSuffixLen += 2 // space + check symbol
+				}
+				if isMergeReady(entry) {
+					prSuffixLen += 6 // " Ready"
 				}
 			}
 
@@ -337,7 +343,19 @@ func (d dashboardModel) renderList(width int) string {
 			if padLen < 0 {
 				padLen = 0
 			}
-			line := StyleSubtle.Render("  ──") + label + prSuffix + StyleSubtle.Render(strings.Repeat("─", padLen))
+
+			// Use flash color for separator dashes if the session has an active flash.
+			sepStyle := StyleSubtle
+			if ps := d.prPollStates[sess.ID]; ps != nil && time.Now().Before(ps.flashUntil) {
+				switch ps.flashColor {
+				case "success":
+					sepStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
+				case "error":
+					sepStyle = lipgloss.NewStyle().Foreground(ColorError)
+				}
+			}
+
+			line := sepStyle.Render("  ──") + label + prSuffix + sepStyle.Render(strings.Repeat("─", padLen))
 			lines = append(lines, line)
 
 		case listItemAgent:
@@ -391,11 +409,20 @@ func (d dashboardModel) renderList(width int) string {
 		}
 	}
 
-	// Render PR summary and diff stats at the bottom of the left panel.
+	// Render PR checks summary and diff stats at the bottom of the left panel.
 	var bottomLines []string
 	if sess := d.selectedSession(); sess != nil {
 		if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
-			bottomLines = append(bottomLines, d.renderPRSummary(entry, width))
+			contentH := d.contentHeight()
+			agentListHeight := len(lines)
+			maxCheckHeight := contentH / 3
+			availCheckHeight := contentH - agentListHeight
+			if availCheckHeight > maxCheckHeight {
+				availCheckHeight = maxCheckHeight
+			}
+			if availCheckHeight >= 2 {
+				bottomLines = append(bottomLines, d.renderChecksSummary(entry, width, availCheckHeight)...)
+			}
 		}
 	}
 	if d.diffStats != nil {
@@ -674,40 +701,154 @@ func (d dashboardModel) renderDiffSummary(width, maxHeight int) []string {
 	return lines
 }
 
-// renderPRSummary renders a compact PR status line for the left panel bottom section.
-func (d dashboardModel) renderPRSummary(entry *prCacheEntry, width int) string {
+// renderChecksSummary renders a rich PR checks section for the left panel bottom.
+// It shows per-check rows with status, name, and duration, plus review status.
+func (d dashboardModel) renderChecksSummary(entry *prCacheEntry, width, maxHeight int) []string {
 	pr := entry.pr
-	checks := entry.checks
 
+	// Header line: "── PR #42 ── Ready ──────"
 	prLabel := fmt.Sprintf("── PR #%d ──", pr.Number)
-	var checkInfo string
-	if checks != nil {
-		checkInfo = fmt.Sprintf(" %d/%d ", checks.Passed, checks.Total)
-		switch checks.State {
-		case "success":
-			checkInfo += StyleSuccess.Render("\u2713")
-		case "failure":
-			checkInfo += StyleError.Render("\u2717")
-		case "pending":
-			checkInfo += StyleWarning.Render("\u25cb")
-		}
+	var badge string
+	var badgeLen int
+	if isMergeReady(entry) {
+		badge = " " + lipgloss.NewStyle().Foreground(ColorSuccess).Render("Ready") + " "
+		badgeLen = 7 // " Ready "
 	}
 
 	sepWidth := width - 2
 	if sepWidth < 0 {
 		sepWidth = 0
 	}
-	// Visible length of label + checkInfo (approximate).
-	visLen := len(prLabel)
-	if checks != nil {
-		visLen += 1 + len(fmt.Sprintf("%d/%d", checks.Passed, checks.Total)) + 2
-	}
-	padLen := sepWidth - visLen
+	padLen := sepWidth - len(prLabel) - badgeLen
 	if padLen < 0 {
 		padLen = 0
 	}
+	header := StyleSubtle.Render(prLabel) + badge + StyleSubtle.Render(strings.Repeat("─", padLen))
 
-	return StyleSubtle.Render(prLabel) + checkInfo + StyleSubtle.Render(strings.Repeat("─", padLen))
+	var lines []string
+	lines = append(lines, header)
+
+	// Review status line.
+	if entry.reviews != nil && maxHeight > 2 {
+		lines = append(lines, d.renderReviewLine(entry.reviews, width))
+	}
+
+	// Per-check rows.
+	if entry.checks != nil && len(entry.checks.Runs) > 0 {
+		availRows := maxHeight - len(lines)
+		lines = append(lines, d.renderCheckRows(entry.checks.Runs, width, availRows)...)
+	}
+
+	return lines
+}
+
+// renderReviewLine renders the review status line.
+func (d dashboardModel) renderReviewLine(reviews *github.ReviewStatus, width int) string {
+	var symbol string
+	var style lipgloss.Style
+	var text string
+	switch reviews.State {
+	case "approved":
+		symbol = "\u2713"
+		style = lipgloss.NewStyle().Foreground(ColorSuccess)
+		text = fmt.Sprintf("%d approved", reviews.Approved)
+	case "changes_requested":
+		symbol = "\u2717"
+		style = lipgloss.NewStyle().Foreground(ColorError)
+		text = fmt.Sprintf("%d changes requested", reviews.ChangesRequested)
+	default:
+		symbol = "\u25cb"
+		style = lipgloss.NewStyle().Foreground(ColorWarning)
+		text = "pending"
+		if reviews.Approved > 0 {
+			text = fmt.Sprintf("%d approved, pending", reviews.Approved)
+		}
+	}
+	return fmt.Sprintf("  Reviews: %s %s", style.Render(symbol), text)
+}
+
+// renderCheckRows renders individual check run rows sorted: failed, pending, passed.
+func (d dashboardModel) renderCheckRows(runs []github.CheckRun, width, availRows int) []string {
+	if availRows <= 0 {
+		return nil
+	}
+
+	// Sort: failed first, then pending/in_progress, then passed.
+	sorted := make([]github.CheckRun, len(runs))
+	copy(sorted, runs)
+	sort.Slice(sorted, func(i, j int) bool {
+		return checkSortOrder(sorted[i]) < checkSortOrder(sorted[j])
+	})
+
+	showMore := false
+	visible := len(sorted)
+	if visible > availRows {
+		visible = availRows - 1 // leave room for "+N more"
+		showMore = true
+	}
+
+	var lines []string
+	for i := 0; i < visible; i++ {
+		run := sorted[i]
+		var symbol string
+		var style lipgloss.Style
+		switch {
+		case run.Status != "completed":
+			symbol = "\u25cb"
+			style = lipgloss.NewStyle().Foreground(ColorWarning)
+		case run.Conclusion == "success" || run.Conclusion == "skipped" || run.Conclusion == "neutral":
+			symbol = "\u2713"
+			style = lipgloss.NewStyle().Foreground(ColorSuccess)
+		default:
+			symbol = "\u2717"
+			style = lipgloss.NewStyle().Foreground(ColorError)
+		}
+
+		// Duration or "running" indicator.
+		var durStr string
+		if run.Status != "completed" {
+			durStr = "running"
+		} else {
+			durStr = formatCheckDuration(run.Duration)
+		}
+		durLen := len(durStr)
+
+		// "  ✓ name       12s"
+		nameWidth := width - 4 - durLen - 1 // "  S " prefix + duration + space
+		if nameWidth < 1 {
+			nameWidth = 1
+		}
+		name := run.Name
+		if len(name) > nameWidth {
+			name = name[:nameWidth-1] + "…"
+		}
+		padName := nameWidth - len(name)
+		if padName < 0 {
+			padName = 0
+		}
+
+		line := fmt.Sprintf("  %s %s%s%s", style.Render(symbol), name, strings.Repeat(" ", padName), StyleSubtle.Render(durStr))
+		lines = append(lines, line)
+	}
+
+	if showMore {
+		remaining := len(sorted) - visible
+		lines = append(lines, StyleSubtle.Render(fmt.Sprintf("  +%d more", remaining)))
+	}
+
+	return lines
+}
+
+// checkSortOrder returns a sort key: 0=failed, 1=pending, 2=passed.
+func checkSortOrder(run github.CheckRun) int {
+	switch {
+	case run.Status == "completed" && run.Conclusion != "success" && run.Conclusion != "skipped" && run.Conclusion != "neutral":
+		return 0 // failed
+	case run.Status != "completed":
+		return 1 // pending/running
+	default:
+		return 2 // passed
+	}
 }
 
 // humanizeElapsed formats a duration for display.

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/baton/internal/github"
@@ -12,6 +13,7 @@ type prPollMsg struct {
 	sessionID string
 	pr        *github.PRState
 	checks    *github.CheckStatus
+	reviews   *github.ReviewStatus
 }
 
 // prCreateMsg carries the result of async PR creation.
@@ -29,16 +31,43 @@ type fixChecksMsg struct {
 
 // prCacheEntry holds cached PR and check status for a session.
 type prCacheEntry struct {
-	pr     *github.PRState
-	checks *github.CheckStatus
+	pr      *github.PRState
+	checks  *github.CheckStatus
+	reviews *github.ReviewStatus
+}
+
+// prSessionState tracks per-session polling state for adaptive PR polling.
+type prSessionState struct {
+	lastPoll       time.Time
+	lastSHACheck   time.Time
+	lastCheckState string // "success", "failure", "pending", ""
+	lastRemoteSHA  string
+	flashUntil     time.Time
+	flashColor     string // "success" or "error"
+	inFlight       bool
+}
+
+// isMergeReady returns true when all conditions for merge readiness are met.
+func isMergeReady(entry *prCacheEntry) bool {
+	if entry == nil || entry.pr == nil {
+		return false
+	}
+	// Require at least one check to prevent premature "Ready" display while CI
+	// is still initializing (API may briefly return zero check runs).
+	checksOK := entry.checks != nil && entry.checks.State == "success" && entry.checks.Total > 0
+	reviewsOK := entry.reviews != nil && entry.reviews.State == "approved"
+	mergeable := entry.pr.Mergeable
+	return checksOK && reviewsOK && mergeable
 }
 
 // prIndicator returns a compact colored string for the session row.
 // Returns empty string if no PR data exists.
-func prIndicator(pr *github.PRState, checks *github.CheckStatus) string {
-	if pr == nil {
+func prIndicator(entry *prCacheEntry) string {
+	if entry == nil || entry.pr == nil {
 		return ""
 	}
+	pr := entry.pr
+	checks := entry.checks
 
 	prNum := fmt.Sprintf("#%d", pr.Number)
 
@@ -63,5 +92,19 @@ func prIndicator(pr *github.PRState, checks *github.CheckStatus) string {
 		checkStyle = lipgloss.NewStyle().Foreground(ColorMuted)
 	}
 
-	return prNum + " " + checkStyle.Render(checkSymbol)
+	result := prNum + " " + checkStyle.Render(checkSymbol)
+	if isMergeReady(entry) {
+		result += " " + lipgloss.NewStyle().Foreground(ColorSuccess).Render("Ready")
+	}
+	return result
+}
+
+// formatCheckDuration formats a duration for check run display.
+func formatCheckDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	m := int(d.Minutes())
+	s := int(d.Seconds()) % 60
+	return fmt.Sprintf("%dm%ds", m, s)
 }


### PR DESCRIPTION
## Summary

- Replace the single 30s selected-session PR poll with per-session adaptive polling (5s pending checks, 10s pushed-no-PR, 30s stable) that covers all sessions and reacts to pushes via throttled `git rev-parse origin/<branch>`
- Extend GitHub client with per-check run detail (`CheckRun` with `Name`/`Status`/`Conclusion`/`StartedAt`/`Duration`) and `GetReviews` (latest-per-user deduplication)
- Rich left-panel checks section: PR header with "Ready" badge (checks passing + reviews approved + mergeable), review status line, per-check rows sorted failed/pending/passed with `+N more` truncation and `12s`/`1m23s` duration formatting
- Check state transition notifications: session row flashes green/red for ~2s and audio plays on `pending` → `success`/`failure` (gated on per-repo `AudioEnabled`, matching idle-transition audio)
- Concurrent in-flight polls capped at 3; `StatusActive`/`Starting` skip guard removed so all sessions stay current

## Test plan

- [ ] `go build -o baton .` compiles cleanly
- [ ] `go test -race ./...` passes (one pre-existing `internal/config` failure is unrelated)
- [ ] `go vet ./...` clean
- [ ] `golangci-lint run` clean
- [ ] Manual: push a branch from a session — PR indicator appears within ~10s
- [ ] Manual: open a PR with CI — per-check list appears in left panel with live status
- [ ] Manual: watch checks complete — session row flashes green/red, audio plays (when `AudioEnabled` is true)
- [ ] Manual: verify "Ready" badge appears when checks pass + reviews approved + no conflicts
- [ ] Manual: select different sessions, confirm all show current data (independent polling)
- [ ] Manual: confirm no UI lag during polling (async commands, throttled SHA checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)