### PR TITLE
Launch 2/4: versioning + GoReleaser + release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Required once the Homebrew tap is wired up in .goreleaser.yaml (PR 3).
+          # Until then the tap block is commented out, so this secret is unused.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 baton
 .baton/
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,98 @@
+version: 2
+
+project_name: baton
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: baton
+    main: .
+    binary: baton
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/devenjarvis/baton/cmd.Version={{.Version}}
+      - -X github.com/devenjarvis/baton/cmd.Commit={{.Commit}}
+      - -X github.com/devenjarvis/baton/cmd.Date={{.Date}}
+
+archives:
+  - id: baton
+    name_template: "baton_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    files:
+      - README.md
+      - LICENSE
+      - CHANGELOG.md
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Refactors
+      regexp: '^.*?refactor(\(.+\))??!?:.+$'
+      order: 2
+    - title: Tests
+      regexp: '^.*?test(\(.+\))??!?:.+$'
+      order: 3
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - '^docs:'
+      - '^chore:'
+      - '^ci:'
+      - '^style:'
+      - 'Merge pull request'
+      - 'Merge remote-tracking branch'
+      - 'Merge branch'
+
+release:
+  draft: false
+  prerelease: auto
+  name_template: "v{{ .Version }}"
+
+# Homebrew publishing — wired in a follow-up PR once the tap repo exists and
+# the PAT is available as HOMEBREW_TAP_GITHUB_TOKEN in this repo's Actions
+# secrets.
+#
+# brews:
+#   - name: baton
+#     repository:
+#       owner: devenjarvis
+#       name: homebrew-tap
+#       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+#     directory: Formula
+#     homepage: https://github.com/devenjarvis/baton
+#     description: Terminal-native orchestrator for parallel Claude Code agents
+#     license: MIT
+#     skip_upload: auto
+#     test: |
+#       system "#{bin}/baton", "--version"
+#     install: |
+#       bin.install "baton"
+#     dependencies:
+#       - name: git

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,11 @@ var rootCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	rootCmd.Version = versionString()
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+}
+
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Version metadata. Populated at build time via -ldflags by GoReleaser; kept
+// as var (not const) so the linker can override them. Default values are the
+// ones produced by a bare `go build`.
+var (
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)
+
+// versionString returns the canonical "baton <version> (<commit>, <date>)" format
+// used by both the `--version` flag and the `version` subcommand.
+func versionString() string {
+	return fmt.Sprintf("baton %s (%s, %s)", Version, Commit, Date)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(versionString())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Part 2 of the four-PR launch stack. Stacked on \`launch/community\` — merge that first.

## Summary

- \`cmd/version.go\` — package vars \`Version\`, \`Commit\`, \`Date\` (defaults: \`dev\`, \`none\`, \`unknown\`), populated at build time via \`-ldflags -X\`. Adds a \`baton version\` subcommand mirroring the \`--version\` flag output for discoverability.
- \`cmd/root.go\` — \`init()\` wires \`rootCmd.Version = versionString()\` and \`SetVersionTemplate(\"{{.Version}}\\n\")\`. Plain \`go build\` yields \`baton dev (none, unknown)\`; linker-overridden builds yield \`baton 0.1.0 (<sha>, <date>)\`.
- \`.goreleaser.yaml\` — GoReleaser v2 config. CGO-free builds for darwin/linux × arm64/amd64, \`tar.gz\` archives that include \`README.md\`/\`LICENSE\`/\`CHANGELOG.md\`, sha256 \`checksums.txt\`, conventional-commit grouped changelog (excluding docs/chore/ci/style commits), prerelease auto-detect on tag suffix. **Homebrew \`brews\` block left commented** — enabled in launch 3/4.
- \`.github/workflows/release.yml\` — triggers on \`v*\` tags. \`actions/checkout@v4\` with \`fetch-depth: 0\`, \`actions/setup-go@v5\` pinned to \`go-version-file: go.mod\`, \`goreleaser/goreleaser-action@v6\` with \`version: \"~> v2\"\`. Passes both \`GITHUB_TOKEN\` and \`HOMEBREW_TAP_GITHUB_TOKEN\` (unused until stack 3 activates the brews block).
- \`.gitignore\` — ignore \`dist/\` (GoReleaser output).

## Stack

1. \`launch/community\` → main
2. **\`launch/release-automation\` → \`launch/community\`** ← you are here
3. \`launch/homebrew\` → \`launch/release-automation\`
4. \`launch/readme-demo\` → \`launch/homebrew\`

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`gofumpt -l .\` clean
- [x] \`goreleaser check\` validates
- [x] \`goreleaser release --snapshot --clean\` produces 4 tarballs + checksums.txt locally
- [x] \`./dist/baton_darwin_arm64_v8.0/baton --version\` → \`baton 0.0.1-next (<sha>, <date>)\`
- [x] Plain \`go build -o baton . && ./baton --version\` → \`baton dev (none, unknown)\`
- [x] \`./baton version\` subcommand matches \`--version\` output
- [ ] Dry-run: push \`v0.0.0-test1\` on a throwaway branch → release workflow produces a draft release with 4 archives; delete the tag + draft afterward.

## Notes

- GoReleaser emits a deprecation warning that \`brews:\` is being phased out in favor of \`homebrew_casks:\`. Non-fatal in v2; will break on v3. Follow-up after the launch stack lands.
- \`HOMEBREW_TAP_GITHUB_TOKEN\` secret is referenced by the workflow but unused until stack PR 3 enables the brews block. Safe to leave it unset for now.