### PR TITLE
feat: chime on visual stability, not Active->Idle transition

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -28,16 +28,19 @@ type Agent struct {
 	pty      *bpty.PTY
 	terminal *vt.Terminal
 
-	mu              sync.RWMutex
-	displayName     string
-	claudePid       int
-	claudeSessionID string
-	hasClaudeName   bool
-	status          Status
-	lastOutput      time.Time
-	lastInput       time.Time
-	composing       bool
-	exitErr         error
+	mu               sync.RWMutex
+	displayName      string
+	claudePid        int
+	claudeSessionID  string
+	hasClaudeName    bool
+	status           Status
+	lastOutput       time.Time
+	lastInput        time.Time
+	composing        bool
+	exitErr          error
+	lastScreenHash   uint64
+	lastScreenChange time.Time
+	chimedForTurn    bool
 
 	done          chan struct{}
 	stop          chan struct{}
@@ -327,6 +330,9 @@ func (a *Agent) statusLoop() {
 		case <-a.stop:
 			return
 		case <-ticker.C:
+			hash := a.terminal.ScreenHash()
+			now := time.Now()
+
 			a.mu.Lock()
 			timeout := idleTimeout
 			if a.composing {
@@ -337,6 +343,15 @@ func (a *Agent) statusLoop() {
 				a.composing = false
 			} else if a.status == StatusIdle && time.Since(a.lastOutput) <= idleTimeout {
 				a.status = StatusActive
+			}
+			// Track visual stability. On first sample, stamp the tick time so
+			// stability is measured from first observation (not time.Time{}).
+			if a.lastScreenChange.IsZero() {
+				a.lastScreenHash = hash
+				a.lastScreenChange = now
+			} else if hash != a.lastScreenHash {
+				a.lastScreenHash = hash
+				a.lastScreenChange = now
 			}
 			a.mu.Unlock()
 		}
@@ -359,6 +374,9 @@ func (a *Agent) SendKey(key xvt.KeyPressEvent) {
 	a.lastInput = time.Now()
 	if key.Code == xvt.KeyEnter {
 		a.composing = false
+		// Enter re-arms the chime: the user just submitted a new turn.
+		// Other keys (edits, backspace, arrow keys) must not reset the flag.
+		a.chimedForTurn = false
 	} else {
 		a.composing = true
 	}
@@ -424,6 +442,44 @@ func (a *Agent) HasReceivedInput() bool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return !a.lastInput.IsZero()
+}
+
+// VisualStableFor returns how long the rendered screen has been unchanged.
+// Returns 0 before the first statusLoop sample has run.
+func (a *Agent) VisualStableFor() time.Duration {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.lastScreenChange.IsZero() {
+		return 0
+	}
+	return time.Since(a.lastScreenChange)
+}
+
+// TimeSinceOutput returns how long since the PTY last produced output.
+// Returns 0 before any output has been observed.
+func (a *Agent) TimeSinceOutput() time.Duration {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.lastOutput.IsZero() {
+		return 0
+	}
+	return time.Since(a.lastOutput)
+}
+
+// ChimedForTurn reports whether the chime has already fired for the current
+// user turn. Resets to false when the user presses Enter.
+func (a *Agent) ChimedForTurn() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.chimedForTurn
+}
+
+// MarkChimedForTurn marks the current turn as having chimed, so the trigger
+// won't re-fire until the user presses Enter to start a new turn.
+func (a *Agent) MarkChimedForTurn() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.chimedForTurn = true
 }
 
 // HasDisplayName reports whether a display name has been explicitly set.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -474,6 +474,84 @@ func TestKillAfterNaturalExitDoesNotPanic(t *testing.T) {
 	a.Kill()
 }
 
+func TestVisualStableForTracksHashChanges(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-visual-stable", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		// Produce one line of output, then go quiet.
+		return exec.Command("bash", "-c", "echo ready; sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the screen to stabilize after initial output.
+	// statusLoop ticks every 500ms; give it enough time for output + one sample.
+	time.Sleep(1500 * time.Millisecond)
+
+	stableA := a.VisualStableFor()
+	if stableA == 0 {
+		t.Fatal("expected VisualStableFor to be non-zero after first sample")
+	}
+
+	// Wait another tick — with no new output, VisualStableFor must grow.
+	time.Sleep(600 * time.Millisecond)
+
+	stableB := a.VisualStableFor()
+	if stableB <= stableA {
+		t.Errorf("expected VisualStableFor to grow while screen unchanged; was %v, now %v", stableA, stableB)
+	}
+}
+
+func TestChimedForTurnResetsOnEnterOnly(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-chime-turn", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo ready; cat")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	// MarkChimedForTurn flips the flag.
+	a.MarkChimedForTurn()
+	if !a.ChimedForTurn() {
+		t.Fatal("expected ChimedForTurn true after MarkChimedForTurn")
+	}
+
+	// SendText must NOT reset the flag.
+	a.SendText("hello")
+	if !a.ChimedForTurn() {
+		t.Error("expected ChimedForTurn to remain true after SendText")
+	}
+
+	// Paste must NOT reset the flag.
+	a.Paste("pasted")
+	if !a.ChimedForTurn() {
+		t.Error("expected ChimedForTurn to remain true after Paste")
+	}
+
+	// Non-Enter keys must NOT reset the flag.
+	a.SendKey(xvt.KeyPressEvent{Code: xvt.KeyBackspace})
+	if !a.ChimedForTurn() {
+		t.Error("expected ChimedForTurn to remain true after Backspace")
+	}
+
+	// Enter RESETS the flag.
+	a.SendKey(xvt.KeyPressEvent{Code: xvt.KeyEnter})
+	if a.ChimedForTurn() {
+		t.Error("expected ChimedForTurn to reset to false after Enter")
+	}
+}
+
 func TestShutdownCleansAll(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo, defaultTestSettings())

--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -51,4 +51,21 @@ func (s Status) Symbol() string {
 const (
 	idleTimeout          = 3 * time.Second
 	composingIdleTimeout = 30 * time.Second
+
+	// visualStabilityWindow is the amount of time the rendered screen must
+	// remain unchanged before an agent is considered visually stable (nothing
+	// animating, no output churn).
+	visualStabilityWindow = 2 * time.Second
+
+	// stuckFallbackTimeout is the grace period after which a silent agent
+	// (no PTY output) is treated as stuck, even if the primary stability
+	// signal never trips.
+	stuckFallbackTimeout = 60 * time.Second
+)
+
+// Exported mirrors of the stability constants for callers outside this package
+// (e.g., the TUI chime trigger) that need to compare against the same window.
+const (
+	VisualStabilityWindow = visualStabilityWindow
+	StuckFallbackTimeout  = stuckFallbackTimeout
 )

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -297,17 +297,30 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			ag := item.agent
 			currentStatus := ag.Status()
 
-			// Check for Active->Idle transition.
+			// Check for Active->Idle transition (preserves downstream side
+			// effects like diff-stats refresh). The chime trigger below uses
+			// a separate frame-stability signal rather than the transition.
 			if prev, ok := a.lastKnownStatus[ag.ID]; ok {
 				if prev == agent.StatusActive && currentStatus == agent.StatusIdle && ag.HasReceivedInput() && !ag.IsShell {
-					resolved := a.resolvedCache[item.repoPath]
-					if resolved.AudioEnabled && a.audioPlayer != nil {
-						a.audioPlayer.Play()
-					}
 					idleTransition = true
 				}
 			}
 			a.lastKnownStatus[ag.ID] = currentStatus
+
+			// Chime trigger: fire once per turn when the agent is truly
+			// awaiting input. Primary signal is frame stability (screen
+			// unchanged for VisualStabilityWindow); fallback is prolonged
+			// silence (no PTY output for StuckFallbackTimeout).
+			if !ag.IsShell && ag.HasReceivedInput() && !ag.ChimedForTurn() &&
+				(currentStatus == agent.StatusActive || currentStatus == agent.StatusIdle) &&
+				(ag.VisualStableFor() >= agent.VisualStabilityWindow ||
+					ag.TimeSinceOutput() >= agent.StuckFallbackTimeout) {
+				resolved := a.resolvedCache[item.repoPath]
+				if resolved.AudioEnabled && a.audioPlayer != nil {
+					a.audioPlayer.Play()
+					ag.MarkChimedForTurn()
+				}
+			}
 
 			// Poll Claude session file for auto-generated name.
 			if !ag.IsShell && !ag.HasClaudeName() {

--- a/internal/vt/bridge.go
+++ b/internal/vt/bridge.go
@@ -5,6 +5,7 @@ package vt
 
 import (
 	"bytes"
+	"hash/fnv"
 	"io"
 	"strings"
 	"sync"
@@ -126,6 +127,17 @@ func (t *Terminal) Write(p []byte) (int, error) {
 // Render returns the full screen as an ANSI-encoded string.
 func (t *Terminal) Render() string {
 	return t.emu.Render()
+}
+
+// ScreenHash returns a deterministic hash of the current visible screen content.
+// Identical rendered screens produce identical hashes; any visible change
+// (rune, color, style, cursor on a filled cell) produces a different hash.
+// Safe to call concurrently with Write/Render — delegates to Render which
+// acquires the emulator lock.
+func (t *Terminal) ScreenHash() uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(t.emu.Render()))
+	return h.Sum64()
 }
 
 // RenderRegion returns a subset of rows from startRow to endRow (inclusive)

--- a/internal/vt/bridge_test.go
+++ b/internal/vt/bridge_test.go
@@ -242,6 +242,80 @@ func TestScrollbackLinesHistoryPreferred(t *testing.T) {
 	}
 }
 
+func TestScreenHashStableWhenUnchanged(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	_, _ = term.Write([]byte("stable content"))
+
+	h1 := term.ScreenHash()
+	h2 := term.ScreenHash()
+	if h1 != h2 {
+		t.Errorf("expected identical hashes for unchanged screen, got %d and %d", h1, h2)
+	}
+}
+
+func TestScreenHashChangesOnWrite(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	_, _ = term.Write([]byte("before"))
+	before := term.ScreenHash()
+
+	_, _ = term.Write([]byte(" after"))
+	after := term.ScreenHash()
+
+	if before == after {
+		t.Errorf("expected hash to change after Write, both are %d", before)
+	}
+}
+
+func TestScreenHashStableAcrossIdenticalWrites(t *testing.T) {
+	a := New(80, 24)
+	defer a.Close()
+	b := New(80, 24)
+	defer b.Close()
+
+	_, _ = a.Write([]byte("same payload"))
+	_, _ = b.Write([]byte("same payload"))
+
+	if a.ScreenHash() != b.ScreenHash() {
+		t.Errorf("expected identical hashes for identical screen content, got %d vs %d",
+			a.ScreenHash(), b.ScreenHash())
+	}
+}
+
+func TestScreenHashChangesOnStyleChange(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	_, _ = term.Write([]byte("plain"))
+	plain := term.ScreenHash()
+
+	// Clear and write the same text but bold.
+	_, _ = term.Write([]byte("\x1b[2J\x1b[H\x1b[1mplain\x1b[0m"))
+	styled := term.ScreenHash()
+
+	if plain == styled {
+		t.Errorf("expected hash to differ when style changes, both are %d", plain)
+	}
+}
+
+func TestScreenHashChangesOnResize(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	_, _ = term.Write([]byte("hello"))
+	before := term.ScreenHash()
+
+	term.Resize(40, 12)
+	after := term.ScreenHash()
+
+	if before == after {
+		t.Errorf("expected hash to change after resize (different render domain), both are %d", before)
+	}
+}
+
 func TestCursorPosition(t *testing.T) {
 	term := New(80, 24)
 	defer term.Close()


### PR DESCRIPTION
## Summary

- Replace the output-timeout chime trigger (`Active → Idle` after 3s silence) with a **frame-stability** signal so the chime fires only when Claude is truly awaiting input.
- New `vt.Terminal.ScreenHash()` (FNV-64a over the existing `Render()`) lets callers detect when the rendered screen stops changing.
- `Agent.statusLoop` samples the hash every 500ms; stamps `lastScreenChange` on first sample and on any change. New accessors `VisualStableFor()`, `TimeSinceOutput()`, `ChimedForTurn()`, `MarkChimedForTurn()`.
- Chime is once-per-turn: `SendKey` re-arms `chimedForTurn` **only on Enter** — composing/edits/paste do not reset it.
- TUI gate (all six must hold): `!IsShell`, `HasReceivedInput`, `!ChimedForTurn`, `Status ∈ {Active, Idle}`, `VisualStableFor ≥ 2s || TimeSinceOutput ≥ 60s`, audio enabled.
- 60s `stuckFallbackTimeout` covers the rare case where stability never lands but the agent is effectively stuck.
- Preserves the existing `lastKnownStatus`/`idleTransition` bookkeeping for downstream side effects (e.g., diff-stats refresh).

## Test plan

- [x] `go test -race ./internal/vt/...` — new `ScreenHash` tests pass (stable-when-unchanged, change-on-write, identity across terminals, style change, resize)
- [x] `go test -race ./internal/agent/...` — new tests `TestVisualStableForTracksHashChanges`, `TestChimedForTurnResetsOnEnterOnly` pass
- [x] `go test -race ./...` — no new regressions (one pre-existing `internal/config` failure unrelated to this change)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` → 0 issues
- [x] `gofumpt -d` → no diff
- [x] `go build -o baton .` succeeds
- [ ] Manual: multi-step task → **0 chimes** during inter-tool pauses
- [ ] Manual: `(y/n)` approval prompt → **exactly 1** chime
- [ ] Manual: task completion → **exactly 1** chime
- [ ] Manual: re-arm on Enter → chime fires once more next turn
- [ ] Manual: `AudioEnabled=false` → no chime
- [ ] Manual: shell agent with `sleep 120` → no chime
- [ ] Manual: 60s-silent Claude → fallback fires exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)