### PR TITLE
Fix diff view crash on hunks ending with empty context line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 ## [Unreleased]
 
+### Fixed
+
+- Diff view no longer crashes with "fragment header miscounts lines: -1 old, -1 new" when a hunk ends with an empty context line. `git.Diff` now uses `runGitRaw` instead of `runGit` so trailing whitespace (space-prefixed empty lines) is preserved for go-gitdiff's line-count validation.
+
 ### Removed
 
 - `f` fix-checks command. Fetching failed check annotations and dispatching them to an idle agent has been removed from the TUI, along with the supporting `GetFailedCheckLogs` client call and `FailedCheck` / `CheckStatus.FailedChecks` types.

--- a/internal/diffmodel/parse_test.go
+++ b/internal/diffmodel/parse_test.go
@@ -373,3 +373,37 @@ func TestParse_OnlyDeletions(t *testing.T) {
 		t.Errorf("counts: %d+/%d-", f.Insertions, f.Deletions)
 	}
 }
+
+func TestParse_TrailingEmptyContextLine(t *testing.T) {
+	// Regression: git.Diff previously used strings.TrimSpace which stripped
+	// trailing " \n" context lines (empty source lines). go-gitdiff then saw
+	// one fewer line than the header declared and returned
+	// "fragment header miscounts lines: -1 old, -1 new".
+	raw := "diff --git a/foo.go b/foo.go\n" +
+		"index abc..def 100644\n" +
+		"--- a/foo.go\n" +
+		"+++ b/foo.go\n" +
+		"@@ -1,4 +1,5 @@\n" +
+		" package main\n" +
+		" \n" +
+		"+// added\n" +
+		" func main() {}\n" +
+		" \n" // trailing empty context line — stripped by TrimSpace before the fix
+	m, err := diffmodel.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse rejected diff ending with empty context line: %v", err)
+	}
+	if len(m.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(m.Files))
+	}
+	f := m.Files[0]
+	if f.Insertions != 1 || f.Deletions != 0 {
+		t.Errorf("counts: %d+/%d-", f.Insertions, f.Deletions)
+	}
+	if len(f.Hunks) != 1 {
+		t.Fatalf("expected 1 hunk, got %d", len(f.Hunks))
+	}
+	if len(f.Hunks[0].Lines) != 5 {
+		t.Errorf("expected 5 hunk lines (4 original + 1 added), got %d", len(f.Hunks[0].Lines))
+	}
+}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -20,7 +20,7 @@ type DiffStats struct {
 // accepted for API compatibility but unused. Uses --diff-filter=AMD so the file
 // list matches GetPerFileDiffStats.
 func Diff(_ string, wt *WorktreeInfo) (string, error) {
-	out, err := runGit(wt.Path, "diff", "--diff-filter=AMD", wt.BaseBranch)
+	out, err := runGitRaw(wt.Path, "diff", "--diff-filter=AMD", wt.BaseBranch)
 	if err != nil {
 		return "", fmt.Errorf("getting diff: %w", err)
 	}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -34,6 +34,21 @@ func runGit(dir string, args ...string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// runGitRaw is like runGit but returns the output without trimming whitespace.
+// Use this for commands like git diff where trailing whitespace is meaningful
+// (context lines representing empty source lines start with a space character
+// and would be corrupted by TrimSpace).
+func runGitRaw(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
 // IsRepo reports whether path is inside a git repository.
 // It runs `git rev-parse --git-dir` in path and returns true on success.
 func IsRepo(path string) bool {


### PR DESCRIPTION
## Summary

- `git.Diff` called `runGit` which applies `strings.TrimSpace` to all output. A unified diff hunk can end with `" \n"` — a space-prefixed empty line representing an empty source line in context. `TrimSpace` stripped this trailing line, causing go-gitdiff's fragment parser to count one fewer line than the header declared and return `"fragment header miscounts lines: -1 old, -1 new"`.
- Added `runGitRaw` (identical to `runGit` but without `TrimSpace`) and switched `git.Diff` to use it so the raw diff is passed to go-gitdiff verbatim.
- Regression test added in `internal/diffmodel/parse_test.go` (`TestParse_TrailingEmptyContextLine`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [x] Manual TUI: open diff view on a session whose last hunk ends with an empty line — previously crashed, now renders correctly

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (`TestParse_TrailingEmptyContextLine`)
- [x] No new public API surface