### PR TITLE
Fix TUI rendering artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 ## [Unreleased]
 
+### Fixed
+
+- Startup splash text artifacts when Claude Code enters its TUI (alt-screen transition detection replaces 500ms delayed resize heuristic).
+- Mid-repaint flicker in dashboard preview (StableRender with 16ms quiescence threshold).
+- VT emulator / lipgloss container sizing mismatch causing displaced content in focusList mode.
+
 ## [0.1.0] — 2026-04-15
 
 Initial public release.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -408,6 +408,18 @@ func (a *Agent) Render() string {
 	return a.terminal.Render()
 }
 
+// StableRender returns a cached render if the terminal was recently written to,
+// avoiding mid-repaint snapshots.
+func (a *Agent) StableRender() string {
+	return a.terminal.StableRender()
+}
+
+// AltScreenEntered returns true if the terminal transitioned into alternate
+// screen mode since the last call. The flag resets on each read.
+func (a *Agent) AltScreenEntered() bool {
+	return a.terminal.AltScreenEntered()
+}
+
 // RenderRegion returns a subset of terminal rows.
 func (a *Agent) RenderRegion(startRow, endRow int) string {
 	return a.terminal.RenderRegion(startRow, endRow)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -40,12 +40,6 @@ type createResultMsg struct {
 	err       error
 }
 
-// splashResizeMsg is a delayed resize sent after agent creation to clear
-// Claude Code's splash text once its TUI has had time to initialize.
-type splashResizeMsg struct {
-	agentID string
-}
-
 // diffStatsMsg carries the result of an async diff stats refresh.
 type diffStatsMsg struct {
 	sessionID string
@@ -306,6 +300,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			a.lastKnownStatus[ag.ID] = currentStatus
 		}
+		// Detect alt-screen transitions and trigger a resize so Claude's TUI
+		// redraws cleanly (replaces the old splashResizeMsg delayed timer).
+		fixedW := a.dashboard.fixedTermWidth()
+		fixedH := a.dashboard.fixedTermHeight()
+		if fixedW > 0 && fixedH > 0 {
+			for _, item := range a.dashboard.items {
+				if item.kind != listItemAgent || item.agent == nil {
+					continue
+				}
+				if item.agent.AltScreenEntered() {
+					item.agent.Resize(fixedH, fixedW)
+				}
+			}
+		}
 		if a.errTicks > 0 {
 			a.errTicks--
 			if a.errTicks == 0 {
@@ -387,16 +395,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
-		// Resize to force a clean redraw — Claude Code's initial splash output
-		// gets baked into the VT before its TUI fully initializes, and a SIGWINCH clears it.
+		// Set initial dimensions before any output arrives. The alt-screen
+		// transition detector in the tick handler will fire a follow-up resize
+		// once Claude's TUI enters alternate screen mode.
 		a.resizeSelectedForDashboard()
-		// Schedule a delayed follow-up resize: the immediate one above sets correct
-		// dimensions but arrives before Claude Code's TUI is ready. The delayed
-		// SIGWINCH hits after the TUI has initialized and triggers a clean redraw.
-		delayedResize := tea.Tick(500*time.Millisecond, func(time.Time) tea.Msg {
-			return splashResizeMsg{agentID: msg.agentID}
-		})
-		return a, delayedResize
+		return a, nil
 
 	case diffStatsMsg:
 		a.diffRefreshInFlight = false
@@ -478,17 +481,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 
-	case splashResizeMsg:
-		// Guard: only resize if we're still on the dashboard and the agent
-		// that triggered this is still selected.
-		if a.view != ViewDashboard {
-			return a, nil
-		}
-		ag := a.dashboard.selectedAgent()
-		if ag != nil && ag.ID == msg.agentID {
-			a.resizeSelectedForDashboard()
-		}
-		return a, nil
 	}
 
 	// Route to the active view.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -193,7 +193,7 @@ func (d dashboardModel) View() string {
 		Height(d.contentHeight())
 	if d.panelFocus == focusTerminal || d.panelFocus == focusConfig {
 		previewStyle = lipgloss.NewStyle().
-			Width(previewWidth).
+			Width(d.fixedTermWidth()).
 			Height(d.contentHeight() - 2).
 			Border(lipgloss.NormalBorder()).
 			BorderForeground(ColorSecondary)
@@ -228,27 +228,12 @@ func (d dashboardModel) fixedTermHeight() int {
 
 // previewTermWidth returns the terminal column count for the preview panel.
 func (d dashboardModel) previewTermWidth() int {
-	listWidth := 30
-	w := d.width - listWidth - 1 // 1 for the list panel's right border
-	if d.panelFocus == focusTerminal {
-		w -= 2 // NormalBorder consumes 1 col each side
-	}
-	return w
+	return d.fixedTermWidth()
 }
 
 // previewTermHeight returns the terminal row count for the preview panel.
 func (d dashboardModel) previewTermHeight() int {
-	h := d.contentHeight() - 4 // title + session info + task info + blank line
-	// Account for PR info line if present.
-	if sess := d.selectedSession(); sess != nil {
-		if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
-			h-- // extra line for PR info
-		}
-	}
-	if d.panelFocus == focusTerminal {
-		h -= 2 // NormalBorder consumes 1 row top and bottom
-	}
-	return h
+	return d.fixedTermHeight()
 }
 
 func (d dashboardModel) emptyView() string {
@@ -512,7 +497,7 @@ func (d dashboardModel) renderPreview(width int) string {
 	var render string
 	if d.scrollOffset > 0 {
 		sbLines := ag.ScrollbackLines()
-		vpLines := strings.Split(ag.Render(), "\n")
+		vpLines := strings.Split(ag.StableRender(), "\n")
 		allLines := append(sbLines, vpLines...)
 
 		vpHeight := d.previewTermHeight()
@@ -526,7 +511,7 @@ func (d dashboardModel) renderPreview(width int) string {
 		}
 		render = strings.Join(allLines[start:end], "\n")
 	} else {
-		render = ag.Render()
+		render = ag.StableRender()
 	}
 
 	previewParts := []string{title, sessionInfo}

--- a/internal/vt/bridge.go
+++ b/internal/vt/bridge.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	xvt "github.com/charmbracelet/x/vt"
 )
@@ -35,6 +37,24 @@ type Terminal struct {
 	// before writing a newline, then capturing the top line before it's lost.
 	history   []string
 	historyMu sync.RWMutex
+
+	// lastWriteNano is the UnixNano timestamp of the last Write() completion.
+	// Atomic because Write() (agent.readLoop goroutine) and StableRender()
+	// (Bubble Tea main goroutine) access it from different goroutines.
+	lastWriteNano atomic.Int64
+
+	// stableRender caches the last Render() snapshot for StableRender().
+	// Only accessed from StableRender() on the Bubble Tea main goroutine.
+	stableRender string
+
+	// wasAltScreen tracks the previous alt-screen state for transition detection.
+	// Only accessed from Write() (agent.readLoop goroutine), no mutex needed.
+	wasAltScreen bool
+
+	// altScreenEntered is set to true on a false->true alt-screen transition.
+	// Written by Write() (agent.readLoop), read by AltScreenEntered() (Bubble Tea).
+	// Protected by historyMu.
+	altScreenEntered bool
 }
 
 // New creates a new Terminal with the given dimensions.
@@ -120,13 +140,49 @@ func (t *Terminal) Write(p []byte) (int, error) {
 		if err != nil {
 			return written, err
 		}
+
+		// Detect false->true alt-screen transition.
+		isAlt := t.emu.IsAltScreen()
+		if isAlt && !t.wasAltScreen {
+			t.historyMu.Lock()
+			t.altScreenEntered = true
+			t.history = nil
+			t.historyMu.Unlock()
+		}
+		t.wasAltScreen = isAlt
 	}
+	t.lastWriteNano.Store(time.Now().UnixNano())
 	return written, nil
 }
 
 // Render returns the full screen as an ANSI-encoded string.
 func (t *Terminal) Render() string {
 	return t.emu.Render()
+}
+
+// StableRender returns a cached render if the terminal was written to within the
+// last 16ms (mid-repaint), otherwise snapshots a fresh Render(). This avoids
+// showing torn/partial frames during rapid emulator updates.
+// Only called from Bubble Tea's main goroutine (View cycle).
+func (t *Terminal) StableRender() string {
+	lastWrite := t.lastWriteNano.Load()
+	if lastWrite > 0 && time.Since(time.Unix(0, lastWrite)) < 16*time.Millisecond {
+		return t.stableRender
+	}
+	t.stableRender = t.emu.Render()
+	return t.stableRender
+}
+
+// AltScreenEntered returns true if a false->true alt-screen transition has been
+// detected since the last call. The flag is reset on each read. This allows the
+// TUI layer to detect when an agent enters alt-screen mode (e.g., Claude Code
+// starting its interactive UI).
+func (t *Terminal) AltScreenEntered() bool {
+	t.historyMu.Lock()
+	entered := t.altScreenEntered
+	t.altScreenEntered = false
+	t.historyMu.Unlock()
+	return entered
 }
 
 // ScreenHash returns a deterministic hash of the current visible screen content.

--- a/internal/vt/bridge_test.go
+++ b/internal/vt/bridge_test.go
@@ -206,36 +206,37 @@ func TestScrollbackLinesAltScreen(t *testing.T) {
 }
 
 func TestScrollbackLinesHistoryPreferred(t *testing.T) {
-	// Verify that our history buffer captures scrollback from both main-screen
-	// and alternate-screen mode. The x/vt emulator's built-in Scrollback() only
-	// covers the main screen, so alt-screen history would otherwise be lost.
+	// Verify that entering alt screen clears pre-existing main-screen history
+	// (startup splash is garbage) and that subsequent alt-screen scrollback is
+	// still captured.
 	term := New(80, 2)
 	defer term.Close()
 
-	// Scroll in main screen to populate VT scrollback AND our history buffer.
+	// Scroll in main screen to populate history.
 	_, _ = term.Write([]byte("MainFirst\r\nMainSecond\r\nMainThird"))
-
-	// Enter alt screen and scroll to populate history with alt-screen content.
-	_, _ = term.Write([]byte("\x1b[?1049h"))
-	_, _ = term.Write([]byte("AltFirst\r\nAltSecond\r\nAltThird"))
-
 	lines := term.ScrollbackLines()
 	if len(lines) == 0 {
-		t.Fatal("expected non-empty scrollback")
+		t.Fatal("expected non-empty scrollback before alt-screen transition")
 	}
-	// Both main-screen and alt-screen lines should appear in history.
-	hasMain := false
+
+	// Enter alt screen — history should be cleared (splash scrollback is garbage).
+	_, _ = term.Write([]byte("\x1b[?1049h"))
+	lines = term.ScrollbackLines()
+	if len(lines) != 0 {
+		t.Errorf("expected empty scrollback after alt-screen transition, got %d lines", len(lines))
+	}
+
+	// Scroll in alt screen — new scrollback should be captured.
+	_, _ = term.Write([]byte("AltFirst\r\nAltSecond\r\nAltThird"))
+	lines = term.ScrollbackLines()
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty scrollback after scrolling in alt screen")
+	}
 	hasAlt := false
 	for _, line := range lines {
-		if strings.Contains(line, "MainFirst") {
-			hasMain = true
-		}
 		if strings.Contains(line, "AltFirst") {
 			hasAlt = true
 		}
-	}
-	if !hasMain {
-		t.Errorf("expected 'MainFirst' in scrollback history, got: %v", lines)
 	}
 	if !hasAlt {
 		t.Errorf("expected 'AltFirst' in scrollback history, got: %v", lines)
@@ -313,6 +314,111 @@ func TestScreenHashChangesOnResize(t *testing.T) {
 
 	if before == after {
 		t.Errorf("expected hash to change after resize (different render domain), both are %d", before)
+	}
+}
+
+func TestStableRenderQuiescent(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	_, _ = term.Write([]byte("Hello, world!"))
+
+	// Wait for writes to settle (well past the 16ms threshold).
+	time.Sleep(20 * time.Millisecond)
+
+	got := term.StableRender()
+	want := term.Render()
+	if got != want {
+		t.Errorf("StableRender() after quiescence should match Render()\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestStableRenderDuringActiveWrites(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	// Write initial content and let it settle.
+	_, _ = term.Write([]byte("initial"))
+	time.Sleep(20 * time.Millisecond)
+
+	// Prime the cache.
+	cached := term.StableRender()
+	if !strings.Contains(cached, "initial") {
+		t.Fatalf("expected StableRender to contain 'initial', got %q", cached)
+	}
+
+	// Write new content — should be within 16ms window.
+	_, _ = term.Write([]byte(" updated"))
+
+	// StableRender should return the cached version (before "updated").
+	got := term.StableRender()
+	if got != cached {
+		t.Errorf("StableRender() during active writes should return cached value\ngot:  %q\nwant: %q", got, cached)
+	}
+
+	// After settling, StableRender should reflect the new content.
+	time.Sleep(20 * time.Millisecond)
+	settled := term.StableRender()
+	if !strings.Contains(settled, "updated") {
+		t.Errorf("StableRender() after settling should contain 'updated', got %q", settled)
+	}
+}
+
+func TestAltScreenEnteredTransition(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	// Before any alt-screen transition, flag should be false.
+	if term.AltScreenEntered() {
+		t.Error("AltScreenEntered() should be false before any alt-screen transition")
+	}
+
+	// Enter alt screen.
+	_, _ = term.Write([]byte("\x1b[?1049h"))
+
+	// Flag should now be true.
+	if !term.AltScreenEntered() {
+		t.Error("AltScreenEntered() should be true after entering alt screen")
+	}
+
+	// Second call should return false (flag is reset on read).
+	if term.AltScreenEntered() {
+		t.Error("AltScreenEntered() should be false on second call (resets after read)")
+	}
+}
+
+func TestAltScreenEnteredClearsHistory(t *testing.T) {
+	term := New(80, 2)
+	defer term.Close()
+
+	// Scroll in main screen to populate history.
+	_, _ = term.Write([]byte("First\r\nSecond\r\nThird"))
+	lines := term.ScrollbackLines()
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty scrollback before alt-screen transition")
+	}
+
+	// Enter alt screen — history should be cleared.
+	_, _ = term.Write([]byte("\x1b[?1049h"))
+	lines = term.ScrollbackLines()
+	if len(lines) != 0 {
+		t.Errorf("expected empty scrollback after alt-screen transition, got %d lines: %v", len(lines), lines)
+	}
+}
+
+func TestAltScreenEnteredNoSpuriousTransition(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	// Enter alt screen.
+	_, _ = term.Write([]byte("\x1b[?1049h"))
+	// Consume the flag.
+	term.AltScreenEntered()
+
+	// Write more content while already in alt screen — no new transition.
+	_, _ = term.Write([]byte("more content in alt screen"))
+	if term.AltScreenEntered() {
+		t.Error("AltScreenEntered() should be false when already in alt screen (no new transition)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix startup splash text artifacts by detecting alt-screen transitions (`\x1b[?1049h`) reactively instead of relying on a 500ms delayed resize heuristic. History is cleared on transition since pre-alt-screen scrollback is garbage.
- Fix mid-repaint flicker by adding `StableRender()` with a 16ms quiescence threshold — returns a cached snapshot while the VT emulator is actively being written to, fresh content when quiet.
- Fix VT/container sizing mismatch by making `previewTermWidth/Height` always return `fixedTermWidth/Height`, eliminating the 2-column-wider container in focusList mode.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` (all pass except pre-existing `TestLoad_MigratesFromLegacyXDGPath`)
- [ ] Manual TUI:
  - Launch baton, create a new Claude session
  - Verify no splash text artifacts on startup
  - Verify Claude's input prompt sits at the bottom in both focusList and focusTerminal
  - Verify no flicker during Claude thinking/responding/prompting transitions
  - Verify switching between focusList and focusTerminal doesn't cause visual jumps

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (`TestStableRender*`, `TestAltScreenEntered*` in `internal/vt/bridge_test.go`)
- [x] No new public API surface without a note in the PR description
  - New public methods: `Terminal.StableRender()`, `Terminal.AltScreenEntered()`, `Agent.StableRender()`, `Agent.AltScreenEntered()` — internal package APIs only, not exported from the module

🤖 Generated with [Claude Code](https://claude.com/claude-code)