### PR TITLE
Remove f fix-checks command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 ## [Unreleased]
 
+### Removed
+
+- `f` fix-checks command. Fetching failed check annotations and dispatching them to an idle agent has been removed from the TUI, along with the supporting `GetFailedCheckLogs` client call and `FailedCheck` / `CheckStatus.FailedChecks` types.
+
 ### Added
 
 - Meaningful branch names derived from the user's first prompt. Sessions still start on a random adjective-noun branch so Claude can launch immediately, but on the first real `user-prompt-submit` hook the branch is renamed in place (via `git branch -m`, which atomically updates the worktree's HEAD symref) to a slug of the prompt — e.g. `baton/warm-ibis` becomes `baton/add-dark-mode-to-dashboard`. Slash commands like `/clear` are skipped so the next real prompt still triggers the rename. Attached sessions and resumed sessions are exempt, since their branch name is already meaningful. The preview header now surfaces `Branch:` alongside the session display name so the rename is visible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Always run `go test -race ./...` before committing — concurrency bugs have bee
 - `internal/agent/` — Composes PTY + VT + git into managed agents. Each agent has 3 goroutines: readLoop (PTY→VT), writeLoop (VT→PTY), statusLoop (idle detection). Sessions group agents sharing a worktree. Manager handles lifecycle and events.
 - `internal/tui/` — Bubble Tea v2 views: dashboard (list + preview), diff summary/detail, global/repo config forms, file browser (add repo), branch picker (session on existing branch/PR), statusbar.
 - `internal/hook/` — Unix-socket server + client for Claude hook events (`session-start`, `stop`, `session-end`, `notification`, `user-prompt-submit`) plus the settings file generator that wires Claude's hooks to `baton hook`.
-- `internal/github/` — GitHub API wrapper for PRs, checks, review status, and check-run log fetching (powers `f` fix-checks).
+- `internal/github/` — GitHub API wrapper for PRs, checks, and review status.
 - `internal/config/` — Global settings (`~/.config/baton/settings.json`) and per-repo settings (`.baton/settings.json`) plus resolution logic.
 - `internal/state/` — Session persistence so `q` detaches cleanly and a later `baton` invocation reattaches.
 - `internal/editor/` — IDE launcher helpers; macOS app probing and quote-aware tokenizer for `open -a "Visual Studio Code"` style commands.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -3,7 +3,6 @@ package github
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	gh "github.com/google/go-github/v69/github"
@@ -89,12 +88,6 @@ func (c *Client) GetChecks(ctx context.Context, owner, repo, ref string) (*Check
 			status.Passed++
 		default:
 			status.Failed++
-			status.FailedChecks = append(status.FailedChecks, FailedCheck{
-				ID:         run.GetID(),
-				Name:       run.GetName(),
-				Conclusion: conclusion,
-				DetailsURL: run.GetDetailsURL(),
-			})
 		}
 
 		cr := CheckRun{
@@ -123,31 +116,6 @@ func (c *Client) GetChecks(ctx context.Context, owner, repo, ref string) (*Check
 	}
 
 	return status, nil
-}
-
-// GetFailedCheckLogs returns the annotations/log output for a specific failed check run.
-func (c *Client) GetFailedCheckLogs(ctx context.Context, owner, repo string, checkRunID int64) (string, error) {
-	annotations, _, err := c.gh.Checks.ListCheckRunAnnotations(ctx, owner, repo, checkRunID, &gh.ListOptions{
-		PerPage: 100,
-	})
-	if err != nil {
-		return "", fmt.Errorf("listing annotations for check run %d: %w", checkRunID, err)
-	}
-
-	if len(annotations) == 0 {
-		return "(no annotations found for this check run)", nil
-	}
-
-	var b strings.Builder
-	for _, a := range annotations {
-		fmt.Fprintf(&b, "%s:%d — %s: %s\n",
-			a.GetPath(),
-			a.GetStartLine(),
-			a.GetAnnotationLevel(),
-			a.GetMessage(),
-		)
-	}
-	return b.String(), nil
 }
 
 // GetReviews returns the aggregated review status for a pull request.

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -16,13 +16,12 @@ type PRState struct {
 
 // CheckStatus holds the combined check/CI status for a git ref.
 type CheckStatus struct {
-	State        string // "success", "failure", "pending"
-	Total        int
-	Passed       int
-	Failed       int
-	Pending      int
-	FailedChecks []FailedCheck
-	Runs         []CheckRun
+	State   string // "success", "failure", "pending"
+	Total   int
+	Passed  int
+	Failed  int
+	Pending int
+	Runs    []CheckRun
 }
 
 // CheckRun holds details about a single check run.
@@ -32,14 +31,6 @@ type CheckRun struct {
 	Conclusion string // "success", "failure", "cancelled", "skipped", etc.
 	StartedAt  time.Time
 	Duration   time.Duration
-}
-
-// FailedCheck holds details about a single failed check run.
-type FailedCheck struct {
-	ID         int64
-	Name       string
-	Conclusion string
-	DetailsURL string
 }
 
 // ReviewStatus holds the aggregated review status for a PR.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -522,12 +521,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.refreshAgentList()
 		return a, nil
 
-	case fixChecksMsg:
-		if msg.err != nil {
-			a.setError(msg.err.Error())
-		}
-		return a, nil
-
 	}
 
 	// Route to the active view.
@@ -931,81 +924,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
-		case "f":
-			// Fix failing checks: fetch logs and send to an idle agent.
-			if a.ghClient == nil {
-				a.setError("GitHub not configured")
-				return a, nil
-			}
-			sess := a.dashboard.selectedSession()
-			if sess == nil {
-				a.setError("No session selected")
-				return a, nil
-			}
-			entry := a.prCache[sess.ID]
-			if entry == nil || entry.pr == nil {
-				a.setError("No PR for this session")
-				return a, nil
-			}
-			if entry.checks == nil || entry.checks.Failed == 0 {
-				a.setError("No failing checks")
-				return a, nil
-			}
-			// Find first idle agent in the session.
-			var targetAgent *agent.Agent
-			for _, ag := range sess.Agents() {
-				if ag.IsShell {
-					continue
-				}
-				if ag.Status() == agent.StatusIdle {
-					targetAgent = ag
-					break
-				}
-			}
-			if targetAgent == nil {
-				a.setError("No idle agent available to fix checks")
-				return a, nil
-			}
-			repoPath := a.dashboard.selectedRepoPath()
-			sessionID := sess.ID
-			prNumber := entry.pr.Number
-			failedChecks := entry.checks.FailedChecks
-			ghClient := a.ghClient
-			ag := targetAgent
-			return a, func() tea.Msg {
-				rawURL, err := git.GetRemoteURL(repoPath)
-				if err != nil {
-					return fixChecksMsg{sessionID: sessionID, err: err}
-				}
-				owner, repo, err := github.ParseRemoteURL(rawURL)
-				if err != nil {
-					return fixChecksMsg{sessionID: sessionID, err: err}
-				}
-				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-				defer cancel()
-
-				var msgBuilder strings.Builder
-				msgBuilder.WriteString(fmt.Sprintf("The following CI checks are failing on PR #%d. Please analyze the failures and fix them:\n\n", prNumber))
-
-				for _, fc := range failedChecks {
-					logs, err := ghClient.GetFailedCheckLogs(ctx, owner, repo, fc.ID)
-					if err != nil {
-						logs = "(failed to fetch logs: " + err.Error() + ")"
-					}
-					// Truncate very long logs.
-					if len(logs) > 4000 {
-						logs = logs[:4000] + "\n...(truncated)"
-					}
-					msgBuilder.WriteString(fmt.Sprintf("## %s\n%s\n\n", fc.Name, logs))
-				}
-
-				message := msgBuilder.String()
-				ag.SendText(message)
-				// Send Enter key to submit.
-				ag.SendKey(xvt.KeyPressEvent{Code: tea.KeyEnter})
-
-				return fixChecksMsg{sessionID: sessionID}
-			}
 		}
 	}
 

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -16,12 +16,6 @@ type prPollMsg struct {
 	reviews   *github.ReviewStatus
 }
 
-// fixChecksMsg carries the result of dispatching fix-checks to an agent.
-type fixChecksMsg struct {
-	sessionID string
-	err       error
-}
-
 // prCacheEntry holds cached PR and check status for a session.
 type prCacheEntry struct {
 	pr      *github.PRState

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -25,7 +25,6 @@ var (
 		{"d", "diff/remove"},
 		{"x", "kill agent"},
 		{"X", "kill session"},
-		{"f", "fix checks"},
 		{"q", "quit"},
 	}
 


### PR DESCRIPTION
## Summary

- Dropped the `f` keybinding that fetched failed check annotations from GitHub and dispatched them to an idle agent in the session. The flow was rarely used and added nontrivial code surface (GitHub annotations fetch, log truncation, idle-agent dispatch) tied to a single hotkey.
- Removed the supporting `GetFailedCheckLogs` client call and the `FailedCheck` type / `CheckStatus.FailedChecks` field. `GetChecks` still reports pass/fail/pending counts for the PR indicator; only the per-run annotation fetch was needed by the removed command.
- Cleaned up the dashboard status bar hint, the `fixChecksMsg` type, and the CLAUDE.md reference to the feature.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (pre-existing unrelated failure in `TestLoad_MigratesFromLegacyXDGPath` also reproduces on `main`)
- [ ] Manual TUI: not required — keybinding and supporting code removed

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (new `### Removed` section)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md` (pure removal; no new behavior)
- [x] No new public API surface without a note in the PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)