### PR TITLE
Add goreleaser config and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 baton
 .baton/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,63 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: baton
+    binary: baton
+    main: .
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: baton
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    formats: [tar.gz]
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "Merge pull request"
+      - "Merge branch"
+
+brews:
+  - name: baton
+    repository:
+      owner: devenjarvis
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/devenjarvis/baton"
+    description: "Terminal-native TUI for orchestrating multiple Claude Code agents in parallel"
+    license: "MIT"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    install: |
+      bin.install "baton"
+    test: |
+      system "#{bin}/baton", "--help"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 ## [Unreleased]
 
+### Added
+
+- GoReleaser config and release workflow: pushing a `v*` tag builds darwin/linux amd64+arm64 archives, publishes a GitHub release, and updates the `devenjarvis/homebrew-tap` formula.
+
 ## [0.1.0] — 2026-04-18
 
 Initial public release.


### PR DESCRIPTION
## Summary

- Adds `.goreleaser.yml` — builds `darwin`/`linux` × `amd64`/`arm64`, produces tarballs + checksums, and writes a Homebrew formula to `devenjarvis/homebrew-tap`.
- Adds `.github/workflows/release.yml` — triggers on `v*` tags and runs `goreleaser-action@v6`. Uses `GITHUB_TOKEN` for the release and `HOMEBREW_TAP_GITHUB_TOKEN` (PAT) for pushing to the tap.
- Fixes the reason the `v0.1.0` release didn't produce artifacts: no release workflow was listening for tag pushes. The tag has been deleted so it can be re-cut after this lands.

## Test plan

- [x] `goreleaser check` validates config
- [x] `goreleaser release --snapshot --clean --skip=publish` — all 4 binaries built, archives produced, formula written
- [ ] After merge: re-push `v0.1.0` tag and confirm the workflow publishes the release and updates the tap

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md` (release tooling — validated via `goreleaser check` + snapshot build)
- [x] No new public API surface without a note in the PR description

## Notes

- Goreleaser warns that `brews` is being phased out in favor of `homebrew_casks`; current config is valid but worth revisiting.
- `HOMEBREW_TAP_GITHUB_TOKEN` secret must be present on the repo before cutting a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)