### PR TITLE
Replace status heuristics with Claude Code hook integration

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -38,11 +38,29 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check claude
-	if path, err := exec.LookPath("claude"); err != nil {
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
 		fmt.Println("  [FAIL] claude: not found")
 		allOk = false
 	} else {
-		fmt.Printf("  [OK]   claude: %s\n", path)
+		fmt.Printf("  [OK]   claude: %s\n", claudePath)
+
+		// Verify claude supports --settings, which baton uses to inject the
+		// hooks that drive status detection and chimes.
+		if supportsSettingsFlag(claudePath) {
+			fmt.Println("  [OK]   claude --settings: supported")
+		} else {
+			fmt.Println("  [FAIL] claude --settings: not supported (required for hook integration)")
+			allOk = false
+		}
+	}
+
+	// Baton's own binary path — hooks commands reference it.
+	if exe, err := os.Executable(); err != nil {
+		fmt.Printf("  [FAIL] baton binary: unresolved (%v)\n", err)
+		allOk = false
+	} else {
+		fmt.Printf("  [OK]   baton binary: %s\n", exe)
 	}
 
 	// Check git repo
@@ -97,4 +115,15 @@ func parseGitVersion(version string) (int, int) {
 func isGitRepo() bool {
 	err := exec.Command("git", "rev-parse", "--is-inside-work-tree").Run()
 	return err == nil
+}
+
+// supportsSettingsFlag returns true if `claude --help` advertises the
+// --settings flag. We only spawn the real binary with --help so this is safe
+// to run from doctor in any environment.
+func supportsSettingsFlag(claudePath string) bool {
+	out, err := exec.Command(claudePath, "--help").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), "--settings")
 }

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/devenjarvis/baton/internal/hook"
+	"github.com/spf13/cobra"
+)
+
+var hookCmd = &cobra.Command{
+	Use:   "hook <event>",
+	Short: "Forward a Claude Code hook event to the running baton process",
+	Long: `hook is invoked by Claude Code via the settings file baton writes before
+spawning a session. It reads the Claude hook JSON payload on stdin and
+forwards it to the baton TUI over the unix socket named by BATON_HOOK_SOCKET.
+
+This command is not intended to be run by humans. Output is kept silent —
+Claude interprets stdout from hooks as feedback. Errors go to stderr. Exit
+code is always 0 so hook failures never block Claude.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runHook,
+	// Silence Cobra's usage printing on error — a stray usage dump would be
+	// interpreted by Claude as hook feedback.
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	rootCmd.AddCommand(hookCmd)
+}
+
+func runHook(cmd *cobra.Command, args []string) error {
+	// Resolve the event kind. Unknown events exit 0 silently so we don't break
+	// Claude if a future hook name is wired in by accident.
+	var kind hook.Kind
+	switch args[0] {
+	case "session-start":
+		kind = hook.KindSessionStart
+	case "stop":
+		kind = hook.KindStop
+	case "session-end":
+		kind = hook.KindSessionEnd
+	default:
+		return nil
+	}
+
+	socketPath := os.Getenv("BATON_HOOK_SOCKET")
+	agentID := os.Getenv("BATON_AGENT_ID")
+	// Without the env vars there's no route to any running baton — exit
+	// silently so running `claude` outside of baton doesn't spew errors.
+	if socketPath == "" || agentID == "" {
+		return nil
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "baton hook: reading stdin:", err)
+		return nil
+	}
+
+	// Parse just the fields we route on; keep the rest in Raw so the server
+	// can inspect extras if it cares later.
+	var payload struct {
+		SessionID string `json:"session_id"`
+		CWD       string `json:"cwd"`
+	}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			// Claude may send a non-JSON payload or nothing at all; that's fine.
+			payload.SessionID = ""
+		}
+	}
+
+	e := hook.Event{
+		Kind:      kind,
+		AgentID:   agentID,
+		SessionID: payload.SessionID,
+		CWD:       payload.CWD,
+		Raw:       json.RawMessage(raw),
+	}
+
+	if err := hook.SendEvent(socketPath, e); err != nil {
+		fmt.Fprintln(os.Stderr, "baton hook: forwarding event:", err)
+	}
+	return nil
+}

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devenjarvis/baton/internal/hook"
+)
+
+// TestHookSubcommandForwards runs the built baton binary with `hook session-start`
+// and asserts the server on the other side receives the event with the right
+// AgentID and parsed session_id.
+func TestHookSubcommandForwards(t *testing.T) {
+	// Find repo root and build the binary into a temp dir.
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	bin := filepath.Join(t.TempDir(), "baton")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("building baton: %v\n%s", err, out)
+	}
+
+	socket := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := hook.NewServer(socket)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	cmd := exec.Command(bin, "hook", "session-start")
+	cmd.Env = append(cmd.Environ(),
+		"BATON_HOOK_SOCKET="+socket,
+		"BATON_AGENT_ID=test-agent-42",
+	)
+	cmd.Stdin = strings.NewReader(`{"session_id":"uuid-xyz","cwd":"/tmp/wt"}`)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("running hook: %v\n%s", err, out)
+	}
+
+	select {
+	case e := <-srv.Events():
+		if e.Kind != hook.KindSessionStart {
+			t.Errorf("kind: got %q, want %q", e.Kind, hook.KindSessionStart)
+		}
+		if e.AgentID != "test-agent-42" {
+			t.Errorf("agent id: got %q, want %q", e.AgentID, "test-agent-42")
+		}
+		if e.SessionID != "uuid-xyz" {
+			t.Errorf("session id: got %q, want %q", e.SessionID, "uuid-xyz")
+		}
+		if e.CWD != "/tmp/wt" {
+			t.Errorf("cwd: got %q, want %q", e.CWD, "/tmp/wt")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for hook event")
+	}
+}
+
+// TestHookSubcommandNoEnv ensures the hook subcommand silently no-ops when
+// BATON_HOOK_SOCKET and BATON_AGENT_ID aren't set — this is the case for a
+// user running `claude` outside of baton.
+func TestHookSubcommandNoEnv(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	bin := filepath.Join(t.TempDir(), "baton")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("building baton: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bin, "hook", "stop")
+	// Deliberately no BATON_* env vars.
+	cmd.Stdin = strings.NewReader(`{}`)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0, got err: %v\n%s", err, out)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected no output, got: %q", out)
+	}
+}
+
+// TestHookSubcommandUnknownEvent ensures unknown event names exit 0 silently.
+func TestHookSubcommandUnknownEvent(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	bin := filepath.Join(t.TempDir(), "baton")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("building baton: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bin, "hook", "made-up-event")
+	cmd.Stdin = strings.NewReader(`{}`)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("expected exit 0 for unknown event, got err: %v\n%s", err, out)
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -208,11 +208,15 @@ func buildSpawnArgs(cfg Config, worktreePath, socketPath string) ([]string, erro
 // buildHookArgs writes the per-agent hooks settings file and returns the
 // `--settings <path>` pair. Returns an empty slice when hooks are disabled
 // (socketPath empty, or agent program is not claude).
+//
+// The file lives at `<worktreePath>/.baton/hooks.json` so it sits inside the
+// already-gitignored `.baton/` tree and doesn't show up as an untracked file
+// in the user's worktree `git status`.
 func buildHookArgs(cfg Config, worktreePath, socketPath string) ([]string, error) {
 	if socketPath == "" || !supportsHooks(cfg) {
 		return nil, nil
 	}
-	hookPath := filepath.Join(worktreePath, ".baton-hooks.json")
+	hookPath := filepath.Join(worktreePath, ".baton", "hooks.json")
 	if err := hook.WriteHooksFile(hookPath); err != nil {
 		return nil, fmt.Errorf("writing hooks settings: %w", err)
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/devenjarvis/baton/internal/hook"
 	bpty "github.com/devenjarvis/baton/internal/pty"
 	"github.com/devenjarvis/baton/internal/vt"
 
@@ -30,7 +30,6 @@ type Agent struct {
 
 	mu               sync.RWMutex
 	displayName      string
-	claudePid        int
 	claudeSessionID  string
 	hasClaudeName    bool
 	status           Status
@@ -38,13 +37,11 @@ type Agent struct {
 	lastInput        time.Time
 	composing        bool
 	exitErr          error
-	lastScreenHash   uint64
-	lastScreenChange time.Time
 	chimedForTurn    bool
+	sessionStartedAt time.Time
+	cleanExit        bool
 
 	done          chan struct{}
-	stop          chan struct{}
-	stopOnce      sync.Once
 	writeLoopDone chan struct{}
 }
 
@@ -67,35 +64,37 @@ func agentProgram(cfg Config) string {
 	return "claude"
 }
 
+// supportsHooks reports whether the configured agent program understands
+// Claude Code's --settings flag and lifecycle hooks. Other programs (e.g. a
+// bash shim used by e2e tests, or a custom tool a user wires in) get no
+// hook wiring — their agents will sit at Active indefinitely, matching the
+// "non-claude" assumption in the hook-integration plan.
+func supportsHooks(cfg Config) bool {
+	return filepath.Base(agentProgram(cfg)) == "claude"
+}
+
 // newAgent creates and starts an agent with the configured agent program.
 // The worktreePath is provided by the session — agents do not create worktrees.
-func newAgent(id string, cfg Config, worktreePath string) (*Agent, error) {
+// socketPath is the unix socket the baton-hook CLI should dial; when non-empty,
+// a Claude settings file is written that routes SessionStart/Stop/SessionEnd
+// events back to this baton process.
+func newAgent(id string, cfg Config, worktreePath, socketPath string) (*Agent, error) {
 	term := vt.New(cfg.Cols, cfg.Rows)
 
 	prog := agentProgram(cfg)
-	var cmd *exec.Cmd
-	if cfg.BypassPermissions {
-		if cfg.Task != "" {
-			cmd = exec.Command(prog, "--dangerously-skip-permissions", cfg.Task)
-		} else {
-			cmd = exec.Command(prog, "--dangerously-skip-permissions")
-		}
-	} else {
-		if cfg.Task != "" {
-			cmd = exec.Command(prog, cfg.Task)
-		} else {
-			cmd = exec.Command(prog)
-		}
+	args, err := buildSpawnArgs(cfg, worktreePath, socketPath)
+	if err != nil {
+		return nil, err
 	}
+	cmd := exec.Command(prog, args...)
 	cmd.Dir = worktreePath
 	cmd.Env = append(cmd.Environ(), "TERM=xterm-256color")
+	applyHookEnv(cmd, cfg, id, socketPath)
 
 	p := &bpty.PTY{}
 	if err := p.Start(cmd, uint16(cfg.Rows), uint16(cfg.Cols)); err != nil {
 		return nil, err
 	}
-
-	claudePid := p.Pid()
 
 	a := &Agent{
 		ID:            id,
@@ -105,10 +104,8 @@ func newAgent(id string, cfg Config, worktreePath string) (*Agent, error) {
 		CreatedAt:     time.Now(),
 		pty:           p,
 		terminal:      term,
-		claudePid:     claudePid,
 		status:        StatusStarting,
 		done:          make(chan struct{}),
-		stop:          make(chan struct{}),
 		writeLoopDone: make(chan struct{}),
 	}
 
@@ -118,7 +115,6 @@ func newAgent(id string, cfg Config, worktreePath string) (*Agent, error) {
 
 	go a.readLoop()
 	go a.writeLoop()
-	go a.statusLoop()
 
 	return a, nil
 }
@@ -131,13 +127,21 @@ func newResumedAgent(
 	cfg Config,
 	worktreePath string,
 	claudeSessionID string,
+	socketPath string,
 ) (*Agent, error) {
 	term := vt.New(cfg.Cols, cfg.Rows)
 
-	args := buildResumeArgs(cfg, claudeSessionID)
+	resumeArgs := buildResumeArgs(cfg, claudeSessionID)
+	hookArgs, err := buildHookArgs(cfg, worktreePath, socketPath)
+	if err != nil {
+		return nil, err
+	}
+	// --settings must come before --resume / --continue (flags before positional args).
+	args := append(hookArgs, resumeArgs...)
 	cmd := exec.Command(agentProgram(cfg), args...)
 	cmd.Dir = worktreePath
 	cmd.Env = append(cmd.Environ(), "TERM=xterm-256color")
+	applyHookEnv(cmd, cfg, id, socketPath)
 
 	p := &bpty.PTY{}
 	if err := p.Start(cmd, uint16(cfg.Rows), uint16(cfg.Cols)); err != nil {
@@ -152,17 +156,14 @@ func newResumedAgent(
 		CreatedAt:       time.Now(),
 		pty:             p,
 		terminal:        term,
-		claudePid:       p.Pid(),
 		claudeSessionID: claudeSessionID,
 		status:          StatusStarting,
 		done:            make(chan struct{}),
-		stop:            make(chan struct{}),
 		writeLoopDone:   make(chan struct{}),
 	}
 
 	go a.readLoop()
 	go a.writeLoop()
-	go a.statusLoop()
 
 	return a, nil
 }
@@ -188,6 +189,49 @@ func buildResumeArgs(cfg Config, claudeSessionID string) []string {
 	return args
 }
 
+// buildSpawnArgs builds the argv for a fresh `claude` invocation, prefixed with
+// the hook settings (`--settings <file>`) when hooks are supported.
+func buildSpawnArgs(cfg Config, worktreePath, socketPath string) ([]string, error) {
+	args, err := buildHookArgs(cfg, worktreePath, socketPath)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.BypassPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+	if cfg.Task != "" {
+		args = append(args, cfg.Task)
+	}
+	return args, nil
+}
+
+// buildHookArgs writes the per-agent hooks settings file and returns the
+// `--settings <path>` pair. Returns an empty slice when hooks are disabled
+// (socketPath empty, or agent program is not claude).
+func buildHookArgs(cfg Config, worktreePath, socketPath string) ([]string, error) {
+	if socketPath == "" || !supportsHooks(cfg) {
+		return nil, nil
+	}
+	hookPath := filepath.Join(worktreePath, ".baton-hooks.json")
+	if err := hook.WriteHooksFile(hookPath); err != nil {
+		return nil, fmt.Errorf("writing hooks settings: %w", err)
+	}
+	return []string{"--settings", hookPath}, nil
+}
+
+// applyHookEnv sets BATON_HOOK_SOCKET and BATON_AGENT_ID on cmd so the
+// baton-hook CLI (invoked by claude) knows where to forward events.
+// No-op when hooks are disabled for this program.
+func applyHookEnv(cmd *exec.Cmd, cfg Config, agentID, socketPath string) {
+	if socketPath == "" || !supportsHooks(cfg) {
+		return
+	}
+	cmd.Env = append(cmd.Env,
+		"BATON_HOOK_SOCKET="+socketPath,
+		"BATON_AGENT_ID="+agentID,
+	)
+}
+
 // newAgentWithCommand creates an agent using a custom command instead of claude.
 // Used for testing. The worktreePath is provided by the session.
 func newAgentWithCommand(id string, cfg Config, worktreePath string, cmd *exec.Cmd) (*Agent, error) {
@@ -209,16 +253,13 @@ func newAgentWithCommand(id string, cfg Config, worktreePath string, cmd *exec.C
 		CreatedAt:     time.Now(),
 		pty:           p,
 		terminal:      term,
-		claudePid:     p.Pid(),
 		status:        StatusStarting,
 		done:          make(chan struct{}),
-		stop:          make(chan struct{}),
 		writeLoopDone: make(chan struct{}),
 	}
 
 	go a.readLoop()
 	go a.writeLoop()
-	go a.statusLoop()
 
 	return a, nil
 }
@@ -253,7 +294,6 @@ func newShellAgent(id string, cfg Config, worktreePath string) (*Agent, error) {
 		displayName:   "shell",
 		status:        StatusStarting,
 		done:          make(chan struct{}),
-		stop:          make(chan struct{}),
 		writeLoopDone: make(chan struct{}),
 	}
 
@@ -318,44 +358,45 @@ func (a *Agent) writeLoop() {
 	}
 }
 
-// statusLoop periodically checks for idle status.
-func (a *Agent) statusLoop() {
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
+// OnHookEvent applies a Claude Code hook event to the agent's state.
+// Returns true if the agent's status changed as a result (so the manager
+// can emit EventStatusChanged).
+//
+// Status transitions driven here replace the old statusLoop heuristic —
+// Claude's SessionStart/Stop/SessionEnd events are the authoritative signal.
+func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 
-	for {
-		select {
-		case <-a.done:
-			return
-		case <-a.stop:
-			return
-		case <-ticker.C:
-			hash := a.terminal.ScreenHash()
-			now := time.Now()
-
-			a.mu.Lock()
-			timeout := idleTimeout
-			if a.composing {
-				timeout = composingIdleTimeout
-			}
-			if a.status == StatusActive && time.Since(a.lastOutput) > timeout && time.Since(a.lastInput) > timeout {
-				a.status = StatusIdle
-				a.composing = false
-			} else if a.status == StatusIdle && time.Since(a.lastOutput) <= idleTimeout {
-				a.status = StatusActive
-			}
-			// Track visual stability. On first sample, stamp the tick time so
-			// stability is measured from first observation (not time.Time{}).
-			if a.lastScreenChange.IsZero() {
-				a.lastScreenHash = hash
-				a.lastScreenChange = now
-			} else if hash != a.lastScreenHash {
-				a.lastScreenHash = hash
-				a.lastScreenChange = now
-			}
-			a.mu.Unlock()
+	switch e.Kind {
+	case hook.KindSessionStart:
+		if e.SessionID != "" {
+			a.claudeSessionID = e.SessionID
 		}
+		a.sessionStartedAt = time.Now()
+		if a.status != StatusActive {
+			a.status = StatusActive
+			return true
+		}
+		return false
+
+	case hook.KindStop:
+		// Claude finished its turn; the user is now in control. Clear the
+		// composing flag so input-display logic returns to its idle baseline.
+		a.composing = false
+		if a.status != StatusIdle {
+			a.status = StatusIdle
+			return true
+		}
+		return false
+
+	case hook.KindSessionEnd:
+		// Flag a clean exit for observability. Actual teardown still goes
+		// through the PTY close path (readLoop -> close(done)).
+		a.cleanExit = true
+		return false
 	}
+	return false
 }
 
 // Render returns the full terminal screen as an ANSI string.
@@ -444,17 +485,6 @@ func (a *Agent) HasReceivedInput() bool {
 	return !a.lastInput.IsZero()
 }
 
-// VisualStableFor returns how long the rendered screen has been unchanged.
-// Returns 0 before the first statusLoop sample has run.
-func (a *Agent) VisualStableFor() time.Duration {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	if a.lastScreenChange.IsZero() {
-		return 0
-	}
-	return time.Since(a.lastScreenChange)
-}
-
 // TimeSinceOutput returns how long since the PTY last produced output.
 // Returns 0 before any output has been observed.
 func (a *Agent) TimeSinceOutput() time.Duration {
@@ -509,70 +539,11 @@ func (a *Agent) ExitErr() error {
 // Kill terminates the agent's process and waits for goroutines to exit.
 // Safe to call multiple times — subsequent calls are no-ops.
 func (a *Agent) Kill() {
-	a.closeStop()
 	_ = a.pty.Close()
 	// Close terminal to unblock writeLoop's Read call.
 	a.terminal.Close()
 	// Wait for writeLoop to finish before returning.
 	<-a.writeLoopDone
-}
-
-// closeStop safely closes the stop channel exactly once.
-func (a *Agent) closeStop() {
-	a.stopOnce.Do(func() { close(a.stop) })
-}
-
-// ClaudeSessionDir overrides the session directory for testing.
-// When empty, claudeSessionDir() uses the real home directory.
-var ClaudeSessionDir string
-
-func claudeSessionDir() string {
-	if ClaudeSessionDir != "" {
-		return ClaudeSessionDir
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".claude", "sessions")
-}
-
-// PollClaudeSessionName reads the Claude session file for this agent's PID
-// and returns the "name" field if present. Returns "" on any error or if
-// the name field is not yet populated.
-func (a *Agent) PollClaudeSessionName() string {
-	a.mu.RLock()
-	pid := a.claudePid
-	a.mu.RUnlock()
-
-	if pid == 0 {
-		return ""
-	}
-
-	dir := claudeSessionDir()
-	if dir == "" {
-		return ""
-	}
-
-	path := filepath.Join(dir, fmt.Sprintf("%d.json", pid))
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-
-	var session struct {
-		Name      string `json:"name"`
-		SessionID string `json:"sessionId"`
-	}
-	if err := json.Unmarshal(data, &session); err != nil {
-		return ""
-	}
-	if session.SessionID != "" {
-		a.mu.Lock()
-		a.claudeSessionID = session.SessionID
-		a.mu.Unlock()
-	}
-	return session.Name
 }
 
 // ClaudeSessionID returns the Claude session ID captured from the session file.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -9,7 +9,18 @@ import (
 
 	xvt "github.com/charmbracelet/x/vt"
 	"github.com/devenjarvis/baton/internal/config"
+	"github.com/devenjarvis/baton/internal/hook"
 )
+
+// hookEvent is a test helper that builds a hook.Event for a given CLI-name event.
+func hookEvent(kind string) hook.Event {
+	return hook.Event{Kind: hook.Kind(kind)}
+}
+
+// hookEventWithSessionID builds a SessionStart event carrying a session ID.
+func hookEventWithSessionID(kind, sessionID string) hook.Event {
+	return hook.Event{Kind: hook.Kind(kind), SessionID: sessionID}
+}
 
 // setupTestRepo creates a temporary git repo with an initial commit.
 func setupTestRepo(t *testing.T) string {
@@ -222,14 +233,14 @@ func TestIdleSuppressedWhileTyping(t *testing.T) {
 	}
 }
 
-func TestIdleTransitionWithoutInput(t *testing.T) {
+func TestIdleDrivenByStopHook(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo, defaultTestSettings())
 	defer mgr.Shutdown()
 
-	cfg := Config{Name: "test-idle-no-input", Task: "test", Rows: 24, Cols: 80}
+	cfg := Config{Name: "test-idle-via-hook", Task: "test", Rows: 24, Cols: 80}
 	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
-		// Produce output then go quiet — no user input at all.
+		// Produce output then stay alive. Without a hook, Active must persist.
 		return exec.Command("bash", "-c", "echo ready; sleep 60")
 	})
 	if err != nil {
@@ -242,20 +253,50 @@ func TestIdleTransitionWithoutInput(t *testing.T) {
 		t.Fatalf("expected Active after output, got %s", s)
 	}
 
-	// Wait past idle timeout (3s) + statusLoop tick (500ms) margin.
+	// With no hook, Active MUST NOT flip to Idle on its own.
 	time.Sleep(4 * time.Second)
+	if s := a.Status(); s != StatusActive {
+		t.Errorf("expected Active without hook event, got %s", s)
+	}
 
+	// Simulated Stop hook flips the agent to Idle.
+	a.OnHookEvent(hookEvent("stop"))
 	if s := a.Status(); s != StatusIdle {
-		t.Errorf("expected Idle after timeout with no input, got %s", s)
+		t.Errorf("expected Idle after Stop hook, got %s", s)
 	}
 }
 
-func TestIdleWhileComposingUsesLongerTimeout(t *testing.T) {
+func TestSessionStartHookCapturesSessionID(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo, defaultTestSettings())
 	defer mgr.Shutdown()
 
-	cfg := Config{Name: "test-composing-idle", Task: "test", Rows: 24, Cols: 80}
+	cfg := Config{Name: "test-session-start", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 2")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changed := a.OnHookEvent(hookEventWithSessionID("session-start", "uuid-abc-123"))
+	if !changed {
+		t.Error("expected status change on SessionStart from Starting")
+	}
+	if s := a.Status(); s != StatusActive {
+		t.Errorf("expected Active after SessionStart, got %s", s)
+	}
+	if got := a.ClaudeSessionID(); got != "uuid-abc-123" {
+		t.Errorf("expected session ID uuid-abc-123, got %q", got)
+	}
+}
+
+func TestStopHookClearsComposing(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-stop-hook", Task: "test", Rows: 24, Cols: 80}
 	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
 		return exec.Command("bash", "-c", "echo ready; cat")
 	})
@@ -263,53 +304,23 @@ func TestIdleWhileComposingUsesLongerTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait for initial output to become Active.
-	time.Sleep(500 * time.Millisecond)
-	if s := a.Status(); s != StatusActive {
-		t.Fatalf("expected Active after output, got %s", s)
-	}
-
-	// Type some text (sets composing = true), then stop typing.
+	time.Sleep(300 * time.Millisecond)
 	a.SendText("hello")
-
-	// Wait 5s — past the normal 3s idle timeout but within composing 30s timeout.
-	time.Sleep(5 * time.Second)
-
-	if s := a.Status(); s != StatusActive {
-		t.Errorf("expected Active while composing (5s pause), got %s", s)
+	a.mu.RLock()
+	if !a.composing {
+		a.mu.RUnlock()
+		t.Fatal("expected composing true before Stop hook")
 	}
-}
+	a.mu.RUnlock()
 
-func TestIdleAfterEnterUsesNormalTimeout(t *testing.T) {
-	repo := setupTestRepo(t)
-	mgr := NewManager(repo, defaultTestSettings())
-	defer mgr.Shutdown()
+	a.OnHookEvent(hookEvent("stop"))
 
-	cfg := Config{Name: "test-enter-idle", Task: "test", Rows: 24, Cols: 80}
-	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
-		return exec.Command("bash", "-c", "echo ready; cat")
-	})
-	if err != nil {
-		t.Fatal(err)
+	a.mu.RLock()
+	if a.composing {
+		a.mu.RUnlock()
+		t.Error("expected composing cleared after Stop hook")
 	}
-
-	// Wait for initial output.
-	time.Sleep(500 * time.Millisecond)
-	if s := a.Status(); s != StatusActive {
-		t.Fatalf("expected Active after output, got %s", s)
-	}
-
-	// Type text then press Enter (clears composing).
-	a.SendText("hello")
-	a.SendKey(xvt.KeyPressEvent{Code: xvt.KeyEnter})
-
-	// Wait past normal 3s idle timeout + tick margin.
-	// cat echoes input back, resetting lastOutput, so allow extra margin.
-	time.Sleep(5 * time.Second)
-
-	if s := a.Status(); s != StatusIdle {
-		t.Errorf("expected Idle after Enter + 4s, got %s", s)
-	}
+	a.mu.RUnlock()
 }
 
 func TestComposingClearedOnEnter(t *testing.T) {
@@ -472,38 +483,6 @@ func TestKillAfterNaturalExitDoesNotPanic(t *testing.T) {
 
 	// Kill on an already-exited agent must not panic.
 	a.Kill()
-}
-
-func TestVisualStableForTracksHashChanges(t *testing.T) {
-	repo := setupTestRepo(t)
-	mgr := NewManager(repo, defaultTestSettings())
-	defer mgr.Shutdown()
-
-	cfg := Config{Name: "test-visual-stable", Task: "test", Rows: 24, Cols: 80}
-	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
-		// Produce one line of output, then go quiet.
-		return exec.Command("bash", "-c", "echo ready; sleep 60")
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Wait for the screen to stabilize after initial output.
-	// statusLoop ticks every 500ms; give it enough time for output + one sample.
-	time.Sleep(1500 * time.Millisecond)
-
-	stableA := a.VisualStableFor()
-	if stableA == 0 {
-		t.Fatal("expected VisualStableFor to be non-zero after first sample")
-	}
-
-	// Wait another tick — with no new output, VisualStableFor must grow.
-	time.Sleep(600 * time.Millisecond)
-
-	stableB := a.VisualStableFor()
-	if stableB <= stableA {
-		t.Errorf("expected VisualStableFor to grow while screen unchanged; was %v, now %v", stableA, stableB)
-	}
 }
 
 func TestChimedForTurnResetsOnEnterOnly(t *testing.T) {

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/devenjarvis/baton/internal/hook"
+)
+
+// TestManagerDispatchesHookEventsToAgent verifies the full path: an external
+// process (simulated via hook.SendEvent from this test) writes to the socket
+// at <repoPath>/.baton/hook.sock, the Manager's dispatcher routes by agent ID,
+// and the agent's state transitions accordingly.
+func TestManagerDispatchesHookEventsToAgent(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	if mgr.HookSocketPath() == "" {
+		t.Fatal("expected hook socket path to be set after NewManager")
+	}
+
+	cfg := Config{Name: "hook-dispatch", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		// Long-running process so the agent doesn't exit mid-test.
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = sess
+
+	// Drain the initial EventCreated event so we can detect EventStatusChanged
+	// below deterministically.
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// Send SessionStart and assert it routes to the agent.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:      hook.KindSessionStart,
+		AgentID:   ag.ID,
+		SessionID: "claude-uuid-42",
+	}); err != nil {
+		t.Fatalf("SendEvent SessionStart: %v", err)
+	}
+
+	// Manager emits EventStatusChanged on each hook-driven status mutation.
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
+	}
+	if got := ag.ClaudeSessionID(); got != "claude-uuid-42" {
+		t.Errorf("expected claude session id %q, got %q", "claude-uuid-42", got)
+	}
+
+	// Simulate Claude's Stop hook at the end of a turn.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindStop,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent Stop: %v", err)
+	}
+
+	if !waitForStatus(t, ag, StatusIdle, 2*time.Second) {
+		t.Fatalf("expected Idle after Stop, got %s", ag.Status())
+	}
+}
+
+// TestManagerDropsUnknownAgentID confirms hook events for an unknown agent are
+// silently dropped (e.g. late Stop arriving after a kill).
+func TestManagerDropsUnknownAgentID(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	// Send an event for an agent that doesn't exist — must not panic.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindSessionStart,
+		AgentID: "does-not-exist",
+	}); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+
+	// Give the dispatcher time to process the drop.
+	time.Sleep(200 * time.Millisecond)
+}
+
+// TestSocketPathPerRepo ensures two managers on different repos use distinct sockets.
+func TestSocketPathPerRepo(t *testing.T) {
+	repo1 := setupTestRepo(t)
+	repo2 := setupTestRepo(t)
+	mgr1 := NewManager(repo1, defaultTestSettings())
+	defer mgr1.Shutdown()
+	mgr2 := NewManager(repo2, defaultTestSettings())
+	defer mgr2.Shutdown()
+
+	if mgr1.HookSocketPath() == "" || mgr2.HookSocketPath() == "" {
+		t.Fatal("expected both managers to have socket paths")
+	}
+	if mgr1.HookSocketPath() == mgr2.HookSocketPath() {
+		t.Errorf("expected distinct socket paths; got %q", mgr1.HookSocketPath())
+	}
+}
+
+// waitForStatus polls the agent status up to d for the desired value.
+func waitForStatus(t *testing.T, a *Agent, want Status, d time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if a.Status() == want {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/devenjarvis/baton/internal/config"
 	"github.com/devenjarvis/baton/internal/git"
+	"github.com/devenjarvis/baton/internal/hook"
 	"github.com/devenjarvis/baton/internal/state"
 )
 
@@ -46,17 +49,105 @@ type Manager struct {
 	events   chan Event
 	done     chan struct{}
 	watchers sync.WaitGroup
+
+	hookServer     *hook.Server
+	hookSocketPath string
+	hookDispatcher sync.WaitGroup
 }
 
 // NewManager creates a new agent manager for the given repo.
+//
+// The manager owns a hook.Server listening on <repoPath>/.baton/hook.sock that
+// routes Claude Code hook events to agents by BATON_AGENT_ID. If the socket
+// fails to start (e.g. filesystem permissions), the manager logs to stderr
+// and continues with hooks disabled; spawned agents will then never transition
+// out of Active.
 func NewManager(repoPath string, settings config.ResolvedSettings) *Manager {
-	return &Manager{
+	m := &Manager{
 		repoPath: repoPath,
 		settings: settings,
 		sessions: make(map[string]*Session),
 		events:   make(chan Event, 64),
 		done:     make(chan struct{}),
 	}
+
+	batonDir := filepath.Join(repoPath, ".baton")
+	if err := os.MkdirAll(batonDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "baton: creating %s: %v (hooks disabled)\n", batonDir, err)
+		return m
+	}
+	socketPath := hookSocketPath(repoPath)
+	srv, err := hook.NewServer(socketPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "baton: starting hook server on %s: %v (hooks disabled)\n", socketPath, err)
+		return m
+	}
+	m.hookServer = srv
+	m.hookSocketPath = socketPath
+
+	m.hookDispatcher.Add(1)
+	go m.dispatchHookEvents()
+
+	return m
+}
+
+// HookSocketPath returns the unix socket path the manager's hook server is
+// listening on, or "" if the server failed to start.
+func (m *Manager) HookSocketPath() string {
+	return m.hookSocketPath
+}
+
+// hookSocketPath returns the unix socket path for a given repoPath.
+//
+// Preferred layout: <repoPath>/.baton/hook.sock — easy to inspect and cleaned
+// up with the rest of baton's per-repo state. macOS limits unix socket paths
+// to 104 bytes, so when the preferred path would exceed a safe threshold we
+// fall back to a short hashed name under os.TempDir(). Tests exercise the
+// fallback path via deeply nested temp directories.
+func hookSocketPath(repoPath string) string {
+	preferred := filepath.Join(repoPath, ".baton", "hook.sock")
+	// 104 is the darwin sun_path limit; leave headroom for the trailing NUL
+	// and any quirks. 100 is comfortably below.
+	if len(preferred) < 100 {
+		return preferred
+	}
+	h := sha256.Sum256([]byte(repoPath))
+	return filepath.Join(os.TempDir(), fmt.Sprintf("baton-%x.sock", h[:8]))
+}
+
+// dispatchHookEvents reads hook events from the server and routes each to the
+// agent named by AgentID. Unknown agent IDs are logged and dropped.
+func (m *Manager) dispatchHookEvents() {
+	defer m.hookDispatcher.Done()
+	for e := range m.hookServer.Events() {
+		a, sessID := m.findAgent(e.AgentID)
+		if a == nil {
+			// This can happen if an agent has already been killed but Claude's
+			// final Stop/SessionEnd hook is still in flight. Drop silently.
+			continue
+		}
+		if changed := a.OnHookEvent(e); changed {
+			m.emit(Event{
+				Type:      EventStatusChanged,
+				AgentID:   a.ID,
+				SessionID: sessID,
+				Status:    a.Status(),
+			})
+		}
+	}
+}
+
+// findAgent locates an agent across all sessions and returns it with the
+// containing session ID.
+func (m *Manager) findAgent(agentID string) (*Agent, string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, s := range m.sessions {
+		if a := s.GetAgent(agentID); a != nil {
+			return a, s.ID
+		}
+	}
+	return nil, ""
 }
 
 // UpdateSettings replaces the manager's resolved settings.
@@ -214,6 +305,7 @@ func (m *Manager) createSessionOnBranchWorktree(branch, baseBranch string, cfg C
 	}
 
 	sess := newSession(id, name, wt)
+	sess.hookSocketPath = m.hookSocketPath
 	// ownsBranch stays false — we didn't create this branch.
 
 	m.mu.Lock()
@@ -287,6 +379,7 @@ func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
 	}
 
 	sess := newSession(id, name, wt)
+	sess.hookSocketPath = m.hookSocketPath
 	sess.ownsBranch = true
 
 	m.mu.Lock()
@@ -528,12 +621,24 @@ func (m *Manager) Shutdown() {
 	wg.Wait()
 
 	m.watchers.Wait()
+	m.stopHookServer()
 
 	m.mu.Lock()
 	m.sessions = make(map[string]*Session)
 	m.mu.Unlock()
 
 	close(m.events)
+}
+
+// stopHookServer closes the hook server and waits for the dispatcher goroutine.
+// Safe to call multiple times; no-op if the server never started.
+func (m *Manager) stopHookServer() {
+	if m.hookServer == nil {
+		return
+	}
+	_ = m.hookServer.Close()
+	m.hookDispatcher.Wait()
+	m.hookServer = nil
 }
 
 // AgentCount returns the total number of agents across all sessions.
@@ -601,6 +706,7 @@ func (m *Manager) Detach() *state.BatonState {
 	wg.Wait()
 
 	m.watchers.Wait()
+	m.stopHookServer()
 
 	m.mu.Lock()
 	m.sessions = make(map[string]*Session)
@@ -636,6 +742,7 @@ func (m *Manager) ResumeSession(ss state.SessionState, cfg Config) error {
 	}
 
 	sess := newSession(ss.ID, ss.Name, wt)
+	sess.hookSocketPath = m.hookSocketPath
 	sess.ownsBranch = ss.OwnsBranch
 	if ss.DisplayName != "" && ss.DisplayName != ss.Name {
 		sess.SetDisplayName(ss.DisplayName)

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -17,11 +17,12 @@ type Session struct {
 	Worktree  *git.WorktreeInfo
 	CreatedAt time.Time
 
-	mu           sync.RWMutex
-	agents       map[string]*Agent
-	nextAgentNum int
-	displayName  string
-	ownsBranch   bool // true if this session created the branch (cleanup should delete it)
+	mu             sync.RWMutex
+	agents         map[string]*Agent
+	nextAgentNum   int
+	displayName    string
+	ownsBranch     bool   // true if this session created the branch (cleanup should delete it)
+	hookSocketPath string // absolute path to the manager's hook socket ("" disables hooks)
 }
 
 // newSession creates a session with the given worktree.
@@ -67,9 +68,10 @@ func (s *Session) AddAgentDefault(cfg Config) (*Agent, error) {
 	s.nextAgentNum++
 	num := s.nextAgentNum
 	id := fmt.Sprintf("%s-agent-%d", s.ID, num)
+	socketPath := s.hookSocketPath
 	s.mu.Unlock()
 
-	a, err := newAgent(id, cfg, s.Worktree.Path)
+	a, err := newAgent(id, cfg, s.Worktree.Path, socketPath)
 	if err != nil {
 		return nil, err
 	}
@@ -90,9 +92,10 @@ func (s *Session) AddAgentResumed(cfg Config, claudeSessionID string) (*Agent, e
 	s.nextAgentNum++
 	num := s.nextAgentNum
 	id := fmt.Sprintf("%s-agent-%d", s.ID, num)
+	socketPath := s.hookSocketPath
 	s.mu.Unlock()
 
-	a, err := newResumedAgent(id, cfg, s.Worktree.Path, claudeSessionID)
+	a, err := newResumedAgent(id, cfg, s.Worktree.Path, claudeSessionID, socketPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/session_name_test.go
+++ b/internal/agent/session_name_test.go
@@ -1,67 +1,6 @@
 package agent
 
-import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
-	"testing"
-)
-
-func TestPollClaudeSessionName_NoFile(t *testing.T) {
-	dir := t.TempDir()
-	old := ClaudeSessionDir
-	ClaudeSessionDir = dir
-	defer func() { ClaudeSessionDir = old }()
-
-	a := &Agent{claudePid: 99999}
-	if got := a.PollClaudeSessionName(); got != "" {
-		t.Errorf("expected empty string for missing file, got %q", got)
-	}
-}
-
-func TestPollClaudeSessionName_NoNameField(t *testing.T) {
-	dir := t.TempDir()
-	old := ClaudeSessionDir
-	ClaudeSessionDir = dir
-	defer func() { ClaudeSessionDir = old }()
-
-	// Write a JSON file without a "name" field.
-	data, _ := json.Marshal(map[string]any{"id": "abc123"})
-	if err := os.WriteFile(filepath.Join(dir, "12345.json"), data, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	a := &Agent{claudePid: 12345}
-	if got := a.PollClaudeSessionName(); got != "" {
-		t.Errorf("expected empty string for missing name field, got %q", got)
-	}
-}
-
-func TestPollClaudeSessionName_WithName(t *testing.T) {
-	dir := t.TempDir()
-	old := ClaudeSessionDir
-	ClaudeSessionDir = dir
-	defer func() { ClaudeSessionDir = old }()
-
-	data, _ := json.Marshal(map[string]any{"name": "fix-auth-bug", "id": "abc123"})
-	if err := os.WriteFile(filepath.Join(dir, "42.json"), data, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	a := &Agent{claudePid: 42}
-	got := a.PollClaudeSessionName()
-	if got != "fix-auth-bug" {
-		t.Errorf("expected %q, got %q", "fix-auth-bug", got)
-	}
-}
-
-func TestPollClaudeSessionName_ZeroPid(t *testing.T) {
-	a := &Agent{claudePid: 0}
-	if got := a.PollClaudeSessionName(); got != "" {
-		t.Errorf("expected empty string for zero PID, got %q", got)
-	}
-}
+import "testing"
 
 func TestSlugify(t *testing.T) {
 	tests := []struct {
@@ -84,32 +23,6 @@ func TestSlugify(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("slugify(%q) = %q, want %q", tc.input, got, tc.want)
 		}
-	}
-}
-
-func TestPollClaudeSessionName_CapturesSessionID(t *testing.T) {
-	dir := t.TempDir()
-	old := ClaudeSessionDir
-	ClaudeSessionDir = dir
-	defer func() { ClaudeSessionDir = old }()
-
-	pid := 12345
-	data, _ := json.Marshal(map[string]string{
-		"sessionId": "test-uuid-123",
-		"name":      "test-session",
-	})
-	_ = os.WriteFile(filepath.Join(dir, fmt.Sprintf("%d.json", pid)), data, 0o644)
-
-	a := &Agent{
-		claudePid: pid,
-	}
-
-	name := a.PollClaudeSessionName()
-	if name != "test-session" {
-		t.Errorf("expected name 'test-session', got %q", name)
-	}
-	if got := a.ClaudeSessionID(); got != "test-uuid-123" {
-		t.Errorf("expected session ID 'test-uuid-123', got %q", got)
 	}
 }
 

--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -1,7 +1,5 @@
 package agent
 
-import "time"
-
 // Status represents the current state of an agent.
 type Status int
 
@@ -47,25 +45,3 @@ func (s Status) Symbol() string {
 		return "?"
 	}
 }
-
-const (
-	idleTimeout          = 3 * time.Second
-	composingIdleTimeout = 30 * time.Second
-
-	// visualStabilityWindow is the amount of time the rendered screen must
-	// remain unchanged before an agent is considered visually stable (nothing
-	// animating, no output churn).
-	visualStabilityWindow = 2 * time.Second
-
-	// stuckFallbackTimeout is the grace period after which a silent agent
-	// (no PTY output) is treated as stuck, even if the primary stability
-	// signal never trips.
-	stuckFallbackTimeout = 60 * time.Second
-)
-
-// Exported mirrors of the stability constants for callers outside this package
-// (e.g., the TUI chime trigger) that need to compare against the same window.
-const (
-	VisualStabilityWindow = visualStabilityWindow
-	StuckFallbackTimeout  = stuckFallbackTimeout
-)

--- a/internal/hook/client.go
+++ b/internal/hook/client.go
@@ -1,0 +1,32 @@
+package hook
+
+import (
+	"encoding/json"
+	"net"
+	"time"
+)
+
+// SendEvent dials the server at socketPath, writes e as a newline-terminated
+// JSON message, and closes the connection.
+//
+// Any error is returned to the caller, but hook-path callers should treat it
+// as non-fatal — hook failures must not block Claude.
+func SendEvent(socketPath string, e Event) error {
+	conn, err := net.DialTimeout("unix", socketPath, 2*time.Second)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Bound the write so a wedged server can't block the hook process forever.
+	_ = conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+
+	data, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	_, err = conn.Write(data)
+	return err
+}

--- a/internal/hook/event.go
+++ b/internal/hook/event.go
@@ -1,0 +1,33 @@
+// Package hook carries Claude Code hook events between a spawned `baton hook`
+// CLI invocation and the long-running baton TUI process over a unix socket.
+//
+// The protocol is newline-delimited JSON: one event per line. See event.go for
+// the struct, server.go for the listener, and client.go for the one-shot sender.
+package hook
+
+import "encoding/json"
+
+// Kind identifies which Claude Code lifecycle event fired.
+type Kind string
+
+const (
+	KindSessionStart Kind = "session-start"
+	KindStop         Kind = "stop"
+	KindSessionEnd   Kind = "session-end"
+)
+
+// Event is the wire-format payload sent from the baton-hook CLI to the
+// baton TUI process.
+//
+// SessionID and CWD come straight from the Claude JSON payload; AgentID is
+// supplied by the CLI wrapper from the BATON_AGENT_ID environment variable
+// so the server can dispatch to the right agent. Raw preserves the original
+// Claude JSON for forward-compatibility with fields the server doesn't
+// currently consume.
+type Event struct {
+	Kind      Kind            `json:"kind"`
+	AgentID   string          `json:"agent_id"`
+	SessionID string          `json:"session_id,omitempty"`
+	CWD       string          `json:"cwd,omitempty"`
+	Raw       json.RawMessage `json:"raw,omitempty"`
+}

--- a/internal/hook/server.go
+++ b/internal/hook/server.go
@@ -1,0 +1,138 @@
+package hook
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+)
+
+// Server listens on a unix socket for hook events and exposes them on a channel.
+//
+// Lifecycle:
+//   - NewServer creates the listener and starts the accept loop.
+//   - Events() returns a channel that emits one Event per newline-delimited JSON
+//     message from any connected client. The channel is closed when the server
+//     shuts down.
+//   - Close stops accepting new connections, waits for in-flight handlers, then
+//     removes the socket file.
+type Server struct {
+	socketPath string
+	listener   net.Listener
+	events     chan Event
+
+	wg       sync.WaitGroup
+	closeMu  sync.Mutex
+	closed   bool
+	closeErr error
+}
+
+// NewServer creates the socket at the given path and starts accepting connections.
+//
+// If a stale socket file exists at the path, it is removed before binding.
+// The directory containing the socket must already exist.
+func NewServer(socketPath string) (*Server, error) {
+	// Remove stale socket file from a previous baton run — unix domain sockets
+	// don't auto-clean on process crash.
+	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("removing stale socket: %w", err)
+	}
+
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("listening on %s: %w", socketPath, err)
+	}
+
+	s := &Server{
+		socketPath: socketPath,
+		listener:   l,
+		events:     make(chan Event, 64),
+	}
+
+	s.wg.Add(1)
+	go s.acceptLoop()
+
+	return s, nil
+}
+
+// SocketPath returns the filesystem path the server is listening on.
+func (s *Server) SocketPath() string {
+	return s.socketPath
+}
+
+// Events returns a channel that emits hook events as they arrive. The channel
+// is closed when the server shuts down.
+func (s *Server) Events() <-chan Event {
+	return s.events
+}
+
+func (s *Server) acceptLoop() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			// Any error here — including "use of closed network connection" on
+			// Close — means we're done accepting.
+			return
+		}
+		s.wg.Add(1)
+		go s.handleConn(conn)
+	}
+}
+
+func (s *Server) handleConn(conn net.Conn) {
+	defer s.wg.Done()
+	defer func() { _ = conn.Close() }()
+
+	scanner := bufio.NewScanner(conn)
+	// Hook payloads can be up to a few KB; bump the scan buffer so large
+	// SessionStart payloads don't trip the default 64KB line limit either way.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var e Event
+		if err := json.Unmarshal(line, &e); err != nil {
+			// Malformed line — skip. Hook failures must not block Claude, and
+			// we don't want one bad client to kill the server.
+			continue
+		}
+		// Non-blocking send: if the consumer is slow, drop rather than wedge
+		// the hook path.
+		select {
+		case s.events <- e:
+		default:
+		}
+	}
+}
+
+// Close stops accepting new connections, waits for in-flight handlers to finish,
+// closes the events channel, and removes the socket file. Idempotent.
+func (s *Server) Close() error {
+	s.closeMu.Lock()
+	if s.closed {
+		s.closeMu.Unlock()
+		return s.closeErr
+	}
+	s.closed = true
+	s.closeMu.Unlock()
+
+	err := s.listener.Close()
+	s.wg.Wait()
+	close(s.events)
+
+	// Best-effort cleanup; Listener.Close may or may not remove the file
+	// depending on the platform.
+	if rmErr := os.Remove(s.socketPath); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) && err == nil {
+		err = rmErr
+	}
+
+	s.closeErr = err
+	return err
+}

--- a/internal/hook/server_test.go
+++ b/internal/hook/server_test.go
@@ -1,0 +1,166 @@
+package hook
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestServerRoundTrip(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer func() {
+		if err := srv.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+
+	want := Event{
+		Kind:      KindSessionStart,
+		AgentID:   "session-1-agent-1",
+		SessionID: "uuid-abc",
+		CWD:       "/tmp/worktree",
+	}
+
+	if err := SendEvent(socketPath, want); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+
+	select {
+	case got := <-srv.Events():
+		if got.Kind != want.Kind {
+			t.Errorf("Kind: got %q, want %q", got.Kind, want.Kind)
+		}
+		if got.AgentID != want.AgentID {
+			t.Errorf("AgentID: got %q, want %q", got.AgentID, want.AgentID)
+		}
+		if got.SessionID != want.SessionID {
+			t.Errorf("SessionID: got %q, want %q", got.SessionID, want.SessionID)
+		}
+		if got.CWD != want.CWD {
+			t.Errorf("CWD: got %q, want %q", got.CWD, want.CWD)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestServerMultipleEvents(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	events := []Event{
+		{Kind: KindSessionStart, AgentID: "a1", SessionID: "s1"},
+		{Kind: KindStop, AgentID: "a1", SessionID: "s1"},
+		{Kind: KindSessionEnd, AgentID: "a1", SessionID: "s1"},
+	}
+	for _, e := range events {
+		if err := SendEvent(socketPath, e); err != nil {
+			t.Fatalf("SendEvent %v: %v", e.Kind, err)
+		}
+	}
+
+	// Each SendEvent opens its own connection and connections race through
+	// Accept, so we can't rely on ordering — just verify all three kinds arrive.
+	seen := make(map[Kind]int)
+	for range events {
+		select {
+		case got := <-srv.Events():
+			seen[got.Kind]++
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for events; seen %v", seen)
+		}
+	}
+	for _, want := range events {
+		if seen[want.Kind] < 1 {
+			t.Errorf("missing event kind %q; seen %v", want.Kind, seen)
+		}
+	}
+}
+
+func TestServerCloseRemovesSocket(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// SocketPath should no longer exist.
+	if err := SendEvent(socketPath, Event{Kind: KindStop, AgentID: "a1"}); err == nil {
+		t.Error("SendEvent to closed server should fail")
+	}
+}
+
+func TestServerCloseIdempotent(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close 1: %v", err)
+	}
+	// Second Close must not panic or deadlock.
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close 2: %v", err)
+	}
+}
+
+func TestServerClosesEventsChannel(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Channel should be closed.
+	_, ok := <-srv.Events()
+	if ok {
+		t.Error("expected events channel to be closed")
+	}
+}
+
+func TestServerStaleSocketReuse(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+
+	// First server.
+	srv1, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer 1: %v", err)
+	}
+	// Deliberately don't Close, then simulate stale by closing only listener.
+	// We just Close properly since Close removes the file; then we touch a
+	// stale file and open again.
+	if err := srv1.Close(); err != nil {
+		t.Fatalf("Close 1: %v", err)
+	}
+
+	// Re-create — should succeed even if file were stale.
+	srv2, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer 2: %v", err)
+	}
+	if err := srv2.Close(); err != nil {
+		t.Fatalf("Close 2: %v", err)
+	}
+}
+
+func TestSendEventNoServer(t *testing.T) {
+	// Dialing a nonexistent socket must fail (caller decides to ignore).
+	if err := SendEvent(filepath.Join(t.TempDir(), "nope.sock"), Event{Kind: KindStop, AgentID: "a"}); err == nil {
+		t.Error("expected error dialing nonexistent socket")
+	}
+}

--- a/internal/hook/settings.go
+++ b/internal/hook/settings.go
@@ -1,0 +1,65 @@
+package hook
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// settingsSchema mirrors the shape Claude's settings.json expects for hooks.
+//
+// Each event name (SessionStart, Stop, SessionEnd) maps to a list of matcher
+// objects, each carrying a list of hook commands. We don't use matchers for
+// lifecycle hooks, so the matcher list has a single empty entry.
+type settingsSchema struct {
+	Hooks map[string][]hookMatcher `json:"hooks"`
+}
+
+type hookMatcher struct {
+	Hooks []hookCommand `json:"hooks"`
+}
+
+type hookCommand struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+// WriteHooksFile writes a minimal Claude settings file to path that wires up
+// SessionStart, Stop, and SessionEnd to `baton hook <event>`.
+//
+// The baton binary is resolved via os.Executable so the generated file works
+// regardless of where Claude is invoked from. Socket path and agent ID are
+// not baked into the command — they travel through BATON_HOOK_SOCKET and
+// BATON_AGENT_ID, which the baton-hook CLI reads at runtime.
+func WriteHooksFile(path string) error {
+	batonPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving baton binary: %w", err)
+	}
+	// Symlink resolution gives us a stable path; fall back to the raw result if
+	// EvalSymlinks fails for any reason.
+	if resolved, err := filepath.EvalSymlinks(batonPath); err == nil {
+		batonPath = resolved
+	}
+
+	schema := settingsSchema{
+		Hooks: map[string][]hookMatcher{
+			"SessionStart": {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook session-start"}}}},
+			"Stop":         {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook stop"}}}},
+			"SessionEnd":   {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook session-end"}}}},
+		},
+	}
+
+	data, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling hooks settings: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating settings dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing hooks settings: %w", err)
+	}
+	return nil
+}

--- a/internal/hook/settings_test.go
+++ b/internal/hook/settings_test.go
@@ -1,0 +1,81 @@
+package hook
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteHooksFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".baton-hooks.json")
+
+	if err := WriteHooksFile(path); err != nil {
+		t.Fatalf("WriteHooksFile: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading hooks file: %v", err)
+	}
+
+	var parsed settingsSchema
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshalling hooks file: %v", err)
+	}
+
+	wantEvents := []string{"SessionStart", "Stop", "SessionEnd"}
+	wantCLIEvents := map[string]string{
+		"SessionStart": "session-start",
+		"Stop":         "stop",
+		"SessionEnd":   "session-end",
+	}
+
+	batonPath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(batonPath); err == nil {
+		batonPath = resolved
+	}
+
+	for _, event := range wantEvents {
+		matchers, ok := parsed.Hooks[event]
+		if !ok {
+			t.Errorf("missing hook for event %q", event)
+			continue
+		}
+		if len(matchers) != 1 {
+			t.Errorf("event %q: expected 1 matcher, got %d", event, len(matchers))
+			continue
+		}
+		if len(matchers[0].Hooks) != 1 {
+			t.Errorf("event %q: expected 1 hook, got %d", event, len(matchers[0].Hooks))
+			continue
+		}
+		hook := matchers[0].Hooks[0]
+		if hook.Type != "command" {
+			t.Errorf("event %q: expected type 'command', got %q", event, hook.Type)
+		}
+		if !strings.HasPrefix(hook.Command, batonPath) {
+			t.Errorf("event %q: command %q does not start with baton path %q", event, hook.Command, batonPath)
+		}
+		if !strings.Contains(hook.Command, "hook "+wantCLIEvents[event]) {
+			t.Errorf("event %q: command %q missing CLI event %q", event, hook.Command, wantCLIEvents[event])
+		}
+	}
+}
+
+func TestWriteHooksFileCreatesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "subdir", "hooks.json")
+
+	if err := WriteHooksFile(path); err != nil {
+		t.Fatalf("WriteHooksFile: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("hooks file not created: %v", err)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -289,7 +289,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		a.refreshAgentList()
-		// Poll for Claude session names and detect Active->Idle transitions.
+		// Detect Active->Idle transitions for diff-stats refresh. Chime
+		// notifications are fired in the EventStatusChanged handler below,
+		// which reacts the instant Claude's Stop hook arrives.
 		idleTransition := false
 		for _, item := range a.dashboard.items {
 			if item.kind != listItemAgent || item.agent == nil {
@@ -297,42 +299,12 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			ag := item.agent
 			currentStatus := ag.Status()
-
-			// Check for Active->Idle transition (preserves downstream side
-			// effects like diff-stats refresh). The chime trigger below uses
-			// a separate frame-stability signal rather than the transition.
 			if prev, ok := a.lastKnownStatus[ag.ID]; ok {
-				if prev == agent.StatusActive && currentStatus == agent.StatusIdle && ag.HasReceivedInput() && !ag.IsShell {
+				if prev == agent.StatusActive && currentStatus == agent.StatusIdle && !ag.IsShell {
 					idleTransition = true
 				}
 			}
 			a.lastKnownStatus[ag.ID] = currentStatus
-
-			// Chime trigger: fire once per turn when the agent is truly
-			// awaiting input. Primary signal is frame stability (screen
-			// unchanged for VisualStabilityWindow); fallback is prolonged
-			// silence (no PTY output for StuckFallbackTimeout).
-			if !ag.IsShell && ag.HasReceivedInput() && !ag.ChimedForTurn() &&
-				(currentStatus == agent.StatusActive || currentStatus == agent.StatusIdle) &&
-				(ag.VisualStableFor() >= agent.VisualStabilityWindow ||
-					ag.TimeSinceOutput() >= agent.StuckFallbackTimeout) {
-				resolved := a.resolvedCache[item.repoPath]
-				if resolved.AudioEnabled && a.audioPlayer != nil {
-					a.audioPlayer.Play()
-					ag.MarkChimedForTurn()
-				}
-			}
-
-			// Poll Claude session file for auto-generated name.
-			if !ag.IsShell && !ag.HasClaudeName() {
-				if name := ag.PollClaudeSessionName(); name != "" {
-					ag.SetDisplayName(name)
-					ag.SetClaudeName(true)
-					if item.session != nil && !item.session.HasDisplayName() {
-						item.session.SetDisplayName(name)
-					}
-				}
-			}
 		}
 		if a.errTicks > 0 {
 			a.errTicks--
@@ -368,6 +340,30 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					delete(a.lastKnownStatus, id)
 				}
 			}
+		}
+		// Chime on Active->Idle transitions driven by Claude's Stop hook.
+		// Fire once per turn; MarkChimedForTurn is reset when the user presses
+		// Enter (see Agent.SendKey).
+		//
+		// We record the new status immediately so two event-driven transitions
+		// in the same tick window (faster than the 100ms tickMsg cadence) stay
+		// self-consistent even when the tick handler hasn't caught up yet.
+		if msg.event.Type == agent.EventStatusChanged {
+			if msg.event.Status == agent.StatusIdle {
+				prev, hadPrev := a.lastKnownStatus[msg.event.AgentID]
+				if mgr := a.managers[msg.repoPath]; mgr != nil {
+					if ag := mgr.Get(msg.event.AgentID); ag != nil && !ag.IsShell {
+						if hadPrev && prev == agent.StatusActive && ag.HasReceivedInput() && !ag.ChimedForTurn() {
+							resolved := a.resolvedCache[msg.repoPath]
+							if resolved.AudioEnabled && a.audioPlayer != nil {
+								a.audioPlayer.Play()
+								ag.MarkChimedForTurn()
+							}
+						}
+					}
+				}
+			}
+			a.lastKnownStatus[msg.event.AgentID] = msg.event.Status
 		}
 		// Refresh list on any agent event — all repos are visible in the dashboard.
 		a.refreshAgentList()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -341,19 +341,18 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
-		// Chime on Active->Idle transitions driven by Claude's Stop hook.
-		// Fire once per turn; MarkChimedForTurn is reset when the user presses
-		// Enter (see Agent.SendKey).
-		//
-		// We record the new status immediately so two event-driven transitions
-		// in the same tick window (faster than the 100ms tickMsg cadence) stay
-		// self-consistent even when the tick handler hasn't caught up yet.
+		// Chime when Claude's Stop hook arrives (EventStatusChanged with Idle).
+		// Gated only by ChimedForTurn + HasReceivedInput: ChimedForTurn is reset
+		// on Enter (Agent.SendKey), so once-per-turn semantics are enforced there
+		// rather than by re-reading lastKnownStatus. This avoids a race with the
+		// 100ms tickMsg: a tick landing between the manager mutating status and
+		// the TUI dequeuing this event would otherwise clobber the cached "prev
+		// was Active" signal and silently suppress the chime.
 		if msg.event.Type == agent.EventStatusChanged {
 			if msg.event.Status == agent.StatusIdle {
-				prev, hadPrev := a.lastKnownStatus[msg.event.AgentID]
 				if mgr := a.managers[msg.repoPath]; mgr != nil {
 					if ag := mgr.Get(msg.event.AgentID); ag != nil && !ag.IsShell {
-						if hadPrev && prev == agent.StatusActive && ag.HasReceivedInput() && !ag.ChimedForTurn() {
+						if ag.HasReceivedInput() && !ag.ChimedForTurn() {
 							resolved := a.resolvedCache[msg.repoPath]
 							if resolved.AudioEnabled && a.audioPlayer != nil {
 								a.audioPlayer.Play()


### PR DESCRIPTION
## Summary

- Replace the screen-hash `statusLoop`, 2s visual-stability chime trigger, and `~/.claude/sessions/<pid>.json` polling with authoritative Claude Code hook events (`SessionStart` / `Stop` / `SessionEnd`) delivered over a per-repo unix socket.
- Each session spawn writes a minimal hooks settings file and passes `claude --settings <file>`, with `BATON_HOOK_SOCKET` + `BATON_AGENT_ID` env vars routing events back to the manager. Manager dispatches by agent ID; TUI chime now fires on the `EventStatusChanged` Active→Idle transition (once per turn, reset on Enter).
- Non-claude agent programs (`bash` in e2e tests, custom tools) keep working — `supportsHooks` gates `--settings` injection so only a binary named `claude` gets hook wiring.

## Test plan

- [x] `go build -o baton .`
- [x] `go test -race ./...` — all new packages + updated agent tests pass (pre-existing `TestLoad_MigratesFromLegacyXDGPath` flake on main unaffected)
- [x] `go vet ./...`, `golangci-lint run` — clean
- [x] `go test -tags e2e -timeout 300s ./internal/e2e/` — all 12 pass
- [x] `./baton doctor` — new `claude --settings` support check and baton-binary resolution check both `[OK]`
- [ ] Manual: fresh `./baton` session → session ID appears in TUI within ~1s, status stays Active during long `Bash` tool call, flips Idle instantly on Claude's Stop, chime fires exactly once per turn
- [ ] Manual: `/exit` in Claude → clean teardown via existing PTY-close path
- [ ] Manual: user's own `SessionStart` hook in `~/.claude/settings.json` still fires alongside baton's (validates `--settings` additive layering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)