### PR TITLE
goreleaser: publish formula into tap Formula/ dir

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,7 @@ brews:
       owner: devenjarvis
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
     homepage: "https://github.com/devenjarvis/baton"
     description: "Terminal-native TUI for orchestrating multiple Claude Code agents in parallel"
     license: "MIT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 - GoReleaser config and release workflow: pushing a `v*` tag builds darwin/linux amd64+arm64 archives, publishes a GitHub release, and updates the `devenjarvis/homebrew-tap` formula.
 
+### Fixed
+
+- GoReleaser now publishes the Homebrew formula into the tap's `Formula/` directory (via `directory: Formula`). v0.1.0 landed `baton.rb` at the tap repo root, where newer Homebrew versions don't discover it — installs with `brew install devenjarvis/tap/baton` would fail with "No available formula."
+
 ## [0.1.0] — 2026-04-18
 
 Initial public release.


### PR DESCRIPTION
## Summary

- v0.1.0 released `baton.rb` to the tap repo root, where newer Homebrew versions don't look — `brew install devenjarvis/tap/baton` failed with "No available formula."
- Add `directory: Formula` to the `brews:` entry in `.goreleaser.yml` so future releases land under `Formula/` alongside the tap's existing `moss.rb`.
- The tap repo has already been fixed out-of-band (moved `baton.rb` → `Formula/baton.rb`), so v0.1.0 is installable now. This PR prevents a regression on the next `v*` tag.

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Next `v*` tag after merge: verify the formula lands at `devenjarvis/homebrew-tap/Formula/baton.rb`.
- [ ] Manual TUI: n/a (config + changelog only)

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)