### PR TITLE
Launch 3/4: Homebrew tap wiring

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,24 +75,25 @@ release:
   prerelease: auto
   name_template: "v{{ .Version }}"
 
-# Homebrew publishing — wired in a follow-up PR once the tap repo exists and
-# the PAT is available as HOMEBREW_TAP_GITHUB_TOKEN in this repo's Actions
-# secrets.
-#
-# brews:
-#   - name: baton
-#     repository:
-#       owner: devenjarvis
-#       name: homebrew-tap
-#       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-#     directory: Formula
-#     homepage: https://github.com/devenjarvis/baton
-#     description: Terminal-native orchestrator for parallel Claude Code agents
-#     license: MIT
-#     skip_upload: auto
-#     test: |
-#       system "#{bin}/baton", "--version"
-#     install: |
-#       bin.install "baton"
-#     dependencies:
-#       - name: git
+# Homebrew publishing. Requires:
+#   1) A public repo at github.com/devenjarvis/homebrew-tap
+#   2) A PAT with `contents: write` on that repo, stored as the
+#      HOMEBREW_TAP_GITHUB_TOKEN secret on this repo's Actions settings.
+# skip_upload: auto keeps snapshots and pre-releases from touching the tap.
+brews:
+  - name: baton
+    repository:
+      owner: devenjarvis
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: https://github.com/devenjarvis/baton
+    description: Terminal-native orchestrator for parallel Claude Code agents
+    license: MIT
+    skip_upload: auto
+    test: |
+      system "#{bin}/baton", "--version"
+    install: |
+      bin.install "baton"
+    dependencies:
+      - name: git

--- a/README.md
+++ b/README.md
@@ -18,11 +18,19 @@ baton doctor
 
 ## Install
 
+### Homebrew (macOS & Linux)
+
+```bash
+brew install devenjarvis/tap/baton
+```
+
+### Go
+
 ```bash
 go install github.com/devenjarvis/baton@latest
 ```
 
-Or build from source:
+### From source
 
 ```bash
 git clone https://github.com/devenjarvis/baton.git


### PR DESCRIPTION
Part 3 of the four-PR launch stack. Stacked on \`launch/release-automation\`.

## Summary

- \`.goreleaser.yaml\` — uncomments the \`brews\` block. On tagged releases GoReleaser will commit \`Formula/baton.rb\` to \`devenjarvis/homebrew-tap\` pointing at the new release's tarballs. \`skip_upload: auto\` keeps snapshots and prereleases from touching the tap.
- \`README.md\` — adds a Homebrew install section above the existing \`go install\` block. (Launch 4/4 will do the full README rewrite.)

## One-time setup before the first tagged release

Before cutting \`v0.1.0\`, the repo owner needs to:

1. **Create a public repo** at \`github.com/devenjarvis/homebrew-tap\` with a one-line README describing the tap. Don't pre-populate any formulas; GoReleaser will push the first one.
2. **Generate a PAT** with \`contents: write\` on the tap repo.
3. **Add the secret** — paste the PAT into \`devenjarvis/baton\`'s Actions secrets as \`HOMEBREW_TAP_GITHUB_TOKEN\`.

Without these, the first tagged release will fail at the \`brews\` step (everything else — tarballs, checksums, GitHub release — will still succeed).

## Stack

1. \`launch/community\` → main
2. \`launch/release-automation\` → \`launch/community\`
3. **\`launch/homebrew\` → \`launch/release-automation\`** ← you are here
4. \`launch/readme-demo\` → \`launch/homebrew\`

## Test plan

- [x] \`goreleaser check\` validates (deprecation warning only — see notes below).
- [ ] First real tag cut after this lands commits \`Formula/baton.rb\` to the tap repo.
- [ ] \`brew install devenjarvis/tap/baton\` installs cleanly on a fresh macOS machine.
- [ ] Installed \`baton --version\` reports the release version (e.g. \`baton 0.1.0 (<sha>, <date>)\`).

## Notes

- GoReleaser deprecation: \`brews:\` is being phased out in favor of \`homebrew_casks:\` in a future major. Non-fatal in v2. Follow-up migration after this stack merges.