### PR TITLE
Run agent/session kill off the UI thread with closing indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 ### Changed
 
+- `x` (kill agent) and `X` (kill session) now tear down off the UI thread and mark the affected row as `closing…` until the worktree teardown completes, so the dashboard stays interactive while Claude exits and `git worktree remove --force` runs.
 - Reverted "Release mouse capture in focus terminal view": the focus terminal view now re-captures the mouse. Text selection via the host terminal's drag was unreliable (copied text included the surrounding TUI frame), and capturing the mouse restores consistent keybinding/scroll behavior in focus mode.
 
 ### Fixed

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -39,6 +39,26 @@ type createResultMsg struct {
 	err       error
 }
 
+// killScope distinguishes an agent-level kill from a session-level kill so the
+// result handler knows which closing set to clean up.
+type killScope int
+
+const (
+	killScopeAgent killScope = iota
+	killScopeSession
+)
+
+// killResultMsg carries the result of an async KillAgent/KillSession call.
+// agentID is empty for session-scoped kills; the closing-set cleanup iterates
+// the manager to find stale IDs instead.
+type killResultMsg struct {
+	scope     killScope
+	sessionID string
+	agentID   string
+	agentIDs  []string // for session scope: all agent IDs that were in the session
+	err       error
+}
+
 // diffStatsMsg carries the result of an async diff stats refresh.
 type diffStatsMsg struct {
 	sessionID string
@@ -89,6 +109,12 @@ type App struct {
 	lastKnownStatus map[string]agent.Status
 	audioPlayer     *audio.Player
 
+	// closingAgents and closingSessions track in-flight kill requests so the
+	// dashboard can render a "closing…" indicator while the async teardown runs.
+	// Lives in the TUI because it's purely a UI concern.
+	closingAgents   map[string]bool
+	closingSessions map[string]bool
+
 	diffStatsCache      map[string]*diffStatsEntry // keyed by session ID
 	diffRefreshInFlight bool
 
@@ -109,6 +135,8 @@ func NewApp() App {
 		diffStatsCache:  make(map[string]*diffStatsEntry),
 		prCache:         make(map[string]*prCacheEntry),
 		prPollStates:    make(map[string]*prSessionState),
+		closingAgents:   make(map[string]bool),
+		closingSessions: make(map[string]bool),
 	}
 }
 
@@ -399,6 +427,28 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// transition detector in the tick handler will fire a follow-up resize
 		// once Claude's TUI enters alternate screen mode.
 		a.resizeSelectedForDashboard()
+		return a, nil
+
+	case killResultMsg:
+		// Clean up closing-set entries regardless of error so the UI never
+		// gets stuck rendering "closing…" on a row whose kill failed.
+		switch msg.scope {
+		case killScopeAgent:
+			delete(a.closingAgents, msg.agentID)
+			delete(a.lastKnownStatus, msg.agentID)
+		case killScopeSession:
+			delete(a.closingSessions, msg.sessionID)
+			for _, id := range msg.agentIDs {
+				delete(a.closingAgents, id)
+				delete(a.lastKnownStatus, id)
+			}
+			delete(a.diffStatsCache, msg.sessionID)
+		}
+		if msg.err != nil {
+			a.setError(msg.err.Error())
+		}
+		a.refreshAgentList()
+		a.updateDashboardDiffStats()
 		return a, nil
 
 	case diffStatsMsg:
@@ -814,7 +864,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 
 		case "x":
-			// Kill the selected agent.
+			// Kill the selected agent asynchronously so the UI stays responsive.
 			item := a.dashboard.selectedItem()
 			if item == nil || item.kind != listItemAgent || item.agent == nil || item.session == nil {
 				return a, nil
@@ -823,15 +873,26 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if mgr == nil {
 				return a, nil
 			}
-			if err := mgr.KillAgent(item.session.ID, item.agent.ID); err != nil {
-				a.setError(err.Error())
+			agentID := item.agent.ID
+			sessionID := item.session.ID
+			// Already dispatched — no-op to avoid double-kills.
+			if a.closingAgents[agentID] {
+				return a, nil
 			}
-			delete(a.lastKnownStatus, item.agent.ID)
+			a.closingAgents[agentID] = true
 			a.refreshAgentList()
-			return a, nil
+			return a, func() tea.Msg {
+				err := mgr.KillAgent(sessionID, agentID)
+				return killResultMsg{
+					scope:     killScopeAgent,
+					sessionID: sessionID,
+					agentID:   agentID,
+					err:       err,
+				}
+			}
 
 		case "X":
-			// Kill the entire parent session of the selected agent.
+			// Kill the entire parent session of the selected agent asynchronously.
 			item := a.dashboard.selectedItem()
 			if item == nil || item.session == nil {
 				return a, nil
@@ -841,16 +902,26 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			}
 			sessID := item.session.ID
+			// Already dispatched — no-op.
+			if a.closingSessions[sessID] {
+				return a, nil
+			}
+			var agentIDs []string
 			for _, ag := range item.session.Agents() {
-				delete(a.lastKnownStatus, ag.ID)
+				agentIDs = append(agentIDs, ag.ID)
+				a.closingAgents[ag.ID] = true
 			}
-			if err := mgr.KillSession(sessID); err != nil {
-				a.setError(err.Error())
-			}
-			delete(a.diffStatsCache, sessID)
+			a.closingSessions[sessID] = true
 			a.refreshAgentList()
-			a.updateDashboardDiffStats()
-			return a, nil
+			return a, func() tea.Msg {
+				err := mgr.KillSession(sessID)
+				return killResultMsg{
+					scope:     killScopeSession,
+					sessionID: sessID,
+					agentIDs:  agentIDs,
+					err:       err,
+				}
+			}
 
 		case "f":
 			// Fix failing checks: fetch logs and send to an idle agent.
@@ -1215,6 +1286,8 @@ func (a *App) setError(msg string) {
 }
 
 func (a *App) refreshAgentList() {
+	a.dashboard.closingAgents = a.closingAgents
+	a.dashboard.closingSessions = a.closingSessions
 	if a.cfg == nil {
 		// Fallback used in tests that set up managers directly without cfg.
 		if mgr := a.managers[a.activeRepo]; mgr != nil {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"testing"
@@ -841,6 +842,183 @@ func TestMouseClickSessionSnapsToAgent(t *testing.T) {
 	// Should snap from session to the nearest agent.
 	if app.dashboard.items[app.dashboard.selected].kind == listItemSession {
 		t.Fatalf("Expected selection to snap away from session row, but selected=%d is a session", app.dashboard.selected)
+	}
+}
+
+// TestKillAgentAsyncMarksClosing verifies that pressing 'x' marks the agent in
+// closingAgents and returns a non-nil Cmd without having called KillAgent
+// synchronously — so the UI stays responsive while the teardown runs in a
+// goroutine.
+func TestKillAgentAsyncMarksClosing(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-killasync-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+
+	// Create a long-running bash agent (sleep 999) so KillAgent has real work
+	// to do and the async path is exercised.
+	sess, ag, err := mgr.CreateSessionWithCommand(
+		agent.Config{Name: "kill-async", Task: "test", Rows: 24, Cols: 80},
+		func(_ string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 999") },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.refreshAgentList()
+
+	// Select the agent row.
+	for i, it := range app.dashboard.items {
+		if it.kind == listItemAgent && it.agent != nil && it.agent.ID == ag.ID {
+			app.dashboard.selected = i
+			break
+		}
+	}
+
+	// Press 'x' — should mark closing and return a non-nil cmd. The agent
+	// must still be present in the manager because the kill is now async.
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	app = model.(App)
+
+	if cmd == nil {
+		t.Fatal("Expected non-nil cmd from 'x' (async kill), got nil")
+	}
+	if !app.closingAgents[ag.ID] {
+		t.Fatalf("Expected closingAgents[%s]=true, got %v", ag.ID, app.closingAgents)
+	}
+	// Dashboard should see the closing flag too.
+	if !app.dashboard.closingAgents[ag.ID] {
+		t.Fatalf("Expected dashboard.closingAgents[%s]=true", ag.ID)
+	}
+	// The manager still has the agent because the goroutine hasn't run yet.
+	if mgr.Get(ag.ID) == nil {
+		t.Fatalf("Expected agent still present in manager before cmd runs, got nil")
+	}
+
+	// Second press on the same agent is a no-op: must return nil cmd so we
+	// don't double-dispatch.
+	_, cmd2 := app.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	if cmd2 != nil {
+		t.Fatal("Expected nil cmd from second 'x' on same agent (no double-dispatch)")
+	}
+
+	// Run the kill cmd; it should return a killResultMsg.
+	msg := cmd()
+	kr, ok := msg.(killResultMsg)
+	if !ok {
+		t.Fatalf("Expected killResultMsg from cmd, got %T", msg)
+	}
+	if kr.scope != killScopeAgent || kr.agentID != ag.ID || kr.sessionID != sess.ID {
+		t.Fatalf("Unexpected killResultMsg: %+v", kr)
+	}
+
+	// Feed the killResultMsg back into the app — closing set should clear
+	// and refreshAgentList should drop the agent from dashboard items.
+	model, _ = app.Update(kr)
+	app = model.(App)
+	if app.closingAgents[ag.ID] {
+		t.Fatalf("Expected closingAgents[%s] cleared after killResultMsg, still set", ag.ID)
+	}
+	for _, it := range app.dashboard.items {
+		if it.kind == listItemAgent && it.agent != nil && it.agent.ID == ag.ID {
+			t.Fatalf("Expected agent %s removed from dashboard after killResultMsg", ag.ID)
+		}
+	}
+}
+
+// TestKillResultMsgClearsClosingSet verifies the session-scope killResultMsg
+// path: closingSessions and closingAgents are both cleared, diff stats cache
+// is invalidated, and refreshAgentList runs.
+func TestKillResultMsgClearsClosingSet(t *testing.T) {
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+
+	// Pre-populate closing sets and diff cache as if 'X' had dispatched.
+	app.closingSessions["sess-1"] = true
+	app.closingAgents["agent-a"] = true
+	app.closingAgents["agent-b"] = true
+	app.lastKnownStatus["agent-a"] = agent.StatusActive
+	app.lastKnownStatus["agent-b"] = agent.StatusActive
+	app.diffStatsCache["sess-1"] = &diffStatsEntry{}
+
+	model, _ := app.Update(killResultMsg{
+		scope:     killScopeSession,
+		sessionID: "sess-1",
+		agentIDs:  []string{"agent-a", "agent-b"},
+	})
+	app = model.(App)
+
+	if app.closingSessions["sess-1"] {
+		t.Fatal("Expected closingSessions[sess-1] cleared")
+	}
+	if app.closingAgents["agent-a"] || app.closingAgents["agent-b"] {
+		t.Fatal("Expected closingAgents cleared for both agents")
+	}
+	if _, ok := app.diffStatsCache["sess-1"]; ok {
+		t.Fatal("Expected diffStatsCache[sess-1] removed")
+	}
+	if _, ok := app.lastKnownStatus["agent-a"]; ok {
+		t.Fatal("Expected lastKnownStatus cleared for agent-a")
+	}
+	// Dashboard should also see the cleared maps (refreshAgentList was called).
+	if app.dashboard.closingSessions == nil {
+		t.Fatal("Expected dashboard.closingSessions wired up after refresh")
+	}
+	if app.dashboard.closingSessions["sess-1"] {
+		t.Fatal("Expected dashboard.closingSessions[sess-1] cleared after refresh")
+	}
+}
+
+// TestKillResultMsgClearsClosingSetOnError verifies that if KillAgent returns
+// an error, the closing-set entry is still cleared (so the row doesn't get
+// stuck rendering "closing…") and the error is surfaced via setError.
+func TestKillResultMsgClearsClosingSetOnError(t *testing.T) {
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+
+	app.closingAgents["agent-x"] = true
+
+	model, _ := app.Update(killResultMsg{
+		scope:     killScopeAgent,
+		sessionID: "sess-1",
+		agentID:   "agent-x",
+		err:       errors.New("kill failed"),
+	})
+	app = model.(App)
+
+	if app.closingAgents["agent-x"] {
+		t.Fatal("Expected closingAgents[agent-x] cleared even on error")
+	}
+	if app.err != "kill failed" {
+		t.Fatalf("Expected err %q, got %q", "kill failed", app.err)
 	}
 }
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -58,15 +58,17 @@ type diffAggregateStats struct {
 
 // dashboardModel shows the hierarchical repo/session/agent list and terminal preview.
 type dashboardModel struct {
-	items        []listItem
-	selected     int
-	width        int
-	height       int
-	panelFocus   panelFocus
-	scrollOffset int
-	diffStats    *diffSummaryData           // nil when no session selected or no data
-	prCache      map[string]*prCacheEntry   // keyed by session ID, passed from App
-	prPollStates map[string]*prSessionState // keyed by session ID, passed from App
+	items           []listItem
+	selected        int
+	width           int
+	height          int
+	panelFocus      panelFocus
+	scrollOffset    int
+	diffStats       *diffSummaryData           // nil when no session selected or no data
+	prCache         map[string]*prCacheEntry   // keyed by session ID, passed from App
+	prPollStates    map[string]*prSessionState // keyed by session ID, passed from App
+	closingAgents   map[string]bool            // keyed by agent ID, passed from App
+	closingSessions map[string]bool            // keyed by session ID, passed from App
 
 	// Repo config form shown in the right panel when focusConfig is active.
 	repoConfigForm *configForm
@@ -289,40 +291,58 @@ func (d dashboardModel) renderList(width int) string {
 			sess := item.session
 			status := sess.Status()
 			symbol := status.Symbol()
+			closing := d.closingSessions != nil && d.closingSessions[sess.ID]
 			var symbolStyle lipgloss.Style
 			// StatusWaiting is intentionally absent: Session.Status() rolls
 			// Waiting up to Active at the session level, so this switch only
 			// ever sees Active/Starting/Idle/Done/Error.
-			switch status {
-			case agent.StatusActive:
-				symbolStyle = lipgloss.NewStyle().Foreground(ColorSecondary)
-			case agent.StatusDone:
-				symbolStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
-			case agent.StatusError:
-				symbolStyle = lipgloss.NewStyle().Foreground(ColorError)
-			default:
+			switch {
+			case closing:
 				symbolStyle = lipgloss.NewStyle().Foreground(ColorMuted)
+			default:
+				switch status {
+				case agent.StatusActive:
+					symbolStyle = lipgloss.NewStyle().Foreground(ColorSecondary)
+				case agent.StatusDone:
+					symbolStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
+				case agent.StatusError:
+					symbolStyle = lipgloss.NewStyle().Foreground(ColorError)
+				default:
+					symbolStyle = lipgloss.NewStyle().Foreground(ColorMuted)
+				}
 			}
 
 			displayName := sess.GetDisplayName()
 
-			// Build PR indicator suffix for the session row.
+			// Build PR indicator suffix for the session row. Skipped while
+			// closing so the " closing…" tag doesn't fight with a PR badge
+			// for limited header width.
 			var prSuffix string
 			var prSuffixLen int
-			if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
-				prSuffix = " " + prIndicator(entry)
-				// Approximate visible length: space + #N + space + symbol + optional " Ready"
-				prSuffixLen = 1 + len(fmt.Sprintf("#%d", entry.pr.Number))
-				if entry.checks != nil {
-					prSuffixLen += 2 // space + check symbol
-				}
-				if isMergeReady(entry) {
-					prSuffixLen += 6 // " Ready"
+			if !closing {
+				if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
+					prSuffix = " " + prIndicator(entry)
+					// Approximate visible length: space + #N + space + symbol + optional " Ready"
+					prSuffixLen = 1 + len(fmt.Sprintf("#%d", entry.pr.Number))
+					if entry.checks != nil {
+						prSuffixLen += 2 // space + check symbol
+					}
+					if isMergeReady(entry) {
+						prSuffixLen += 6 // " Ready"
+					}
 				}
 			}
 
+			// Reserve width for " closing…" suffix when closing.
+			closingTag := ""
+			closingTagLen := 0
+			if closing {
+				closingTag = " closing…"
+				closingTagLen = 9
+			}
+
 			// 4 for "  ──", 3 for " symbol ", 1 trailing space, plus some padding chars
-			maxNameLen := width - 10 - prSuffixLen
+			maxNameLen := width - 10 - prSuffixLen - closingTagLen
 			if maxNameLen < 5 {
 				maxNameLen = 5
 			}
@@ -330,8 +350,16 @@ func (d dashboardModel) renderList(width int) string {
 				displayName = displayName[:maxNameLen-1] + "…"
 			}
 
-			label := fmt.Sprintf(" %s %s ", symbolStyle.Render(symbol), displayName)
-			labelLen := len(symbol) + 1 + len(displayName) + 2 + prSuffixLen
+			nameStyle := lipgloss.NewStyle()
+			if closing {
+				nameStyle = StyleSubtle
+			}
+			label := fmt.Sprintf(" %s %s", symbolStyle.Render(symbol), nameStyle.Render(displayName))
+			if closing {
+				label += StyleSubtle.Render(closingTag)
+			}
+			label += " "
+			labelLen := len(symbol) + 1 + len(displayName) + 2 + prSuffixLen + closingTagLen
 			padLen := width - 4 - labelLen
 			if padLen < 0 {
 				padLen = 0
@@ -339,12 +367,14 @@ func (d dashboardModel) renderList(width int) string {
 
 			// Use flash color for separator dashes if the session has an active flash.
 			sepStyle := StyleSubtle
-			if ps := d.prPollStates[sess.ID]; ps != nil && time.Now().Before(ps.flashUntil) {
-				switch ps.flashColor {
-				case "success":
-					sepStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
-				case "error":
-					sepStyle = lipgloss.NewStyle().Foreground(ColorError)
+			if !closing {
+				if ps := d.prPollStates[sess.ID]; ps != nil && time.Now().Before(ps.flashUntil) {
+					switch ps.flashColor {
+					case "success":
+						sepStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
+					case "error":
+						sepStyle = lipgloss.NewStyle().Foreground(ColorError)
+					}
 				}
 			}
 
@@ -356,16 +386,19 @@ func (d dashboardModel) renderList(width int) string {
 			ag := item.agent
 			status := ag.Status()
 			symbol := status.Symbol()
-			elapsed := humanizeElapsed(ag.Elapsed())
+			closing := d.closingAgents != nil && d.closingAgents[ag.ID]
 
 			if ag.IsShell {
 				symbol = "$"
 			}
 
 			var style lipgloss.Style
-			if ag.IsShell {
+			switch {
+			case closing:
 				style = lipgloss.NewStyle().Foreground(ColorMuted)
-			} else {
+			case ag.IsShell:
+				style = lipgloss.NewStyle().Foreground(ColorMuted)
+			default:
 				switch status {
 				case agent.StatusActive:
 					style = lipgloss.NewStyle().Foreground(ColorSecondary)
@@ -382,7 +415,20 @@ func (d dashboardModel) renderList(width int) string {
 				}
 			}
 
-			nameWidth := width - 18 // space for indent, symbol, elapsed, padding
+			// Suffix: elapsed time in the normal case, "closing…" when dispatched.
+			// Width budgeting keeps the "closing…" tag inside the same column so
+			// the layout doesn't shift while the kill is in flight.
+			suffix := humanizeElapsed(ag.Elapsed())
+			suffixWidth := 5
+			if closing {
+				suffix = "closing…"
+				suffixWidth = 9 // visual width of the suffix including ellipsis
+			}
+
+			nameWidth := width - 13 - suffixWidth
+			if nameWidth < 1 {
+				nameWidth = 1
+			}
 			name := ag.GetDisplayName()
 			if len(name) > nameWidth {
 				name = name[:nameWidth-1] + "…"
@@ -393,12 +439,25 @@ func (d dashboardModel) renderList(width int) string {
 				agentPrefix = "    " + StyleActive.Render("▸ ")
 			}
 
-			line := fmt.Sprintf("%s%s %-*s %5s",
+			renderedSuffix := suffix
+			if closing {
+				renderedSuffix = StyleSubtle.Render(suffix)
+			}
+			nameRendered := name
+			if closing {
+				nameRendered = StyleSubtle.Render(name)
+			}
+			padName := nameWidth - len(name)
+			if padName < 0 {
+				padName = 0
+			}
+
+			line := fmt.Sprintf("%s%s %s%s %s",
 				agentPrefix,
 				style.Render(symbol),
-				nameWidth,
-				name,
-				elapsed,
+				nameRendered,
+				strings.Repeat(" ", padName),
+				renderedSuffix,
 			)
 			lines = append(lines, line)
 		}


### PR DESCRIPTION
## Summary

- Pressing `x` (kill agent) or `X` (kill session) used to block Bubble Tea's `Update()` synchronously on `agent.Kill()` + `git worktree remove --force`, freezing the event loop for multiple seconds while Claude exited and the worktree was torn down.
- Both handlers now dispatch teardown via a `tea.Cmd` that calls `mgr.KillAgent` / `mgr.KillSession` off the UI thread and return a new `killResultMsg` when the goroutine finishes.
- The App tracks the in-flight kills in `closingAgents` / `closingSessions` maps and the dashboard dims the affected row(s) and renders `closing…` in place of the elapsed / status suffix until the result lands.
- A second press on an already-closing agent/session is a no-op, so the user can't double-dispatch.
- The closing-set entry is cleared regardless of whether the manager call errored, so a row can never get stuck rendering `closing…`.
- Detach (`q` / `ctrl+c`) stays synchronous by design — the app is about to exit, so there is no "feels hung" window.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` (pre-existing `TestLoad_MigratesFromLegacyXDGPath` in `internal/config` fails on my machine regardless of this branch — touches no files on this PR)
- [x] `./baton doctor` — all checks OK, hook pipeline round-trip passes
- [ ] Manual TUI: `./baton`, create a session with `n`, give Claude a long-running tool call, press `x` — row should immediately dim and show `closing…`, arrow keys still move the selection, row disappears when teardown finishes. Repeat with `X` on a whole session (bonus: with a worktree containing lots of build artifacts, to reproduce the original slow-cleanup case).

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (`TestKillAgentAsyncMarksClosing`, `TestKillResultMsgClearsClosingSet`, `TestKillResultMsgClearsClosingSetOnError`)
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)