### PR TITLE
Restore auto-naming of sessions and agents from first prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 ### Fixed
 
 - GoReleaser now publishes the Homebrew formula into the tap's `Formula/` directory (via `directory: Formula`). v0.1.0 landed `baton.rb` at the tap repo root, where newer Homebrew versions don't discover it — installs with `brew install devenjarvis/tap/baton` would fail with "No available formula."
+- Restore auto-naming of sessions and agents from the first Claude prompt (was broken in 0.1.0 hook refactor). The dashboard now relabels a fresh agent's random `adjective-noun` placeholder to a slugified version of the user's first prompt as soon as the `UserPromptSubmit` hook fires; sessions that already have a display name (branch-derived or restored from state) are preserved.
 
 ## [0.1.0] — 2026-04-18
 

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -67,11 +67,13 @@ func runHook(cmd *cobra.Command, args []string) error {
 
 	// Parse just the fields we route on; keep the rest in Raw so the server
 	// can inspect extras if it cares later. `message` is only populated by
-	// Notification payloads — other kinds will leave it empty.
+	// Notification payloads; `prompt` only by UserPromptSubmit — other kinds
+	// leave them empty.
 	var payload struct {
 		SessionID string `json:"session_id"`
 		CWD       string `json:"cwd"`
 		Message   string `json:"message"`
+		Prompt    string `json:"prompt"`
 	}
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &payload); err != nil {
@@ -87,6 +89,9 @@ func runHook(cmd *cobra.Command, args []string) error {
 		CWD:       payload.CWD,
 		Message:   payload.Message,
 		Raw:       json.RawMessage(raw),
+	}
+	if kind == hook.KindUserPromptSubmit {
+		e.Prompt = payload.Prompt
 	}
 
 	if err := hook.SendEvent(socketPath, e); err != nil {

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -48,14 +48,17 @@ func TestHookSubcommandForwards(t *testing.T) {
 	bin := buildBaton(t)
 
 	cases := []struct {
+		name        string
 		subcmd      string
 		wantKind    hook.Kind
 		stdin       string
 		wantSession string
 		wantCWD     string
 		wantMessage string
+		wantPrompt  string
 	}{
 		{
+			name:        "session-start",
 			subcmd:      "session-start",
 			wantKind:    hook.KindSessionStart,
 			stdin:       `{"session_id":"uuid-xyz","cwd":"/tmp/wt"}`,
@@ -63,17 +66,20 @@ func TestHookSubcommandForwards(t *testing.T) {
 			wantCWD:     "/tmp/wt",
 		},
 		{
+			name:        "stop",
 			subcmd:      "stop",
 			wantKind:    hook.KindStop,
 			stdin:       `{"session_id":"uuid-xyz"}`,
 			wantSession: "uuid-xyz",
 		},
 		{
+			name:     "session-end",
 			subcmd:   "session-end",
 			wantKind: hook.KindSessionEnd,
 			stdin:    `{}`,
 		},
 		{
+			name:        "notification",
 			subcmd:      "notification",
 			wantKind:    hook.KindNotification,
 			stdin:       `{"session_id":"uuid-xyz","message":"Claude needs your permission to use Bash"}`,
@@ -81,15 +87,32 @@ func TestHookSubcommandForwards(t *testing.T) {
 			wantMessage: "Claude needs your permission to use Bash",
 		},
 		{
+			name:        "user-prompt-submit",
 			subcmd:      "user-prompt-submit",
 			wantKind:    hook.KindUserPromptSubmit,
 			stdin:       `{"session_id":"uuid-xyz"}`,
 			wantSession: "uuid-xyz",
 		},
+		{
+			name:        "user-prompt-submit-with-prompt",
+			subcmd:      "user-prompt-submit",
+			wantKind:    hook.KindUserPromptSubmit,
+			stdin:       `{"session_id":"uuid-xyz","prompt":"investigate flaky checkout test"}`,
+			wantSession: "uuid-xyz",
+			wantPrompt:  "investigate flaky checkout test",
+		},
+		{
+			name:        "notification-ignores-prompt",
+			subcmd:      "notification",
+			wantKind:    hook.KindNotification,
+			stdin:       `{"session_id":"uuid-xyz","prompt":"should be dropped","message":"perm"}`,
+			wantSession: "uuid-xyz",
+			wantMessage: "perm",
+		},
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.subcmd, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// macOS caps unix socket paths at 104 bytes — t.TempDir() under the
 			// test name is too long, so use a short dir under os.TempDir().
@@ -134,6 +157,9 @@ func TestHookSubcommandForwards(t *testing.T) {
 				}
 				if e.Message != tc.wantMessage {
 					t.Errorf("message: got %q, want %q", e.Message, tc.wantMessage)
+				}
+				if e.Prompt != tc.wantPrompt {
+					t.Errorf("prompt: got %q, want %q", e.Prompt, tc.wantPrompt)
 				}
 			case <-time.After(3 * time.Second):
 				t.Fatal("timed out waiting for hook event")

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -302,3 +302,303 @@ func waitForStatus(t *testing.T, a *Agent, want Status, d time.Duration) bool {
 	}
 	return false
 }
+
+// waitForClaudeName polls HasClaudeName() up to d for the desired value.
+// The rename side-effect runs after OnHookEvent inside the dispatcher goroutine,
+// so tests that care about naming must wait on this rather than on status.
+func waitForClaudeName(t *testing.T, a *Agent, want bool, d time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if a.HasClaudeName() == want {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// sendUserPromptSubmit is a convenience wrapper that dispatches a
+// UserPromptSubmit event through the manager's hook socket and waits for
+// HasClaudeName() to flip — the only reliable signal that applyAutoName has
+// finished running on the dispatcher goroutine.
+func sendUserPromptSubmit(t *testing.T, mgr *Manager, a *Agent, prompt string) {
+	t.Helper()
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: a.ID,
+		Prompt:  prompt,
+	}); err != nil {
+		t.Fatalf("SendEvent UserPromptSubmit: %v", err)
+	}
+	if !waitForClaudeName(t, a, true, 2*time.Second) {
+		t.Fatalf("HasClaudeName did not flip true after UserPromptSubmit")
+	}
+}
+
+// TestManagerRenamesOnFirstUserPromptSubmit verifies that the first
+// UserPromptSubmit with a non-empty prompt slugifies and applies it as the
+// display name on both the agent and its session.
+func TestManagerRenamesOnFirstUserPromptSubmit(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "rename-first", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	if sess.HasDisplayName() {
+		t.Fatalf("precondition: fresh random-named session should not have a display name")
+	}
+
+	sendUserPromptSubmit(t, mgr, ag, "Investigate flaky checkout test!")
+
+	const want = "investigate-flaky-checkout-test"
+	if got := ag.GetDisplayName(); got != want {
+		t.Errorf("agent display name: got %q, want %q", got, want)
+	}
+	if got := sess.GetDisplayName(); got != want {
+		t.Errorf("session display name: got %q, want %q", got, want)
+	}
+}
+
+// TestManagerSecondUserPromptSubmitDoesNotRename verifies that once
+// HasClaudeName is set (on the first prompt), subsequent UserPromptSubmit
+// events leave the display name alone even when the new prompt is different.
+func TestManagerSecondUserPromptSubmitDoesNotRename(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "rename-second", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	sendUserPromptSubmit(t, mgr, ag, "first prompt wins")
+
+	const want = "first-prompt-wins"
+	if got := ag.GetDisplayName(); got != want {
+		t.Fatalf("after first prompt: agent = %q, want %q", got, want)
+	}
+
+	// Second prompt must be a no-op. HasClaudeName is already true, so we
+	// can't reuse sendUserPromptSubmit's wait — just wait on status as a
+	// barrier that the dispatcher processed the event.
+	ag.mu.Lock()
+	ag.status = StatusIdle
+	ag.mu.Unlock()
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "later prompt should be ignored",
+	}); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after second UserPromptSubmit")
+	}
+
+	if got := ag.GetDisplayName(); got != want {
+		t.Errorf("agent display name changed: got %q, want %q", got, want)
+	}
+	if got := sess.GetDisplayName(); got != want {
+		t.Errorf("session display name changed: got %q, want %q", got, want)
+	}
+}
+
+// TestManagerEmptyPromptConsumesOneShotGate verifies the one-shot rule:
+// a UserPromptSubmit with an empty prompt still flips HasClaudeName, so a
+// subsequent non-empty prompt cannot silently rename the agent.
+func TestManagerEmptyPromptConsumesOneShotGate(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "rename-empty", Task: "initial task", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// newAgentWithCommand (used by CreateSessionWithCommand) doesn't set a
+	// displayName from cfg.Task the way newAgent does — so the agent's
+	// display name falls through to cfg.Name until the first UPS renames it.
+	const interim = "rename-empty"
+	if got := ag.GetDisplayName(); got != interim {
+		t.Fatalf("precondition: agent display name, got %q want %q", got, interim)
+	}
+
+	// Empty prompt: must flip HasClaudeName but NOT rename.
+	sendUserPromptSubmit(t, mgr, ag, "")
+	if got := ag.GetDisplayName(); got != interim {
+		t.Errorf("empty-prompt UPS renamed agent: got %q, want %q", got, interim)
+	}
+	if sess.HasDisplayName() {
+		t.Errorf("empty-prompt UPS set a session display name")
+	}
+
+	// Follow-up non-empty prompt is ignored (gate already consumed).
+	ag.mu.Lock()
+	ag.status = StatusIdle
+	ag.mu.Unlock()
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "too late",
+	}); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after second UserPromptSubmit")
+	}
+	if got := ag.GetDisplayName(); got != interim {
+		t.Errorf("late prompt renamed agent past the gate: got %q, want %q", got, interim)
+	}
+}
+
+// TestManagerPreservesSessionDisplayName verifies that when a session already
+// has a display name (e.g. derived from an attached branch via
+// slugifyBranchName, or restored from persisted state), the first
+// UserPromptSubmit still renames the agent but leaves the session name alone.
+func TestManagerPreservesSessionDisplayName(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "rename-branch", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	const sessPreset = "add-login"
+	sess.SetDisplayName(sessPreset)
+
+	sendUserPromptSubmit(t, mgr, ag, "refactor auth middleware")
+
+	const wantAgent = "refactor-auth-middleware"
+	if got := ag.GetDisplayName(); got != wantAgent {
+		t.Errorf("agent rename: got %q, want %q", got, wantAgent)
+	}
+	if got := sess.GetDisplayName(); got != sessPreset {
+		t.Errorf("session display name overwritten: got %q, want %q", got, sessPreset)
+	}
+}
+
+// TestManagerDoneAgentIgnoresLateRename verifies that a stray UserPromptSubmit
+// event for a Done/Error agent doesn't auto-rename the terminal row. Mirrors
+// the Done-agent guard in OnHookEvent.
+func TestManagerDoneAgentIgnoresLateRename(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "rename-done", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	ag.mu.Lock()
+	ag.status = StatusDone
+	ag.mu.Unlock()
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "too late to rename",
+	}); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+	// Give the dispatcher time to process — no observable barrier since the
+	// status guard in OnHookEvent short-circuits and HasClaudeName stays false.
+	time.Sleep(200 * time.Millisecond)
+
+	if ag.HasClaudeName() {
+		t.Error("HasClaudeName flipped true on a Done agent")
+	}
+	if got := ag.GetDisplayName(); got != "rename-done" {
+		t.Errorf("Done agent renamed: got %q, want %q", got, "rename-done")
+	}
+	if sess.HasDisplayName() {
+		t.Error("session renamed by late UPS on Done agent")
+	}
+}
+
+// TestManagerUnslugifiablePromptLeavesNamesUnchanged verifies a prompt that
+// slugifies to empty (e.g. all punctuation) doesn't clear existing names and
+// still consumes the one-shot gate.
+func TestManagerUnslugifiablePromptLeavesNamesUnchanged(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "rename-punct", Task: "keep me", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// See TestManagerEmptyPromptConsumesOneShotGate — custom-command agents
+	// don't derive a display name from cfg.Task, so the baseline is cfg.Name.
+	const interim = "rename-punct"
+	if got := ag.GetDisplayName(); got != interim {
+		t.Fatalf("precondition: agent display name, got %q want %q", got, interim)
+	}
+
+	sendUserPromptSubmit(t, mgr, ag, "!!! ??? ...")
+
+	if got := ag.GetDisplayName(); got != interim {
+		t.Errorf("agent display name overwritten: got %q, want %q", got, interim)
+	}
+	if sess.HasDisplayName() {
+		t.Errorf("session display name set from unslugifiable prompt")
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -116,7 +116,9 @@ func hookSocketPath(repoPath string) string {
 }
 
 // dispatchHookEvents reads hook events from the server and routes each to the
-// agent named by AgentID. Unknown agent IDs are logged and dropped.
+// agent named by AgentID. Unknown agent IDs are dropped silently. On the
+// first UserPromptSubmit for an agent, the prompt is slugified and applied
+// as the auto-generated display name on both the agent and its session.
 func (m *Manager) dispatchHookEvents() {
 	defer m.hookDispatcher.Done()
 	for e := range m.hookServer.Events() {
@@ -134,7 +136,35 @@ func (m *Manager) dispatchHookEvents() {
 				Status:    a.Status(),
 			})
 		}
+		if e.Kind == hook.KindUserPromptSubmit {
+			m.applyAutoName(a, sessID, e.Prompt)
+		}
 	}
+}
+
+// applyAutoName derives a display name from the first UserPromptSubmit prompt
+// and applies it to the agent and (if unset) the session. One-shot: once
+// HasClaudeName is true the agent is never renamed again, even when the
+// first prompt slugifies to empty — mirrors the old Claude-session-file
+// auto-name behavior so we don't silently overwrite a user-accepted name
+// later in the session.
+//
+// Mirrors OnHookEvent's late-event guard: a stray UserPromptSubmit arriving
+// after the agent reached Done or Error must not rename a terminal row.
+func (m *Manager) applyAutoName(a *Agent, sessID, prompt string) {
+	if a.HasClaudeName() {
+		return
+	}
+	if st := a.Status(); st == StatusDone || st == StatusError {
+		return
+	}
+	if slug := slugify(prompt); slug != "" {
+		a.SetDisplayName(slug)
+		if sess := m.GetSession(sessID); sess != nil && !sess.HasDisplayName() {
+			sess.SetDisplayName(slug)
+		}
+	}
+	a.SetClaudeName(true)
 }
 
 // findAgent locates an agent across all sessions and returns it with the

--- a/internal/hook/event.go
+++ b/internal/hook/event.go
@@ -24,7 +24,8 @@ const (
 // SessionID and CWD come straight from the Claude JSON payload; AgentID is
 // supplied by the CLI wrapper from the BATON_AGENT_ID environment variable
 // so the server can dispatch to the right agent. Message is populated from
-// Notification payloads (empty for other kinds). Raw preserves the original
+// Notification payloads (empty for other kinds). Prompt is populated from
+// UserPromptSubmit payloads (empty for other kinds). Raw preserves the original
 // Claude JSON for forward-compatibility with fields the server doesn't
 // currently consume.
 type Event struct {
@@ -33,5 +34,6 @@ type Event struct {
 	SessionID string          `json:"session_id,omitempty"`
 	CWD       string          `json:"cwd,omitempty"`
 	Message   string          `json:"message,omitempty"`
+	Prompt    string          `json:"prompt,omitempty"`
 	Raw       json.RawMessage `json:"raw,omitempty"`
 }


### PR DESCRIPTION
## Summary

- The 0.1.0 hook refactor (commit `4aead88`) removed the polling code that wrote a human-readable display name to new sessions/agents, so they stuck on the random `adjective-noun` placeholder. Polling can't be restored because Claude Code no longer emits a `name` in `~/.claude/sessions/<pid>.json`.
- Thread the `UserPromptSubmit` hook's `prompt` field through the existing socket plumbing (`hook.Event.Prompt`) and rename the agent + session on the first UPS, one-shot via the existing `HasClaudeName` gate.
- Sessions with an explicit display name (branch-derived via `slugifyBranchName`, or restored from persisted state) are preserved — agent still renames.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` (the pre-existing `internal/config/TestLoad_MigratesFromLegacyXDGPath` failure reproduces on `origin/main` and is unrelated)
- [x] `go test -tags e2e -timeout 300s ./internal/e2e/`
- [x] `./baton doctor`
- [ ] Manual TUI: create a fresh session, submit a prompt, confirm dashboard relabels from random name to the slugified prompt within one tick; submit a second prompt, confirm the name does *not* change; create a session attached to an existing branch, confirm session name stays branch-derived while the agent still picks up the prompt-based name; detach with `q` and relaunch, confirm renamed sessions/agents persist.

Six new tests in `internal/agent/hook_integration_test.go` cover the rename semantics end-to-end through the real hook socket: first-rename, second-no-op, empty-prompt-consumes-gate, pre-set-session-name-preserved, unslugifiable-prompt-no-op, and Done-agent-late-event-guard. The existing chime re-arm test still passes.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (six new integration tests in `internal/agent/hook_integration_test.go`, plus prompt round-trip subtests in `cmd/hook_test.go`)
- [x] No new public API surface beyond `hook.Event.Prompt` (added with `omitempty` and only populated for `KindUserPromptSubmit` — noted in the field's docstring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)