### PR TITLE
Add Waiting status + verified hook pipeline

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -183,10 +183,12 @@ func checkHookPipeline(batonExe string) error {
 
 	cmd := exec.Command(batonExe, "hook", "session-start")
 	// Scrub any BATON_* env inherited from a parent baton session — the
-	// check must exercise *this* temp socket, not a lingering one.
+	// check must exercise *this* temp socket, not a lingering one. Filter
+	// by the full `BATON_` prefix so future vars (not just the two used
+	// today) stay isolated from the doctor subprocess.
 	baseEnv := make([]string, 0, len(os.Environ()))
 	for _, kv := range os.Environ() {
-		if strings.HasPrefix(kv, "BATON_HOOK_SOCKET=") || strings.HasPrefix(kv, "BATON_AGENT_ID=") {
+		if strings.HasPrefix(kv, "BATON_") {
 			continue
 		}
 		baseEnv = append(baseEnv, kv)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/devenjarvis/baton/internal/hook"
 	"github.com/spf13/cobra"
 )
 
@@ -56,11 +59,23 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	// Baton's own binary path — hooks commands reference it.
-	if exe, err := os.Executable(); err != nil {
+	batonExe, err := resolveBatonBinary()
+	if err != nil {
 		fmt.Printf("  [FAIL] baton binary: unresolved (%v)\n", err)
 		allOk = false
 	} else {
-		fmt.Printf("  [OK]   baton binary: %s\n", exe)
+		fmt.Printf("  [OK]   baton binary: %s\n", batonExe)
+	}
+
+	// Hook pipeline round-trip: spin up a temporary socket, invoke
+	// `baton hook session-start` against it, and confirm the event arrives.
+	if batonExe != "" {
+		if err := checkHookPipeline(batonExe); err != nil {
+			fmt.Printf("  [FAIL] hook pipeline: %v\n", err)
+			allOk = false
+		} else {
+			fmt.Println("  [OK]   hook pipeline: socket round-trip ok")
+		}
 	}
 
 	// Check git repo
@@ -126,4 +141,72 @@ func supportsSettingsFlag(claudePath string) bool {
 		return false
 	}
 	return strings.Contains(string(out), "--settings")
+}
+
+// resolveBatonBinary returns the baton binary path, preferring the resolved
+// symlink target. Mirrors the logic in internal/agent so doctor invokes the
+// same binary the hooks file would invoke.
+func resolveBatonBinary() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return exe, nil
+}
+
+// checkHookPipeline exercises the socket round-trip: it spins up a hook
+// server on a short temp path, runs `baton hook session-start` with the
+// socket env wired up, and confirms the event arrives within 2 seconds.
+// Returns a descriptive error on failure so users can act on it.
+func checkHookPipeline(batonExe string) error {
+	// macOS caps unix socket paths at 104 bytes. Use os.TempDir with a short
+	// name and surface a friendly error if it still won't fit.
+	sockDir, err := os.MkdirTemp("", "bd")
+	if err != nil {
+		return fmt.Errorf("temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(sockDir) }()
+
+	socket := filepath.Join(sockDir, "h.sock")
+	if len(socket) > 103 {
+		return fmt.Errorf("socket path too long for this platform (%d bytes)", len(socket))
+	}
+
+	srv, err := hook.NewServer(socket)
+	if err != nil {
+		return fmt.Errorf("socket bind: %w", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	cmd := exec.Command(batonExe, "hook", "session-start")
+	// Scrub any BATON_* env inherited from a parent baton session — the
+	// check must exercise *this* temp socket, not a lingering one.
+	baseEnv := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "BATON_HOOK_SOCKET=") || strings.HasPrefix(kv, "BATON_AGENT_ID=") {
+			continue
+		}
+		baseEnv = append(baseEnv, kv)
+	}
+	cmd.Env = append(baseEnv,
+		"BATON_HOOK_SOCKET="+socket,
+		"BATON_AGENT_ID=doctor",
+	)
+	cmd.Stdin = strings.NewReader(`{"session_id":"doctor","cwd":"/"}`)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("hook cli: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	select {
+	case e := <-srv.Events():
+		if e.Kind != hook.KindSessionStart || e.AgentID != "doctor" {
+			return fmt.Errorf("unexpected event: kind=%q agent=%q", e.Kind, e.AgentID)
+		}
+		return nil
+	case <-time.After(2 * time.Second):
+		return fmt.Errorf("event not received within 2s")
+	}
 }

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"testing"
+)
+
+// TestCheckHookPipeline exercises the doctor self-check: it builds the baton
+// binary, invokes checkHookPipeline against it, and asserts the socket round
+// trip succeeds. Uses buildBaton from hook_test.go.
+func TestCheckHookPipeline(t *testing.T) {
+	bin := buildBaton(t)
+	if err := checkHookPipeline(bin); err != nil {
+		t.Fatalf("checkHookPipeline: %v", err)
+	}
+}
+
+// TestCheckHookPipelineBadBinary verifies the check surfaces an actionable
+// error when the baton binary path is wrong.
+func TestCheckHookPipelineBadBinary(t *testing.T) {
+	err := checkHookPipeline("/nonexistent/baton-binary")
+	if err == nil {
+		t.Fatal("expected error for missing binary, got nil")
+	}
+}

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -43,6 +43,10 @@ func runHook(cmd *cobra.Command, args []string) error {
 		kind = hook.KindStop
 	case "session-end":
 		kind = hook.KindSessionEnd
+	case "notification":
+		kind = hook.KindNotification
+	case "user-prompt-submit":
+		kind = hook.KindUserPromptSubmit
 	default:
 		return nil
 	}
@@ -62,10 +66,12 @@ func runHook(cmd *cobra.Command, args []string) error {
 	}
 
 	// Parse just the fields we route on; keep the rest in Raw so the server
-	// can inspect extras if it cares later.
+	// can inspect extras if it cares later. `message` is only populated by
+	// Notification payloads — other kinds will leave it empty.
 	var payload struct {
 		SessionID string `json:"session_id"`
 		CWD       string `json:"cwd"`
+		Message   string `json:"message"`
 	}
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &payload); err != nil {
@@ -79,6 +85,7 @@ func runHook(cmd *cobra.Command, args []string) error {
 		AgentID:   agentID,
 		SessionID: payload.SessionID,
 		CWD:       payload.CWD,
+		Message:   payload.Message,
 		Raw:       json.RawMessage(raw),
 	}
 

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -11,54 +12,133 @@ import (
 	"github.com/devenjarvis/baton/internal/hook"
 )
 
-// TestHookSubcommandForwards runs the built baton binary with `hook session-start`
-// and asserts the server on the other side receives the event with the right
-// AgentID and parsed session_id.
-func TestHookSubcommandForwards(t *testing.T) {
-	// Find repo root and build the binary into a temp dir.
+// envWithout returns env with the named vars filtered out.
+func envWithout(env []string, names ...string) []string {
+	filtered := make([]string, 0, len(env))
+outer:
+	for _, kv := range env {
+		for _, n := range names {
+			if strings.HasPrefix(kv, n+"=") {
+				continue outer
+			}
+		}
+		filtered = append(filtered, kv)
+	}
+	return filtered
+}
+
+// buildBaton builds the baton binary into a temp dir and returns the path.
+func buildBaton(t *testing.T) string {
+	t.Helper()
 	_, thisFile, _, _ := runtime.Caller(0)
 	repoRoot := filepath.Dir(filepath.Dir(thisFile))
-
 	bin := filepath.Join(t.TempDir(), "baton")
 	build := exec.Command("go", "build", "-o", bin, ".")
 	build.Dir = repoRoot
 	if out, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("building baton: %v\n%s", err, out)
 	}
+	return bin
+}
 
-	socket := filepath.Join(t.TempDir(), "hook.sock")
-	srv, err := hook.NewServer(socket)
-	if err != nil {
-		t.Fatalf("NewServer: %v", err)
+// TestHookSubcommandForwards runs the built baton binary with each supported
+// subcommand and asserts the server receives the event with the right kind,
+// AgentID, and parsed payload fields.
+func TestHookSubcommandForwards(t *testing.T) {
+	bin := buildBaton(t)
+
+	cases := []struct {
+		subcmd      string
+		wantKind    hook.Kind
+		stdin       string
+		wantSession string
+		wantCWD     string
+		wantMessage string
+	}{
+		{
+			subcmd:      "session-start",
+			wantKind:    hook.KindSessionStart,
+			stdin:       `{"session_id":"uuid-xyz","cwd":"/tmp/wt"}`,
+			wantSession: "uuid-xyz",
+			wantCWD:     "/tmp/wt",
+		},
+		{
+			subcmd:      "stop",
+			wantKind:    hook.KindStop,
+			stdin:       `{"session_id":"uuid-xyz"}`,
+			wantSession: "uuid-xyz",
+		},
+		{
+			subcmd:   "session-end",
+			wantKind: hook.KindSessionEnd,
+			stdin:    `{}`,
+		},
+		{
+			subcmd:      "notification",
+			wantKind:    hook.KindNotification,
+			stdin:       `{"session_id":"uuid-xyz","message":"Claude needs your permission to use Bash"}`,
+			wantSession: "uuid-xyz",
+			wantMessage: "Claude needs your permission to use Bash",
+		},
+		{
+			subcmd:      "user-prompt-submit",
+			wantKind:    hook.KindUserPromptSubmit,
+			stdin:       `{"session_id":"uuid-xyz"}`,
+			wantSession: "uuid-xyz",
+		},
 	}
-	defer func() { _ = srv.Close() }()
 
-	cmd := exec.Command(bin, "hook", "session-start")
-	cmd.Env = append(cmd.Environ(),
-		"BATON_HOOK_SOCKET="+socket,
-		"BATON_AGENT_ID=test-agent-42",
-	)
-	cmd.Stdin = strings.NewReader(`{"session_id":"uuid-xyz","cwd":"/tmp/wt"}`)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("running hook: %v\n%s", err, out)
-	}
+	for _, tc := range cases {
+		t.Run(tc.subcmd, func(t *testing.T) {
+			t.Parallel()
+			// macOS caps unix socket paths at 104 bytes — t.TempDir() under the
+			// test name is too long, so use a short dir under os.TempDir().
+			sockDir, err := os.MkdirTemp("", "bh")
+			if err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+			socket := filepath.Join(sockDir, "h.sock")
+			srv, err := hook.NewServer(socket)
+			if err != nil {
+				t.Fatalf("NewServer: %v", err)
+			}
+			defer func() { _ = srv.Close() }()
 
-	select {
-	case e := <-srv.Events():
-		if e.Kind != hook.KindSessionStart {
-			t.Errorf("kind: got %q, want %q", e.Kind, hook.KindSessionStart)
-		}
-		if e.AgentID != "test-agent-42" {
-			t.Errorf("agent id: got %q, want %q", e.AgentID, "test-agent-42")
-		}
-		if e.SessionID != "uuid-xyz" {
-			t.Errorf("session id: got %q, want %q", e.SessionID, "uuid-xyz")
-		}
-		if e.CWD != "/tmp/wt" {
-			t.Errorf("cwd: got %q, want %q", e.CWD, "/tmp/wt")
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for hook event")
+			cmd := exec.Command(bin, "hook", tc.subcmd)
+			// Strip parent BATON_* env to avoid leaking outer baton session
+			// state into the test subprocess.
+			cleanEnv := envWithout(os.Environ(), "BATON_HOOK_SOCKET", "BATON_AGENT_ID")
+			cmd.Env = append(cleanEnv,
+				"BATON_HOOK_SOCKET="+socket,
+				"BATON_AGENT_ID=test-agent-42",
+			)
+			cmd.Stdin = strings.NewReader(tc.stdin)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("running hook: %v\n%s", err, out)
+			}
+
+			select {
+			case e := <-srv.Events():
+				if e.Kind != tc.wantKind {
+					t.Errorf("kind: got %q, want %q", e.Kind, tc.wantKind)
+				}
+				if e.AgentID != "test-agent-42" {
+					t.Errorf("agent id: got %q, want %q", e.AgentID, "test-agent-42")
+				}
+				if e.SessionID != tc.wantSession {
+					t.Errorf("session id: got %q, want %q", e.SessionID, tc.wantSession)
+				}
+				if e.CWD != tc.wantCWD {
+					t.Errorf("cwd: got %q, want %q", e.CWD, tc.wantCWD)
+				}
+				if e.Message != tc.wantMessage {
+					t.Errorf("message: got %q, want %q", e.Message, tc.wantMessage)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("timed out waiting for hook event")
+			}
+		})
 	}
 }
 
@@ -66,18 +146,12 @@ func TestHookSubcommandForwards(t *testing.T) {
 // BATON_HOOK_SOCKET and BATON_AGENT_ID aren't set — this is the case for a
 // user running `claude` outside of baton.
 func TestHookSubcommandNoEnv(t *testing.T) {
-	_, thisFile, _, _ := runtime.Caller(0)
-	repoRoot := filepath.Dir(filepath.Dir(thisFile))
-
-	bin := filepath.Join(t.TempDir(), "baton")
-	build := exec.Command("go", "build", "-o", bin, ".")
-	build.Dir = repoRoot
-	if out, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("building baton: %v\n%s", err, out)
-	}
+	bin := buildBaton(t)
 
 	cmd := exec.Command(bin, "hook", "stop")
-	// Deliberately no BATON_* env vars.
+	// Deliberately no BATON_* env vars — if baton itself was launched inside
+	// another baton session the parent env may have leaked them in, so filter.
+	cmd.Env = envWithout(os.Environ(), "BATON_HOOK_SOCKET", "BATON_AGENT_ID")
 	cmd.Stdin = strings.NewReader(`{}`)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -90,15 +164,7 @@ func TestHookSubcommandNoEnv(t *testing.T) {
 
 // TestHookSubcommandUnknownEvent ensures unknown event names exit 0 silently.
 func TestHookSubcommandUnknownEvent(t *testing.T) {
-	_, thisFile, _, _ := runtime.Caller(0)
-	repoRoot := filepath.Dir(filepath.Dir(thisFile))
-
-	bin := filepath.Join(t.TempDir(), "baton")
-	build := exec.Command("go", "build", "-o", bin, ".")
-	build.Dir = repoRoot
-	if out, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("building baton: %v\n%s", err, out)
-	}
+	bin := buildBaton(t)
 
 	cmd := exec.Command(bin, "hook", "made-up-event")
 	cmd.Stdin = strings.NewReader(`{}`)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -416,7 +416,12 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 	case hook.KindUserPromptSubmit:
 		// User just submitted a new turn. Re-arm the chime and drive the
 		// agent back to Active — this is the authoritative re-arm signal
-		// alongside the existing SendKey(Enter) path.
+		// alongside the existing SendKey(Enter) path. Mirror the Notification
+		// guard: a late event after the agent exited must not resurrect a
+		// Done or Error row, and must not reset chimedForTurn either.
+		if a.status == StatusDone || a.status == StatusError {
+			return false
+		}
 		a.chimedForTurn = false
 		if a.status != StatusActive {
 			a.status = StatusActive

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -399,6 +399,30 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 		// through the PTY close path (readLoop -> close(done)).
 		a.cleanExit = true
 		return false
+
+	case hook.KindNotification:
+		// Claude is waiting for the user (typically a permission prompt).
+		// Only override Active/Waiting so a late Notification can't revive a
+		// Done or Error agent, and don't clobber Idle either — if Claude sent
+		// Stop already, a trailing Notification shouldn't re-attention the row.
+		if a.status == StatusActive || a.status == StatusWaiting {
+			if a.status != StatusWaiting {
+				a.status = StatusWaiting
+				return true
+			}
+		}
+		return false
+
+	case hook.KindUserPromptSubmit:
+		// User just submitted a new turn. Re-arm the chime and drive the
+		// agent back to Active — this is the authoritative re-arm signal
+		// alongside the existing SendKey(Enter) path.
+		a.chimedForTurn = false
+		if a.status != StatusActive {
+			a.status = StatusActive
+			return true
+		}
+		return false
 	}
 	return false
 }

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -243,6 +243,53 @@ func TestDoneAgentIgnoresLateNotification(t *testing.T) {
 	}
 }
 
+// TestDoneAgentIgnoresLateUserPromptSubmit verifies a Done agent stays Done
+// (and its chimedForTurn flag is NOT reset) when a stray UserPromptSubmit
+// event arrives after the agent has already exited.
+func TestDoneAgentIgnoresLateUserPromptSubmit(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "done-ignore-ups", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// Force Done, and set chimedForTurn=true so a silent reset would be
+	// observable if the guard regresses.
+	ag.mu.Lock()
+	ag.status = StatusDone
+	ag.chimedForTurn = true
+	ag.mu.Unlock()
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent UserPromptSubmit: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	if got := ag.Status(); got != StatusDone {
+		t.Errorf("expected Done to be preserved, got %s", got)
+	}
+	ag.mu.Lock()
+	chimed := ag.chimedForTurn
+	ag.mu.Unlock()
+	if !chimed {
+		t.Error("expected chimedForTurn to stay true on Done agent, got reset")
+	}
+}
+
 // waitForStatus polls the agent status up to d for the desired value.
 func waitForStatus(t *testing.T, a *Agent, want Status, d time.Duration) bool {
 	t.Helper()

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -105,6 +105,144 @@ func TestSocketPathPerRepo(t *testing.T) {
 	}
 }
 
+// TestManagerDispatchesNotificationAndStop verifies the Notification hook drives
+// the agent to StatusWaiting and a subsequent Stop returns it to StatusIdle.
+func TestManagerDispatchesNotificationAndStop(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "notif-dispatch", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain EventCreated.
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// SessionStart → Active.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindSessionStart,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent SessionStart: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
+	}
+
+	// Notification → Waiting.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindNotification,
+		AgentID: ag.ID,
+		Message: "Claude needs your permission to use Bash",
+	}); err != nil {
+		t.Fatalf("SendEvent Notification: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusWaiting, 2*time.Second) {
+		t.Fatalf("expected Waiting after Notification, got %s", ag.Status())
+	}
+
+	// Stop → Idle.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindStop,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent Stop: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusIdle, 2*time.Second) {
+		t.Fatalf("expected Idle after Stop, got %s", ag.Status())
+	}
+}
+
+// TestManagerUserPromptSubmitRearmsChime verifies UserPromptSubmit both
+// re-arms the chime flag and transitions Idle→Active.
+func TestManagerUserPromptSubmitRearmsChime(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "ups-dispatch", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// Seed: agent is Idle and the chime has already fired this turn.
+	ag.mu.Lock()
+	ag.status = StatusIdle
+	ag.chimedForTurn = true
+	ag.mu.Unlock()
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent UserPromptSubmit: %v", err)
+	}
+
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after UserPromptSubmit, got %s", ag.Status())
+	}
+	if ag.ChimedForTurn() {
+		t.Error("expected chimedForTurn to be reset by UserPromptSubmit")
+	}
+}
+
+// TestDoneAgentIgnoresLateNotification verifies a Done agent stays Done
+// when a late Notification event arrives (e.g. race between Claude emitting
+// a prompt and the agent process having already been killed/finished).
+func TestDoneAgentIgnoresLateNotification(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "done-ignore", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// Force the agent to Done.
+	ag.mu.Lock()
+	ag.status = StatusDone
+	ag.mu.Unlock()
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindNotification,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent Notification: %v", err)
+	}
+
+	// Give the dispatcher time to process — the status must remain Done.
+	time.Sleep(200 * time.Millisecond)
+	if got := ag.Status(); got != StatusDone {
+		t.Errorf("expected Done to be preserved, got %s", got)
+	}
+}
+
 // waitForStatus polls the agent status up to d for the desired value.
 func waitForStatus(t *testing.T, a *Agent, want Status, d time.Duration) bool {
 	t.Helper()

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -191,7 +191,9 @@ func (s *Session) Status() Status {
 		nonShellCount++
 		st := a.Status()
 		switch st {
-		case StatusActive:
+		case StatusActive, StatusWaiting:
+			// Waiting rolls up as Active at the session header so a session
+			// with any waiting agent still reads as attention-worthy.
 			return StatusActive
 		case StatusStarting:
 			hasStarting = true

--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -6,6 +6,7 @@ type Status int
 const (
 	StatusStarting Status = iota
 	StatusActive
+	StatusWaiting
 	StatusIdle
 	StatusDone
 	StatusError
@@ -17,6 +18,8 @@ func (s Status) String() string {
 		return "Starting"
 	case StatusActive:
 		return "Active"
+	case StatusWaiting:
+		return "Waiting"
 	case StatusIdle:
 		return "Idle"
 	case StatusDone:
@@ -35,6 +38,8 @@ func (s Status) Symbol() string {
 		return "◎"
 	case StatusActive:
 		return "●"
+	case StatusWaiting:
+		return "◐"
 	case StatusIdle:
 		return "○"
 	case StatusDone:

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -62,11 +62,12 @@ func repoRoot() string {
 
 // Session wraps a tu CLI session for e2e testing.
 type Session struct {
-	t       *testing.T
-	name    string
-	tempDir string // parent temp dir
-	home    string // fake HOME
-	repoDir string // temp git repo (also CWD for baton)
+	t        *testing.T
+	name     string
+	tempDir  string   // parent temp dir
+	home     string   // fake HOME
+	repoDir  string   // temp git repo (also CWD for baton)
+	extraEnv []string // additional "K=V" env entries to pass through tu to baton
 }
 
 // newSession creates an isolated test environment and launches baton via tu.
@@ -147,18 +148,27 @@ func (s *Session) Start() {
 	// developer's real ~/.gitconfig (signing keys, hooks, templates) doesn't
 	// leak in. We deliberately do NOT set GIT_DIR/GIT_WORK_TREE — those would
 	// override git's repo discovery and break it.
-	cmd := exec.Command("tu", "run",
+	args := []string{
+		"run",
 		"--name", s.name,
 		"--size", "120x40",
-		"--env", "HOME="+s.home,
-		"--env", "XDG_CONFIG_HOME="+filepath.Join(s.home, ".config"),
-		"--env", "XDG_DATA_HOME="+filepath.Join(s.home, ".local", "share"),
-		"--env", "XDG_CACHE_HOME="+filepath.Join(s.home, ".cache"),
-		"--env", "GIT_CONFIG_GLOBAL="+filepath.Join(s.home, ".gitconfig"),
+		"--env", "HOME=" + s.home,
+		"--env", "XDG_CONFIG_HOME=" + filepath.Join(s.home, ".config"),
+		"--env", "XDG_DATA_HOME=" + filepath.Join(s.home, ".local", "share"),
+		"--env", "XDG_CACHE_HOME=" + filepath.Join(s.home, ".cache"),
+		"--env", "GIT_CONFIG_GLOBAL=" + filepath.Join(s.home, ".gitconfig"),
 		"--env", "GIT_CONFIG_SYSTEM=/dev/null",
-		"--cwd", s.repoDir,
-		"--", batonBin,
-	)
+		// Scrub parent baton hook wiring so running these tests from inside
+		// another baton session doesn't leak a live socket into the child's
+		// env (the stub would forward hook events to the wrong socket).
+		"--env", "BATON_HOOK_SOCKET=",
+		"--env", "BATON_AGENT_ID=",
+	}
+	for _, kv := range s.extraEnv {
+		args = append(args, "--env", kv)
+	}
+	args = append(args, "--cwd", s.repoDir, "--", batonBin)
+	cmd := exec.Command("tu", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		s.t.Fatalf("e2e: tu run failed: %v\n%s", err, out)

--- a/internal/e2e/hooks_test.go
+++ b/internal/e2e/hooks_test.go
@@ -1,0 +1,144 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// claudeStubScript is a bash stub installed as `<dir>/claude`. Baton's
+// supportsHooks check keys off filepath.Base(agent_program), so the file must
+// be named `claude`. The stub ignores any args (baton passes
+// `--settings <path>`), inherits BATON_HOOK_SOCKET / BATON_AGENT_ID from
+// baton's env wiring, and drives the pipeline by invoking
+// `$BATON_E2E_BATON hook <event>` at scripted intervals.
+//
+// Sequence (seconds since start):
+//
+//	0.3  session-start   → Active
+//	1.5  notification    → Waiting
+//	3.5  stop            → Idle
+//	5.5  user-prompt-submit → Active (re-armed)
+//	7.5  stop            → Idle
+//	then sleep 3600 so baton keeps it alive until test teardown kills it.
+const claudeStubScript = `#!/bin/bash
+echo "claude-e2e-stub ready"
+sleep 0.3
+"$BATON_E2E_BATON" hook session-start <<< '{"session_id":"e2e-sess-1","cwd":"/tmp"}'
+sleep 1.2
+"$BATON_E2E_BATON" hook notification <<< '{"session_id":"e2e-sess-1","message":"Claude needs permission"}'
+sleep 2
+"$BATON_E2E_BATON" hook stop <<< '{"session_id":"e2e-sess-1"}'
+sleep 2
+"$BATON_E2E_BATON" hook user-prompt-submit <<< '{"session_id":"e2e-sess-1"}'
+sleep 2
+"$BATON_E2E_BATON" hook stop <<< '{"session_id":"e2e-sess-1"}'
+sleep 3600
+`
+
+// TestHookPipeline drives baton through a scripted bash "claude" stub that
+// emits each hook kind in turn, and asserts the dashboard bubble transitions
+// Active → Waiting → Idle → Active → Idle. This is the end-to-end check that
+// the plan calls for: hooks file wiring, socket forwarding, agent status
+// transitions, and dashboard rendering all working in concert.
+func TestHookPipeline(t *testing.T) {
+	// Install the stub as a file named `claude` in a short-path temp dir.
+	// The basename must be exactly "claude" so baton's supportsHooks check
+	// fires and the agent gets --settings + socket env wired up.
+	stubDir, err := os.MkdirTemp("", "bs")
+	if err != nil {
+		t.Fatalf("mkdir stub dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stubDir) })
+	stubPath := filepath.Join(stubDir, "claude")
+	if err := os.WriteFile(stubPath, []byte(claudeStubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	s := newSession(t)
+	// Point both global and repo config at the stub so whichever baton reads
+	// wins, and pass BATON_E2E_BATON through tu so the stub can invoke the
+	// hook CLI without needing to know the binary path itself.
+	writeJSON(t, filepath.Join(s.home, ".baton", "config.json"), map[string]any{
+		"agent_program":      stubPath,
+		"bypass_permissions": false,
+	})
+	writeJSON(t, filepath.Join(s.repoDir, ".baton", "config.json"), map[string]any{
+		"agent_program":      stubPath,
+		"bypass_permissions": false,
+	})
+	s.extraEnv = append(s.extraEnv, "BATON_E2E_BATON="+batonBin)
+	s.Start()
+
+	s.WaitForText("AGENTS", 10000)
+	s.Press("n")
+	// After "n", baton spawns the stub and auto-focuses its PTY. The stub
+	// prints a greeting; wait for it so we know the process is live before
+	// bouncing back to the dashboard to read status symbols.
+	s.WaitForText("claude-e2e-stub ready", 10000)
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	// Active (●) — session-start fires at t≈0.3s.
+	if !waitForAgentSymbol(s, "●", 5000) {
+		t.Fatalf("never observed Active (●) symbol\nScreen:\n%s", s.Screenshot())
+	}
+	// Waiting (◐) — notification fires at t≈1.5s.
+	if !waitForAgentSymbol(s, "◐", 5000) {
+		t.Fatalf("never observed Waiting (◐) symbol\nScreen:\n%s", s.Screenshot())
+	}
+	// Idle (○) — stop fires at t≈3.5s.
+	if !waitForAgentSymbol(s, "○", 5000) {
+		t.Fatalf("never observed Idle (○) after Stop\nScreen:\n%s", s.Screenshot())
+	}
+	// Active (●) again — user-prompt-submit fires at t≈5.5s and re-arms.
+	// This is the observable signal that UserPromptSubmit transitioned the
+	// bubble back to Active. (The chime re-arm flag is not visible on
+	// screen; the second Idle below confirms the manager saw the transition
+	// and emitted a status-change event.)
+	if !waitForAgentSymbol(s, "●", 5000) {
+		t.Fatalf("never observed re-armed Active (●) after UserPromptSubmit\nScreen:\n%s", s.Screenshot())
+	}
+	// Idle (○) again — stop fires at t≈7.5s. This doubles as a re-arm check:
+	// if UserPromptSubmit hadn't re-armed, there'd be no intermediate Active
+	// and the second Stop would be a no-op status-wise.
+	if !waitForAgentSymbol(s, "○", 5000) {
+		t.Fatalf("never observed final Idle (○) after second Stop\nScreen:\n%s", s.Screenshot())
+	}
+}
+
+// waitForAgentSymbol polls Screenshot until an agent row with the given
+// leading status symbol is visible, or timeoutMs elapses.
+func waitForAgentSymbol(s *Session, symbol string, timeoutMs int) bool {
+	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if screenHasAgentSymbol(s.Screenshot(), symbol) {
+			return true
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	return screenHasAgentSymbol(s.Screenshot(), symbol)
+}
+
+// screenHasAgentSymbol reports whether any line in screen is an agent row
+// starting (after whitespace and optional selection arrow) with symbol+space.
+// Session-header rows (which contain box-drawing "──") are skipped so a
+// session's rolled-up status doesn't mask the agent-row symbol we care about.
+func screenHasAgentSymbol(screen, symbol string) bool {
+	needle := symbol + " "
+	for _, line := range strings.Split(screen, "\n") {
+		if strings.Contains(line, "──") {
+			continue
+		}
+		trimmed := strings.TrimLeft(line, " ")
+		trimmed = strings.TrimPrefix(trimmed, "▸ ")
+		if strings.HasPrefix(trimmed, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/e2e/lifecycle_test.go
+++ b/internal/e2e/lifecycle_test.go
@@ -157,10 +157,10 @@ func TestSessionKill(t *testing.T) {
 
 // countAgentRows counts agent rows in the dashboard sidebar.
 // Agent rows are indented under sessions and start with a status symbol from
-// agent.Status.Symbol(): ◎ ● ○ ✓ ✗ (or "$" for shell agents). Session header
+// agent.Status.Symbol(): ◎ ● ◐ ○ ✓ ✗ (or "$" for shell agents). Session header
 // rows contain box-drawing dashes "──", so we skip those.
 func countAgentRows(screen string) int {
-	statusSymbols := []string{"◎ ", "● ", "○ ", "✓ ", "✗ ", "$ "}
+	statusSymbols := []string{"◎ ", "● ", "◐ ", "○ ", "✓ ", "✗ ", "$ "}
 	count := 0
 	for _, line := range strings.Split(screen, "\n") {
 		// Strip leading whitespace and the optional selection arrow.

--- a/internal/hook/event.go
+++ b/internal/hook/event.go
@@ -11,9 +11,11 @@ import "encoding/json"
 type Kind string
 
 const (
-	KindSessionStart Kind = "session-start"
-	KindStop         Kind = "stop"
-	KindSessionEnd   Kind = "session-end"
+	KindSessionStart     Kind = "session-start"
+	KindStop             Kind = "stop"
+	KindSessionEnd       Kind = "session-end"
+	KindNotification     Kind = "notification"
+	KindUserPromptSubmit Kind = "user-prompt-submit"
 )
 
 // Event is the wire-format payload sent from the baton-hook CLI to the
@@ -21,7 +23,8 @@ const (
 //
 // SessionID and CWD come straight from the Claude JSON payload; AgentID is
 // supplied by the CLI wrapper from the BATON_AGENT_ID environment variable
-// so the server can dispatch to the right agent. Raw preserves the original
+// so the server can dispatch to the right agent. Message is populated from
+// Notification payloads (empty for other kinds). Raw preserves the original
 // Claude JSON for forward-compatibility with fields the server doesn't
 // currently consume.
 type Event struct {
@@ -29,5 +32,6 @@ type Event struct {
 	AgentID   string          `json:"agent_id"`
 	SessionID string          `json:"session_id,omitempty"`
 	CWD       string          `json:"cwd,omitempty"`
+	Message   string          `json:"message,omitempty"`
 	Raw       json.RawMessage `json:"raw,omitempty"`
 }

--- a/internal/hook/settings.go
+++ b/internal/hook/settings.go
@@ -45,9 +45,11 @@ func WriteHooksFile(path string) error {
 
 	schema := settingsSchema{
 		Hooks: map[string][]hookMatcher{
-			"SessionStart": {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook session-start"}}}},
-			"Stop":         {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook stop"}}}},
-			"SessionEnd":   {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook session-end"}}}},
+			"SessionStart":     {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook session-start"}}}},
+			"Stop":             {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook stop"}}}},
+			"SessionEnd":       {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook session-end"}}}},
+			"Notification":     {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook notification"}}}},
+			"UserPromptSubmit": {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook user-prompt-submit"}}}},
 		},
 	}
 

--- a/internal/hook/settings_test.go
+++ b/internal/hook/settings_test.go
@@ -26,11 +26,13 @@ func TestWriteHooksFile(t *testing.T) {
 		t.Fatalf("unmarshalling hooks file: %v", err)
 	}
 
-	wantEvents := []string{"SessionStart", "Stop", "SessionEnd"}
+	wantEvents := []string{"SessionStart", "Stop", "SessionEnd", "Notification", "UserPromptSubmit"}
 	wantCLIEvents := map[string]string{
-		"SessionStart": "session-start",
-		"Stop":         "stop",
-		"SessionEnd":   "session-end",
+		"SessionStart":     "session-start",
+		"Stop":             "stop",
+		"SessionEnd":       "session-end",
+		"Notification":     "notification",
+		"UserPromptSubmit": "user-prompt-submit",
 	}
 
 	batonPath, err := os.Executable()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -357,7 +357,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the TUI dequeuing this event would otherwise clobber the cached "prev
 		// was Active" signal and silently suppress the chime.
 		if msg.event.Type == agent.EventStatusChanged {
-			if msg.event.Status == agent.StatusIdle {
+			// Chime on both Idle (Claude finished its turn) and Waiting
+			// (Claude needs user input). ChimedForTurn is the shared gate:
+			// whichever fires first in a turn wins, and the other is
+			// silently skipped. The flag resets on Enter or UserPromptSubmit.
+			if msg.event.Status == agent.StatusIdle || msg.event.Status == agent.StatusWaiting {
 				if mgr := a.managers[msg.repoPath]; mgr != nil {
 					if ag := mgr.Get(msg.event.AgentID); ag != nil && !ag.IsShell {
 						if ag.HasReceivedInput() && !ag.ChimedForTurn() {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -290,11 +290,12 @@ func (d dashboardModel) renderList(width int) string {
 			status := sess.Status()
 			symbol := status.Symbol()
 			var symbolStyle lipgloss.Style
+			// StatusWaiting is intentionally absent: Session.Status() rolls
+			// Waiting up to Active at the session level, so this switch only
+			// ever sees Active/Starting/Idle/Done/Error.
 			switch status {
 			case agent.StatusActive:
 				symbolStyle = lipgloss.NewStyle().Foreground(ColorSecondary)
-			case agent.StatusWaiting:
-				symbolStyle = lipgloss.NewStyle().Foreground(ColorWaiting)
 			case agent.StatusDone:
 				symbolStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
 			case agent.StatusError:

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -14,6 +14,11 @@ import (
 	"github.com/devenjarvis/baton/internal/github"
 )
 
+// ColorWaiting is the accent used for agents in StatusWaiting (permission
+// prompts, input blocks). Scoped to the dashboard because no other view
+// needs it today — add to theme.go if another view ever surfaces waiting.
+var ColorWaiting = lipgloss.Color("#D946EF")
+
 // listItemKind distinguishes repo headers, session rows, and agent rows in the dashboard list.
 type listItemKind int
 
@@ -288,6 +293,8 @@ func (d dashboardModel) renderList(width int) string {
 			switch status {
 			case agent.StatusActive:
 				symbolStyle = lipgloss.NewStyle().Foreground(ColorSecondary)
+			case agent.StatusWaiting:
+				symbolStyle = lipgloss.NewStyle().Foreground(ColorWaiting)
 			case agent.StatusDone:
 				symbolStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
 			case agent.StatusError:
@@ -361,6 +368,8 @@ func (d dashboardModel) renderList(width int) string {
 				switch status {
 				case agent.StatusActive:
 					style = lipgloss.NewStyle().Foreground(ColorSecondary)
+				case agent.StatusWaiting:
+					style = lipgloss.NewStyle().Foreground(ColorWaiting)
 				case agent.StatusDone:
 					style = lipgloss.NewStyle().Foreground(ColorSuccess)
 				case agent.StatusError:


### PR DESCRIPTION
## Summary

- Wire two new Claude Code hook events (`Notification`, `UserPromptSubmit`) end-to-end: hooks-file schema → `baton hook <event>` CLI → unix socket → agent state machine.
- Add `StatusWaiting` (symbol `◐`, magenta) driven by `Notification`. `UserPromptSubmit` transitions back to Active and re-arms the per-turn chime. Both handlers refuse to resurrect Done/Error agents.
- Chime now fires on Waiting *or* Idle, still gated by the existing per-turn debounce so at most one chime per user turn.
- `baton doctor` gains a socket round-trip self-check (`[OK] hook pipeline: socket round-trip ok`).
- New e2e test (`TestHookPipeline`, `//go:build e2e`) drives a scripted bash stub named `claude` and asserts the dashboard bubble sequence Active → Waiting → Idle → Active → Idle.

## Test plan

- [x] `go build -o baton .`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run` (0 issues)
- [x] `go test -race ./...` (pre-existing `TestLoad_MigratesFromLegacyXDGPath` failure on main is unrelated to this PR)
- [x] `./baton doctor` prints `[OK] hook pipeline: socket round-trip ok`
- [x] `go test -tags e2e -timeout 300s -v ./internal/e2e/` (all 13 tests, incl. new `TestHookPipeline`)
- [ ] Manual TUI smoke: spawn a claude agent, trigger a permission prompt, observe magenta `◐` + chime; grant permission, observe return to yellow `●`; let claude finish, observe gray `○` + no double-chime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)