### PR TITLE
Launch 1/4: community health files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+go.sum linguist-generated=true
+demo/baton.gif binary linguist-generated=true
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Something in Baton is broken or behaving unexpectedly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the fields below so we can reproduce it.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, in one or two sentences?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact steps someone else can run to see the bug.
+      placeholder: |
+        1. Run `baton` in a repo with 2+ agents
+        2. Press `d` on agent 1
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include error messages or screenshots if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: "`baton doctor` output"
+      description: Paste the full output of `baton doctor`. This is the fastest way to triage most issues.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Baton version
+      description: Output of `baton --version`.
+      placeholder: "baton 0.1.0 (abc123, 2026-01-01)"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 14.5 / Ubuntu 24.04 / ..."
+    validations:
+      required: true
+  - type: input
+    id: go
+    attributes:
+      label: Go version (only if building from source)
+      description: Output of `go version`.
+      placeholder: "go version go1.25.0 darwin/arm64"
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else?
+      description: Logs, config snippets, related issues — anything that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/devenjarvis/baton/security/advisories/new
+    about: Please report security issues privately via GitHub Security Advisories, not public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a new feature or enhancement for Baton.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do? What's getting in the way today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What would you like Baton to do? A rough sketch is fine.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why they fell short.
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else?
+      description: Screenshots, mockups, links to related issues.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- Bullet points describing what changed and why. Focus on the *why* — the diff shows the *what*. -->
+
+-
+
+## Test plan
+
+<!-- Check the commands you actually ran. Add manual TUI steps when UI behavior changed. -->
+
+- [ ] `go build ./...`
+- [ ] `go vet ./...`
+- [ ] `gofumpt -l .` (clean)
+- [ ] `golangci-lint run ./...`
+- [ ] `go test -race ./...`
+- [ ] Manual TUI:
+
+## Checklist
+
+- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
+- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
+- [ ] No new public API surface without a note in the PR description

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      charm:
+        patterns:
+          - "charm.land/*"
+          - "github.com/charmbracelet/*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to Baton will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Every PR should update the `[Unreleased]` section with a short entry describing the change.
+
+## [Unreleased]
+
+## [0.1.0] — 2026-04-15
+
+Initial public release.
+
+### Added
+
+- Dashboard view listing all managed agents with live status (idle/active/error) and visual-stability detection.
+- Focus mode: full-screen interactive session with a selected agent; all keys forwarded to the PTY.
+- Diff view: two-mode experience — summary list sorted by change magnitude, and side-by-side (≥120 cols) or unified (below) detail view.
+- Merge: `git merge --no-ff` from a worktree branch into the base branch with cleanup of the worktree.
+- Prompt and merge overlays for creating and landing agent work without leaving the TUI.
+- `baton doctor` command for validating the environment (Go, git, `claude` on PATH).
+- Mouse support on the dashboard (click-to-select, click-to-focus).
+- Isolated git worktrees under `.baton/worktrees/<name>` on branches `baton/<name>`.
+- Virtual terminal bridge built on `charmbracelet/x/vt` for thread-safe rendering of agent output.
+
+[Unreleased]: https://github.com/devenjarvis/baton/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/devenjarvis/baton/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to Baton
+
+Baton is an early, single-maintainer project. Focused bug reports, fixes, and small features are the easiest kind of contribution to review.
+
+## Filing issues
+
+Search existing issues (open and closed) before opening a new one.
+
+- **Bugs** — use the "Bug report" form. Include `baton doctor` output, steps to reproduce, and expected vs. actual behavior.
+- **Feature requests** — use the "Feature request" form. Describe the underlying problem, not just the proposal.
+- **Security vulnerabilities** — do not file a public issue. See [SECURITY.md](./SECURITY.md).
+
+## Development setup
+
+Requirements:
+
+- Go 1.25+
+- Git 2.20+
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude` on PATH) — runtime-only
+
+```bash
+git clone https://github.com/devenjarvis/baton.git
+cd baton
+go build -o baton .
+./baton doctor
+```
+
+## Build, test, lint
+
+```bash
+go build -o baton .         # build
+go test ./...               # run all tests
+go test -race ./...         # run with race detector
+go vet ./...                # static analysis
+golangci-lint run           # lint (config in .golangci.yml)
+gofumpt -w .                # format all Go files
+```
+
+Always run `go test -race ./...` before opening a PR. Baton runs several goroutines per agent (PTY/VT/git) and the race detector has caught real bugs here.
+
+End-to-end TUI tests live in `internal/e2e/` and require the `tu` CLI v0.6.0+:
+
+```bash
+go test -tags e2e -timeout 300s -v ./internal/e2e/
+```
+
+## PR workflow
+
+1. Fork the repo and branch from `main`.
+2. Keep PRs focused — one concern per PR.
+3. Add or update tests. Bug fixes should include a regression test where practical.
+4. Update `CHANGELOG.md` under `[Unreleased]`.
+5. Run locally before pushing: `go test -race ./... && go vet ./... && golangci-lint run && gofumpt -l .` (the last should print nothing).
+6. Open a PR. The template prompts for summary and test plan.
+
+## Commit messages
+
+Match the existing style (see `git log`):
+
+- `feat: <what>` — new user-facing functionality
+- `fix: <what>` — bug fix
+- `test: <what>` — test-only changes
+- `refactor: <what>` — no behavior change
+- `docs: <what>` — documentation
+- `chore: <what>` — tooling, dependencies, release plumbing
+
+One-liners are fine. A body is welcome when the *why* isn't obvious from the diff.
+
+## Architecture
+
+Read the Architecture section in [README.md](./README.md) and the key patterns in [`CLAUDE.md`](./CLAUDE.md) before making non-trivial changes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Deven Jarvis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported versions
+
+Baton is pre-1.0. Only the latest released version receives security fixes.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately. Do **not** open a public GitHub issue.
+
+**Preferred:** use GitHub's private vulnerability reporting on this repo — go to the [Security tab](https://github.com/devenjarvis/baton/security) and click "Report a vulnerability."
+
+**Fallback:** email `devenjarvis@gmail.com` with subject line `[baton security]`.
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce (or a proof-of-concept)
+- The version of Baton you tested against (`baton --version`)
+- Your environment (OS, Go version if building from source)
+
+You should receive an acknowledgment within a few days. Once the issue is confirmed, a fix will be coordinated before any public disclosure.


### PR DESCRIPTION
Part 1 of a four-PR open-source launch series. Merges first — zero risk, pure docs.

## Summary

- `LICENSE` (MIT, © 2026 Deven Jarvis) — the README has always claimed MIT; now the file exists.
- `CONTRIBUTING.md` — dev setup (Go 1.25+, git 2.20+, \`claude\` on PATH), build/test/lint commands, PR workflow, commit-message conventions lifted from \`git log\`.
- \`SECURITY.md\` — routes vulnerability reports to GitHub private advisories with email fallback.
- \`CHANGELOG.md\` — [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with an \`[Unreleased]\` header and a \`[0.1.0]\` placeholder summarizing current functionality.
- \`.github/ISSUE_TEMPLATE/\` — YAML forms for bugs (requires \`baton doctor\` output) and feature requests, plus a \`config.yml\` that disables blank issues.
- \`.github/PULL_REQUEST_TEMPLATE.md\` — matches the summary/test-plan/checklist pattern from recent merged PRs.
- \`.github/dependabot.yml\` — weekly gomod + github-actions updates on Mondays; \`charm\` group pins \`charm.land/*\` and \`github.com/charmbracelet/*\` together.
- \`.gitattributes\` — marks \`go.sum\` and the demo GIF as \`linguist-generated\`. CHANGELOG deliberately not marked (would collapse diffs in review UI).

## Stack

This PR is the base of a four-PR stack:

1. **\`launch/community\` → main** ← you are here
2. \`launch/release-automation\` → \`launch/community\`
3. \`launch/homebrew\` → \`launch/release-automation\`
4. \`launch/readme-demo\` → \`launch/homebrew\`

Merge in order. Each subsequent PR will rebase onto \`main\` once its predecessor lands.

## Test plan

- [ ] GitHub's Community tab (\`/community\`) lights up License, Contributing, Security, Issue templates, PR template after merge.
- [ ] New-issue form picker appears with bug / feature / security links.
- [ ] New-PR body pre-fills from the template.
- [ ] Dependabot opens its first grouped PR on the Monday following merge.

## Notes

- Code of Conduct was intentionally dropped from scope.
- No code changes in this PR — should need no CI except lint/vet passes.