### PR TITLE
test: add e2e TUI tests using tu CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,30 @@ jobs:
         run: |
           go install mvdan.cc/gofumpt@latest
           test -z "$(gofumpt -l .)"
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Configure git for tests
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@test.com"
+
+      - name: Install tu
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/flipbit03/terminal-use/main/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Build baton
+        run: go build -o baton .
+
+      - name: Run e2e tests
+        run: go test -tags e2e -timeout 300s -v ./internal/e2e/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ gofumpt -w .                # format all Go files
 - `internal/git/` — Tests use temp repos with real git commands
 - `internal/agent/` — Tests use `bash -c` commands instead of claude
 - `internal/tui/` — Manual testing only (TUI views)
+- `internal/e2e/` — End-to-end TUI tests using `tu` CLI (headless virtual terminal). Requires `tu` v0.6.0+. Run with: `go test -tags e2e -timeout 300s -v ./internal/e2e/`
 
 Always run `go test -race ./...` before committing — concurrency bugs have been caught and fixed by the race detector.
 

--- a/internal/e2e/dashboard_test.go
+++ b/internal/e2e/dashboard_test.go
@@ -1,0 +1,78 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDashboardRendersOnStartup(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	// Wait for the dashboard to render.
+	s.WaitForText("AGENTS", 10000)
+
+	// Verify: "AGENTS" header appears in sidebar.
+	s.AssertScreenContains("AGENTS")
+
+	// Verify: status bar hints render.
+	s.AssertScreenContains("navigate")
+	s.AssertScreenContains("new session")
+	s.AssertScreenContains("quit")
+
+	// Verify: the repo basename appears on screen. The directory is named
+	// "e2erepo-<suffix>" so it's distinctive enough that a substring match
+	// can't false-positive on common UI text.
+	s.AssertScreenContains(filepath.Base(s.repoDir))
+}
+
+func TestNavigationJK(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	// Wait for the dashboard to render.
+	s.WaitForText("AGENTS", 10000)
+
+	// Create first session: press "n" which creates a session and auto-focuses terminal.
+	// Wait for the status bar to show terminal-focus hints (e.g., "back" for esc).
+	s.Press("n")
+	s.WaitForText("back", 10000)
+
+	// Press Escape to return to list mode. Wait for "navigate" hint in status bar.
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	// Create second session.
+	s.Press("n")
+	s.WaitForText("back", 10000)
+
+	// Return to list mode.
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	// After creating 2 sessions, the selection is on the last agent (bottom of list).
+	// Take a screenshot to record the initial position.
+	initial := s.Screenshot()
+
+	// Press "k" to move up to the first agent.
+	s.Press("k")
+	s.WaitStable(500)
+	afterK := s.Screenshot()
+
+	// Verify the screen changed (selection moved up).
+	if initial == afterK {
+		t.Errorf("expected screen to change after pressing k, but it did not\nScreen:\n%s", afterK)
+	}
+
+	// Press "j" to move back down to the second agent.
+	s.Press("j")
+	s.WaitStable(500)
+	afterJ := s.Screenshot()
+
+	// Verify the screen changed again (selection moved down).
+	if afterK == afterJ {
+		t.Errorf("expected screen to change after pressing j, but it did not\nScreen:\n%s", afterJ)
+	}
+}

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -1,0 +1,356 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var batonBin string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "baton-e2e-bin-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	bin := filepath.Join(tmp, "baton")
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	// Build from the repo root (two levels up from internal/e2e).
+	cmd.Dir = filepath.Join(repoRoot())
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: failed to build baton: %v\n", err)
+		os.Exit(1)
+	}
+	batonBin = bin
+	os.Exit(m.Run())
+}
+
+// repoRoot returns the project root by walking up from this file's directory.
+func repoRoot() string {
+	// This file is at internal/e2e/helpers_test.go, so root is ../..
+	// Use runtime-independent approach: find go.mod.
+	dir, err := os.Getwd()
+	if err != nil {
+		panic("e2e: cannot get working directory: " + err.Error())
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			panic("e2e: cannot find repo root (no go.mod found)")
+		}
+		dir = parent
+	}
+}
+
+// Session wraps a tu CLI session for e2e testing.
+type Session struct {
+	t       *testing.T
+	name    string
+	tempDir string // parent temp dir
+	home    string // fake HOME
+	repoDir string // temp git repo (also CWD for baton)
+}
+
+// newSession creates an isolated test environment and launches baton via tu.
+// It sets up a fake HOME with baton config, a temp git repo, and starts baton.
+// Cleanup is automatic via t.Cleanup.
+func newSession(t *testing.T) *Session {
+	t.Helper()
+
+	suffix := randomSuffix()
+	name := sanitizeName(t.Name()) + "-" + suffix
+
+	tempDir := t.TempDir()
+	home := filepath.Join(tempDir, "home")
+	// Use a distinctive directory name so screen assertions can match it
+	// without colliding with common UI strings like "repository".
+	repoDir := filepath.Join(tempDir, "e2erepo-"+suffix)
+
+	// Create directory structure.
+	for _, d := range []string{
+		home,
+		filepath.Join(home, ".baton"),
+		repoDir,
+		filepath.Join(repoDir, ".baton"),
+	} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("e2e: mkdir %s: %v", d, err)
+		}
+	}
+
+	// Write a minimal gitconfig in fake HOME (we redirect GIT_CONFIG_GLOBAL
+	// here in Start() to avoid picking up the developer's real ~/.gitconfig).
+	writeFile(t, filepath.Join(home, ".gitconfig"),
+		"[user]\n\tname = e2e-test\n\temail = e2e@test.local\n[init]\n\tdefaultBranch = main\n",
+	)
+
+	// Write global config: set agent_program to bash.
+	globalCfg := map[string]any{
+		"agent_program":      "bash",
+		"bypass_permissions": false,
+	}
+	writeJSON(t, filepath.Join(home, ".baton", "config.json"), globalCfg)
+
+	// Write repo config: override agent_program and bypass_permissions.
+	repoCfg := map[string]any{
+		"agent_program":      "bash",
+		"bypass_permissions": false,
+	}
+	writeJSON(t, filepath.Join(repoDir, ".baton", "config.json"), repoCfg)
+
+	// Initialize a git repo so baton can auto-register it.
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "config", "user.email", "test@test.com")
+	// Create an initial commit so the repo has a branch.
+	writeFile(t, filepath.Join(repoDir, "README.md"), "# test repo\n")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "initial commit")
+
+	s := &Session{
+		t:       t,
+		name:    name,
+		tempDir: tempDir,
+		home:    home,
+		repoDir: repoDir,
+	}
+
+	t.Cleanup(func() { s.Kill() })
+	return s
+}
+
+// Start launches baton inside a tu virtual terminal session.
+func (s *Session) Start() {
+	s.t.Helper()
+	// Hardening against env leakage from the host: pin XDG paths inside the
+	// fake HOME, and redirect git's global config to the fake HOME so the
+	// developer's real ~/.gitconfig (signing keys, hooks, templates) doesn't
+	// leak in. We deliberately do NOT set GIT_DIR/GIT_WORK_TREE — those would
+	// override git's repo discovery and break it.
+	cmd := exec.Command("tu", "run",
+		"--name", s.name,
+		"--size", "120x40",
+		"--env", "HOME="+s.home,
+		"--env", "XDG_CONFIG_HOME="+filepath.Join(s.home, ".config"),
+		"--env", "XDG_DATA_HOME="+filepath.Join(s.home, ".local", "share"),
+		"--env", "XDG_CACHE_HOME="+filepath.Join(s.home, ".cache"),
+		"--env", "GIT_CONFIG_GLOBAL="+filepath.Join(s.home, ".gitconfig"),
+		"--env", "GIT_CONFIG_SYSTEM=/dev/null",
+		"--cwd", s.repoDir,
+		"--", batonBin,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s.t.Fatalf("e2e: tu run failed: %v\n%s", err, out)
+	}
+}
+
+// WaitForText waits until the screen content matches the given regex.
+func (s *Session) WaitForText(pattern string, timeoutMs int) {
+	s.t.Helper()
+	cmd := exec.Command("tu", "wait",
+		"--name", s.name,
+		"--text", pattern,
+		"--timeout", fmt.Sprintf("%d", timeoutMs),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		screen := s.Screenshot()
+		s.t.Fatalf("e2e: WaitForText(%q) timed out after %dms: %v\n%s\nScreen:\n%s",
+			pattern, timeoutMs, err, out, screen)
+	}
+}
+
+// WaitStable waits until the screen is unchanged for the given duration.
+func (s *Session) WaitStable(ms int) {
+	s.t.Helper()
+	cmd := exec.Command("tu", "wait",
+		"--name", s.name,
+		"--stable", fmt.Sprintf("%d", ms),
+		"--timeout", fmt.Sprintf("%d", ms+5000),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s.t.Logf("e2e: WaitStable(%dms) warning: %v\n%s", ms, err, out)
+	}
+}
+
+// Press sends one or more keystrokes to the terminal.
+func (s *Session) Press(keys ...string) {
+	s.t.Helper()
+	args := append([]string{"press", "--name", s.name}, keys...)
+	cmd := exec.Command("tu", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s.t.Fatalf("e2e: Press(%v) failed: %v\n%s", keys, err, out)
+	}
+}
+
+// Type sends literal text to the terminal.
+func (s *Session) Type(text string) {
+	s.t.Helper()
+	cmd := exec.Command("tu", "type", "--name", s.name, text)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s.t.Fatalf("e2e: Type(%q) failed: %v\n%s", text, err, out)
+	}
+}
+
+// Screenshot captures the current terminal screen as plain text.
+// When stdout is piped (as it is here), tu auto-detects non-TTY and emits
+// JSON regardless of the --json flag, so we always parse the JSON envelope
+// and return just the `content` field.
+func (s *Session) Screenshot() string {
+	s.t.Helper()
+	cmd := exec.Command("tu", "screenshot", "--json", "--name", s.name)
+	out, err := cmd.Output()
+	if err != nil {
+		s.t.Fatalf("e2e: Screenshot failed: %v", err)
+	}
+	var env struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		s.t.Fatalf("e2e: parsing screenshot JSON: %v\n%s", err, out)
+	}
+	return env.Content
+}
+
+// Kill terminates the tu session. Safe to call multiple times.
+func (s *Session) Kill() {
+	// Best-effort kill; ignore errors (session may already be dead).
+	_ = exec.Command("tu", "kill", "--name", s.name).Run()
+}
+
+// tuStatus holds parsed output from tu status --json.
+type tuStatus struct {
+	Alive    bool `json:"alive"`
+	ExitCode *int `json:"exit_code"`
+}
+
+// Status returns the session status (alive, exit code).
+func (s *Session) Status() (alive bool, exitCode int) {
+	s.t.Helper()
+	cmd := exec.Command("tu", "status", "--json", "--name", s.name)
+	out, err := cmd.Output()
+	if err != nil {
+		// Session not found means it's dead.
+		return false, -1
+	}
+	var st tuStatus
+	if err := json.Unmarshal(out, &st); err != nil {
+		s.t.Fatalf("e2e: parsing status JSON: %v\n%s", err, out)
+	}
+	code := -1
+	if st.ExitCode != nil {
+		code = *st.ExitCode
+	}
+	return st.Alive, code
+}
+
+// AssertScreenContains asserts that the current screen contains the given substring.
+func (s *Session) AssertScreenContains(substr string) {
+	s.t.Helper()
+	screen := s.Screenshot()
+	if !strings.Contains(screen, substr) {
+		s.t.Errorf("e2e: screen does not contain %q\nScreen:\n%s", substr, screen)
+	}
+}
+
+// AssertScreenNotContains asserts that the current screen does NOT contain the given substring.
+func (s *Session) AssertScreenNotContains(substr string) {
+	s.t.Helper()
+	screen := s.Screenshot()
+	if strings.Contains(screen, substr) {
+		s.t.Errorf("e2e: screen unexpectedly contains %q\nScreen:\n%s", substr, screen)
+	}
+}
+
+// AssertScreenMatches asserts that the current screen matches the given regex.
+func (s *Session) AssertScreenMatches(pattern string) {
+	s.t.Helper()
+	screen := s.Screenshot()
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		s.t.Fatalf("e2e: invalid regex %q: %v", pattern, err)
+	}
+	if !re.MatchString(screen) {
+		s.t.Errorf("e2e: screen does not match /%s/\nScreen:\n%s", pattern, screen)
+	}
+}
+
+// --- helpers ---
+
+func randomSuffix() string {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		panic("e2e: rand.Read failed: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
+func sanitizeName(name string) string {
+	// Replace any non-alphanumeric character with a dash, collapse runs.
+	var b strings.Builder
+	prev := byte('-')
+	for i := range len(name) {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			b.WriteByte(c)
+			prev = c
+		} else if prev != '-' {
+			b.WriteByte('-')
+			prev = '-'
+		}
+	}
+	s := strings.Trim(b.String(), "-")
+	if len(s) > 40 {
+		s = s[:40]
+	}
+	return s
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("e2e: marshalling JSON: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("e2e: writing %s: %v", path, err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("e2e: writing %s: %v", path, err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("e2e: git %v failed: %v\n%s", args, err, out)
+	}
+}

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -115,14 +115,16 @@ func newSession(t *testing.T) *Session {
 	}
 	writeJSON(t, filepath.Join(repoDir, ".baton", "config.json"), repoCfg)
 
-	// Initialize a git repo so baton can auto-register it.
-	runGit(t, repoDir, "init")
-	runGit(t, repoDir, "config", "user.name", "Test")
-	runGit(t, repoDir, "config", "user.email", "test@test.com")
+	// Initialize a git repo so baton can auto-register it. Use the same
+	// sandboxed git env as Start() so the developer's real ~/.gitconfig
+	// (signing keys, hooks, templates) doesn't break test setup.
+	runGit(t, repoDir, home, "init")
+	runGit(t, repoDir, home, "config", "user.name", "Test")
+	runGit(t, repoDir, home, "config", "user.email", "test@test.com")
 	// Create an initial commit so the repo has a branch.
 	writeFile(t, filepath.Join(repoDir, "README.md"), "# test repo\n")
-	runGit(t, repoDir, "add", ".")
-	runGit(t, repoDir, "commit", "-m", "initial commit")
+	runGit(t, repoDir, home, "add", ".")
+	runGit(t, repoDir, home, "commit", "-m", "initial commit")
 
 	s := &Session{
 		t:       t,
@@ -220,9 +222,9 @@ func (s *Session) Type(text string) {
 func (s *Session) Screenshot() string {
 	s.t.Helper()
 	cmd := exec.Command("tu", "screenshot", "--json", "--name", s.name)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		s.t.Fatalf("e2e: Screenshot failed: %v", err)
+		s.t.Fatalf("e2e: Screenshot failed: %v\n%s", err, out)
 	}
 	var env struct {
 		Content string `json:"content"`
@@ -233,10 +235,22 @@ func (s *Session) Screenshot() string {
 	return env.Content
 }
 
-// Kill terminates the tu session. Safe to call multiple times.
+// Kill terminates the tu session. Safe to call multiple times. Logs (but does
+// not fail the test on) errors that aren't "session already gone" — silent
+// failures here would leak orphan tu sessions and only surface via `tu list`
+// on a future run.
 func (s *Session) Kill() {
-	// Best-effort kill; ignore errors (session may already be dead).
-	_ = exec.Command("tu", "kill", "--name", s.name).Run()
+	cmd := exec.Command("tu", "kill", "--name", s.name)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return
+	}
+	// Treat any "not found"/"no such session" output as expected.
+	lower := strings.ToLower(string(out))
+	if strings.Contains(lower, "not found") || strings.Contains(lower, "no such") {
+		return
+	}
+	s.t.Logf("e2e: tu kill --name %s returned %v: %s", s.name, err, out)
 }
 
 // tuStatus holds parsed output from tu status --json.
@@ -245,14 +259,19 @@ type tuStatus struct {
 	ExitCode *int `json:"exit_code"`
 }
 
-// Status returns the session status (alive, exit code).
+// Status returns the session status (alive, exit code). A "session not found"
+// error from tu is treated as "dead" (alive=false, exitCode=-1); other errors
+// fail the test so debugging isn't hidden behind a generic dead-session result.
 func (s *Session) Status() (alive bool, exitCode int) {
 	s.t.Helper()
 	cmd := exec.Command("tu", "status", "--json", "--name", s.name)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		// Session not found means it's dead.
-		return false, -1
+		lower := strings.ToLower(string(out))
+		if strings.Contains(lower, "not found") || strings.Contains(lower, "no such") {
+			return false, -1
+		}
+		s.t.Fatalf("e2e: tu status failed: %v\n%s", err, out)
 	}
 	var st tuStatus
 	if err := json.Unmarshal(out, &st); err != nil {
@@ -345,10 +364,18 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
-func runGit(t *testing.T, dir string, args ...string) {
+// runGit runs `git <args>` in dir with a sandboxed global config (pointed at
+// home/.gitconfig) and a /dev/null system config. This isolates the test from
+// the developer's real ~/.gitconfig (gpg signing, hooks, templates, etc.).
+func runGit(t *testing.T, dir, home string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"GIT_CONFIG_GLOBAL="+filepath.Join(home, ".gitconfig"),
+		"GIT_CONFIG_SYSTEM=/dev/null",
+	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("e2e: git %v failed: %v\n%s", args, err, out)

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 var batonBin string
@@ -181,6 +182,10 @@ func (s *Session) WaitForText(pattern string, timeoutMs int) {
 }
 
 // WaitStable waits until the screen is unchanged for the given duration.
+// Best-effort: a timeout is silent, since with a bash agent emitting cursor
+// activity the screen rarely fully stabilizes — but the wait still serves as
+// a "give the next render a chance" pause. Tests should rely on WaitForText
+// or content assertions for actual synchronization.
 func (s *Session) WaitStable(ms int) {
 	s.t.Helper()
 	cmd := exec.Command("tu", "wait",
@@ -188,10 +193,23 @@ func (s *Session) WaitStable(ms int) {
 		"--stable", fmt.Sprintf("%d", ms),
 		"--timeout", fmt.Sprintf("%d", ms+5000),
 	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		s.t.Logf("e2e: WaitStable(%dms) warning: %v\n%s", ms, err, out)
+	_, _ = cmd.CombinedOutput()
+}
+
+// WaitForExit polls Status until the process is no longer alive or timeoutMs
+// elapses. Returns the final (alive, exitCode). Use this instead of
+// WaitStable+Status when confirming that baton has exited.
+func (s *Session) WaitForExit(timeoutMs int) (alive bool, exitCode int) {
+	s.t.Helper()
+	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+	for time.Now().Before(deadline) {
+		alive, exitCode = s.Status()
+		if !alive {
+			return alive, exitCode
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
+	return s.Status()
 }
 
 // Press sends one or more keystrokes to the terminal.

--- a/internal/e2e/lifecycle_test.go
+++ b/internal/e2e/lifecycle_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // repoOnlyHint is shown in the dashboard preview when only a repo is selected
@@ -64,17 +65,35 @@ func TestAgentAddition(t *testing.T) {
 			beforeAgentCount, s.Screenshot())
 	}
 
-	// Add a second agent to the session.
+	// Add a second agent to the session. After "c", baton creates an agent
+	// asynchronously and auto-focuses its terminal. We can't rely on
+	// WaitForText(`\$`) to signal a new prompt — the FIRST agent's prompt may
+	// still be visible in the preview pane, so the wait can match instantly
+	// without the new agent existing yet. Instead, poll the agent-row count
+	// after escaping back to the list.
 	s.Press("c")
 	s.WaitForText(`\$`, 10000)
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
-	afterAgentCount := countAgentRows(s.Screenshot())
-	if afterAgentCount <= beforeAgentCount {
-		t.Errorf("expected agent row count to increase from %d, got %d\n%s",
-			beforeAgentCount, afterAgentCount, s.Screenshot())
+	if !waitForAgentCount(s, beforeAgentCount+1, 10000) {
+		t.Errorf("expected agent row count to reach %d after adding, last seen %d\n%s",
+			beforeAgentCount+1, countAgentRows(s.Screenshot()), s.Screenshot())
 	}
+}
+
+// waitForAgentCount polls Screenshot for up to timeoutMs and returns true once
+// countAgentRows reaches at least min. Used to handle async agent creation
+// where a render-driven wait (WaitForText) isn't sufficient.
+func waitForAgentCount(s *Session, min, timeoutMs int) bool {
+	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if countAgentRows(s.Screenshot()) >= min {
+			return true
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	return countAgentRows(s.Screenshot()) >= min
 }
 
 // TestAgentKill verifies that pressing "x" kills the selected agent.

--- a/internal/e2e/lifecycle_test.go
+++ b/internal/e2e/lifecycle_test.go
@@ -1,0 +1,162 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// repoOnlyHint is shown in the dashboard preview when only a repo is selected
+// and it has no sessions yet. We use it as a sentinel for "no sessions exist
+// in this repo" — once a session is created and selected, the preview switches
+// to showing the worktree path / task / terminal output instead.
+const repoOnlyHint = "Press enter to configure this repo"
+
+// TestSessionCreation verifies that pressing "n" on the dashboard creates a
+// new session, auto-focuses the terminal showing a bash prompt, and that
+// pressing Escape returns to the list where a session row is now visible.
+func TestSessionCreation(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	s.WaitForText("AGENTS", 10000)
+
+	// Sanity: no agent rows yet, and the repo-only hint is visible.
+	if got := countAgentRows(s.Screenshot()); got != 0 {
+		t.Fatalf("expected 0 agent rows before create, got %d\n%s", got, s.Screenshot())
+	}
+	s.AssertScreenContains(repoOnlyHint)
+
+	// Press "n" to create a new session — auto-focuses the terminal.
+	s.Press("n")
+	s.WaitForText(`\$`, 10000)
+
+	// Return to list focus — wait for the dashboard's "navigate" hint
+	// to confirm the focus actually switched back.
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	// After creating a session, the sidebar should show at least one agent row.
+	if got := countAgentRows(s.Screenshot()); got < 1 {
+		t.Errorf("expected at least 1 agent row after create, got %d\n%s",
+			got, s.Screenshot())
+	}
+}
+
+// TestAgentAddition verifies that pressing "c" adds a second agent row to an
+// existing session.
+func TestAgentAddition(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	s.WaitForText("AGENTS", 10000)
+
+	// Create the first session/agent.
+	s.Press("n")
+	s.WaitForText(`\$`, 10000)
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	beforeAgentCount := countAgentRows(s.Screenshot())
+	if beforeAgentCount < 1 {
+		t.Fatalf("expected at least 1 agent row before adding, got %d\n%s",
+			beforeAgentCount, s.Screenshot())
+	}
+
+	// Add a second agent to the session.
+	s.Press("c")
+	s.WaitForText(`\$`, 10000)
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	afterAgentCount := countAgentRows(s.Screenshot())
+	if afterAgentCount <= beforeAgentCount {
+		t.Errorf("expected agent row count to increase from %d, got %d\n%s",
+			beforeAgentCount, afterAgentCount, s.Screenshot())
+	}
+}
+
+// TestAgentKill verifies that pressing "x" kills the selected agent.
+// With one agent in the session, killing it removes the whole session,
+// so the agent count should drop back to 0 and the repo-only hint reappears.
+func TestAgentKill(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	s.WaitForText("AGENTS", 10000)
+
+	s.Press("n")
+	s.WaitForText(`\$`, 10000)
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	// Sanity: at least one agent row exists.
+	if countAgentRows(s.Screenshot()) == 0 {
+		t.Fatalf("expected agent row before kill, got none\n%s", s.Screenshot())
+	}
+
+	// Navigate down to the agent row, then kill it.
+	s.Press("j")
+	s.WaitStable(500)
+	s.Press("x")
+
+	// Wait for the repo-only hint to reappear (sole-agent kill removes the
+	// session; selection falls back to the repo header which shows this hint).
+	s.WaitForText(repoOnlyHint, 10000)
+	if got := countAgentRows(s.Screenshot()); got != 0 {
+		t.Errorf("expected 0 agent rows after kill, got %d\n%s", got, s.Screenshot())
+	}
+}
+
+// TestSessionKill verifies that pressing "X" kills the entire session and
+// removes its rows from the sidebar.
+func TestSessionKill(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	s.WaitForText("AGENTS", 10000)
+
+	s.Press("n")
+	s.WaitForText(`\$`, 10000)
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	// Sanity: agent rows exist before the kill.
+	if got := countAgentRows(s.Screenshot()); got == 0 {
+		t.Fatalf("expected agent row(s) before session kill, got 0\n%s", s.Screenshot())
+	}
+
+	s.Press("X")
+
+	// After killing the only session, the repo-only hint reappears.
+	s.WaitForText(repoOnlyHint, 10000)
+	if got := countAgentRows(s.Screenshot()); got != 0 {
+		t.Errorf("expected 0 agent rows after session kill, got %d\n%s", got, s.Screenshot())
+	}
+}
+
+// countAgentRows counts agent rows in the dashboard sidebar.
+// Agent rows are indented under sessions and start with a status symbol from
+// agent.Status.Symbol(): ◎ ● ○ ✓ ✗ (or "$" for shell agents). Session header
+// rows contain box-drawing dashes "──", so we skip those.
+func countAgentRows(screen string) int {
+	statusSymbols := []string{"◎ ", "● ", "○ ", "✓ ", "✗ ", "$ "}
+	count := 0
+	for _, line := range strings.Split(screen, "\n") {
+		// Strip leading whitespace and the optional selection arrow.
+		trimmed := strings.TrimLeft(line, " ")
+		trimmed = strings.TrimPrefix(trimmed, "▸ ")
+		// Session-header rows contain box-drawing dashes; skip them.
+		if strings.Contains(line, "──") {
+			continue
+		}
+		for _, sym := range statusSymbols {
+			if strings.HasPrefix(trimmed, sym) {
+				count++
+				break
+			}
+		}
+	}
+	return count
+}

--- a/internal/e2e/quit_test.go
+++ b/internal/e2e/quit_test.go
@@ -13,9 +13,8 @@ func TestQuitNoAgents(t *testing.T) {
 	s.WaitForText("AGENTS", 10000)
 
 	s.Press("q")
-	s.WaitStable(2000)
 
-	alive, exitCode := s.Status()
+	alive, exitCode := s.WaitForExit(5000)
 	if alive {
 		t.Fatalf("expected process to have exited, but it is still alive")
 	}
@@ -34,25 +33,22 @@ func TestQuitConfirmation(t *testing.T) {
 
 	// Create a new agent session (bash).
 	s.Press("n")
-	s.WaitForText("\\$", 10000)
+	s.WaitForText(`\$`, 10000)
 
 	// Return to list focus so quit key is handled at the app level.
 	s.Press("Escape")
-	s.WaitStable(1000)
+	s.WaitForText("navigate", 10000)
 
-	// First "q" — should show confirmation, not exit.
+	// First "q" — should show confirmation banner. The banner is distinctive
+	// (only rendered when confirmQuit is set); the always-present status bar
+	// hints don't say "Agents are running".
 	s.Press("q")
-	s.WaitStable(1000)
-
-	// The confirmation banner is distinctive (and only shown when confirmQuit
-	// is set); the always-present status bar hints don't say "Agents are running".
-	s.AssertScreenContains("Agents are running")
+	s.WaitForText("Agents are running", 5000)
 
 	// Second "q" — actually detach and exit.
 	s.Press("q")
-	s.WaitStable(3000)
 
-	alive, exitCode := s.Status()
+	alive, exitCode := s.WaitForExit(10000)
 	if alive {
 		t.Fatalf("expected process to have exited after detach, but it is still alive")
 	}
@@ -71,26 +67,21 @@ func TestForceQuit(t *testing.T) {
 
 	// Create a new agent session (bash).
 	s.Press("n")
-	s.WaitForText("\\$", 10000)
+	s.WaitForText(`\$`, 10000)
 
 	// Return to list focus so quit key is handled at the app level.
 	s.Press("Escape")
-	s.WaitStable(1000)
+	s.WaitForText("navigate", 10000)
 
-	// First "Q" — should show confirmation, not exit.
+	// First "Q" — should show confirmation banner.
 	s.Press("Q")
-	s.WaitStable(1000)
+	s.WaitForText("Agents are running", 5000)
 
-	// The confirmation banner is distinctive (and only shown when confirmQuit
-	// is set); the always-present status bar hints don't say "Agents are running".
-	s.AssertScreenContains("Agents are running")
-
-	// Second "Q" — actually force quit and exit.
+	// Second "Q" — actually force quit and exit. Force quit cleans up
+	// worktrees and kills agents, which can take a few seconds.
 	s.Press("Q")
-	// Force quit cleans up worktrees and kills agents, which can take a few seconds.
-	s.WaitStable(5000)
 
-	alive, exitCode := s.Status()
+	alive, exitCode := s.WaitForExit(15000)
 	if alive {
 		t.Fatalf("expected process to have exited after force quit, but it is still alive")
 	}

--- a/internal/e2e/quit_test.go
+++ b/internal/e2e/quit_test.go
@@ -1,0 +1,100 @@
+//go:build e2e
+
+package e2e
+
+import "testing"
+
+// TestQuitNoAgents verifies that pressing "q" with no running agents exits
+// baton immediately with exit code 0.
+func TestQuitNoAgents(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	s.WaitForText("AGENTS", 10000)
+
+	s.Press("q")
+	s.WaitStable(2000)
+
+	alive, exitCode := s.Status()
+	if alive {
+		t.Fatalf("expected process to have exited, but it is still alive")
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+// TestQuitConfirmation verifies the detach (q) flow when agents are running:
+// first "q" shows a confirmation message, second "q" detaches and exits.
+func TestQuitConfirmation(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	s.WaitForText("AGENTS", 10000)
+
+	// Create a new agent session (bash).
+	s.Press("n")
+	s.WaitForText("\\$", 10000)
+
+	// Return to list focus so quit key is handled at the app level.
+	s.Press("Escape")
+	s.WaitStable(1000)
+
+	// First "q" — should show confirmation, not exit.
+	s.Press("q")
+	s.WaitStable(1000)
+
+	// The confirmation banner is distinctive (and only shown when confirmQuit
+	// is set); the always-present status bar hints don't say "Agents are running".
+	s.AssertScreenContains("Agents are running")
+
+	// Second "q" — actually detach and exit.
+	s.Press("q")
+	s.WaitStable(3000)
+
+	alive, exitCode := s.Status()
+	if alive {
+		t.Fatalf("expected process to have exited after detach, but it is still alive")
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+}
+
+// TestForceQuit verifies the force quit (Q) flow when agents are running:
+// first "Q" shows a confirmation message, second "Q" force quits and exits.
+func TestForceQuit(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	s.WaitForText("AGENTS", 10000)
+
+	// Create a new agent session (bash).
+	s.Press("n")
+	s.WaitForText("\\$", 10000)
+
+	// Return to list focus so quit key is handled at the app level.
+	s.Press("Escape")
+	s.WaitStable(1000)
+
+	// First "Q" — should show confirmation, not exit.
+	s.Press("Q")
+	s.WaitStable(1000)
+
+	// The confirmation banner is distinctive (and only shown when confirmQuit
+	// is set); the always-present status bar hints don't say "Agents are running".
+	s.AssertScreenContains("Agents are running")
+
+	// Second "Q" — actually force quit and exit.
+	s.Press("Q")
+	// Force quit cleans up worktrees and kills agents, which can take a few seconds.
+	s.WaitStable(5000)
+
+	alive, exitCode := s.Status()
+	if alive {
+		t.Fatalf("expected process to have exited after force quit, but it is still alive")
+	}
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+}

--- a/internal/e2e/views_test.go
+++ b/internal/e2e/views_test.go
@@ -1,0 +1,93 @@
+//go:build e2e
+
+package e2e
+
+import "testing"
+
+func TestSettingsOverlay(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	// Wait for dashboard to appear.
+	s.WaitForText("AGENTS", 10000)
+
+	// Press "s" to open global settings overlay.
+	s.Press("s")
+	s.WaitStable(1000)
+
+	// Verify settings view content appears — look for setting field labels.
+	s.AssertScreenContains("Audio Enabled")
+	s.AssertScreenContains("Bypass Permissions")
+
+	// Press Escape to return to dashboard.
+	s.Press("Escape")
+	s.WaitStable(1000)
+
+	// Verify dashboard is restored.
+	s.AssertScreenContains("AGENTS")
+}
+
+func TestDiffView(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	// Wait for dashboard to appear.
+	s.WaitForText("AGENTS", 10000)
+
+	// Create a new session — "n" key. This auto-focuses the terminal.
+	s.Press("n")
+
+	// Wait for bash prompt inside the worktree.
+	s.WaitForText("\\$", 10000)
+
+	// Create a file, stage it, and commit so it shows up in branch diff.
+	s.Type("echo test > file.txt && git add file.txt && git commit -m 'add file'\n")
+	s.WaitStable(2000)
+
+	// Press Escape to return to list focus.
+	s.Press("Escape")
+	s.WaitStable(1000)
+
+	// Press "d" to open diff view.
+	s.Press("d")
+	s.WaitStable(2000)
+
+	// Verify the diff view shows the new file. We assert on the diff status
+	// bar hints (which are only rendered in the diff view, not the dashboard)
+	// AND on the file name, so the assertion can't pass if the diff view
+	// failed to open.
+	screen := s.Screenshot()
+	t.Logf("Diff view screen:\n%s", screen)
+	s.AssertScreenContains("file.txt")
+	s.AssertScreenContains("scroll diff") // unique to diffHints
+
+	// Exit diff view.
+	s.Press("Escape")
+	s.WaitStable(1000)
+
+	// Verify dashboard is restored.
+	s.AssertScreenContains("AGENTS")
+}
+
+func TestFileBrowser(t *testing.T) {
+	s := newSession(t)
+	s.Start()
+
+	// Wait for dashboard to appear.
+	s.WaitForText("AGENTS", 10000)
+
+	// Press "a" to open file browser overlay.
+	s.Press("a")
+	s.WaitStable(1000)
+
+	// Verify the file browser overlay is showing its characteristic headers.
+	s.AssertScreenContains("DIRECTORIES")
+	s.AssertScreenContains("DETAILS")
+
+	// Press Escape to close.
+	s.Press("Escape")
+	s.WaitStable(1000)
+
+	// Verify dashboard is restored.
+	s.AssertScreenContains("AGENTS")
+}

--- a/internal/e2e/views_test.go
+++ b/internal/e2e/views_test.go
@@ -4,26 +4,31 @@ package e2e
 
 import "testing"
 
+// Anchor strings used to wait for specific TUI views to render.
+//
+//   - dashboardAnchor: only appears in the dashboard status bar (not in any
+//     overlay's hint set, all of which use "navigate" too).
+//   - listFocusAnchor: dashboard text shown only when focus is on the list
+//     panel (terminal focus uses focusTerminalHints, which omits this).
+const (
+	dashboardAnchor = "new session"
+	listFocusAnchor = "new session"
+)
+
 func TestSettingsOverlay(t *testing.T) {
 	s := newSession(t)
 	s.Start()
 
-	// Wait for dashboard to appear.
 	s.WaitForText("AGENTS", 10000)
 
-	// Press "s" to open global settings overlay.
+	// Press "s" to open global settings overlay; wait for a known field label.
 	s.Press("s")
-	s.WaitStable(1000)
-
-	// Verify settings view content appears — look for setting field labels.
-	s.AssertScreenContains("Audio Enabled")
+	s.WaitForText("Audio Enabled", 5000)
 	s.AssertScreenContains("Bypass Permissions")
 
 	// Press Escape to return to dashboard.
 	s.Press("Escape")
-	s.WaitStable(1000)
-
-	// Verify dashboard is restored.
+	s.WaitForText(dashboardAnchor, 5000)
 	s.AssertScreenContains("AGENTS")
 }
 
@@ -31,41 +36,30 @@ func TestDiffView(t *testing.T) {
 	s := newSession(t)
 	s.Start()
 
-	// Wait for dashboard to appear.
 	s.WaitForText("AGENTS", 10000)
 
-	// Create a new session — "n" key. This auto-focuses the terminal.
+	// Create a new session — "n" key auto-focuses the terminal.
 	s.Press("n")
+	s.WaitForText(`\$`, 10000)
 
-	// Wait for bash prompt inside the worktree.
-	s.WaitForText("\\$", 10000)
+	// Create + commit a file in the worktree, then a sentinel echo we can
+	// wait for so we know the commit completed before moving on.
+	s.Type("echo test > file.txt && git add file.txt && git commit -m 'add file' && echo COMMIT_DONE\n")
+	s.WaitForText("COMMIT_DONE", 10000)
 
-	// Create a file, stage it, and commit so it shows up in branch diff.
-	s.Type("echo test > file.txt && git add file.txt && git commit -m 'add file'\n")
-	s.WaitStable(2000)
-
-	// Press Escape to return to list focus.
+	// Return to list focus.
 	s.Press("Escape")
-	s.WaitStable(1000)
+	s.WaitForText(listFocusAnchor, 5000)
 
-	// Press "d" to open diff view.
+	// Press "d" to open diff view; wait for the diff status bar (only rendered
+	// in the diff view, not the dashboard).
 	s.Press("d")
-	s.WaitStable(2000)
-
-	// Verify the diff view shows the new file. We assert on the diff status
-	// bar hints (which are only rendered in the diff view, not the dashboard)
-	// AND on the file name, so the assertion can't pass if the diff view
-	// failed to open.
-	screen := s.Screenshot()
-	t.Logf("Diff view screen:\n%s", screen)
+	s.WaitForText("scroll diff", 5000)
 	s.AssertScreenContains("file.txt")
-	s.AssertScreenContains("scroll diff") // unique to diffHints
 
 	// Exit diff view.
 	s.Press("Escape")
-	s.WaitStable(1000)
-
-	// Verify dashboard is restored.
+	s.WaitForText(dashboardAnchor, 5000)
 	s.AssertScreenContains("AGENTS")
 }
 
@@ -73,21 +67,16 @@ func TestFileBrowser(t *testing.T) {
 	s := newSession(t)
 	s.Start()
 
-	// Wait for dashboard to appear.
 	s.WaitForText("AGENTS", 10000)
 
-	// Press "a" to open file browser overlay.
+	// Press "a" to open file browser overlay; wait for a header that's unique
+	// to the browser.
 	s.Press("a")
-	s.WaitStable(1000)
-
-	// Verify the file browser overlay is showing its characteristic headers.
-	s.AssertScreenContains("DIRECTORIES")
+	s.WaitForText("DIRECTORIES", 5000)
 	s.AssertScreenContains("DETAILS")
 
 	// Press Escape to close.
 	s.Press("Escape")
-	s.WaitStable(1000)
-
-	// Verify dashboard is restored.
+	s.WaitForText(dashboardAnchor, 5000)
 	s.AssertScreenContains("AGENTS")
 }


### PR DESCRIPTION
## Summary

Adds an end-to-end test suite for the Baton TUI under `internal/e2e/`, plus an independent CI job. Tests use the [`tu`](https://github.com/flipbit03/terminal-use) CLI (a headless virtual terminal) to spawn baton, send keystrokes, and assert on screen content.

**Coverage (12 tests, opt-in via `//go:build e2e`):**
- Dashboard rendering and j/k navigation
- Session/agent lifecycle: `n` create, `c` add, `x`/`X` kill (real assertions on agent-row count)
- View transitions: `s` settings, `d` diff, `a` file browser
- Quit/detach: `q` (with confirmation banner), `Q` force-quit, `q` with no agents

**Infrastructure (`internal/e2e/helpers_test.go`):**
- `TestMain` builds baton once
- Per-test isolation: fake `HOME`, temp git repo with distinctive name, unique tu session names
- Sandboxed env (`XDG_*`, `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`) prevents host config leakage
- Bash agent (`agent_program=bash`, `bypass_permissions=false`) substitutes for claude

**CI:** new `e2e` job installs tu via the official script and runs the suite with a 300s timeout. Independent of the existing `check` job (no `-race` — these are process-level tests).

**Docs:** CLAUDE.md updated with the new test package.

## Test plan

- [x] `go test -tags e2e -timeout 300s -count=2 ./internal/e2e/` — 24/24 pass locally (~165s)
- [x] `go test -race -timeout 120s ./...` — no impact on existing tests
- [x] `golangci-lint run --build-tags=e2e ./internal/e2e/` — 0 issues
- [x] `gofumpt -l .` — clean
- [x] `tu list` after suite — empty (no orphan sessions)
- [ ] CI `check` job passes (verified by Github)
- [ ] CI new `e2e` job passes (verified by Github)