### PR TITLE
Revert focus-mode mouse capture release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 ## [Unreleased]
 
+### Changed
+
+- Reverted "Release mouse capture in focus terminal view": the focus terminal view now re-captures the mouse. Text selection via the host terminal's drag was unreliable (copied text included the surrounding TUI frame), and capturing the mouse restores consistent keybinding/scroll behavior in focus mode.
+
 ## [0.1.0] — 2026-04-18
 
 Initial public release.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -962,6 +962,28 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 
+	if msg, ok := msg.(tea.MouseWheelMsg); ok {
+		if a.dashboard.panelFocus == focusTerminal {
+			ag := a.dashboard.selectedAgent()
+			if ag != nil {
+				switch msg.Button {
+				case tea.MouseWheelUp:
+					a.dashboard.scrollOffset += 3
+					maxOffset := len(ag.ScrollbackLines())
+					if a.dashboard.scrollOffset > maxOffset {
+						a.dashboard.scrollOffset = maxOffset
+					}
+				case tea.MouseWheelDown:
+					a.dashboard.scrollOffset -= 3
+					if a.dashboard.scrollOffset < 0 {
+						a.dashboard.scrollOffset = 0
+					}
+				}
+			}
+		}
+		return a, nil
+	}
+
 	prevSelected := a.dashboard.selected
 	var cmd tea.Cmd
 	a.dashboard, cmd = a.dashboard.Update(msg)
@@ -1328,7 +1350,7 @@ func (a App) View() tea.View {
 
 	v := tea.NewView(content)
 	v.AltScreen = true
-	if a.view == ViewDashboard && a.dashboard.panelFocus != focusTerminal {
+	if a.view == ViewDashboard {
 		v.MouseMode = tea.MouseModeCellMotion
 	}
 	return v

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -599,6 +599,107 @@ func TestMouseClickPreviewEntersFocus(t *testing.T) {
 	}
 }
 
+func TestMouseWheelScrollInFocusTerminal(t *testing.T) {
+	requireClaude(t)
+	dir, err := os.MkdirTemp("", "baton-wheel-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+
+	// Create a session with an agent that writes 40 lines.
+	sess, ag, err := mgr.CreateSessionWithCommand(agent.Config{
+		Name:     "wheel-test",
+		Task:     "test",
+		RepoPath: dir,
+		Rows:     24,
+		Cols:     80,
+	}, func(_ string) *exec.Cmd {
+		return exec.Command("bash", "-c", "for i in $(seq 1 40); do echo Line $i; done; sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = sess // used for session creation
+
+	// Wait for bash output to be processed into scrollback.
+	time.Sleep(300 * time.Millisecond)
+
+	if len(ag.ScrollbackLines()) == 0 {
+		t.Fatal("Expected scrollback lines after bash output")
+	}
+
+	// Build an app with this agent directly in dashboard items.
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.dashboard.items = []listItem{
+		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
+	}
+	app.dashboard.panelFocus = focusTerminal
+
+	// a. WheelUp in focusTerminal increases scrollOffset by 3.
+	app.dashboard.scrollOffset = 0
+	model, _ := app.Update(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	app = model.(App)
+	if app.dashboard.scrollOffset != 3 {
+		t.Fatalf("Expected scrollOffset=3 after WheelUp, got %d", app.dashboard.scrollOffset)
+	}
+
+	// b. WheelDown in focusTerminal decreases scrollOffset (clamped to 0).
+	app.dashboard.scrollOffset = 3
+	model, _ = app.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+	app = model.(App)
+	if app.dashboard.scrollOffset != 0 {
+		t.Fatalf("Expected scrollOffset=0 after WheelDown from 3, got %d", app.dashboard.scrollOffset)
+	}
+
+	// Another WheelDown should not go negative.
+	model, _ = app.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+	app = model.(App)
+	if app.dashboard.scrollOffset != 0 {
+		t.Fatalf("Expected scrollOffset=0 after WheelDown from 0 (no negative), got %d", app.dashboard.scrollOffset)
+	}
+
+	// a2. WheelUp ceiling clamp: offset above sbLen is clamped to sbLen.
+	app.dashboard.panelFocus = focusTerminal
+	sbLen := len(ag.ScrollbackLines())
+	app.dashboard.scrollOffset = sbLen + 100
+	model, _ = app.Update(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	app = model.(App)
+	if app.dashboard.scrollOffset != sbLen {
+		t.Fatalf("Expected scrollOffset clamped to %d, got %d", sbLen, app.dashboard.scrollOffset)
+	}
+
+	// c. WheelUp in focusList is a no-op.
+	app.dashboard.panelFocus = focusList
+	app.dashboard.scrollOffset = 0
+	model, _ = app.Update(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	app = model.(App)
+	if app.dashboard.scrollOffset != 0 {
+		t.Fatalf("Expected scrollOffset=0 (no-op in focusList), got %d", app.dashboard.scrollOffset)
+	}
+}
+
 func TestErrorPersistsAcrossTicks(t *testing.T) {
 	app := NewApp()
 	app.width = 120

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -31,7 +31,6 @@ var (
 
 	focusTerminalHints = []keyHint{
 		{"enter", "send"},
-		{"drag", "select text"},
 		{"pgup/pgdn", "scroll"},
 		{"home", "live"},
 		{"esc", "back"},


### PR DESCRIPTION
## Summary

- Reverts #50 ("Release mouse capture in focus terminal view"). Drag-to-select in the host terminal included the surrounding TUI frame, so the copy UX never actually worked as intended.
- Restores cell-motion mouse capture in focus mode and the `MouseWheelMsg` scrollback handler (3-line steps, clamped to scrollback bounds).
- Brings back the `TestMouseWheelScrollInFocusTerminal` unit test and drops the `drag / select text` focus-mode status-bar hint.
- `CHANGELOG.md` `[Unreleased]` notes the revert and why.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/tui/...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...` (one pre-existing failure on main in `internal/config/TestLoad_MigratesFromLegacyXDGPath`, unrelated to this revert)
- [ ] Manual TUI: focus an agent, confirm mouse wheel scrolls scrollback and that keybindings/selection in focus mode behave like pre-#50.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] Revert is covered by the restored `TestMouseWheelScrollInFocusTerminal` test
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)