### PR TITLE
Wire PreToolUse hook to clear Waiting indicator on permission approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 ### Fixed
 
+- Permission-prompt approvals now clear the waiting indicator immediately via Claude's `PreToolUse` hook, instead of lingering yellow until the turn ends.
 - GoReleaser now publishes the Homebrew formula into the tap's `Formula/` directory (via `directory: Formula`). v0.1.0 landed `baton.rb` at the tap repo root, where newer Homebrew versions don't discover it — installs with `brew install devenjarvis/tap/baton` would fail with "No available formula."
 
 ## [0.1.0] — 2026-04-18

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -47,6 +47,8 @@ func runHook(cmd *cobra.Command, args []string) error {
 		kind = hook.KindNotification
 	case "user-prompt-submit":
 		kind = hook.KindUserPromptSubmit
+	case "pre-tool-use":
+		kind = hook.KindPreToolUse
 	default:
 		return nil
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -428,6 +428,23 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 			return true
 		}
 		return false
+
+	case hook.KindPreToolUse:
+		// Claude resumed tool execution — authoritative signal that the
+		// agent is no longer waiting on the user (e.g. a permission prompt
+		// was just approved). Clear Waiting back to Active so the yellow
+		// indicator doesn't linger until Stop fires at end of turn.
+		// Mirror the late-event guard on Notification/UserPromptSubmit so a
+		// trailing event can't revive a Done or Error row. Do NOT reset
+		// chimedForTurn: that's gated to new user turns, not every tool call.
+		if a.status == StatusDone || a.status == StatusError {
+			return false
+		}
+		if a.status != StatusActive {
+			a.status = StatusActive
+			return true
+		}
+		return false
 	}
 	return false
 }

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -290,6 +290,116 @@ func TestDoneAgentIgnoresLateUserPromptSubmit(t *testing.T) {
 	}
 }
 
+// TestManagerPreToolUseClearsWaiting verifies PreToolUse transitions a Waiting
+// agent back to Active — the fix path for approved permission prompts, where
+// Claude does not fire UserPromptSubmit but does fire PreToolUse when it
+// resumes tool execution.
+func TestManagerPreToolUseClearsWaiting(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "pretooluse-dispatch", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// SessionStart → Active.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindSessionStart,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent SessionStart: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
+	}
+
+	// Notification → Waiting.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindNotification,
+		AgentID: ag.ID,
+		Message: "Claude needs your permission to use Bash",
+	}); err != nil {
+		t.Fatalf("SendEvent Notification: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusWaiting, 2*time.Second) {
+		t.Fatalf("expected Waiting after Notification, got %s", ag.Status())
+	}
+
+	// Mark chimedForTurn so we can verify PreToolUse does NOT reset it —
+	// chime re-arming is a per-turn signal, not a per-tool-call signal.
+	ag.mu.Lock()
+	ag.chimedForTurn = true
+	ag.mu.Unlock()
+
+	// PreToolUse → Active (permission approved, Claude resumed).
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindPreToolUse,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent PreToolUse: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after PreToolUse, got %s", ag.Status())
+	}
+	if !ag.ChimedForTurn() {
+		t.Error("expected chimedForTurn to remain true across PreToolUse (it's per-turn, not per-tool)")
+	}
+}
+
+// TestDoneAgentIgnoresLatePreToolUse verifies a Done agent stays Done when a
+// stray PreToolUse event arrives after the agent has already exited.
+func TestDoneAgentIgnoresLatePreToolUse(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "done-ignore-ptu", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	ag.mu.Lock()
+	ag.status = StatusDone
+	ag.chimedForTurn = true
+	ag.mu.Unlock()
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindPreToolUse,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent PreToolUse: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	if got := ag.Status(); got != StatusDone {
+		t.Errorf("expected Done to be preserved, got %s", got)
+	}
+	ag.mu.Lock()
+	chimed := ag.chimedForTurn
+	ag.mu.Unlock()
+	if !chimed {
+		t.Error("expected chimedForTurn to stay true on Done agent, got reset")
+	}
+}
+
 // waitForStatus polls the agent status up to d for the desired value.
 func waitForStatus(t *testing.T, a *Agent, want Status, d time.Duration) bool {
 	t.Helper()

--- a/internal/hook/event.go
+++ b/internal/hook/event.go
@@ -16,6 +16,7 @@ const (
 	KindSessionEnd       Kind = "session-end"
 	KindNotification     Kind = "notification"
 	KindUserPromptSubmit Kind = "user-prompt-submit"
+	KindPreToolUse       Kind = "pre-tool-use"
 )
 
 // Event is the wire-format payload sent from the baton-hook CLI to the

--- a/internal/hook/settings.go
+++ b/internal/hook/settings.go
@@ -50,6 +50,7 @@ func WriteHooksFile(path string) error {
 			"SessionEnd":       {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook session-end"}}}},
 			"Notification":     {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook notification"}}}},
 			"UserPromptSubmit": {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook user-prompt-submit"}}}},
+			"PreToolUse":       {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook pre-tool-use"}}}},
 		},
 	}
 

--- a/internal/hook/settings_test.go
+++ b/internal/hook/settings_test.go
@@ -26,13 +26,14 @@ func TestWriteHooksFile(t *testing.T) {
 		t.Fatalf("unmarshalling hooks file: %v", err)
 	}
 
-	wantEvents := []string{"SessionStart", "Stop", "SessionEnd", "Notification", "UserPromptSubmit"}
+	wantEvents := []string{"SessionStart", "Stop", "SessionEnd", "Notification", "UserPromptSubmit", "PreToolUse"}
 	wantCLIEvents := map[string]string{
 		"SessionStart":     "session-start",
 		"Stop":             "stop",
 		"SessionEnd":       "session-end",
 		"Notification":     "notification",
 		"UserPromptSubmit": "user-prompt-submit",
+		"PreToolUse":       "pre-tool-use",
 	}
 
 	batonPath, err := os.Executable()


### PR DESCRIPTION
## Summary

- When Claude asks for permission (`Notification` hook), baton already flips the agent to `StatusWaiting` (yellow). But when the user approves with `2`, **no** `UserPromptSubmit` fires — so the row stayed yellow until Claude's end-of-turn `Stop`. This wires Claude's `PreToolUse` hook (the authoritative "Claude resumed tool execution" signal) to clear `Waiting → Active` the moment the user approves.
- Late-event guards mirror `Notification`/`UserPromptSubmit`: `PreToolUse` is ignored on `Done`/`Error` agents, and it deliberately does **not** reset `chimedForTurn` — that's per-turn, not per-tool-call, so the chime stays once-per-turn gated.
- Rejection path is unchanged: `Stop → Idle` continues to handle it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./...` — hook/agent packages green; one pre-existing unrelated failure in `internal/config/TestLoad_MigratesFromLegacyXDGPath` on macOS (test sets `XDG_CONFIG_HOME` but `os.UserConfigDir()` uses `~/Library/Application Support` on darwin). Not in this diff.
- [x] `./baton doctor` — all checks pass including hook-pipeline socket round-trip.
- [ ] Manual TUI: launch `./baton`, create a session, ask Claude to run a permission-gated command (e.g. `run "ls" in bash`); confirm the row flips to `ColorWaiting` yellow on the prompt, then returns to `ColorSecondary` blue the instant `2` is pressed — before Claude finishes its turn. Also confirm rejection (`1`) still transitions `Waiting → Idle` via `Stop`.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (Fixed)
- [x] New behavior has tests (`TestManagerPreToolUseClearsWaiting`, `TestDoneAgentIgnoresLatePreToolUse`; `TestWriteHooksFile` extended)
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)