### PR TITLE
Fix split diff line dancing: tab expansion + side-by-side truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 ### Fixed
 
 - Diff view no longer crashes with "fragment header miscounts lines: -1 old, -1 new" when a hunk ends with an empty context line. `git.Diff` now uses `runGitRaw` instead of `runGit` so trailing whitespace (space-prefixed empty lines) is preserved for go-gitdiff's line-count validation.
+- Side-by-side diff no longer "line dances" on tab-indented code. Tabs are now expanded to 4 spaces before width measurement so `ansi.StringWidth` returns the correct display width. Side-by-side mode also switches from wrapping to truncation, so each diff row always occupies exactly one physical terminal line and the `│` separator stays stable while scrolling.
 
 ### Removed
 

--- a/internal/tui/diff/render.go
+++ b/internal/tui/diff/render.go
@@ -187,7 +187,8 @@ func (r *Renderer) writeUnifiedLine(b *strings.Builder, l diffmodel.Line, width,
 		markStyle = styleCtxMark
 	}
 
-	colored := r.colorize(l.Text, content)
+	text := expandTabs(l.Text)
+	colored := r.colorize(text, content)
 	wrapped := diffmodel.WrapCell(colored, content)
 	numStr := formatGutter(num, gutter-1)
 
@@ -244,13 +245,15 @@ func (r *Renderer) writeSideBySideRow(
 	b *strings.Builder, row diffmodel.Row,
 	numW, content int,
 ) {
-	// Build left cell.
 	leftMark, leftStyle, leftNum, leftText := cellParts(
 		row.LeftBlank, row.LeftKind, row.LeftNum, row.LeftText,
 	)
 	rightMark, rightStyle, rightNum, rightText := cellParts(
 		row.RightBlank, row.RightKind, row.RightNum, row.RightText,
 	)
+
+	leftText = expandTabs(leftText)
+	rightText = expandTabs(rightText)
 
 	var leftColored, rightColored string
 	if !row.LeftBlank {
@@ -267,59 +270,50 @@ func (r *Renderer) writeSideBySideRow(
 		leftColored, rightColored = overlayWordDiff(leftColored, leftText, rightColored, rightText)
 	}
 
-	leftLines := diffmodel.WrapCell(leftColored, content)
-	rightLines := diffmodel.WrapCell(rightColored, content)
+	// Side-by-side truncates to exactly one physical terminal line per row,
+	// eliminating wrap-count mismatches between the two panes.
+	var leftCell, rightCell string
 	if row.LeftBlank {
-		leftLines = []string{""}
+		leftCell = strings.Repeat(" ", content)
+	} else {
+		leftCell = padTo(truncateVisible(leftColored, content), content)
 	}
 	if row.RightBlank {
-		rightLines = []string{""}
+		rightCell = strings.Repeat(" ", content)
+	} else {
+		rightCell = padTo(truncateVisible(rightColored, content), content)
 	}
-	l, r2 := diffmodel.ZipWrappedRow(leftLines, rightLines)
 
-	for i := range l {
-		var lNumStr, rNumStr string
-		if i == 0 && !row.LeftBlank {
-			lNumStr = formatGutter(leftNum, numW)
-		} else {
-			lNumStr = strings.Repeat(" ", numW)
-		}
-		if i == 0 && !row.RightBlank {
-			rNumStr = formatGutter(rightNum, numW)
-		} else {
-			rNumStr = strings.Repeat(" ", numW)
-		}
-
-		lMarkRendered := ""
-		rMarkRendered := ""
-		if !row.LeftBlank {
-			lMarkRendered = leftStyle.Render(leftMark)
-		} else {
-			lMarkRendered = " "
-		}
-		if !row.RightBlank {
-			rMarkRendered = rightStyle.Render(rightMark)
-		} else {
-			rMarkRendered = " "
-		}
-
-		leftCell := padTo(l[i], content)
-		rightCell := padTo(r2[i], content)
-
-		leftBlock := styleGutter.Render(lNumStr) + " " + lMarkRendered + leftCell
-		rightBlock := styleGutter.Render(rNumStr) + " " + rMarkRendered + rightCell
-
-		// Apply row backgrounds per side.
-		if !row.LeftBlank {
-			leftBlock = applyRowBg(row.LeftKind, leftBlock)
-		}
-		if !row.RightBlank {
-			rightBlock = applyRowBg(row.RightKind, rightBlock)
-		}
-
-		sep := styleGutter.Render(" │ ")
-		b.WriteString(leftBlock + sep + rightBlock + "\n")
+	lNumStr := strings.Repeat(" ", numW)
+	rNumStr := strings.Repeat(" ", numW)
+	if !row.LeftBlank {
+		lNumStr = formatGutter(leftNum, numW)
 	}
+	if !row.RightBlank {
+		rNumStr = formatGutter(rightNum, numW)
+	}
+
+	lMarkRendered := " "
+	rMarkRendered := " "
+	if !row.LeftBlank {
+		lMarkRendered = leftStyle.Render(leftMark)
+	}
+	if !row.RightBlank {
+		rMarkRendered = rightStyle.Render(rightMark)
+	}
+
+	leftBlock := styleGutter.Render(lNumStr) + " " + lMarkRendered + leftCell
+	rightBlock := styleGutter.Render(rNumStr) + " " + rMarkRendered + rightCell
+
+	if !row.LeftBlank {
+		leftBlock = applyRowBg(row.LeftKind, leftBlock)
+	}
+	if !row.RightBlank {
+		rightBlock = applyRowBg(row.RightKind, rightBlock)
+	}
+
+	sep := styleGutter.Render(" │ ")
+	b.WriteString(leftBlock + sep + rightBlock + "\n")
 }
 
 func cellParts(blank bool, kind diffmodel.LineKind, num int, text string) (mark string, ms lipgloss.Style, n int, t string) {
@@ -508,6 +502,14 @@ func isSGRReset(seq string) bool {
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+const tabSize = 4
+
+// expandTabs replaces tab characters with spaces so ansi.StringWidth measures
+// the correct display width before any wrapping or truncation occurs.
+func expandTabs(s string) string {
+	return strings.ReplaceAll(s, "\t", strings.Repeat(" ", tabSize))
+}
 
 // padTo pads s with spaces on the right until its visible width reaches n.
 func padTo(s string, n int) string {

--- a/internal/tui/diff/render_test.go
+++ b/internal/tui/diff/render_test.go
@@ -111,6 +111,7 @@ func TestRender_BinaryFile(t *testing.T) {
 }
 
 func TestRender_WrapsLongLine(t *testing.T) {
+	// Unified mode wraps long lines and emits WrapMarker; side-by-side uses truncation instead.
 	long := strings.Repeat("x", 200)
 	raw := "diff --git a/foo.txt b/foo.txt\n" +
 		"index abc..def 100644\n" +
@@ -135,6 +136,58 @@ func TestRender_WrapsLongLine(t *testing.T) {
 	// There must be wrap markers somewhere.
 	if !strings.Contains(out, diffmodel.WrapMarker) {
 		t.Errorf("expected wrap marker in output, got:\n%s", out)
+	}
+}
+
+func TestRender_SideBySideNoWrapMarker(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	raw := "diff --git a/foo.txt b/foo.txt\n" +
+		"index abc..def 100644\n" +
+		"--- a/foo.txt\n" +
+		"+++ b/foo.txt\n" +
+		"@@ -1 +1 @@\n" +
+		"-old\n" +
+		"+" + long + "\n"
+	f := parseOrFail(t, raw)
+	r := diff.NewRenderer(f)
+
+	out := r.Render(120, true)
+	if out == "" {
+		t.Fatal("empty render")
+	}
+	if strings.Contains(out, diffmodel.WrapMarker) {
+		t.Errorf("side-by-side must not contain WrapMarker:\n%s", out)
+	}
+	for i, line := range strings.Split(out, "\n") {
+		if w := ansi.StringWidth(line); w > 120 {
+			t.Errorf("line %d width %d > 120", i, w)
+		}
+	}
+}
+
+func TestRender_SideBySideTabExpansion(t *testing.T) {
+	raw := "diff --git a/foo.go b/foo.go\n" +
+		"index abc..def 100644\n" +
+		"--- a/foo.go\n" +
+		"+++ b/foo.go\n" +
+		"@@ -1,2 +1,2 @@\n" +
+		"-\tfunc Old()\n" +
+		"+\tfunc New()\n" +
+		" \tbody\n"
+	f := parseOrFail(t, raw)
+	r := diff.NewRenderer(f)
+
+	out := r.Render(120, true)
+	if out == "" {
+		t.Fatal("empty render")
+	}
+	if strings.Contains(stripped(out), "\t") {
+		t.Errorf("output should not contain raw tabs after expansion")
+	}
+	for i, line := range strings.Split(out, "\n") {
+		if w := ansi.StringWidth(line); w > 120 {
+			t.Errorf("line %d width %d > 120 (tab expansion may be missing)", i, w)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Tab-width mismatch fixed**: `ansi.StringWidth` counted `\t` as 0 columns while the terminal rendered it as up to 8. Added `expandTabs` helper (tab → 4 spaces) called before `colorize()` in both unified and side-by-side paths so width measurements are always correct.
- **Wrap-count mismatch fixed**: Paired add/delete rows with different text lengths produced different numbers of wrapped physical lines per side, causing every subsequent context row to shift downward on scroll. Side-by-side mode now uses truncation instead of wrapping, so each diff row always occupies exactly one physical terminal line — matching GitHub, GitLab, and VS Code split-view behavior.
- Unified mode wrapping (with `↵` markers) is preserved.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (new tests + existing all pass; pre-existing `internal/config` and `internal/pty` failures are unrelated and exist on `main`)
- [x] `TestRender_SideBySideNoWrapMarker` — side-by-side output for a 200-char line contains no `WrapMarker` and every rendered line fits within width
- [x] `TestRender_SideBySideTabExpansion` — tab-indented diff renders without raw `\t` in output and without any line exceeding width
- [ ] Manual TUI: open baton on a Go repo with pending changes → side-by-side mode → no content spills onto unexpected lines; `│` separator appears on every row; view is stable while scrolling

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests
- [x] No new public API surface