### PR TITLE
feat: elegant two-mode diff viewer

### DIFF
--- a/internal/e2e/views_test.go
+++ b/internal/e2e/views_test.go
@@ -51,10 +51,10 @@ func TestDiffView(t *testing.T) {
 	s.Press("Escape")
 	s.WaitForText(listFocusAnchor, 5000)
 
-	// Press "d" to open diff view; wait for the diff status bar (only rendered
-	// in the diff view, not the dashboard).
+	// Press "d" to open diff view; wait for the diff summary status bar hint
+	// (only rendered in the diff view).
 	s.Press("d")
-	s.WaitForText("scroll diff", 5000)
+	s.WaitForText("top/bot", 5000)
 	s.AssertScreenContains("file.txt")
 
 	// Exit diff view.

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -58,9 +58,40 @@ func GetDiffStats(repoPath string, wt *WorktreeInfo) (*DiffStats, error) {
 
 // DiffFile holds the parsed diff for a single file.
 type DiffFile struct {
-	Status string   // "M", "A", or "D"
-	Path   string   // file path from b/... header
-	Lines  []string // all diff lines for this file including headers
+	Status     string   // "M", "A", or "D"
+	Path       string   // file path from b/... header
+	Lines      []string // all diff lines for this file including headers
+	Insertions int      // count of added lines (excluding +++ header)
+	Deletions  int      // count of deleted lines (excluding --- header)
+}
+
+// HunkLineKind distinguishes context, addition, and deletion lines within a hunk.
+type HunkLineKind int
+
+const (
+	// HunkLineContext is an unchanged context line.
+	HunkLineContext HunkLineKind = iota
+	// HunkLineAddition is an added line (prefix '+').
+	HunkLineAddition
+	// HunkLineDeletion is a deleted line (prefix '-').
+	HunkLineDeletion
+)
+
+// HunkLine is a single line within a diff hunk.
+type HunkLine struct {
+	Kind HunkLineKind
+	// Text is the literal line content with the leading '+', '-', or ' ' prefix stripped.
+	Text string
+}
+
+// Hunk is a contiguous block of changes within a file's diff.
+type Hunk struct {
+	OldStart int
+	OldCount int
+	NewStart int
+	NewCount int
+	Header   string // raw @@ ... @@ line
+	Lines    []HunkLine
 }
 
 // ParseDiffFiles splits a raw unified diff into per-file chunks.
@@ -105,6 +136,14 @@ func ParseDiffFiles(rawDiff string) []DiffFile {
 		} else if line == "deleted file mode" || strings.HasPrefix(line, "deleted file mode ") {
 			current.Status = "D"
 		}
+		// Count insertions/deletions, skipping the +++/--- file header lines.
+		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+			// file header; do not count
+		} else if strings.HasPrefix(line, "+") {
+			current.Insertions++
+		} else if strings.HasPrefix(line, "-") {
+			current.Deletions++
+		}
 		current.Lines = append(current.Lines, line)
 	}
 
@@ -114,6 +153,117 @@ func ParseDiffFiles(rawDiff string) []DiffFile {
 	}
 
 	return files
+}
+
+// ParseHunks extracts the structured hunks from a DiffFile. Returns an empty
+// slice for binary files or files with no hunks.
+func ParseHunks(f DiffFile) []Hunk {
+	var hunks []Hunk
+	var current *Hunk
+
+	for _, line := range f.Lines {
+		// Skip file-level preamble lines.
+		if strings.HasPrefix(line, "diff --git ") ||
+			strings.HasPrefix(line, "index ") ||
+			strings.HasPrefix(line, "new file mode") ||
+			strings.HasPrefix(line, "deleted file mode") ||
+			strings.HasPrefix(line, "old mode") ||
+			strings.HasPrefix(line, "new mode") ||
+			strings.HasPrefix(line, "similarity index") ||
+			strings.HasPrefix(line, "rename from") ||
+			strings.HasPrefix(line, "rename to") ||
+			strings.HasPrefix(line, "copy from") ||
+			strings.HasPrefix(line, "copy to") ||
+			strings.HasPrefix(line, "Binary files") ||
+			strings.HasPrefix(line, "--- ") ||
+			strings.HasPrefix(line, "+++ ") ||
+			line == "---" ||
+			line == "+++" {
+			continue
+		}
+		if strings.HasPrefix(line, "@@") {
+			// Flush previous.
+			if current != nil {
+				hunks = append(hunks, *current)
+			}
+			h := parseHunkHeader(line)
+			current = &h
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		// "\ No newline at end of file" is a meta line; skip it.
+		if strings.HasPrefix(line, "\\") {
+			continue
+		}
+		// In unified diff format, every line inside a hunk has a leading
+		// '+', '-', or ' '. A bare empty line therefore means we've walked
+		// off the end of the hunk content (trailing newline in the raw diff).
+		switch {
+		case strings.HasPrefix(line, "+"):
+			current.Lines = append(current.Lines, HunkLine{
+				Kind: HunkLineAddition,
+				Text: line[1:],
+			})
+		case strings.HasPrefix(line, "-"):
+			current.Lines = append(current.Lines, HunkLine{
+				Kind: HunkLineDeletion,
+				Text: line[1:],
+			})
+		case strings.HasPrefix(line, " "):
+			current.Lines = append(current.Lines, HunkLine{
+				Kind: HunkLineContext,
+				Text: line[1:],
+			})
+		}
+	}
+
+	if current != nil {
+		hunks = append(hunks, *current)
+	}
+	return hunks
+}
+
+// parseHunkHeader parses a line like "@@ -1,3 +1,4 @@ optional section" into a Hunk.
+func parseHunkHeader(line string) Hunk {
+	h := Hunk{Header: line, OldCount: 1, NewCount: 1}
+	// Expected form: @@ -oldStart[,oldCount] +newStart[,newCount] @@ ...
+	rest := strings.TrimPrefix(line, "@@")
+	// Find the closing "@@".
+	end := strings.Index(rest, "@@")
+	if end < 0 {
+		return h
+	}
+	spec := strings.TrimSpace(rest[:end])
+	parts := strings.Fields(spec)
+	for _, p := range parts {
+		if strings.HasPrefix(p, "-") {
+			h.OldStart, h.OldCount = parseRange(p[1:])
+		} else if strings.HasPrefix(p, "+") {
+			h.NewStart, h.NewCount = parseRange(p[1:])
+		}
+	}
+	return h
+}
+
+// parseRange parses "start,count" or just "start", returning start and count (default 1).
+func parseRange(s string) (int, int) {
+	start, count := 0, 1
+	comma := strings.Index(s, ",")
+	if comma < 0 {
+		if n, err := strconv.Atoi(s); err == nil {
+			start = n
+		}
+		return start, count
+	}
+	if n, err := strconv.Atoi(s[:comma]); err == nil {
+		start = n
+	}
+	if n, err := strconv.Atoi(s[comma+1:]); err == nil {
+		count = n
+	}
+	return start, count
 }
 
 // FileStat holds per-file diff statistics.

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -44,6 +44,12 @@ index abc1234..def5678 100644
 	if f.Lines[0] != "diff --git a/foo.go b/foo.go" {
 		t.Errorf("first line should be diff header, got %q", f.Lines[0])
 	}
+	if f.Insertions != 1 {
+		t.Errorf("expected 1 insertion, got %d", f.Insertions)
+	}
+	if f.Deletions != 0 {
+		t.Errorf("expected 0 deletions, got %d", f.Deletions)
+	}
 }
 
 func TestParseDiffFiles_AddedAndDeleted(t *testing.T) {
@@ -110,6 +116,198 @@ Binary files a/image.png and b/image.png differ
 		if len(line) > 0 && (line[0] == '+' || line[0] == '-') {
 			t.Errorf("binary file should not have +/- lines, got %q", line)
 		}
+	}
+}
+
+func TestParseDiffFiles_InsertionDeletionCounts(t *testing.T) {
+	rawDiff := `diff --git a/added.txt b/added.txt
+new file mode 100644
+index 0000000..1234567
+--- /dev/null
++++ b/added.txt
+@@ -0,0 +1,3 @@
++line1
++line2
++line3
+diff --git a/deleted.txt b/deleted.txt
+deleted file mode 100644
+index 1234567..0000000
+--- a/deleted.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-gone1
+-gone2
+diff --git a/mod.txt b/mod.txt
+index abc..def 100644
+--- a/mod.txt
++++ b/mod.txt
+@@ -1,3 +1,3 @@
+ keep
+-old
++new
+ tail
+`
+	files := git.ParseDiffFiles(rawDiff)
+	if len(files) != 3 {
+		t.Fatalf("expected 3 files, got %d", len(files))
+	}
+	checks := map[string]struct{ ins, del int }{
+		"added.txt":   {3, 0},
+		"deleted.txt": {0, 2},
+		"mod.txt":     {1, 1},
+	}
+	for _, f := range files {
+		want := checks[f.Path]
+		if f.Insertions != want.ins {
+			t.Errorf("%s: expected %d insertions, got %d", f.Path, want.ins, f.Insertions)
+		}
+		if f.Deletions != want.del {
+			t.Errorf("%s: expected %d deletions, got %d", f.Path, want.del, f.Deletions)
+		}
+	}
+}
+
+func TestParseHunks_SingleHunk(t *testing.T) {
+	// Note: git outputs " \n" (space+newline) for blank context lines, not
+	// bare empty lines. Build the string explicitly so the blank context
+	// line in the hunk body has the required leading space.
+	rawDiff := "diff --git a/foo.go b/foo.go\n" +
+		"index abc1234..def5678 100644\n" +
+		"--- a/foo.go\n" +
+		"+++ b/foo.go\n" +
+		"@@ -1,3 +1,4 @@\n" +
+		" package main\n" +
+		" \n" +
+		"+// added comment\n" +
+		" func main() {}\n"
+	files := git.ParseDiffFiles(rawDiff)
+	hunks := git.ParseHunks(files[0])
+	if len(hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(hunks))
+	}
+	h := hunks[0]
+	if h.OldStart != 1 || h.OldCount != 3 {
+		t.Errorf("old range: expected 1,3 got %d,%d", h.OldStart, h.OldCount)
+	}
+	if h.NewStart != 1 || h.NewCount != 4 {
+		t.Errorf("new range: expected 1,4 got %d,%d", h.NewStart, h.NewCount)
+	}
+	if len(h.Lines) != 4 {
+		t.Fatalf("expected 4 hunk lines, got %d", len(h.Lines))
+	}
+	if h.Lines[0].Kind != git.HunkLineContext || h.Lines[0].Text != "package main" {
+		t.Errorf("line 0 wrong: kind=%v text=%q", h.Lines[0].Kind, h.Lines[0].Text)
+	}
+	if h.Lines[1].Kind != git.HunkLineContext || h.Lines[1].Text != "" {
+		t.Errorf("line 1 wrong: kind=%v text=%q", h.Lines[1].Kind, h.Lines[1].Text)
+	}
+	if h.Lines[2].Kind != git.HunkLineAddition || h.Lines[2].Text != "// added comment" {
+		t.Errorf("line 2 wrong: kind=%v text=%q", h.Lines[2].Kind, h.Lines[2].Text)
+	}
+	if h.Lines[3].Kind != git.HunkLineContext || h.Lines[3].Text != "func main() {}" {
+		t.Errorf("line 3 wrong: kind=%v text=%q", h.Lines[3].Kind, h.Lines[3].Text)
+	}
+}
+
+func TestParseHunks_MultipleHunks(t *testing.T) {
+	rawDiff := `diff --git a/foo.go b/foo.go
+index abc..def 100644
+--- a/foo.go
++++ b/foo.go
+@@ -1,3 +1,3 @@
+ a
+-b
++B
+ c
+@@ -10,2 +10,3 @@
+ x
++Y
+ z
+`
+	files := git.ParseDiffFiles(rawDiff)
+	hunks := git.ParseHunks(files[0])
+	if len(hunks) != 2 {
+		t.Fatalf("expected 2 hunks, got %d", len(hunks))
+	}
+	if hunks[0].OldStart != 1 || hunks[1].OldStart != 10 {
+		t.Errorf("hunk starts wrong: %d, %d", hunks[0].OldStart, hunks[1].OldStart)
+	}
+	if len(hunks[0].Lines) != 4 {
+		t.Errorf("hunk 0 lines: expected 4, got %d", len(hunks[0].Lines))
+	}
+	if len(hunks[1].Lines) != 3 {
+		t.Errorf("hunk 1 lines: expected 3, got %d", len(hunks[1].Lines))
+	}
+}
+
+func TestParseHunks_AddedFile(t *testing.T) {
+	rawDiff := `diff --git a/new.txt b/new.txt
+new file mode 100644
+index 0000000..1234567
+--- /dev/null
++++ b/new.txt
+@@ -0,0 +1,2 @@
++hello
++world
+`
+	files := git.ParseDiffFiles(rawDiff)
+	hunks := git.ParseHunks(files[0])
+	if len(hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(hunks))
+	}
+	if len(hunks[0].Lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(hunks[0].Lines))
+	}
+	for i, l := range hunks[0].Lines {
+		if l.Kind != git.HunkLineAddition {
+			t.Errorf("line %d: expected addition, got %v", i, l.Kind)
+		}
+	}
+}
+
+func TestParseHunks_DeletedFile(t *testing.T) {
+	rawDiff := `diff --git a/old.txt b/old.txt
+deleted file mode 100644
+index 1234567..0000000
+--- a/old.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-goodbye
+-world
+`
+	files := git.ParseDiffFiles(rawDiff)
+	hunks := git.ParseHunks(files[0])
+	if len(hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(hunks))
+	}
+	for i, l := range hunks[0].Lines {
+		if l.Kind != git.HunkLineDeletion {
+			t.Errorf("line %d: expected deletion, got %v", i, l.Kind)
+		}
+	}
+}
+
+func TestParseHunks_BinaryFile(t *testing.T) {
+	rawDiff := `diff --git a/image.png b/image.png
+index abc1234..def5678 100644
+Binary files a/image.png and b/image.png differ
+`
+	files := git.ParseDiffFiles(rawDiff)
+	hunks := git.ParseHunks(files[0])
+	if len(hunks) != 0 {
+		t.Errorf("expected 0 hunks for binary file, got %d", len(hunks))
+	}
+}
+
+func TestParseHunks_EmptyDiff(t *testing.T) {
+	files := git.ParseDiffFiles("")
+	if len(files) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(files))
+	}
+	// Ensure ParseHunks on a zero-value DiffFile also behaves.
+	hunks := git.ParseHunks(git.DiffFile{})
+	if len(hunks) != 0 {
+		t.Errorf("expected 0 hunks for empty DiffFile, got %d", len(hunks))
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -770,10 +770,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.setError(err.Error())
 					return a, nil
 				}
-				if rawDiff == "" {
-					a.setError("No changes yet")
-					return a, nil
-				}
+				// Always enter the diff view; the empty state is handled by
+				// the renderer when there are no files.
 				files := git.ParseDiffFiles(rawDiff)
 				a.view = ViewDiff
 				a.diff = newDiffModel(sess.GetDisplayName(), files, a.width, a.height-1)
@@ -1448,7 +1446,11 @@ func (a App) View() tea.View {
 		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)
 	case ViewDiff:
 		body := a.diff.View()
-		statusbar := renderStatusBar(diffHints, a.width)
+		hints := diffSummaryHints
+		if a.diff.Mode() == detailMode {
+			hints = diffDetailHints
+		}
+		statusbar := renderStatusBar(hints, a.width)
 		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)
 	case ViewMerge:
 		content = a.merge.View()

--- a/internal/tui/diffrender.go
+++ b/internal/tui/diffrender.go
@@ -1,0 +1,528 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+	git "github.com/devenjarvis/baton/internal/git"
+)
+
+// sideBySideMinWidth is the terminal width threshold below which the detail
+// view falls back to unified rendering.
+const sideBySideMinWidth = 120
+
+// diffBarWidth is the width of the per-file +/- visual bar in the summary.
+const diffBarWidth = 20
+
+// ── Summary ──────────────────────────────────────────────────────────────────
+
+// renderSummary renders the full-width list of changed files. Rows are assumed
+// to already be sorted by magnitude by the caller. The selected row is
+// highlighted.
+func renderSummary(agentName string, files []git.DiffFile, selected, width, height int) string {
+	if height < 1 {
+		return ""
+	}
+	if width < 1 {
+		width = 1
+	}
+
+	var totalIns, totalDel int
+	for _, f := range files {
+		totalIns += f.Insertions
+		totalDel += f.Deletions
+	}
+
+	fileCount := fmt.Sprintf("%d file", len(files))
+	if len(files) != 1 {
+		fileCount += "s"
+	}
+
+	addStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
+	delStyle := lipgloss.NewStyle().Foreground(ColorError)
+	mutedStyle := lipgloss.NewStyle().Foreground(ColorMuted)
+
+	title := StyleTitle.Render(agentName) + "  " +
+		mutedStyle.Render(fileCount) + "  " +
+		addStyle.Render(fmt.Sprintf("+%d", totalIns)) + "  " +
+		delStyle.Render(fmt.Sprintf("-%d", totalDel))
+
+	rowsAvail := height - 2 // title + blank
+	if rowsAvail < 1 {
+		rowsAvail = 1
+	}
+
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorSecondary)
+	normalStyle := lipgloss.NewStyle().Foreground(ColorText)
+	addStatusStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
+	delStatusStyle := lipgloss.NewStyle().Foreground(ColorError)
+	modStatusStyle := lipgloss.NewStyle().Foreground(ColorWarning)
+
+	// Compute column widths. Format per row:
+	//   "<S>  <path…>  <bar>  +X -Y"
+	// Fixed: status(1) + 2 + bar(diffBarWidth) + 2 + counts.
+	// Path takes the rest.
+	countsWidth := 12 // generous: "+9999 -9999" = 11
+	barWidth := diffBarWidth
+	fixed := 1 + 2 + barWidth + 2 + countsWidth + 2 // spaces around path too
+	pathWidth := width - fixed
+	if pathWidth < 8 {
+		pathWidth = 8
+	}
+
+	// Reserve one slot for the overflow indicator when the list doesn't fit.
+	visibleRows := rowsAvail
+	hasOverflow := len(files) > rowsAvail
+	if hasOverflow {
+		visibleRows = rowsAvail - 1
+		if visibleRows < 1 {
+			visibleRows = 1
+		}
+	}
+	// Compute a window so the selected row stays visible.
+	top := 0
+	if selected >= visibleRows {
+		top = selected - visibleRows + 1
+	}
+	if top > len(files)-visibleRows {
+		top = len(files) - visibleRows
+	}
+	if top < 0 {
+		top = 0
+	}
+	end := top + visibleRows
+	if end > len(files) {
+		end = len(files)
+	}
+
+	rows := make([]string, 0, rowsAvail)
+	for i := top; i < end; i++ {
+		f := files[i]
+		var statusStr string
+		switch f.Status {
+		case "A":
+			statusStr = addStatusStyle.Render("A")
+		case "D":
+			statusStr = delStatusStyle.Render("D")
+		default:
+			statusStr = modStatusStyle.Render("M")
+		}
+
+		path := truncatePathLeft(f.Path, pathWidth)
+		var pathRendered string
+		if i == selected {
+			pathRendered = selectedStyle.Render(padRight(path, pathWidth))
+		} else {
+			pathRendered = normalStyle.Render(padRight(path, pathWidth))
+		}
+
+		bar := renderChangeBar(f.Insertions, f.Deletions, barWidth)
+		counts := addStyle.Render(fmt.Sprintf("+%d", f.Insertions)) + " " +
+			delStyle.Render(fmt.Sprintf("-%d", f.Deletions))
+
+		row := statusStr + "  " + pathRendered + "  " + bar + "  " + counts
+		rows = append(rows, row)
+	}
+	if hasOverflow {
+		above := top
+		below := len(files) - end
+		var label string
+		switch {
+		case above > 0 && below > 0:
+			label = fmt.Sprintf("↑ %d more above  ·  ↓ %d more below", above, below)
+		case above > 0:
+			label = fmt.Sprintf("↑ %d more above", above)
+		default:
+			label = fmt.Sprintf("↓ %d more below", below)
+		}
+		rows = append(rows, mutedStyle.Render(label))
+	}
+	for len(rows) < rowsAvail {
+		rows = append(rows, "")
+	}
+
+	return title + "\n\n" + strings.Join(rows, "\n")
+}
+
+// renderChangeBar returns a fixed-width bar showing the proportion of
+// insertions to deletions. Fills green for additions and red for deletions
+// proportional to their count.
+func renderChangeBar(ins, del, width int) string {
+	if width < 1 {
+		return ""
+	}
+	total := ins + del
+	addStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
+	delStyle := lipgloss.NewStyle().Foreground(ColorError)
+	mutedStyle := lipgloss.NewStyle().Foreground(ColorMuted)
+
+	if total == 0 {
+		return mutedStyle.Render(strings.Repeat("─", width))
+	}
+	addN := (ins * width) / total
+	delN := (del * width) / total
+	// Ensure each side gets at least 1 cell if it has any changes.
+	if ins > 0 && addN == 0 {
+		addN = 1
+	}
+	if del > 0 && delN == 0 {
+		delN = 1
+	}
+	if addN+delN > width {
+		// Trim deletions first to fit.
+		delN = width - addN
+		if delN < 0 {
+			addN = width
+			delN = 0
+		}
+	}
+	padN := width - addN - delN
+	if padN < 0 {
+		padN = 0
+	}
+	return addStyle.Render(strings.Repeat("+", addN)) +
+		delStyle.Render(strings.Repeat("-", delN)) +
+		mutedStyle.Render(strings.Repeat(" ", padN))
+}
+
+// ── Detail ───────────────────────────────────────────────────────────────────
+
+// renderDetail renders the header and body for one file's diff. Chooses
+// side-by-side or unified based on available width.
+func renderDetail(agentName string, file git.DiffFile, hunks []git.Hunk, scroll, width, height int) string {
+	if height < 1 {
+		return ""
+	}
+	if width < 1 {
+		width = 1
+	}
+
+	addStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
+	delStyle := lipgloss.NewStyle().Foreground(ColorError)
+	mutedStyle := lipgloss.NewStyle().Foreground(ColorMuted)
+
+	status := file.Status
+	if status == "" {
+		status = "M"
+	}
+	header := StyleTitle.Render(agentName) + "  " +
+		mutedStyle.Render(status+" "+file.Path) + "  " +
+		addStyle.Render(fmt.Sprintf("+%d", file.Insertions)) + "  " +
+		delStyle.Render(fmt.Sprintf("-%d", file.Deletions))
+
+	bodyHeight := height - 2 // header + blank
+	if bodyHeight < 1 {
+		bodyHeight = 1
+	}
+
+	var body string
+	if width >= sideBySideMinWidth {
+		body = renderSideBySide(hunks, width, bodyHeight, scroll)
+	} else {
+		body = renderUnified(hunks, width, bodyHeight, scroll)
+	}
+
+	return header + "\n\n" + body
+}
+
+// sideBySideRow is a single visual row in the side-by-side body.
+type sideBySideRow struct {
+	leftKind  git.HunkLineKind
+	leftText  string
+	leftNum   int // 0 means blank/no number
+	rightKind git.HunkLineKind
+	rightText string
+	rightNum  int
+	// hasLeft/hasRight distinguish "blank filler" from "context that happens to be empty".
+	hasLeft  bool
+	hasRight bool
+	// isHunkHeader indicates a row that spans both sides showing the @@ header.
+	isHunkHeader bool
+	headerText   string
+}
+
+// renderSideBySide renders the detail body as two columns.
+func renderSideBySide(hunks []git.Hunk, width, height, scroll int) string {
+	if height < 1 {
+		return ""
+	}
+	rows := buildSideBySideRows(hunks)
+
+	start := scroll
+	if start < 0 {
+		start = 0
+	}
+	if start > len(rows) {
+		start = len(rows)
+	}
+	end := start + height
+	if end > len(rows) {
+		end = len(rows)
+	}
+
+	// Column widths: 5-char gutter per side, 1-char separator between gutter and content.
+	// Layout: [num:4][space][content] | [num:4][space][content]
+	// Total fixed: 4 + 1 (gutter right border space) + 1 (separator) + 1 (gutter left space after sep) + 4 + 1 = 12
+	gutterWidth := 4
+	sepWidth := 3 // " │ "
+	content := (width - 2*gutterWidth - 2 - sepWidth) / 2
+	if content < 4 {
+		content = 4
+	}
+
+	addStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
+	delStyle := lipgloss.NewStyle().Foreground(ColorError)
+	mutedStyle := lipgloss.NewStyle().Foreground(ColorMuted)
+	hunkStyle := lipgloss.NewStyle().Foreground(ColorSecondary)
+	contextStyle := lipgloss.NewStyle().Foreground(ColorText)
+
+	out := make([]string, 0, height)
+	for _, r := range rows[start:end] {
+		if r.isHunkHeader {
+			line := hunkStyle.Render(truncate(r.headerText, width))
+			out = append(out, padRight(line, width))
+			continue
+		}
+		leftNum := renderGutter(r.leftNum, gutterWidth, r.hasLeft, mutedStyle)
+		rightNum := renderGutter(r.rightNum, gutterWidth, r.hasRight, mutedStyle)
+
+		leftText := padRight(truncate(r.leftText, content), content)
+		rightText := padRight(truncate(r.rightText, content), content)
+
+		if r.hasLeft {
+			leftText = styleHunkKind(r.leftKind, leftText, addStyle, delStyle, contextStyle)
+		} else {
+			leftText = mutedStyle.Render(leftText)
+		}
+		if r.hasRight {
+			rightText = styleHunkKind(r.rightKind, rightText, addStyle, delStyle, contextStyle)
+		} else {
+			rightText = mutedStyle.Render(rightText)
+		}
+
+		sep := mutedStyle.Render(" │ ")
+		out = append(out, leftNum+" "+leftText+sep+rightNum+" "+rightText)
+	}
+
+	for len(out) < height {
+		out = append(out, "")
+	}
+	return strings.Join(out, "\n")
+}
+
+func renderGutter(num, width int, has bool, style lipgloss.Style) string {
+	if !has || num == 0 {
+		return style.Render(strings.Repeat(" ", width))
+	}
+	s := fmt.Sprintf("%*d", width, num)
+	return style.Render(s)
+}
+
+func styleHunkKind(kind git.HunkLineKind, text string, add, del, ctx lipgloss.Style) string {
+	switch kind {
+	case git.HunkLineAddition:
+		return add.Render(text)
+	case git.HunkLineDeletion:
+		return del.Render(text)
+	default:
+		return ctx.Render(text)
+	}
+}
+
+// buildSideBySideRows walks all hunks and produces visual rows. Deletion+addition
+// runs are paired row-by-row.
+func buildSideBySideRows(hunks []git.Hunk) []sideBySideRow {
+	rows := make([]sideBySideRow, 0, len(hunks))
+	for _, h := range hunks {
+		rows = append(rows, sideBySideRow{isHunkHeader: true, headerText: h.Header})
+		oldNum := h.OldStart
+		newNum := h.NewStart
+		var pendingDel []git.HunkLine
+		var pendingDelNums []int
+		var pendingAdd []git.HunkLine
+		var pendingAddNums []int
+
+		flush := func() {
+			max := len(pendingDel)
+			if len(pendingAdd) > max {
+				max = len(pendingAdd)
+			}
+			for i := 0; i < max; i++ {
+				var row sideBySideRow
+				if i < len(pendingDel) {
+					row.leftKind = pendingDel[i].Kind
+					row.leftText = pendingDel[i].Text
+					row.leftNum = pendingDelNums[i]
+					row.hasLeft = true
+				}
+				if i < len(pendingAdd) {
+					row.rightKind = pendingAdd[i].Kind
+					row.rightText = pendingAdd[i].Text
+					row.rightNum = pendingAddNums[i]
+					row.hasRight = true
+				}
+				rows = append(rows, row)
+			}
+			pendingDel = pendingDel[:0]
+			pendingDelNums = pendingDelNums[:0]
+			pendingAdd = pendingAdd[:0]
+			pendingAddNums = pendingAddNums[:0]
+		}
+
+		for _, l := range h.Lines {
+			switch l.Kind {
+			case git.HunkLineContext:
+				flush()
+				rows = append(rows, sideBySideRow{
+					leftKind:  git.HunkLineContext,
+					leftText:  l.Text,
+					leftNum:   oldNum,
+					hasLeft:   true,
+					rightKind: git.HunkLineContext,
+					rightText: l.Text,
+					rightNum:  newNum,
+					hasRight:  true,
+				})
+				oldNum++
+				newNum++
+			case git.HunkLineDeletion:
+				pendingDel = append(pendingDel, l)
+				pendingDelNums = append(pendingDelNums, oldNum)
+				oldNum++
+			case git.HunkLineAddition:
+				pendingAdd = append(pendingAdd, l)
+				pendingAddNums = append(pendingAddNums, newNum)
+				newNum++
+			}
+		}
+		flush()
+	}
+	return rows
+}
+
+// renderUnified renders the detail body as a single-column unified diff.
+func renderUnified(hunks []git.Hunk, width, height, scroll int) string {
+	if height < 1 {
+		return ""
+	}
+
+	addStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
+	delStyle := lipgloss.NewStyle().Foreground(ColorError)
+	hunkStyle := lipgloss.NewStyle().Foreground(ColorSecondary)
+	contextStyle := lipgloss.NewStyle().Foreground(ColorText)
+
+	lines := make([]string, 0, len(hunks))
+	for _, h := range hunks {
+		lines = append(lines, hunkStyle.Render(truncate(h.Header, width)))
+		for _, l := range h.Lines {
+			var prefix, styled string
+			switch l.Kind {
+			case git.HunkLineAddition:
+				prefix = "+"
+				styled = addStyle.Render(truncate(prefix+l.Text, width))
+			case git.HunkLineDeletion:
+				prefix = "-"
+				styled = delStyle.Render(truncate(prefix+l.Text, width))
+			default:
+				prefix = " "
+				styled = contextStyle.Render(truncate(prefix+l.Text, width))
+			}
+			lines = append(lines, styled)
+		}
+	}
+
+	start := scroll
+	if start < 0 {
+		start = 0
+	}
+	if start > len(lines) {
+		start = len(lines)
+	}
+	end := start + height
+	if end > len(lines) {
+		end = len(lines)
+	}
+	out := make([]string, 0, height)
+	out = append(out, lines[start:end]...)
+	for len(out) < height {
+		out = append(out, "")
+	}
+	return strings.Join(out, "\n")
+}
+
+// ── Empty state ──────────────────────────────────────────────────────────────
+
+// renderEmptyState returns a centered "no changes" message.
+func renderEmptyState(agentName string, width, height int) string {
+	if height < 1 {
+		return ""
+	}
+	if width < 1 {
+		width = 1
+	}
+	iconStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorSecondary)
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorText)
+	subtleStyle := lipgloss.NewStyle().Foreground(ColorMuted)
+
+	icon := iconStyle.Render("·")
+	title := titleStyle.Render("No changes yet")
+	subtitle := subtleStyle.Render(agentName + " hasn't modified any files in its worktree.")
+
+	block := lipgloss.JoinVertical(lipgloss.Center, icon, title, subtitle)
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, block)
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// truncate hard-truncates a string to n display cells, appending "…" if
+// truncation occurred. Rune-safe.
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= n {
+		return s
+	}
+	if n == 1 {
+		return "…"
+	}
+	// Keep n-1 runes and append ellipsis.
+	count := 0
+	end := 0
+	for i := range s {
+		if count == n-1 {
+			end = i
+			break
+		}
+		count++
+	}
+	return s[:end] + "…"
+}
+
+// padRight pads s with spaces on the right to reach n display cells.
+func padRight(s string, n int) string {
+	w := lipgloss.Width(s)
+	if w >= n {
+		return s
+	}
+	return s + strings.Repeat(" ", n-w)
+}
+
+// truncatePathLeft truncates a path from the left (preserving the tail) with
+// a leading ellipsis when it exceeds n runes.
+func truncatePathLeft(path string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(path) <= n {
+		return path
+	}
+	if n == 1 {
+		return "…"
+	}
+	// Keep the last n-1 runes.
+	runes := []rune(path)
+	return "…" + string(runes[len(runes)-(n-1):])
+}

--- a/internal/tui/diffview.go
+++ b/internal/tui/diffview.go
@@ -1,203 +1,199 @@
 package tui
 
 import (
-	"fmt"
-	"strings"
+	"sort"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/charmbracelet/lipgloss"
 	git "github.com/devenjarvis/baton/internal/git"
 )
 
-const leftPanelWidth = 28
+// diffMode selects between the summary and detail views.
+type diffMode int
 
-// diffModel displays a split-pane diff browser.
-// Left panel: file list. Right panel: per-file diff.
+const (
+	summaryMode diffMode = iota
+	detailMode
+)
+
+// diffModel drives the two-mode diff browser.
 type diffModel struct {
-	agentName   string
-	files       []git.DiffFile
-	selected    int // index of selected file in left panel
-	rightOffset int // scroll offset for right panel
-	width       int
-	height      int
+	agentName string
+	files     []git.DiffFile
+	hunks     [][]git.Hunk // parallel to files; pre-parsed once
+	mode      diffMode
+	selected  int // index of selected file in summary
+	scroll    int // scroll offset in detail mode
+	width     int
+	height    int
 }
 
+type diffCloseMsg struct{}
+
+// newDiffModel constructs a diffModel. Files are sorted by total change
+// magnitude (descending, tie-break on path ascending) and hunks are
+// pre-parsed for each file.
 func newDiffModel(agentName string, files []git.DiffFile, width, height int) diffModel {
+	sorted := make([]git.DiffFile, len(files))
+	copy(sorted, files)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		mi := sorted[i].Insertions + sorted[i].Deletions
+		mj := sorted[j].Insertions + sorted[j].Deletions
+		if mi != mj {
+			return mi > mj
+		}
+		return sorted[i].Path < sorted[j].Path
+	})
+
+	hunks := make([][]git.Hunk, len(sorted))
+	for i, f := range sorted {
+		hunks[i] = git.ParseHunks(f)
+	}
+
 	return diffModel{
 		agentName: agentName,
-		files:     files,
+		files:     sorted,
+		hunks:     hunks,
+		mode:      summaryMode,
 		width:     width,
 		height:    height,
 	}
 }
 
+// Mode exposes the current mode to callers (e.g., status-bar hint selection).
+func (d diffModel) Mode() diffMode {
+	return d.mode
+}
+
 func (d diffModel) Update(msg tea.Msg) (diffModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
-		switch msg.String() {
-		case "q", "esc":
-			return d, func() tea.Msg { return diffCloseMsg{} }
-		case "j", "down":
-			if d.selected < len(d.files)-1 {
-				d.selected++
-				d.rightOffset = 0
-			}
-		case "k", "up":
-			if d.selected > 0 {
-				d.selected--
-				d.rightOffset = 0
-			}
-		case "d":
-			// Page-scroll right panel down.
-			d.rightOffset += d.viewHeight() / 2
-			if max := d.maxRightOffset(); d.rightOffset > max {
-				d.rightOffset = max
-			}
-		case "u":
-			// Page-scroll right panel up.
-			d.rightOffset -= d.viewHeight() / 2
-			if d.rightOffset < 0 {
-				d.rightOffset = 0
-			}
+		if d.mode == detailMode {
+			return d.updateDetail(msg)
+		}
+		return d.updateSummary(msg)
+	}
+	return d, nil
+}
+
+func (d diffModel) updateSummary(msg tea.KeyPressMsg) (diffModel, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		return d, func() tea.Msg { return diffCloseMsg{} }
+	}
+	if len(d.files) == 0 {
+		return d, nil
+	}
+	switch msg.String() {
+	case "j", "down":
+		if d.selected < len(d.files)-1 {
+			d.selected++
+		}
+	case "k", "up":
+		if d.selected > 0 {
+			d.selected--
+		}
+	case "g":
+		d.selected = 0
+	case "G":
+		d.selected = len(d.files) - 1
+	case "enter", "l", "right":
+		d.mode = detailMode
+		d.scroll = 0
+	}
+	return d, nil
+}
+
+func (d diffModel) updateDetail(msg tea.KeyPressMsg) (diffModel, tea.Cmd) {
+	switch msg.String() {
+	case "q":
+		return d, func() tea.Msg { return diffCloseMsg{} }
+	case "esc", "h", "left":
+		d.mode = summaryMode
+		d.scroll = 0
+		return d, nil
+	}
+	if len(d.files) == 0 {
+		return d, nil
+	}
+	switch msg.String() {
+	case "j", "down":
+		d.scroll++
+		d.clampScroll()
+	case "k", "up":
+		d.scroll--
+		if d.scroll < 0 {
+			d.scroll = 0
+		}
+	case "d", "ctrl+d":
+		d.scroll += d.detailBodyHeight() / 2
+		d.clampScroll()
+	case "u", "ctrl+u":
+		d.scroll -= d.detailBodyHeight() / 2
+		if d.scroll < 0 {
+			d.scroll = 0
+		}
+	case "n":
+		if d.selected < len(d.files)-1 {
+			d.selected++
+			d.scroll = 0
+		}
+	case "p":
+		if d.selected > 0 {
+			d.selected--
+			d.scroll = 0
 		}
 	}
 	return d, nil
 }
 
-type diffCloseMsg struct{}
-
-// viewHeight is the usable content height (total minus title row).
-// d.height is already set to terminal height minus the statusbar row.
-func (d diffModel) viewHeight() int {
-	h := d.height - 1 // minus title row
+// detailBodyHeight returns the approximate height available for the detail
+// body (total minus header + blank).
+func (d diffModel) detailBodyHeight() int {
+	h := d.height - 2
 	if h < 1 {
 		return 1
 	}
 	return h
 }
 
-// maxRightOffset returns the maximum scroll offset for the right panel.
-func (d diffModel) maxRightOffset() int {
-	if len(d.files) == 0 {
-		return 0
+// clampScroll keeps scroll within the bounds of the current file's rendered
+// detail body. It accounts for the current render mode (side-by-side vs
+// unified), since side-by-side pairs del/add runs into fewer rows.
+func (d *diffModel) clampScroll() {
+	if len(d.files) == 0 || d.selected < 0 || d.selected >= len(d.hunks) {
+		d.scroll = 0
+		return
 	}
-	lines := d.files[d.selected].Lines
-	max := len(lines) - d.viewHeight()
+	var total int
+	if d.width >= sideBySideMinWidth {
+		total = len(buildSideBySideRows(d.hunks[d.selected]))
+	} else {
+		for _, h := range d.hunks[d.selected] {
+			total += 1 + len(h.Lines) // header + lines
+		}
+	}
+	max := total - d.detailBodyHeight()
 	if max < 0 {
-		return 0
+		max = 0
 	}
-	return max
+	if d.scroll > max {
+		d.scroll = max
+	}
 }
 
 func (d diffModel) View() string {
-	// ── Title bar ──────────────────────────────────────────────────────────
-	fileCount := fmt.Sprintf("%d file", len(d.files))
-	if len(d.files) != 1 {
-		fileCount += "s"
+	if len(d.files) == 0 {
+		return renderEmptyState(d.agentName, d.width, d.height)
 	}
-	title := StyleTitle.Render(d.agentName) + "  " + StyleSubtle.Render(fileCount)
-
-	// ── Left panel: file list ───────────────────────────────────────────────
-	addStatusStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
-	delStatusStyle := lipgloss.NewStyle().Foreground(ColorError)
-	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorSecondary)
-	normalStyle := lipgloss.NewStyle().Foreground(ColorText)
-
-	maxPathLen := leftPanelWidth - 2 // "A " prefix is 2 chars (letter + space)
-
-	vh := d.viewHeight()
-	var leftLines []string
-	for i, f := range d.files {
-		// Status letter with color.
-		var statusStr string
-		switch f.Status {
-		case "A":
-			statusStr = addStatusStyle.Render("A")
-		case "D":
-			statusStr = delStatusStyle.Render("D")
-		default:
-			statusStr = "M"
-		}
-
-		// Truncate path to fit.
-		path := f.Path
-		if len(path) > maxPathLen {
-			path = "…" + path[len(path)-maxPathLen+1:]
-		}
-
-		// Render path separately to preserve status letter color on selected row.
-		if i == d.selected {
-			entry := statusStr + " " + selectedStyle.Render(path)
-			leftLines = append(leftLines, entry)
-		} else {
-			entry := statusStr + " " + normalStyle.Render(path)
-			leftLines = append(leftLines, entry)
-		}
+	if d.mode == detailMode {
+		return renderDetail(
+			d.agentName,
+			d.files[d.selected],
+			d.hunks[d.selected],
+			d.scroll,
+			d.width,
+			d.height,
+		)
 	}
-
-	// Pad left panel to fill viewHeight.
-	for len(leftLines) < vh {
-		leftLines = append(leftLines, "")
-	}
-
-	leftPanel := lipgloss.NewStyle().
-		Width(leftPanelWidth).
-		Height(vh).
-		BorderRight(true).
-		BorderStyle(lipgloss.NormalBorder()).
-		BorderForeground(ColorMuted).
-		Render(strings.Join(leftLines, "\n"))
-
-	// ── Right panel: diff of selected file ─────────────────────────────────
-	addStyle := lipgloss.NewStyle().Foreground(ColorSuccess)
-	delStyle := lipgloss.NewStyle().Foreground(ColorError)
-	hunkStyle := lipgloss.NewStyle().Foreground(ColorSecondary)
-	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorText)
-
-	var diffLines []string
-	if len(d.files) > 0 {
-		diffLines = d.files[d.selected].Lines
-	}
-
-	end := d.rightOffset + vh
-	if end > len(diffLines) {
-		end = len(diffLines)
-	}
-	start := d.rightOffset
-	if start > len(diffLines) {
-		start = len(diffLines)
-	}
-
-	var rendered []string
-	for _, line := range diffLines[start:end] {
-		switch {
-		case strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---"):
-			rendered = append(rendered, headerStyle.Render(line))
-		case strings.HasPrefix(line, "@@"):
-			rendered = append(rendered, hunkStyle.Render(line))
-		case strings.HasPrefix(line, "+"):
-			rendered = append(rendered, addStyle.Render(line))
-		case strings.HasPrefix(line, "-"):
-			rendered = append(rendered, delStyle.Render(line))
-		case strings.HasPrefix(line, "diff "):
-			rendered = append(rendered, headerStyle.Render(line))
-		default:
-			rendered = append(rendered, line)
-		}
-	}
-
-	rightWidth := d.width - leftPanelWidth - 1 // -1 for border
-	if rightWidth < 1 {
-		rightWidth = 1
-	}
-
-	rightPanel := lipgloss.NewStyle().
-		Width(rightWidth).
-		Height(vh).
-		Render(strings.Join(rendered, "\n"))
-
-	// ── Assemble ────────────────────────────────────────────────────────────
-	body := lipgloss.JoinHorizontal(lipgloss.Top, leftPanel, rightPanel)
-
-	return title + "\n" + body
+	return renderSummary(d.agentName, d.files, d.selected, d.width, d.height)
 }

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -39,10 +39,19 @@ var (
 		{"⇧esc", "interrupt"},
 	}
 
-	diffHints = []keyHint{
+	diffSummaryHints = []keyHint{
 		{"j/k", "files"},
-		{"d/u", "scroll diff"},
-		{"q/esc", "back"},
+		{"enter", "open"},
+		{"g/G", "top/bot"},
+		{"q", "back"},
+	}
+
+	diffDetailHints = []keyHint{
+		{"j/k", "scroll"},
+		{"d/u", "page"},
+		{"n/p", "file"},
+		{"esc", "summary"},
+		{"q", "back"},
 	}
 
 	repoBrowsingHints = []keyHint{


### PR DESCRIPTION
## Summary

- Redesigned the worktree diff view as a two-mode experience: a summary list sorted by change magnitude, and a detail view (side-by-side above 120 columns, unified below)
- Added structured hunk parsing (`git.ParseHunks`) and per-file `Insertions`/`Deletions` counts to `git.DiffFile`
- New `internal/tui/diffrender.go` — pure render functions for summary, detail, side-by-side, unified, and empty state
- Rewrote `diffModel` as a summary/detail state machine with mode-aware scrolling
- Replaced the "No changes yet" error flash with a proper centered empty state
- Status-bar hints now switch per mode

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./internal/git/... ./internal/tui/...`
- [ ] Manual TUI: `d` on a session with changes → summary renders sorted by magnitude; `enter` → side-by-side detail; `esc`/`h` returns to summary preserving selection; `n`/`p` cycles files in detail
- [ ] Manual TUI: `d` on a session with no changes shows centered empty state; `q`/`esc` closes cleanly
- [ ] Manual TUI: resize below 120 columns → detail falls back to unified; resize back → side-by-side returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)