### PR TITLE
Upgrade file browser: filter, scroll, hidden toggle, breadcrumb

### DIFF
--- a/internal/tui/filebrowser.go
+++ b/internal/tui/filebrowser.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,13 +19,17 @@ type fileBrowserCancelMsg struct{}
 
 // fileBrowserModel is a sub-component for browsing and selecting git repo directories.
 type fileBrowserModel struct {
-	currentDir string
-	entries    []os.DirEntry // only dirs, no hidden
-	selected   int
-	isGitRepo  bool   // cached git.IsRepo for selected entry
-	gitBranch  string // cached branch name for selected entry
-	width      int
-	height     int
+	currentDir   string
+	entries      []os.DirEntry // only dirs
+	filtered     []int         // indices into entries
+	selected     int           // index into filtered
+	scrollOffset int
+	filter       string
+	showHidden   bool
+	isGitRepo    bool   // cached git.IsRepo for selected entry
+	gitBranch    string // cached branch name for selected entry
+	width        int
+	height       int
 }
 
 // newFileBrowserModel creates a fileBrowserModel starting at the user's home directory.
@@ -36,13 +41,15 @@ func newFileBrowserModel() fileBrowserModel {
 	m := fileBrowserModel{
 		currentDir: home,
 	}
-	m.entries = loadEntries(home)
+	m.entries = loadEntries(home, false)
+	m.applyFilter()
 	m.refreshGitStatus()
 	return m
 }
 
-// loadEntries reads subdirectories (no files, no hidden dirs) from dir.
-func loadEntries(dir string) []os.DirEntry {
+// loadEntries reads subdirectories from dir. Hidden dirs (starting with ".") are
+// included only when showHidden is true.
+func loadEntries(dir string, showHidden bool) []os.DirEntry {
 	all, err := os.ReadDir(dir)
 	if err != nil {
 		return nil
@@ -52,7 +59,7 @@ func loadEntries(dir string) []os.DirEntry {
 		if !e.IsDir() {
 			continue
 		}
-		if strings.HasPrefix(e.Name(), ".") {
+		if !showHidden && strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
 		entries = append(entries, e)
@@ -64,9 +71,10 @@ func loadEntries(dir string) []os.DirEntry {
 func (m fileBrowserModel) Update(msg tea.Msg) (fileBrowserModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
-		switch msg.String() {
+		key := msg.String()
+		switch key {
 		case "j", "down":
-			if m.selected < len(m.entries)-1 {
+			if m.selected < len(m.filtered)-1 {
 				m.selected++
 				m.refreshGitStatus()
 			}
@@ -76,30 +84,61 @@ func (m fileBrowserModel) Update(msg tea.Msg) (fileBrowserModel, tea.Cmd) {
 				m.refreshGitStatus()
 			}
 		case "enter":
-			if len(m.entries) == 0 {
+			if len(m.filtered) == 0 {
 				break
 			}
-			path := filepath.Join(m.currentDir, m.entries[m.selected].Name())
+			entry := m.entries[m.filtered[m.selected]]
+			path := filepath.Join(m.currentDir, entry.Name())
 			if m.isGitRepo {
 				return m, func() tea.Msg { return fileBrowserSelectMsg{path: path} }
 			}
 			// Descend into the directory.
 			m.currentDir = path
-			m.entries = loadEntries(path)
+			m.entries = loadEntries(path, m.showHidden)
+			m.filter = ""
+			m.scrollOffset = 0
+			m.applyFilter()
 			m.selected = 0
 			m.refreshGitStatus()
 		case "backspace":
-			parent := filepath.Dir(m.currentDir)
-			if parent != m.currentDir {
-				m.currentDir = parent
-				m.entries = loadEntries(parent)
-				m.selected = 0
+			if len(m.filter) > 0 {
+				m.filter = m.filter[:len(m.filter)-1]
+				m.applyFilter()
 				m.refreshGitStatus()
+			} else {
+				parent := filepath.Dir(m.currentDir)
+				if parent != m.currentDir {
+					m.currentDir = parent
+					m.entries = loadEntries(parent, m.showHidden)
+					m.filter = ""
+					m.scrollOffset = 0
+					m.applyFilter()
+					m.selected = 0
+					m.refreshGitStatus()
+				}
 			}
 		case "esc":
 			return m, func() tea.Msg { return fileBrowserCancelMsg{} }
+		case ".":
+			m.showHidden = !m.showHidden
+			m.entries = loadEntries(m.currentDir, m.showHidden)
+			m.filter = ""
+			m.scrollOffset = 0
+			m.applyFilter()
+			if m.selected >= len(m.filtered) {
+				m.selected = max(0, len(m.filtered)-1)
+			}
+			m.refreshGitStatus()
+		default:
+			// Single printable character → add to filter.
+			if len(key) == 1 && key[0] >= ' ' && key[0] <= '~' {
+				m.filter += key
+				m.applyFilter()
+				m.refreshGitStatus()
+			}
 		}
 	}
+	m.ensureVisible()
 	return m, nil
 }
 
@@ -133,6 +172,96 @@ func (m fileBrowserModel) View() string {
 	)
 }
 
+// renderBreadcrumb renders the currentDir as a styled breadcrumb path.
+// Substitutes "~" for the home directory prefix. Truncates from the left with "…"
+// when the rendered width exceeds maxWidth.
+func (m fileBrowserModel) renderBreadcrumb(maxWidth int) string {
+	if maxWidth < 1 {
+		maxWidth = 1
+	}
+
+	// Substitute home directory prefix with ~.
+	display := m.currentDir
+	leadingHome := false
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if display == home {
+			display = "~"
+			leadingHome = true
+		} else if strings.HasPrefix(display, home+string(filepath.Separator)) {
+			display = "~" + display[len(home):]
+			leadingHome = true
+		}
+	}
+
+	// Split into segments. Preserve a leading "/" for absolute paths that don't start with ~.
+	leadingRoot := !leadingHome && strings.HasPrefix(display, string(filepath.Separator))
+	trimmed := strings.Trim(display, string(filepath.Separator))
+	var segments []string
+	if trimmed != "" {
+		segments = strings.Split(trimmed, string(filepath.Separator))
+	}
+
+	sep := StyleSubtle.Render(" / ")
+	sepPlain := " / "
+
+	// Build from the right, dropping leading segments until it fits.
+	// Start by trying to include everything; if too wide, progressively elide.
+	build := func(start int, elided bool) (string, int) {
+		var styled strings.Builder
+		plainLen := 0
+
+		if elided {
+			styled.WriteString(StyleSubtle.Render("…"))
+			plainLen++
+		} else if leadingRoot {
+			styled.WriteString(StyleSubtle.Render("/"))
+			plainLen++
+		}
+
+		for i := start; i < len(segments); i++ {
+			if i > start || elided || leadingRoot {
+				styled.WriteString(sep)
+				plainLen += len(sepPlain)
+			}
+			styled.WriteString(segments[i])
+			plainLen += len(segments[i])
+		}
+		return styled.String(), plainLen
+	}
+
+	// Handle empty (e.g. just "~" with no trailing segments — shouldn't happen normally).
+	if len(segments) == 0 {
+		if leadingHome {
+			return "~"
+		}
+		if leadingRoot {
+			return StyleSubtle.Render("/")
+		}
+		return ""
+	}
+
+	// Try full, then progressively elide from the left.
+	for start := 0; start < len(segments); start++ {
+		out, width := build(start, start > 0)
+		if width <= maxWidth {
+			return out
+		}
+	}
+
+	// Even the last segment alone is too wide — fall back to a compact form.
+	// If the panel is very narrow (maxWidth < "… / x" = 5 chars), just render "…".
+	if maxWidth < len(sepPlain)+2 {
+		return StyleSubtle.Render("…")
+	}
+	last := segments[len(segments)-1]
+	// Reserve space for "… / ".
+	room := maxWidth - (1 + len(sepPlain)) // 1 for "…"
+	if len(last) > room {
+		last = last[:room]
+	}
+	return StyleSubtle.Render("…") + sep + last
+}
+
 // renderDirList renders the left panel with the directory listing.
 func (m fileBrowserModel) renderDirList(width int) string {
 	title := StyleTitle.Render("DIRECTORIES")
@@ -142,28 +271,61 @@ func (m fileBrowserModel) renderDirList(width int) string {
 	}
 	separator := StyleSubtle.Render(strings.Repeat("─", sepWidth))
 
-	lines := make([]string, 0, 4+len(m.entries))
+	lines := make([]string, 0, 6+len(m.filtered))
 	lines = append(lines, title, separator)
-	lines = append(lines, StyleSubtle.Render(m.currentDir))
-	lines = append(lines, "")
-
-	if len(m.entries) == 0 {
-		lines = append(lines, StyleSubtle.Render("  (empty)"))
+	lines = append(lines, m.renderBreadcrumb(width-2))
+	if m.showHidden {
+		lines = append(lines, StyleSubtle.Render("(showing hidden)"))
 	}
 
-	for i, e := range m.entries {
+	// Filter indicator.
+	if m.filter != "" {
+		lines = append(lines, StyleSubtle.Render("filter: ")+m.filter)
+	}
+	lines = append(lines, "")
+
+	if len(m.filtered) == 0 {
+		if m.filter != "" {
+			lines = append(lines, StyleSubtle.Render("  No matches"))
+		} else {
+			lines = append(lines, StyleSubtle.Render("  (empty)"))
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	// Use the same visible-lines budget as ensureVisible so the selected entry
+	// is never scrolled off-screen. This reserves space for both scroll indicators.
+	visibleLines := m.visibleEntryLines()
+	total := len(m.filtered)
+	above := m.scrollOffset
+	end := m.scrollOffset + visibleLines
+	if end > total {
+		end = total
+	}
+	below := total - end
+
+	if above > 0 {
+		lines = append(lines, StyleSubtle.Render(fmt.Sprintf("  ↑ %d more", above)))
+	}
+
+	for fi := m.scrollOffset; fi < end; fi++ {
+		idx := m.filtered[fi]
 		prefix := "  "
-		if i == m.selected {
+		if fi == m.selected {
 			prefix = StyleActive.Render("▸ ")
 		}
 
-		name := e.Name()
+		name := m.entries[idx].Name()
 		maxLen := width - 4
 		if len(name) > maxLen {
 			name = name[:maxLen-1] + "…"
 		}
 
 		lines = append(lines, prefix+name)
+	}
+
+	if below > 0 {
+		lines = append(lines, StyleSubtle.Render(fmt.Sprintf("  ↓ %d more", below)))
 	}
 
 	return strings.Join(lines, "\n")
@@ -181,12 +343,12 @@ func (m fileBrowserModel) renderDetails(width int) string {
 	var lines []string
 	lines = append(lines, title, separator)
 
-	if len(m.entries) == 0 {
+	if len(m.filtered) == 0 {
 		lines = append(lines, StyleSubtle.Render("No subdirectories"))
 		return strings.Join(lines, "\n")
 	}
 
-	entry := m.entries[m.selected]
+	entry := m.entries[m.filtered[m.selected]]
 	path := filepath.Join(m.currentDir, entry.Name())
 
 	lines = append(lines, "")
@@ -208,14 +370,62 @@ func (m fileBrowserModel) renderDetails(width int) string {
 	return strings.Join(lines, "\n")
 }
 
+// ensureVisible adjusts scrollOffset so that selected is within the visible window.
+func (m *fileBrowserModel) ensureVisible() {
+	visibleLines := m.visibleEntryLines()
+	if m.selected < m.scrollOffset {
+		m.scrollOffset = m.selected
+	}
+	if m.selected >= m.scrollOffset+visibleLines {
+		m.scrollOffset = m.selected - visibleLines + 1
+	}
+	if m.scrollOffset < 0 {
+		m.scrollOffset = 0
+	}
+}
+
+// visibleEntryLines returns the number of entry rows that fit in the left panel,
+// reserving space for header lines and (conservatively) both scroll indicators.
+func (m fileBrowserModel) visibleEntryLines() int {
+	// Header: title + separator + breadcrumb + optional hidden + optional filter + blank.
+	headerLines := 4
+	if m.showHidden {
+		headerLines++
+	}
+	if m.filter != "" {
+		headerLines++
+	}
+	// Reserve space for both scroll indicators conservatively. This may scroll one
+	// row earlier than strictly necessary, but guarantees selected is never clipped.
+	visible := m.height - headerLines - 2
+	if visible < 1 {
+		visible = 1
+	}
+	return visible
+}
+
+// applyFilter updates the filtered indices based on the current filter string.
+func (m *fileBrowserModel) applyFilter() {
+	m.filtered = nil
+	lower := strings.ToLower(m.filter)
+	for i, e := range m.entries {
+		if lower == "" || strings.Contains(strings.ToLower(e.Name()), lower) {
+			m.filtered = append(m.filtered, i)
+		}
+	}
+	if m.selected >= len(m.filtered) {
+		m.selected = max(0, len(m.filtered)-1)
+	}
+}
+
 // refreshGitStatus updates the cached isGitRepo and gitBranch for the selected entry.
 func (m *fileBrowserModel) refreshGitStatus() {
-	if len(m.entries) == 0 {
+	if len(m.filtered) == 0 {
 		m.isGitRepo = false
 		m.gitBranch = ""
 		return
 	}
-	path := filepath.Join(m.currentDir, m.entries[m.selected].Name())
+	path := filepath.Join(m.currentDir, m.entries[m.filtered[m.selected]].Name())
 	m.isGitRepo = git.IsRepo(path)
 	if m.isGitRepo {
 		branch, err := git.BaseBranch(path)

--- a/internal/tui/filebrowser.go
+++ b/internal/tui/filebrowser.go
@@ -120,9 +120,17 @@ func (m fileBrowserModel) Update(msg tea.Msg) (fileBrowserModel, tea.Cmd) {
 		case "esc":
 			return m, func() tea.Msg { return fileBrowserCancelMsg{} }
 		case ".":
+			// With a filter active, treat `.` as a normal filter character so that
+			// names like "next.js" or "v2.0" are reachable. Toggle hidden only when
+			// the filter is empty.
+			if m.filter != "" {
+				m.filter += "."
+				m.applyFilter()
+				m.refreshGitStatus()
+				break
+			}
 			m.showHidden = !m.showHidden
 			m.entries = loadEntries(m.currentDir, m.showHidden)
-			m.filter = ""
 			m.scrollOffset = 0
 			m.applyFilter()
 			if m.selected >= len(m.filtered) {
@@ -202,31 +210,32 @@ func (m fileBrowserModel) renderBreadcrumb(maxWidth int) string {
 	}
 
 	sep := StyleSubtle.Render(" / ")
-	sepPlain := " / "
+	sepWidth := 3 // " / " is 3 ASCII cells
 
 	// Build from the right, dropping leading segments until it fits.
-	// Start by trying to include everything; if too wide, progressively elide.
+	// Widths are measured in display cells via lipgloss.Width so that multi-byte
+	// and wide (CJK) segment names are handled correctly.
 	build := func(start int, elided bool) (string, int) {
 		var styled strings.Builder
-		plainLen := 0
+		width := 0
 
 		if elided {
 			styled.WriteString(StyleSubtle.Render("…"))
-			plainLen++
+			width++
 		} else if leadingRoot {
 			styled.WriteString(StyleSubtle.Render("/"))
-			plainLen++
+			width++
 		}
 
 		for i := start; i < len(segments); i++ {
 			if i > start || elided || leadingRoot {
 				styled.WriteString(sep)
-				plainLen += len(sepPlain)
+				width += sepWidth
 			}
 			styled.WriteString(segments[i])
-			plainLen += len(segments[i])
+			width += lipgloss.Width(segments[i])
 		}
-		return styled.String(), plainLen
+		return styled.String(), width
 	}
 
 	// Handle empty (e.g. just "~" with no trailing segments — shouldn't happen normally).
@@ -249,15 +258,21 @@ func (m fileBrowserModel) renderBreadcrumb(maxWidth int) string {
 	}
 
 	// Even the last segment alone is too wide — fall back to a compact form.
-	// If the panel is very narrow (maxWidth < "… / x" = 5 chars), just render "…".
-	if maxWidth < len(sepPlain)+2 {
+	// If the panel is very narrow (maxWidth < "… / x" = 5 cells), just render "…".
+	if maxWidth < sepWidth+2 {
 		return StyleSubtle.Render("…")
 	}
 	last := segments[len(segments)-1]
 	// Reserve space for "… / ".
-	room := maxWidth - (1 + len(sepPlain)) // 1 for "…"
-	if len(last) > room {
-		last = last[:room]
+	room := maxWidth - (1 + sepWidth) // 1 for "…"
+	// Rune-safe truncation to avoid emitting invalid UTF-8 mid-codepoint.
+	// This may slightly over-truncate for wide (CJK) chars but never under-truncates.
+	if lipgloss.Width(last) > room {
+		runes := []rune(last)
+		for len(runes) > 0 && lipgloss.Width(string(runes)) > room {
+			runes = runes[:len(runes)-1]
+		}
+		last = string(runes)
 	}
 	return StyleSubtle.Render("…") + sep + last
 }

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -47,8 +47,10 @@ var (
 
 	repoBrowsingHints = []keyHint{
 		{"j/k", "navigate"},
+		{"type", "filter"},
 		{"enter", "open/select"},
 		{"backspace", "up"},
+		{".", "hidden"},
 		{"esc", "cancel"},
 	}
 


### PR DESCRIPTION
## Summary

Upgrades the repo-add file browser (opened with `a` from the dashboard) with scrolling, filtering, and visual polish — previously long directory lists clipped at the terminal height with no way to jump.

- **Type-ahead filter** — printable chars narrow the list (case-insensitive substring); backspace clears the filter first, then navigates up when empty. Follows the `branchpicker.go` pattern.
- **Viewport scrolling** — `scrollOffset` tracked with a shared `visibleEntryLines()` budget between `ensureVisible` and `renderDirList`; `↑ N more` / `↓ N more` indicators appear when entries are clipped.
- **Hidden-dir toggle** — `.` toggles `showHidden` (only when filter is empty, so names like `next.js`/`v2.0` remain filterable). `(showing hidden)` indicator under the breadcrumb.
- **Breadcrumb** — styled path with `~` home substitution and left-truncation. Uses `lipgloss.Width` for display-aware widths and rune-safe truncation so multi-byte paths don't corrupt.
- **Status bar hints** — `repoBrowsingHints` now includes `type → filter` and `. → hidden`.

## Test plan

- [x] `go build -o baton .`
- [x] `go vet ./...`
- [x] `golangci-lint run`
- [x] `go test -race ./internal/tui/...`
- [ ] Launch `./baton`, press `a`:
  - [ ] Type chars — list filters live
  - [ ] Backspace clears filter first, then navigates up
  - [ ] Navigate to a big dir (e.g. `~/`) — scroll indicators appear, selected stays visible
  - [ ] `.` toggles hidden dirs; `(showing hidden)` indicator appears
  - [ ] Type `.` with a filter active — added to filter (try `next.js`, `v2.0`)
  - [ ] Breadcrumb shows `~ / ...` with left-truncation on deep paths
  - [ ] Enter on a git repo selects it; enter on a non-repo descends
  - [ ] Esc returns to dashboard
  - [ ] Status bar shows updated hints

## Notes

Pre-existing failure in `internal/config/TestLoad_MigratesFromLegacyXDGPath` is unrelated to this change (reproduced on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)