### PR TITLE
Add configurable IDE launcher

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -25,6 +25,7 @@ type GlobalSettings struct {
 	DefaultBranch     *string `json:"default_branch,omitempty"`
 	BranchPrefix      *string `json:"branch_prefix,omitempty"`
 	AgentProgram      *string `json:"agent_program,omitempty"`
+	IDECommand        *string `json:"ide_command,omitempty"`
 }
 
 // RepoSettings holds per-repo overrides stored at <repo>/.baton/config.json.
@@ -34,6 +35,7 @@ type RepoSettings struct {
 	DefaultBranch     *string `json:"default_branch,omitempty"`
 	BranchPrefix      *string `json:"branch_prefix,omitempty"`
 	AgentProgram      *string `json:"agent_program,omitempty"`
+	IDECommand        *string `json:"ide_command,omitempty"`
 	WorktreeDir       *string `json:"worktree_dir,omitempty"`
 }
 
@@ -45,6 +47,7 @@ type ResolvedSettings struct {
 	DefaultBranch     string // "" means auto-detect
 	BranchPrefix      string
 	AgentProgram      string
+	IDECommand        string
 	WorktreeDir       string
 }
 
@@ -75,6 +78,9 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		if global.AgentProgram != nil {
 			r.AgentProgram = *global.AgentProgram
 		}
+		if global.IDECommand != nil {
+			r.IDECommand = *global.IDECommand
+		}
 	}
 
 	if repo != nil {
@@ -89,6 +95,9 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		}
 		if repo.AgentProgram != nil {
 			r.AgentProgram = *repo.AgentProgram
+		}
+		if repo.IDECommand != nil {
+			r.IDECommand = *repo.IDECommand
 		}
 		if repo.WorktreeDir != nil {
 			r.WorktreeDir = *repo.WorktreeDir

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -702,6 +702,30 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return createResultMsg{sessionID: sessionID, agentID: ag.ID}
 			}
 
+		case "e":
+			// Open the selected session's worktree in the configured IDE.
+			sess := a.dashboard.selectedSession()
+			if sess == nil {
+				a.setError("No session selected")
+				return a, nil
+			}
+			repoPath := a.dashboard.selectedRepoPath()
+			ideCmd := strings.TrimSpace(a.resolvedCache[repoPath].IDECommand)
+			if ideCmd == "" {
+				a.setError("No IDE configured (set 'IDE Command' in settings)")
+				return a, nil
+			}
+			parts := strings.Fields(ideCmd)
+			worktreePath := sess.Worktree.Path
+			exe := parts[0]
+			args := append(parts[1:], worktreePath)
+			go func() {
+				cmd := exec.Command(exe, args...)
+				cmd.Dir = worktreePath
+				_ = cmd.Start()
+			}()
+			return a, nil
+
 		case "a":
 			// Open file browser to add a new repo.
 			a.repoBrowser = newFileBrowserModel()
@@ -1268,6 +1292,10 @@ func (a *App) initRepoConfigForm(repoPath string) {
 	if rs.AgentProgram != nil {
 		agentProgram = *rs.AgentProgram
 	}
+	ideCommand := ""
+	if rs.IDECommand != nil {
+		ideCommand = *rs.IDECommand
+	}
 	worktreeDir := ""
 	if rs.WorktreeDir != nil {
 		worktreeDir = *rs.WorktreeDir
@@ -1279,6 +1307,7 @@ func (a *App) initRepoConfigForm(repoPath string) {
 	fields = addTextInput(fields, "Default Branch", defaultBranch, "auto-detect", inputWidth)
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
+	fields = addTextInput(fields, "IDE Command", ideCommand, "e.g. code -n", inputWidth)
 	fields = addTextInput(fields, "Worktree Directory", worktreeDir, config.DefaultWorktreeDir, inputWidth)
 
 	form := newConfigForm(fields, a.dashboard.previewTermWidth())
@@ -1306,6 +1335,9 @@ func (a App) extractRepoSettings() *config.RepoSettings {
 	}
 	if v := form.textValue("Agent Program"); v != "" {
 		s.AgentProgram = &v
+	}
+	if v := form.textValue("IDE Command"); v != "" {
+		s.IDECommand = &v
 	}
 	if v := form.textValue("Worktree Directory"); v != "" {
 		s.WorktreeDir = &v

--- a/internal/tui/globalconfig.go
+++ b/internal/tui/globalconfig.go
@@ -47,6 +47,10 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	if gs.AgentProgram != nil {
 		agentProgram = *gs.AgentProgram
 	}
+	ideCommand := ""
+	if gs.IDECommand != nil {
+		ideCommand = *gs.IDECommand
+	}
 
 	inputWidth := 30
 
@@ -56,6 +60,7 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	fields = addTextInput(fields, "Default Branch", defaultBranch, "auto-detect", inputWidth)
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
+	fields = addTextInput(fields, "IDE Command", ideCommand, "e.g. code -n", inputWidth)
 
 	return globalConfigModel{
 		form:   newConfigForm(fields, width),
@@ -118,6 +123,9 @@ func (m globalConfigModel) extractSettings() *config.GlobalSettings {
 	}
 	if v := m.form.textValue("Agent Program"); v != "" {
 		s.AgentProgram = &v
+	}
+	if v := m.form.textValue("IDE Command"); v != "" {
+		s.IDECommand = &v
 	}
 
 	return s

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -18,6 +18,7 @@ var (
 		{"n", "new session"},
 		{"c", "add agent"},
 		{"t", "shell"},
+		{"e", "open in IDE"},
 		{"s", "settings"},
 		{"a", "add repo"},
 		{"o", "open branch"},


### PR DESCRIPTION
Users can set an IDE Command in global or per-repo settings, then press 'e'
on the dashboard to open the selected session's worktree in that IDE. The
command is split on whitespace and the worktree path is appended, so values
like "code", "code -n", "cursor", or "idea" all work.