### PR TITLE
Forward mouse wheel to agents in alt-screen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 ### Fixed
 
 - GoReleaser now publishes the Homebrew formula into the tap's `Formula/` directory (via `directory: Formula`). v0.1.0 landed `baton.rb` at the tap repo root, where newer Homebrew versions don't discover it — installs with `brew install devenjarvis/tap/baton` would fail with "No available formula."
+- Mouse-wheel scrolling now works inside Claude Code's `/tui fullscreen` mode. When the focused agent is in alt-screen, wheel events are forwarded to the agent (so Claude's internal scrollback handles them) instead of being consumed by baton's own scrollback buffer, which is inert for alt-screen apps. Exiting fullscreen restores baton's scrollback. Entering fullscreen while scrolled back snaps the preview back to live.
 
 ## [0.1.0] — 2026-04-18
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -470,6 +470,21 @@ func (a *Agent) SendKey(key xvt.KeyPressEvent) {
 	a.terminal.SendKey(key)
 }
 
+// SendMouse forwards a mouse event to the VT terminal. The terminal's emulator
+// only emits bytes to the PTY when the running program has enabled mouse
+// reporting (DECSET 1000/1002/1003 + SGR 1006), so this is a no-op when the
+// agent hasn't opted in. Used to drive Claude Code's `/tui fullscreen` scrollback.
+func (a *Agent) SendMouse(m xvt.Mouse) {
+	a.terminal.SendMouse(m)
+}
+
+// IsAltScreen reports whether the agent's terminal is currently rendering into
+// the alternate screen buffer (DECSET 1049). True while Claude is in
+// `/tui fullscreen`; false for normal line-mode Claude.
+func (a *Agent) IsAltScreen() bool {
+	return a.terminal.IsAltScreen()
+}
+
 // SendText forwards text input to the VT terminal.
 func (a *Agent) SendText(text string) {
 	a.mu.Lock()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -301,12 +301,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		fixedW := a.dashboard.fixedTermWidth()
 		fixedH := a.dashboard.fixedTermHeight()
 		if fixedW > 0 && fixedH > 0 {
+			selected := a.dashboard.selectedAgent()
 			for _, item := range a.dashboard.items {
 				if item.kind != listItemAgent || item.agent == nil {
 					continue
 				}
 				if item.agent.AltScreenEntered() {
 					item.agent.Resize(fixedH, fixedW)
+					// VT history is cleared on alt-screen entry; any prior
+					// scrollOffset now indexes into an empty buffer and would
+					// leave the preview visually frozen until the user hits
+					// home. Snap the currently focused agent back to live.
+					if item.agent == selected {
+						a.dashboard.scrollOffset = 0
+					}
 				}
 			}
 		}
@@ -966,6 +974,15 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.dashboard.panelFocus == focusTerminal {
 			ag := a.dashboard.selectedAgent()
 			if ag != nil {
+				// Alt-screen apps (Claude's /tui fullscreen, vim, less) redraw
+				// the viewport instead of scrolling — baton's scrollback is
+				// inert for them. Forward the wheel event so the app can drive
+				// its own scrollback. SendMouse is a no-op unless the app has
+				// enabled mouse reporting.
+				if ag.IsAltScreen() {
+					a.forwardWheelToAgent(ag, msg)
+					return a, nil
+				}
 				switch msg.Button {
 				case tea.MouseWheelUp:
 					a.dashboard.scrollOffset += 3
@@ -1212,6 +1229,53 @@ func (a *App) resizeAllForDashboard() {
 func (a *App) setError(msg string) {
 	a.err = msg
 	a.errTicks = 30
+}
+
+// forwardWheelToAgent encodes a mouse wheel event and feeds it to the agent's
+// terminal. Coordinates are translated from dashboard-screen space to cells
+// relative to the agent's PTY viewport and clamped to [0,W)×[0,H). The
+// emulator only emits bytes when the running program has enabled mouse
+// reporting (DECSET 1000/1002/1003 + SGR 1006).
+func (a *App) forwardWheelToAgent(ag *agent.Agent, msg tea.MouseWheelMsg) {
+	// Row/col offsets to the terminal viewport's top-left cell in screen
+	// space. Mirrors the hardcoded layout assumed by fixedTermHeight
+	// (contentHeight − 4 metadata rows − 2 border rows) plus whatever banner
+	// rows the app layer has pushed the dashboard down by. Exact precision
+	// isn't critical — most alt-screen apps treat wheel events as
+	// direction-only — but translating keeps the coords inside the viewport.
+	dashboardTopY := 0
+	if a.err != "" {
+		dashboardTopY++
+	}
+	if a.confirmQuit {
+		dashboardTopY++
+	}
+	const (
+		previewColOffset    = 32 // list panel width + list-panel right border
+		previewLeftBorder   = 1
+		previewTopBorder    = 1
+		previewMetadataRows = 4 // title, sessionInfo, taskInfo, blank separator
+	)
+	termX := msg.X - previewColOffset - previewLeftBorder
+	if termX < 0 {
+		termX = 0
+	}
+	if w := a.dashboard.fixedTermWidth(); w > 0 && termX >= w {
+		termX = w - 1
+	}
+	termY := msg.Y - dashboardTopY - previewTopBorder - previewMetadataRows
+	if termY < 0 {
+		termY = 0
+	}
+	if h := a.dashboard.fixedTermHeight(); h > 0 && termY >= h {
+		termY = h - 1
+	}
+	ag.SendMouse(xvt.MouseWheel{
+		X:      termX,
+		Y:      termY,
+		Button: xvt.MouseButton(msg.Button),
+		Mod:    xvt.KeyMod(msg.Mod),
+	})
 }
 
 func (a *App) refreshAgentList() {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -700,6 +700,133 @@ func TestMouseWheelScrollInFocusTerminal(t *testing.T) {
 	}
 }
 
+// waitForAltScreen polls ag.IsAltScreen() until true or the timeout expires.
+func waitForAltScreen(t *testing.T, ag *agent.Agent) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ag.IsAltScreen() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("agent did not enter alt-screen within timeout")
+}
+
+// altScreenBashCmd emits DECSET 1049 (alt-screen) + 1002 (button-event mouse)
+// + 1006 (SGR ext encoding) so the agent both enters alt-screen AND accepts
+// SendMouse events, then sleeps so the process stays alive.
+func altScreenBashCmd(_ string) *exec.Cmd {
+	return exec.Command("bash", "-c", `printf '\033[?1049h\033[?1002h\033[?1006h'; sleep 10`)
+}
+
+func TestMouseWheelForwardsInAltScreen(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-alt-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+
+	sess, ag, err := mgr.CreateSessionWithCommand(agent.Config{
+		Name: "alt-wheel", Task: "test", RepoPath: dir, Rows: 24, Cols: 80,
+	}, altScreenBashCmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForAltScreen(t, ag)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.dashboard.items = []listItem{
+		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
+	}
+	app.dashboard.panelFocus = focusTerminal
+
+	// Set a non-zero offset so we can tell the wheel branch didn't mutate it.
+	app.dashboard.scrollOffset = 5
+	model, _ := app.Update(tea.MouseWheelMsg{Button: tea.MouseWheelUp, X: 40, Y: 10})
+	app = model.(App)
+	if app.dashboard.scrollOffset != 5 {
+		t.Fatalf("expected scrollOffset untouched (=5) when agent is in alt-screen, got %d", app.dashboard.scrollOffset)
+	}
+
+	model, _ = app.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown, X: 40, Y: 10})
+	app = model.(App)
+	if app.dashboard.scrollOffset != 5 {
+		t.Fatalf("expected scrollOffset untouched on WheelDown in alt-screen, got %d", app.dashboard.scrollOffset)
+	}
+}
+
+func TestScrollOffsetResetsOnAltScreenEntry(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-alt-reset-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+
+	sess, ag, err := mgr.CreateSessionWithCommand(agent.Config{
+		Name: "alt-reset", Task: "test", RepoPath: dir, Rows: 24, Cols: 80,
+	}, altScreenBashCmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForAltScreen(t, ag)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.dashboard.items = []listItem{
+		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
+	}
+	app.dashboard.selected = 0
+	app.dashboard.scrollOffset = 42
+
+	// A tickMsg drives the alt-screen-entered consumer. Since selected==ag,
+	// the transition should reset scrollOffset to 0.
+	model, _ := app.Update(tickMsg(time.Now()))
+	app = model.(App)
+	if app.dashboard.scrollOffset != 0 {
+		t.Fatalf("expected scrollOffset reset to 0 after alt-screen entry tick, got %d", app.dashboard.scrollOffset)
+	}
+}
+
 func TestErrorPersistsAcrossTicks(t *testing.T) {
 	app := NewApp()
 	app.width = 120

--- a/internal/vt/bridge.go
+++ b/internal/vt/bridge.go
@@ -225,6 +225,20 @@ func (t *Terminal) SendKey(key xvt.KeyPressEvent) {
 	t.emu.SendKey(key)
 }
 
+// SendMouse forwards a mouse event to the emulator. The emulator only emits
+// encoded bytes when the app has enabled mouse reporting (DECSET 1000/1002/1003
+// plus an extended-encoding mode like SGR 1006); otherwise this is a no-op —
+// which is the desired behavior for agents that haven't opted into mouse input.
+func (t *Terminal) SendMouse(m xvt.Mouse) {
+	t.emu.SendMouse(m)
+}
+
+// IsAltScreen reports whether the emulator is currently in alternate-screen
+// mode. Safe to call concurrently with Write.
+func (t *Terminal) IsAltScreen() bool {
+	return t.emu.IsAltScreen()
+}
+
 // SendText forwards text input to the emulator.
 func (t *Terminal) SendText(text string) {
 	t.emu.SendText(text)

--- a/internal/vt/bridge_test.go
+++ b/internal/vt/bridge_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	xvt "github.com/charmbracelet/x/vt"
 )
 
 func TestWriteAndRender(t *testing.T) {
@@ -419,6 +421,87 @@ func TestAltScreenEnteredNoSpuriousTransition(t *testing.T) {
 	_, _ = term.Write([]byte("more content in alt screen"))
 	if term.AltScreenEntered() {
 		t.Error("AltScreenEntered() should be false when already in alt screen (no new transition)")
+	}
+}
+
+// readAllAvailable drains up to bufsz bytes from term.Read in the background.
+// Used by tests that need to assert what bytes the emulator wrote to the PTY
+// side after a SendKey/SendMouse call.
+func readAllAvailable(t *testing.T, term *Terminal) []byte {
+	t.Helper()
+	type res struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		buf := make([]byte, 1024)
+		n, err := term.Read(buf)
+		ch <- res{buf[:n], err}
+	}()
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			t.Fatalf("Read failed: %v", r.err)
+		}
+		return r.data
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read timed out after 2 seconds")
+		return nil
+	}
+}
+
+func TestSendMouseEmitsSGRWhenReportingEnabled(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	// Enable button-event mouse reporting (DECSET 1002) + SGR ext mode (1006).
+	// Without this pair the emulator emits nothing, matching real terminals
+	// that only forward mouse bytes to apps that opted in.
+	_, _ = term.Write([]byte("\x1b[?1002h\x1b[?1006h"))
+
+	term.SendMouse(xvt.MouseWheel{X: 5, Y: 7, Button: xvt.MouseWheelUp})
+
+	got := string(readAllAvailable(t, term))
+	// SGR wheel-up: ESC [ < 64 ; X+1 ; Y+1 M  (coords are 1-based)
+	want := "\x1b[<64;6;8M"
+	if got != want {
+		t.Errorf("SendMouse wheel-up SGR: got %q, want %q", got, want)
+	}
+}
+
+func TestSendMouseNoOpWhenReportingDisabled(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	// Kick the bridgeRead goroutine by writing a harmless byte we can drain.
+	// Without any reporting mode enabled, SendMouse must not emit anything —
+	// so we use SendText after to verify nothing from SendMouse is lurking.
+	term.SendMouse(xvt.MouseWheel{X: 1, Y: 1, Button: xvt.MouseWheelDown})
+	term.SendText("x")
+
+	got := string(readAllAvailable(t, term))
+	if got != "x" {
+		t.Errorf("expected only SendText bytes %q after no-reporting SendMouse, got %q", "x", got)
+	}
+}
+
+func TestIsAltScreen(t *testing.T) {
+	term := New(80, 24)
+	defer term.Close()
+
+	if term.IsAltScreen() {
+		t.Error("expected IsAltScreen() false before any writes")
+	}
+
+	_, _ = term.Write([]byte("\x1b[?1049h"))
+	if !term.IsAltScreen() {
+		t.Error("expected IsAltScreen() true after DECSET 1049")
+	}
+
+	_, _ = term.Write([]byte("\x1b[?1049l"))
+	if term.IsAltScreen() {
+		t.Error("expected IsAltScreen() false after DECRST 1049")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Mouse-wheel events were being consumed by baton's own scrollback buffer even when the focused agent was in alt-screen mode (Claude's `/tui fullscreen`, vim, less, etc). Baton's scrollback is inert for alt-screen apps — they redraw the viewport instead — so the user saw wheel input do nothing.
- Now, when the focused agent's terminal is in alt-screen, wheel events are forwarded to the agent via `SendMouse`. The VT emulator only emits bytes if the app enabled mouse reporting (DECSET 1000/1002/1003 + SGR 1006), so this is a no-op for agents that haven't opted in.
- Coordinates are translated from dashboard-screen space to cells relative to the agent's PTY viewport and clamped inside it. Most alt-screen apps treat wheel events as direction-only, but keeping coords inside the viewport is safer.
- On alt-screen entry the focused agent's `scrollOffset` is reset to 0 — VT history is cleared on alt-screen entry, so any prior offset indexes into an empty buffer and would leave the preview visually frozen until the user hit home.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `go test -race ./...` — all packages pass except a pre-existing failure in `internal/config` (`TestLoad_MigratesFromLegacyXDGPath`) that also fails on `main`, unrelated to this change.
- [ ] `golangci-lint run ./...`
- [ ] Manual TUI: scroll wheel inside Claude `/tui fullscreen` and confirm scrollback moves; exit fullscreen and confirm baton scrollback still responds; enter fullscreen while scrolled back and confirm preview snaps to live.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (`internal/vt/bridge_test.go`, `internal/tui/app_test.go`)
- [x] New public API (`Terminal.SendMouse`, `Terminal.IsAltScreen`, `Agent.SendMouse`, `Agent.IsAltScreen`) — used only by the TUI layer; documented in doc comments.