### PR TITLE
Add baton version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,7 +18,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
+      - -X github.com/devenjarvis/baton/cmd.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Every PR should update the `[Unreleased]` section with a short entry describing 
 
 ### Added
 
+- `baton version` command prints the current version (injected via ldflags at release build time; defaults to `dev`).
 - `p` key and left-panel click on the PR/checks summary section now open the session's pull request in the default browser (`open` on macOS, `xdg-open` on Linux, `start` on Windows).
 - Rebuilt diff view with stable side-by-side layout, syntax highlighting, word-level intra-line diff, file-tree picker, and live (uncommitted) diff support. `git.Diff` now runs from inside the worktree against the base branch (`--diff-filter=AMD`), mirroring the sidebar stats so the detail view populates before the agent commits. The renderer is a fresh `internal/diffmodel` + `internal/tui/diff` stack with ANSI-aware width measurement, wrap-with-`↵` markers for long lines, and a `s` key to toggle side-by-side on demand. Side-by-side threshold dropped from 120 to 100 cols; keys `n/p` were replaced by the tree (`j/k/h/l/enter`).
 - Branch renaming now uses `claude -p --model claude-haiku-4-5` to summarize the first prompt into a 3-5 word slug; falls back to the old slugify on failure. Toggle via `smart_branch_names`. Session display name now updates to match the Haiku-generated slug after the async rename completes.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of baton",
+	RunE: runVersion,
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+func runVersion(cmd *cobra.Command, args []string) error {
+	fmt.Printf("baton version %s\n", version)
+	return nil
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -11,7 +12,7 @@ var version = "dev"
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of baton",
-	RunE: runVersion,
+	RunE:  runVersion,
 }
 
 func init() {
@@ -19,6 +20,25 @@ func init() {
 }
 
 func runVersion(cmd *cobra.Command, args []string) error {
-	fmt.Printf("baton version %s\n", version)
+	fmt.Printf("baton version %s\n", resolvedVersion())
 	return nil
+}
+
+// resolvedVersion returns the ldflags-injected version for release builds,
+// the short VCS commit hash for local builds, or "dev" as a last resort.
+func resolvedVersion() string {
+	if version != "dev" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" && len(s.Value) > 0 {
+				if len(s.Value) > 7 {
+					return s.Value[:7]
+				}
+				return s.Value
+			}
+		}
+	}
+	return "dev"
 }


### PR DESCRIPTION
## Summary

- Adds `baton version` subcommand that prints the current version to stdout
- Defaults to the short git commit hash for local builds (via `runtime/debug.ReadBuildInfo()`), falling back to `"dev"` when no VCS info is available
- Tagged GoReleaser release builds inject the real version via `-ldflags "-X github.com/devenjarvis/baton/cmd.version={{.Version}}"`
- Fixes the GoReleaser config which previously pointed ldflags at `main.version` (non-existent) instead of `cmd.version`

## Test plan

- [ ] `go build -o baton . && ./baton version` → prints `baton version <short-commit-hash>`
- [ ] `go build -o baton -ldflags "-X github.com/devenjarvis/baton/cmd.version=v0.1.0" . && ./baton version` → prints `baton version v0.1.0`
- [ ] `baton --help` lists `version` in the subcommand list
- [ ] `go test ./...` passes