### PR TITLE
Prepare 0.1.0 release: docs accuracy pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,37 +9,29 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 ## [Unreleased]
 
-### Added
-
-- IDE editor dropdown in global and per-repo settings. On macOS, probes `/Applications` and `~/Applications` for a curated list of editors (Zed, VS Code, Cursor, JetBrains IDEs) and generates `open -a "<App>"` invocations that take focus and support opening additional worktrees alongside an already-running editor window. Custom Command option preserves free-text entry; legacy stored values load unchanged.
-
-### Changed
-
-- Dashboard keybindings pruned: removed `p` (PR create/open), `m` (merge), and the force-quit `Q`. The remaining `q` handles the detach-and-exit flow; per-session cleanup stays on `X`. PR polling, status indicators, and `f` (fix checks) are unchanged.
-- Focus terminal view now releases mouse capture so the host terminal's native click-and-drag text selection works. Mouse-wheel scrollback in focus mode is replaced by keyboard scrollback (`pgup` / `pgdn` / `home`).
-
-### Fixed
-
-- Startup splash text artifacts when Claude Code enters its TUI (alt-screen transition detection replaces 500ms delayed resize heuristic).
-- Mid-repaint flicker in dashboard preview (StableRender with 16ms quiescence threshold).
-- VT emulator / lipgloss container sizing mismatch causing displaced content in focusList mode.
-- IDE launch path now uses a quote-aware tokenizer so multi-word app names in `open -a "Visual Studio Code"` style commands launch correctly instead of fragmenting on whitespace.
-
-## [0.1.0] — 2026-04-15
+## [0.1.0] — 2026-04-18
 
 Initial public release.
 
 ### Added
 
-- Dashboard view listing all managed agents with live status (idle/active/error) and visual-stability detection.
-- Focus mode: full-screen interactive session with a selected agent; all keys forwarded to the PTY.
-- Diff view: two-mode experience — summary list sorted by change magnitude, and side-by-side (≥120 cols) or unified (below) detail view.
+- Dashboard view listing all managed repos, sessions, and agents with live status (idle/active/waiting/done/error) and visual-stability detection.
+- Focus mode: interactive preview of a selected agent with keys forwarded to the PTY, keyboard scrollback (`pgup` / `pgdn` / `home`), and native click-and-drag text selection in the host terminal.
+- Diff view: summary list sorted by change magnitude, plus side-by-side (≥120 cols) or unified (below) detail view.
 - Merge: `git merge --no-ff` from a worktree branch into the base branch with cleanup of the worktree.
 - Prompt and merge overlays for creating and landing agent work without leaving the TUI.
-- `baton doctor` command for validating the environment (Go, git, `claude` on PATH).
+- `baton doctor` for validating git, `claude` on PATH (with `--settings` support), the baton binary, hook-pipeline round-trip, git repo, and GitHub auth.
+- Hook pipeline: per-session settings file wires Claude Code's hooks (`session-start`, `stop`, `session-end`, `notification`, `user-prompt-submit`) to `baton hook <event>`, routed back to the running TUI over a unix socket for hook-driven status detection.
+- GitHub integration: PR creation, checks/review polling, and a "fix failing checks" flow (`f`) that fetches failed check logs and dispatches them to an idle agent.
+- IDE editor dropdown in global and per-repo settings. On macOS, probes `/Applications` and `~/Applications` for a curated list of editors (Zed, VS Code, Cursor, JetBrains IDEs) and generates `open -a "<App>"` invocations that take focus and support opening additional worktrees alongside an already-running editor window. Custom Command option preserves free-text entry.
+- Shell agent: open a shell in the selected session's worktree without leaving the TUI (`t`).
+- Branch picker: start a session on an existing branch or PR (`o`).
+- Global and per-repo settings persisted on disk (`AgentProgram`, `BypassPermissions`, `IDECommand`, etc.).
+- Session persistence: `q` detaches cleanly; a later `baton` invocation reattaches to preserved worktrees.
 - Mouse support on the dashboard (click-to-select, click-to-focus).
-- Isolated git worktrees under `.baton/worktrees/<name>` on branches `baton/<name>`.
+- Isolated git worktrees under `.baton/worktrees/<name>` on branches `baton/<name>`, with `.baton/` auto-added to the repo's `.gitignore` on first run.
 - Virtual terminal bridge built on `charmbracelet/x/vt` for thread-safe rendering of agent output.
+- Optional audio chimes for status transitions.
 
 [Unreleased]: https://github.com/devenjarvis/baton/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/devenjarvis/baton/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,46 +8,67 @@ Baton is a terminal-native TUI for orchestrating multiple Claude Code agents in 
 
 ```bash
 go build -o baton .         # build
-go test ./...               # run all tests
-go test -race ./...         # run with race detector
+go test ./...               # unit tests
+go test -race ./...         # with race detector (required before commit)
 go vet ./...                # static analysis
 golangci-lint run           # lint (uses .golangci.yml)
 gofumpt -w .                # format all Go files
-./baton doctor              # validate environment
+./baton doctor              # validate environment + hook pipeline round-trip
 ```
 
-## Architecture
+End-to-end TUI tests live under `internal/e2e/` behind the `e2e` build tag and need `tu` v0.6.0+:
 
-- `cmd/` — Cobra CLI commands (root launches TUI, doctor validates env)
-- `internal/pty/` — Raw PTY I/O wrapper around `creack/pty`. No goroutines — callers manage read loops.
-- `internal/vt/` — Virtual terminal bridge around `x/vt.SafeEmulator`. Uses an `io.Pipe` bridge for `Read()` to allow thread-safe `Close()`.
-- `internal/git/` — Git worktree CRUD, diff, merge via `exec.Command("git", ...)`. Worktrees live at `.baton/worktrees/<name>` with branches `baton/<name>`.
-- `internal/agent/` — Composes PTY + VT + git into managed agents. Each agent has 3 goroutines: readLoop (PTY->VT), writeLoop (VT->PTY), statusLoop (idle detection). Manager handles lifecycle and events.
-- `internal/tui/` — Bubble Tea v2 views: dashboard, focus, diff, prompt overlay, merge overlay, statusbar.
-
-## Key Patterns
-
-- **Bubble Tea v2**: `View()` returns `tea.View` (not string). Use `tea.NewView(content)` with `v.AltScreen = true`. No `tea.WithAltScreen()` option.
-- **Charm imports**: Bubble Tea v2 is `charm.land/bubbletea/v2`. Lipgloss is still `github.com/charmbracelet/lipgloss`. x/vt is `github.com/charmbracelet/x/vt`.
-- **Key forwarding**: `tea.KeyPressMsg` converts directly to `xvt.KeyPressEvent` — same underlying `ultraviolet.Key` struct.
-- **Thread safety**: VT bridge uses an `io.Pipe` to decouple `Read()` from `SafeEmulator.Read()`, so `Close()` can unblock readers without racing on internal emulator state.
-- **Agent names**: Must match `[a-zA-Z0-9][a-zA-Z0-9_-]*`. Enforced in `Manager.Create()`.
-- **Shutdown sequence**: Close `m.done` -> kill agents -> wait for watcher goroutines -> close events channel. Agent kill: close PTY -> close terminal (unblocks writeLoop) -> wait for writeLoopDone.
-
-## Testing
-
-- `internal/pty/` — Tests echo, cat round-trip, close+done
-- `internal/vt/` — Tests write/render, ANSI preservation, resize, SendText/Read
-- `internal/git/` — Tests use temp repos with real git commands
-- `internal/agent/` — Tests use `bash -c` commands instead of claude
-- `internal/tui/` — Manual testing only (TUI views)
-- `internal/e2e/` — End-to-end TUI tests using `tu` CLI (headless virtual terminal). Requires `tu` v0.6.0+. Run with: `go test -tags e2e -timeout 300s -v ./internal/e2e/`
+```bash
+go test -tags e2e -timeout 300s -v ./internal/e2e/
+```
 
 Always run `go test -race ./...` before committing — concurrency bugs have been caught and fixed by the race detector.
 
+## Architecture
+
+- `cmd/root.go` — Cobra root, launches the TUI.
+- `cmd/doctor.go` — Environment validation (git ≥ 2.20, `claude` on PATH with `--settings` support, hook-socket round-trip, git repo, GitHub auth).
+- `cmd/hook.go` — Not for humans. Claude Code invokes `baton hook <event>` per the settings file baton writes; it forwards the JSON payload to the running baton over `BATON_HOOK_SOCKET`. Always exits 0 so hook failures never block Claude.
+- `internal/pty/` — Raw PTY I/O around `creack/pty`. No goroutines — callers manage read loops.
+- `internal/vt/` — Virtual terminal bridge around `x/vt.SafeEmulator`. Uses an `io.Pipe` for `Read()` so `Close()` is thread-safe without racing emulator internals.
+- `internal/git/` — Worktree CRUD, diff, merge via `exec.Command("git", ...)`. Worktrees live at `.baton/worktrees/<name>` on branches `baton/<name>`.
+- `internal/agent/` — Composes PTY + VT + git into managed agents. Each agent has 3 goroutines: readLoop (PTY→VT), writeLoop (VT→PTY), statusLoop (idle detection). Sessions group agents sharing a worktree. Manager handles lifecycle and events.
+- `internal/tui/` — Bubble Tea v2 views: dashboard (list + preview), diff summary/detail, global/repo config forms, file browser (add repo), branch picker (session on existing branch/PR), statusbar.
+- `internal/hook/` — Unix-socket server + client for Claude hook events (`session-start`, `stop`, `session-end`, `notification`, `user-prompt-submit`) plus the settings file generator that wires Claude's hooks to `baton hook`.
+- `internal/github/` — GitHub API wrapper for PRs, checks, review status, and check-run log fetching (powers `f` fix-checks).
+- `internal/config/` — Global settings (`~/.config/baton/settings.json`) and per-repo settings (`.baton/settings.json`) plus resolution logic.
+- `internal/state/` — Session persistence so `q` detaches cleanly and a later `baton` invocation reattaches.
+- `internal/editor/` — IDE launcher helpers; macOS app probing and quote-aware tokenizer for `open -a "Visual Studio Code"` style commands.
+- `internal/audio/` — Optional chimes for status transitions (best-effort; nil on failure).
+- `internal/e2e/` — End-to-end TUI tests driven by the `tu` headless virtual terminal (build tag `e2e`).
+
+## Key Patterns
+
+- **Bubble Tea v2**: `View()` returns `tea.View`, not string. Use `tea.NewView(content)` with `v.AltScreen = true`. No `tea.WithAltScreen()` option.
+- **Charm imports**: Bubble Tea v2 is `charm.land/bubbletea/v2`. Lipgloss is still `github.com/charmbracelet/lipgloss`. x/vt is `github.com/charmbracelet/x/vt`.
+- **Key forwarding**: `tea.KeyPressMsg` converts directly to `xvt.KeyPressEvent` — same underlying `ultraviolet.Key` struct.
+- **Thread safety**: VT bridge uses an `io.Pipe` to decouple `Read()` from `SafeEmulator.Read()`, so `Close()` can unblock readers without racing emulator state.
+- **Agent names**: Must match `[a-zA-Z0-9][a-zA-Z0-9_-]*`. Enforced in `Manager.Create()`.
+- **Shutdown sequence**: close `m.done` → kill agents → wait for watcher goroutines → close events channel. Agent kill: close PTY → close terminal (unblocks writeLoop) → wait for writeLoopDone.
+- **Hooks**: Baton writes a per-session settings JSON and launches `claude --settings <path>` so each hook invocation carries `BATON_HOOK_SOCKET` and `BATON_AGENT_ID` env, routing events back over a unix socket. Running `claude` outside baton exits the hook CLI silently.
+- **Status detection**: visual-stability detection + hook-driven signals classify agents as idle / active / waiting / done / error. `StatusWaiting` is distinct (permission prompts, input blocks) and surfaces in a dashboard accent color.
+
+## Testing
+
+- `internal/pty/` — Echo, cat round-trip, close+done.
+- `internal/vt/` — Write/render, ANSI preservation, resize, SendText/Read.
+- `internal/git/` — Real git on temp repos.
+- `internal/agent/` — Uses `bash -c` instead of `claude`.
+- `internal/hook/` — Socket server unit tests, settings generator tests.
+- `internal/config/` — Global + per-repo settings, resolution, migration.
+- `internal/tui/` — Mostly manual; `app_test.go` and `idecommand_test.go` cover the testable pieces.
+- `internal/e2e/` — End-to-end via `tu` CLI, `e2e` build tag.
+
 ## Conventions
 
-- Mouse support: click-to-select (left panel) and click-to-focus (right panel) on dashboard only. No config files, no scrollback in preview
-- Agent program is hardcoded to `claude` (no program selector)
-- `.baton/` is gitignored (auto-added on first run)
-- Errors display briefly in the TUI and clear on next tick
+- Mouse support: click-to-select (left panel) and click-to-focus (right panel) on the dashboard only.
+- Agent program defaults to `claude` but is configurable via global/per-repo settings (`AgentProgram`).
+- `.baton/` is gitignored (auto-added to the repo's `.gitignore` on first run).
+- Errors display briefly in the TUI and clear on next tick; no modal error dialogs.
+- Claude hook CLI (`baton hook`) is silent on stdout and always exits 0 — Claude interprets stdout as hook feedback.
+- Changelog: every PR should add a line under `[Unreleased]` in `CHANGELOG.md`.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 # Baton
 
-A terminal-native tool for orchestrating multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents in parallel. Each agent runs in an isolated git worktree with its own PTY, rendered via a virtual terminal emulator. Monitor agents from a dashboard, interact in focus mode, review diffs, and merge results — all without leaving the terminal.
+A terminal-native tool for orchestrating multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents in parallel. Each agent runs in an isolated git worktree with its own PTY, rendered via a virtual terminal emulator. Monitor agents from a single dashboard, interact in focus mode, review diffs, open PRs, fix failing CI checks, and merge results — all without leaving the terminal.
 
 No tmux dependency.
+
+> ⚠️ **Alpha software — here be dragons.** Baton is on its very first public release (v0.1.0). APIs, on-disk state layout, config schema, and keybindings may change without notice between versions. The TUI, hook pipeline, and session-resume layers are still stabilizing; expect rough edges and the occasional crash. Git operations are conservative — Baton only writes to `baton/*` branches inside `.baton/worktrees/` and uses `git merge --no-ff` with explicit confirmation — but please keep your work committed and file issues when things break.
 
 ## Requirements
 
 - Go 1.25+
 - Git 2.20+
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude` on PATH)
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude` on PATH, with `--settings` support for hook integration)
+- Optional: `gh` CLI or `GITHUB_TOKEN` for PR creation, checks polling, and the "fix failing checks" flow
 
-Verify with:
+Verify your environment with:
 
 ```bash
 baton doctor
 ```
+
+`doctor` validates git, Claude Code, the baton binary, hook-pipeline round-trip, the current directory is a git repo, and GitHub auth.
 
 ## Install
 
@@ -38,61 +43,104 @@ Run `baton` inside a git repository:
 baton
 ```
 
+The first run auto-registers the current directory as a repo and adds `.baton/` to `.gitignore`. Additional repos can be added from the TUI (`a`).
+
 ### Keybindings
 
-**Dashboard:**
+**Dashboard** (list focused):
 
-| Key | Action |
-|-----|--------|
-| `j` / `k` | Navigate agent list |
-| `enter` | Focus selected agent (full-screen interactive) |
-| `n` | Create new agent |
-| `d` | View diff for selected agent |
-| `x` | Kill selected agent |
-| `m` | Merge selected agent's changes |
-| `q` | Quit (confirms if agents running) |
+| Key       | Action                                                     |
+|-----------|------------------------------------------------------------|
+| `j` / `k` | Navigate repos, sessions, and agents                       |
+| `⏎` / `→` | Focus terminal preview (on agent) or repo config (on repo) |
+| `n`       | Create a new session                                       |
+| `c`       | Add another agent to the selected session                  |
+| `t`       | Open or focus a shell in the selected session's worktree   |
+| `e`       | Open selected session's worktree in the configured IDE     |
+| `o`       | Create session on an existing branch or PR                 |
+| `a`       | Add a repo (file browser)                                  |
+| `s`       | Global settings                                            |
+| `d`       | Diff the session's worktree, or remove selected repo       |
+| `x`       | Kill the selected agent                                    |
+| `X`       | Kill the selected agent's entire session                   |
+| `f`       | Fix failing CI checks on the session's PR                  |
+| `q`       | Detach and exit (prompts if agents are running)            |
 
-**Focus mode:**
+**Focus mode** (terminal preview focused):
 
-| Key | Action |
-|-----|--------|
-| `ctrl+b` | Return to dashboard |
-| *all other keys* | Forwarded to the agent |
+| Key              | Action                                        |
+|------------------|-----------------------------------------------|
+| `ctrl+e` / `esc` | Return to list                                |
+| `shift+esc`      | Send ESC to the agent (e.g. Claude interrupt) |
+| `pgup` / `pgdn`  | Scroll backward / forward                     |
+| `home`           | Jump back to live output                      |
+| *drag*           | Native terminal text selection                |
+| *other keys*     | Forwarded to the agent                        |
 
-**Diff view:**
+**Diff summary:**
 
-| Key | Action |
-|-----|--------|
-| `j` / `k` | Scroll |
-| `d` / `u` | Page down / up |
-| `q` / `esc` | Back to dashboard |
+| Key       | Action             |
+|-----------|--------------------|
+| `j` / `k` | Navigate files     |
+| `⏎`       | Open file detail   |
+| `g` / `G` | Top / bottom       |
+| `q`       | Back to dashboard  |
+
+**Diff detail:**
+
+| Key       | Action              |
+|-----------|---------------------|
+| `j` / `k` | Scroll              |
+| `d` / `u` | Page down / up      |
+| `n` / `p` | Next / prev file    |
+| `esc`     | Back to summary     |
+| `q`       | Back to dashboard   |
+
+Click support on the dashboard: click a row in the list to select it; click in the preview panel to enter focus mode.
 
 ## How It Works
 
-When you create an agent, Baton:
+When you create a session, Baton:
 
-1. Creates an isolated git worktree at `.baton/worktrees/<name>` with branch `baton/<name>`
-2. Spawns `claude "<task>"` in a PTY inside that worktree
-3. Feeds PTY output through a virtual terminal emulator ([charmbracelet/x/vt](https://github.com/charmbracelet/x/vt))
-4. Renders the emulator's ANSI output in the TUI via [Bubble Tea v2](https://github.com/charmbracelet/bubbletea)
+1. Creates an isolated git worktree at `.baton/worktrees/<name>` on branch `baton/<name>`.
+2. Writes a settings file wiring Claude Code's hooks (`session-start`, `stop`, `notification`, `user-prompt-submit`, `session-end`) to `baton hook <event>` and points Claude at it with `claude --settings`.
+3. Spawns `claude "<task>"` in a PTY inside the worktree.
+4. Feeds PTY output through a virtual terminal emulator ([charmbracelet/x/vt](https://github.com/charmbracelet/x/vt)) and renders it in the dashboard via [Bubble Tea v2](https://github.com/charmbracelet/bubbletea).
+5. Listens on a per-process unix socket for hook events so the TUI can distinguish idle / active / waiting / done states without screen-scraping.
 
-When you merge, Baton runs `git merge --no-ff` from the worktree branch into your base branch, then cleans up the worktree.
+When you merge, Baton runs `git merge --no-ff` from the worktree branch into the session's base branch and cleans up the worktree.
 
 ## Architecture
 
 ```
 main.go              Entry point
 cmd/
-  root.go            Cobra root command, launches TUI
-  doctor.go          Environment validation
+  root.go            Cobra root, launches TUI
+  doctor.go          Environment validation (git, claude, hook round-trip)
+  hook.go            Forwards Claude hook payloads to the running baton over a unix socket
 internal/
-  pty/               PTY wrapper (creack/pty)
-  vt/                Virtual terminal bridge (x/vt SafeEmulator)
-  git/               Worktree CRUD, diff, merge
-  agent/             Agent lifecycle (PTY + VT + git composed)
-  tui/               Bubble Tea views (dashboard, focus, diff, prompt, merge)
+  pty/               Raw PTY wrapper (creack/pty)
+  vt/                Virtual terminal bridge (x/vt SafeEmulator + io.Pipe)
+  git/               Worktree CRUD, diff, merge via exec.Command("git", ...)
+  agent/             Agent + Session + Manager (composes PTY + VT + git, runs read/write/status loops)
+  tui/               Bubble Tea v2 views (dashboard, diff, repo/global config, file/branch pickers)
+  hook/              Unix-socket server + client for Claude Code hook events
+  github/            GitHub API wrapper for PRs, checks, review status
+  config/            Global and per-repo settings (JSON on disk, resolved at runtime)
+  state/             Session persistence across baton restarts
+  editor/            IDE launcher helpers (macOS app probing, quote-aware tokenizer)
+  audio/             Optional chimes for status transitions
+  e2e/               End-to-end TUI tests (behind the `e2e` build tag)
 ```
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md). Bug reports and focused PRs are welcome; because Baton is a single-maintainer alpha, larger feature proposals should start as an issue.
+
+## Security
+
+See [SECURITY.md](./SECURITY.md) for how to report vulnerabilities.
 
 ## License
 
-MIT
+MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary

Documentation-only pass to make the repo ready for the v0.1.0 public release.

- **README**: add a prominent alpha / "here be dragons" warning; fix the keybindings tables so they match the current TUI (`ctrl+e`/`esc` to exit focus, `shift+esc` to interrupt, full dashboard key list from `statusbar.go`, split diff summary vs. detail); rewrite "How It Works" to cover the hook pipeline; rewrite the architecture map to list every real package under `internal/` plus `cmd/hook.go`.
- **CLAUDE.md**: expand the architecture list to cover `hook`, `github`, `config`, `state`, `editor`, `audio`, and `e2e`; drop the stale "agent program is hardcoded" line (it's configurable via `AgentProgram`, defaults to `claude`); document the hook settings flow and `StatusWaiting`.
- **CHANGELOG**: fold the `[Unreleased]` items into `[0.1.0] — 2026-04-18`, expand the 0.1.0 list to reflect everything actually shipping (hook pipeline, GitHub integration, IDE launcher, shell agent, branch picker, session persistence, settings, waiting status, mouse support, audio chimes), leave `[Unreleased]` empty for the next PR.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: n/a — docs-only

## Checklist

- [x] Updated `CHANGELOG.md` (this PR *is* the release)
- [x] No code changes, so no new tests needed
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)