### PR TITLE
Add fragment-based changelog to eliminate merge conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Assemble changelog
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          go run ./scripts/changelog --version "$VERSION"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,43 +5,6 @@ All notable changes to Baton will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Every PR should update the `[Unreleased]` section with a short entry describing the change.
-
-## [Unreleased]
-
-### Fixed
-
-- Branch rename now uses argument text from skill invocations (e.g. `/plan-it add dark mode` → `add-dark-mode`) instead of keeping the placeholder name. Pure slash commands with no arguments (e.g. `/clear`) still skip the rename.
-- Diff view no longer crashes with "fragment header miscounts lines: -1 old, -1 new" when a hunk ends with an empty context line. `git.Diff` now uses `runGitRaw` instead of `runGit` so trailing whitespace (space-prefixed empty lines) is preserved for go-gitdiff's line-count validation.
-- Side-by-side diff no longer "line dances" on tab-indented code. Tabs are now expanded to 4 spaces before width measurement so `ansi.StringWidth` returns the correct display width. Side-by-side mode also switches from wrapping to truncation, so each diff row always occupies exactly one physical terminal line and the `│` separator stays stable while scrolling.
-
-### Removed
-
-- `f` fix-checks command. Fetching failed check annotations and dispatching them to an idle agent has been removed from the TUI, along with the supporting `GetFailedCheckLogs` client call and `FailedCheck` / `CheckStatus.FailedChecks` types.
-
-### Added
-
-- `baton version` command prints the current version (injected via ldflags at release build time; defaults to `dev`).
-- `p` key and left-panel click on the PR/checks summary section now open the session's pull request in the default browser (`open` on macOS, `xdg-open` on Linux, `start` on Windows).
-- Rebuilt diff view with stable side-by-side layout, syntax highlighting, word-level intra-line diff, file-tree picker, and live (uncommitted) diff support. `git.Diff` now runs from inside the worktree against the base branch (`--diff-filter=AMD`), mirroring the sidebar stats so the detail view populates before the agent commits. The renderer is a fresh `internal/diffmodel` + `internal/tui/diff` stack with ANSI-aware width measurement, wrap-with-`↵` markers for long lines, and a `s` key to toggle side-by-side on demand. Side-by-side threshold dropped from 120 to 100 cols; keys `n/p` were replaced by the tree (`j/k/h/l/enter`).
-- Branch renaming now uses `claude -p --model claude-haiku-4-5` to summarize the first prompt into a 3-5 word slug; falls back to the old slugify on failure. Toggle via `smart_branch_names`. Session display name now updates to match the Haiku-generated slug after the async rename completes.
-- Meaningful branch names derived from the user's first prompt. Sessions still start on a random adjective-noun branch so Claude can launch immediately, but on the first real `user-prompt-submit` hook the branch is renamed in place (via `git branch -m`, which atomically updates the worktree's HEAD symref) to a slug of the prompt — e.g. `baton/warm-ibis` becomes `baton/add-dark-mode-to-dashboard`. Slash commands like `/clear` are skipped so the next real prompt still triggers the rename. Attached sessions and resumed sessions are exempt, since their branch name is already meaningful. The preview header now surfaces `Branch:` alongside the session display name so the rename is visible.
-- `{user}` and `{date}` template variables in `BranchPrefix`. `{user}` resolves from `git config user.name` (falling back to `$USER`), slugified; `{date}` resolves to today's `YYYY-MM-DD`. Unknown `{tokens}` are left literal so existing prefixes with braces are unaffected. Example: `BranchPrefix: "{user}/"` produces `dj/add-dark-mode` for a first-prompt rename.
-- GoReleaser config and release workflow: pushing a `v*` tag builds darwin/linux amd64+arm64 archives, publishes a GitHub release, and updates the `devenjarvis/homebrew-tap` formula.
-
-### Changed
-
-- `x` (kill agent) and `X` (kill session) now tear down off the UI thread and mark the affected row as `closing…` until the worktree teardown completes, so the dashboard stays interactive while Claude exits and `git worktree remove --force` runs.
-- Reverted "Release mouse capture in focus terminal view": the focus terminal view now re-captures the mouse. Text selection via the host terminal's drag was unreliable (copied text included the surrounding TUI frame), and capturing the mouse restores consistent keybinding/scroll behavior in focus mode.
-
-### Fixed
-
-- Stale-text artifacts overlaying the agent preview (most visible on Claude plan-approval prompts and between normal Q&A turns). Fixed by padding every VT render line to the full viewport width with a terminating style reset (`RenderPadded`) so previous-frame trailing cells are overwritten, invalidating the `StableRender` cache on resize and alt-screen entry, taking atomic scrollback+viewport snapshots under a single lock, and aligning the preview box's inner height to the VT dimensions.
-- Permission-prompt approvals now clear the waiting indicator immediately via Claude's `PreToolUse` hook, instead of lingering yellow until the turn ends.
-- GoReleaser now publishes the Homebrew formula into the tap's `Formula/` directory (via `directory: Formula`). v0.1.0 landed `baton.rb` at the tap repo root, where newer Homebrew versions don't discover it — installs with `brew install devenjarvis/tap/baton` would fail with "No available formula."
-- Restore auto-naming of sessions and agents from the first Claude prompt (was broken in 0.1.0 hook refactor). The dashboard now relabels a fresh agent's random `adjective-noun` placeholder to a slugified version of the user's first prompt as soon as the `UserPromptSubmit` hook fires; sessions that already have a display name (branch-derived or restored from state) are preserved.
-- Mouse-wheel scrolling now works inside Claude Code's `/tui fullscreen` mode. When the focused agent is in alt-screen, wheel events are forwarded to the agent (so Claude's internal scrollback handles them) instead of being consumed by baton's own scrollback buffer, which is inert for alt-screen apps. Exiting fullscreen restores baton's scrollback. Entering fullscreen while scrolled back snaps the preview back to live.
-
 ## [0.1.0] — 2026-04-18
 
 Initial public release.
@@ -66,5 +29,4 @@ Initial public release.
 - Virtual terminal bridge built on `charmbracelet/x/vt` for thread-safe rendering of agent output.
 - Optional audio chimes for status transitions.
 
-[Unreleased]: https://github.com/devenjarvis/baton/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/devenjarvis/baton/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,4 +72,4 @@ Always run `go test -race ./...` before committing — concurrency bugs have bee
 - `.baton/` is gitignored (auto-added to the repo's `.gitignore` on first run).
 - Errors display briefly in the TUI and clear on next tick; no modal error dialogs.
 - Claude hook CLI (`baton hook`) is silent on stdout and always exits 0 — Claude interprets stdout as hook feedback.
-- Changelog: every PR should add a line under `[Unreleased]` in `CHANGELOG.md`.
+- Changelog: every PR should add a fragment file under `changelog.d/` (e.g. `changelog.d/fix-login-redirect.md`) using `### Added`, `### Fixed`, etc. section headers. A release script assembles fragments into `CHANGELOG.md` when a version is cut.

--- a/changelog.d/add-branch-prefix-templates.md
+++ b/changelog.d/add-branch-prefix-templates.md
@@ -1,0 +1,3 @@
+### Added
+
+- `{user}` and `{date}` template variables in `BranchPrefix`. `{user}` resolves from `git config user.name` (falling back to `$USER`), slugified; `{date}` resolves to today's `YYYY-MM-DD`. Unknown `{tokens}` are left literal so existing prefixes with braces are unaffected. Example: `BranchPrefix: "{user}/"` produces `dj/add-dark-mode` for a first-prompt rename.

--- a/changelog.d/add-goreleaser.md
+++ b/changelog.d/add-goreleaser.md
@@ -1,0 +1,3 @@
+### Added
+
+- GoReleaser config and release workflow: pushing a `v*` tag builds darwin/linux amd64+arm64 archives, publishes a GitHub release, and updates the `devenjarvis/homebrew-tap` formula.

--- a/changelog.d/add-meaningful-branch-names.md
+++ b/changelog.d/add-meaningful-branch-names.md
@@ -1,0 +1,3 @@
+### Added
+
+- Meaningful branch names derived from the user's first prompt. Sessions still start on a random adjective-noun branch so Claude can launch immediately, but on the first real `user-prompt-submit` hook the branch is renamed in place (via `git branch -m`, which atomically updates the worktree's HEAD symref) to a slug of the prompt — e.g. `baton/warm-ibis` becomes `baton/add-dark-mode-to-dashboard`. Slash commands like `/clear` are skipped so the next real prompt still triggers the rename. Attached sessions and resumed sessions are exempt, since their branch name is already meaningful. The preview header now surfaces `Branch:` alongside the session display name so the rename is visible.

--- a/changelog.d/add-open-pr-in-browser.md
+++ b/changelog.d/add-open-pr-in-browser.md
@@ -1,0 +1,3 @@
+### Added
+
+- `p` key and left-panel click on the PR/checks summary section now open the session's pull request in the default browser (`open` on macOS, `xdg-open` on Linux, `start` on Windows).

--- a/changelog.d/add-rebuilt-diff-view.md
+++ b/changelog.d/add-rebuilt-diff-view.md
@@ -1,0 +1,3 @@
+### Added
+
+- Rebuilt diff view with stable side-by-side layout, syntax highlighting, word-level intra-line diff, file-tree picker, and live (uncommitted) diff support. `git.Diff` now runs from inside the worktree against the base branch (`--diff-filter=AMD`), mirroring the sidebar stats so the detail view populates before the agent commits. The renderer is a fresh `internal/diffmodel` + `internal/tui/diff` stack with ANSI-aware width measurement, wrap-with-`↵` markers for long lines, and a `s` key to toggle side-by-side on demand. Side-by-side threshold dropped from 120 to 100 cols; keys `n/p` were replaced by the tree (`j/k/h/l/enter`).

--- a/changelog.d/add-smart-branch-naming.md
+++ b/changelog.d/add-smart-branch-naming.md
@@ -1,0 +1,3 @@
+### Added
+
+- Branch renaming now uses `claude -p --model claude-haiku-4-5` to summarize the first prompt into a 3-5 word slug; falls back to the old slugify on failure. Toggle via `smart_branch_names`. Session display name now updates to match the Haiku-generated slug after the async rename completes.

--- a/changelog.d/add-version-command.md
+++ b/changelog.d/add-version-command.md
@@ -1,0 +1,3 @@
+### Added
+
+- `baton version` command prints the current version (injected via ldflags at release build time; defaults to `dev`).

--- a/changelog.d/change-async-kill.md
+++ b/changelog.d/change-async-kill.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `x` (kill agent) and `X` (kill session) now tear down off the UI thread and mark the affected row as `closing…` until the worktree teardown completes, so the dashboard stays interactive while Claude exits and `git worktree remove --force` runs.

--- a/changelog.d/change-revert-mouse-capture.md
+++ b/changelog.d/change-revert-mouse-capture.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Reverted "Release mouse capture in focus terminal view": the focus terminal view now re-captures the mouse. Text selection via the host terminal's drag was unreliable (copied text included the surrounding TUI frame), and capturing the mouse restores consistent keybinding/scroll behavior in focus mode.

--- a/changelog.d/fix-branch-rename-skill-invocations.md
+++ b/changelog.d/fix-branch-rename-skill-invocations.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Branch rename now uses argument text from skill invocations (e.g. `/plan-it add dark mode` → `add-dark-mode`) instead of keeping the placeholder name. Pure slash commands with no arguments (e.g. `/clear`) still skip the rename.

--- a/changelog.d/fix-diff-crash.md
+++ b/changelog.d/fix-diff-crash.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Diff view no longer crashes with "fragment header miscounts lines: -1 old, -1 new" when a hunk ends with an empty context line. `git.Diff` now uses `runGitRaw` instead of `runGit` so trailing whitespace (space-prefixed empty lines) is preserved for go-gitdiff's line-count validation.

--- a/changelog.d/fix-goreleaser-homebrew-formula.md
+++ b/changelog.d/fix-goreleaser-homebrew-formula.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- GoReleaser now publishes the Homebrew formula into the tap's `Formula/` directory (via `directory: Formula`). v0.1.0 landed `baton.rb` at the tap repo root, where newer Homebrew versions don't discover it — installs with `brew install devenjarvis/tap/baton` would fail with "No available formula."

--- a/changelog.d/fix-mouse-wheel-fullscreen.md
+++ b/changelog.d/fix-mouse-wheel-fullscreen.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Mouse-wheel scrolling now works inside Claude Code's `/tui fullscreen` mode. When the focused agent is in alt-screen, wheel events are forwarded to the agent (so Claude's internal scrollback handles them) instead of being consumed by baton's own scrollback buffer, which is inert for alt-screen apps. Exiting fullscreen restores baton's scrollback. Entering fullscreen while scrolled back snaps the preview back to live.

--- a/changelog.d/fix-permission-prompt-waiting.md
+++ b/changelog.d/fix-permission-prompt-waiting.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Permission-prompt approvals now clear the waiting indicator immediately via Claude's `PreToolUse` hook, instead of lingering yellow until the turn ends.

--- a/changelog.d/fix-session-auto-naming.md
+++ b/changelog.d/fix-session-auto-naming.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Restore auto-naming of sessions and agents from the first Claude prompt (was broken in 0.1.0 hook refactor). The dashboard now relabels a fresh agent's random `adjective-noun` placeholder to a slugified version of the user's first prompt as soon as the `UserPromptSubmit` hook fires; sessions that already have a display name (branch-derived or restored from state) are preserved.

--- a/changelog.d/fix-split-diff-tab-indented.md
+++ b/changelog.d/fix-split-diff-tab-indented.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Side-by-side diff no longer "line dances" on tab-indented code. Tabs are now expanded to 4 spaces before width measurement so `ansi.StringWidth` returns the correct display width. Side-by-side mode also switches from wrapping to truncation, so each diff row always occupies exactly one physical terminal line and the `│` separator stays stable while scrolling.

--- a/changelog.d/fix-stale-text-artifacts.md
+++ b/changelog.d/fix-stale-text-artifacts.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Stale-text artifacts overlaying the agent preview (most visible on Claude plan-approval prompts and between normal Q&A turns). Fixed by padding every VT render line to the full viewport width with a terminating style reset (`RenderPadded`) so previous-frame trailing cells are overwritten, invalidating the `StableRender` cache on resize and alt-screen entry, taking atomic scrollback+viewport snapshots under a single lock, and aligning the preview box's inner height to the VT dimensions.

--- a/changelog.d/remove-fix-checks-command.md
+++ b/changelog.d/remove-fix-checks-command.md
@@ -1,0 +1,3 @@
+### Removed
+
+- `f` fix-checks command. Fetching failed check annotations and dispatching them to an idle agent has been removed from the TUI, along with the supporting `GetFailedCheckLogs` client call and `FailedCheck` / `CheckStatus.FailedChecks` types.

--- a/scripts/changelog/main.go
+++ b/scripts/changelog/main.go
@@ -1,0 +1,222 @@
+// changelog assembles fragment files from changelog.d/ into CHANGELOG.md.
+//
+// Usage:
+//
+//	go run ./scripts/changelog --version 0.2.0
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// sectionOrder defines Keep a Changelog canonical ordering.
+var sectionOrder = []string{
+	"Added",
+	"Changed",
+	"Deprecated",
+	"Removed",
+	"Fixed",
+	"Security",
+}
+
+func main() {
+	version := flag.String("version", "", "version to release (e.g. 0.2.0)")
+	flag.Parse()
+
+	if *version == "" {
+		fmt.Fprintln(os.Stderr, "error: --version is required")
+		os.Exit(1)
+	}
+
+	// Locate repo root relative to this script's invocation directory.
+	// When run via `go run ./scripts/changelog`, the working directory is
+	// the module root. Accept the cwd as the root.
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	changelog := filepath.Join(cwd, "CHANGELOG.md")
+	fragmentsDir := filepath.Join(cwd, "changelog.d")
+
+	if err := run(changelog, fragmentsDir, *version, time.Now()); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run is the testable core of the tool.
+func run(changelogPath, fragmentsDir, version string, now time.Time) error {
+	// 1. Collect fragment files (skip .gitkeep and hidden files).
+	entries, err := os.ReadDir(fragmentsDir)
+	if err != nil {
+		return fmt.Errorf("reading changelog.d: %w", err)
+	}
+
+	var fragmentFiles []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name == ".gitkeep" || strings.HasPrefix(name, ".") {
+			continue
+		}
+		fragmentFiles = append(fragmentFiles, filepath.Join(fragmentsDir, name))
+	}
+
+	if len(fragmentFiles) == 0 {
+		return errors.New("no fragment files found in changelog.d (nothing to release)")
+	}
+
+	// 2. Parse fragments into section buckets.
+	buckets := make(map[string][]string) // section name → bullet lines
+
+	sectionRe := regexp.MustCompile(`^###\s+(.+)$`)
+
+	for _, path := range fragmentFiles {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+
+		var currentSection string
+		scanner := bufio.NewScanner(strings.NewReader(string(content)))
+		for scanner.Scan() {
+			line := scanner.Text()
+			if m := sectionRe.FindStringSubmatch(line); m != nil {
+				currentSection = strings.TrimSpace(m[1])
+				continue
+			}
+			if currentSection == "" {
+				continue
+			}
+			// Collect non-empty lines (bullets, continuation lines)
+			if strings.TrimSpace(line) != "" {
+				buckets[currentSection] = append(buckets[currentSection], line)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("scanning %s: %w", path, err)
+		}
+	}
+
+	// 3. Build new version section.
+	dateStr := now.Format("2006-01-02")
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "## [%s] — %s\n", version, dateStr)
+
+	for _, sec := range sectionOrder {
+		bullets, ok := buckets[sec]
+		if !ok || len(bullets) == 0 {
+			continue
+		}
+		fmt.Fprintf(&sb, "\n### %s\n\n", sec)
+		for _, b := range bullets {
+			fmt.Fprintln(&sb, b)
+		}
+	}
+
+	newSection := sb.String()
+
+	// 4. Read current CHANGELOG.md.
+	changelogBytes, err := os.ReadFile(changelogPath)
+	if err != nil {
+		return fmt.Errorf("reading CHANGELOG.md: %w", err)
+	}
+	changelogContent := string(changelogBytes)
+
+	// 5. Insert new section before the first `## [` line (which may be a
+	//    prior release or an [Unreleased] section that was already removed).
+	insertRe := regexp.MustCompile(`(?m)^## \[`)
+	loc := insertRe.FindStringIndex(changelogContent)
+	var updated string
+	if loc != nil {
+		updated = changelogContent[:loc[0]] + newSection + "\n" + changelogContent[loc[0]:]
+	} else {
+		// No existing versioned section — just append.
+		updated = changelogContent + "\n" + newSection
+	}
+
+	// 6. Update comparison links at the bottom.
+	//    We need to:
+	//      a) Replace existing [Unreleased]: ...HEAD  with the new Unreleased link.
+	//      b) Insert a new versioned comparison link after (or instead of) the old one.
+	//
+	//    Strategy: rebuild the links block at the bottom.
+
+	// Find the previous latest version. First try the existing [Unreleased] link;
+	// if that was already removed (normal post-Task-3 state), fall back to the
+	// first versioned ## [X.Y.Z] section header in the file.
+	prevVersionRe := regexp.MustCompile(`\[Unreleased\]: https://github\.com/([^/]+/[^/]+)/compare/v([^.]+\.[^.]+\.[^.]+)\.\.\.HEAD`)
+	prevMatch := prevVersionRe.FindStringSubmatch(updated)
+
+	repoSlug := "devenjarvis/baton" // fallback
+	prevVersion := ""
+	if prevMatch != nil {
+		repoSlug = prevMatch[1]
+		prevVersion = prevMatch[2]
+	} else {
+		// No [Unreleased] link — extract prev version from the original changelog
+		// content before the new section was inserted (so we don't accidentally
+		// match the version we're currently releasing).
+		sectionVerRe := regexp.MustCompile(`(?m)^## \[(\d+\.\d+\.\d+)\]`)
+		if m := sectionVerRe.FindStringSubmatch(changelogContent); m != nil {
+			prevVersion = m[1]
+		}
+	}
+
+	newUnreleasedLink := fmt.Sprintf("[Unreleased]: https://github.com/%s/compare/v%s...HEAD", repoSlug, version)
+
+	// Replace old [Unreleased] link, or insert new ones before the existing links block.
+	oldUnreleasedRe := regexp.MustCompile(`(?m)^\[Unreleased\]: .*$`)
+	if oldUnreleasedRe.MatchString(updated) {
+		updated = oldUnreleasedRe.ReplaceAllString(updated, newUnreleasedLink)
+	} else {
+		// No existing [Unreleased] link — insert new links before the first [ref]:
+		// line so the conventional order ([Unreleased], newest→oldest) is preserved.
+		firstRefRe := regexp.MustCompile(`(?m)^\[`)
+		if loc := firstRefRe.FindStringIndex(updated); loc != nil {
+			updated = updated[:loc[0]] + newUnreleasedLink + "\n" + updated[loc[0]:]
+		} else {
+			updated = strings.TrimRight(updated, "\n") + "\n" + newUnreleasedLink + "\n"
+		}
+	}
+
+	// Insert new versioned link. If we found a previous version, insert the
+	// new link right after the [Unreleased] line.
+	if prevVersion != "" {
+		newVersionLink := fmt.Sprintf("[%s]: https://github.com/%s/compare/v%s...v%s", version, repoSlug, prevVersion, version)
+		// Insert after the Unreleased link line.
+		updated = strings.Replace(
+			updated,
+			newUnreleasedLink,
+			newUnreleasedLink+"\n"+newVersionLink,
+			1,
+		)
+	}
+
+	// 7. Write updated CHANGELOG.md.
+	if err := os.WriteFile(changelogPath, []byte(updated), 0o644); err != nil {
+		return fmt.Errorf("writing CHANGELOG.md: %w", err)
+	}
+
+	// 8. Delete processed fragment files (leave .gitkeep).
+	for _, path := range fragmentFiles {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("removing fragment %s: %w", path, err)
+		}
+	}
+
+	fmt.Printf("Released %s (%s) from %d fragment(s)\n", version, dateStr, len(fragmentFiles))
+	return nil
+}

--- a/scripts/changelog/main.go
+++ b/scripts/changelog/main.go
@@ -62,7 +62,7 @@ func run(changelogPath, fragmentsDir, version string, now time.Time) error {
 		return fmt.Errorf("reading changelog.d: %w", err)
 	}
 
-	var fragmentFiles []string
+	fragmentFiles := make([]string, 0, len(entries))
 	for _, e := range entries {
 		if e.IsDir() {
 			continue

--- a/scripts/changelog/main_test.go
+++ b/scripts/changelog/main_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNoFragmentsExitsNonZero verifies that when changelog.d contains only
+// .gitkeep (no real fragment files), run() returns a non-nil error.
+func TestNoFragmentsExitsNonZero(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create changelog.d with only .gitkeep
+	fragmentsDir := filepath.Join(dir, "changelog.d")
+	if err := os.MkdirAll(fragmentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fragmentsDir, ".gitkeep"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a minimal CHANGELOG.md
+	changelog := filepath.Join(dir, "CHANGELOG.md")
+	if err := os.WriteFile(changelog, []byte(minimalChangelog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := run(changelog, fragmentsDir, "0.2.0", time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC))
+	if err == nil {
+		t.Fatal("expected non-nil error when no fragments exist, got nil")
+	}
+}
+
+// TestBasicAssembly verifies that a single fragment with ### Added and one
+// bullet point produces a new versioned section in CHANGELOG.md.
+func TestBasicAssembly(t *testing.T) {
+	dir := t.TempDir()
+
+	fragmentsDir := filepath.Join(dir, "changelog.d")
+	if err := os.MkdirAll(fragmentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write .gitkeep (should be preserved)
+	if err := os.WriteFile(filepath.Join(fragmentsDir, ".gitkeep"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write one fragment
+	fragment := `### Added
+
+- My shiny new feature.
+`
+	if err := os.WriteFile(filepath.Join(fragmentsDir, "add-feature.md"), []byte(fragment), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create CHANGELOG.md with a prior versioned release and comparison links
+	changelog := filepath.Join(dir, "CHANGELOG.md")
+	if err := os.WriteFile(changelog, []byte(minimalChangelog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := run(changelog, fragmentsDir, "0.2.0", time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	contents, err := os.ReadFile(changelog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(contents)
+
+	// New versioned section header must be present
+	if !strings.Contains(got, "## [0.2.0] — 2026-04-19") {
+		t.Errorf("expected '## [0.2.0] — 2026-04-19' in output, got:\n%s", got)
+	}
+
+	// The bullet must appear under Added
+	if !strings.Contains(got, "- My shiny new feature.") {
+		t.Errorf("expected fragment bullet in output, got:\n%s", got)
+	}
+
+	// Fragment file must be deleted
+	if _, err := os.Stat(filepath.Join(fragmentsDir, "add-feature.md")); !os.IsNotExist(err) {
+		t.Errorf("expected fragment file to be deleted after assembly")
+	}
+
+	// .gitkeep must remain
+	if _, err := os.Stat(filepath.Join(fragmentsDir, ".gitkeep")); err != nil {
+		t.Errorf("expected .gitkeep to remain: %v", err)
+	}
+
+	// New comparison links must be present
+	if !strings.Contains(got, "[0.2.0]: https://github.com/devenjarvis/baton/compare/v0.1.0...v0.2.0") {
+		t.Errorf("expected new versioned comparison link, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[Unreleased]: https://github.com/devenjarvis/baton/compare/v0.2.0...HEAD") {
+		t.Errorf("expected updated Unreleased link, got:\n%s", got)
+	}
+}
+
+// minimalChangelog is a CHANGELOG.md that matches the post-Task-3 state:
+// header block, one prior versioned section, and comparison links at the bottom.
+const minimalChangelog = `# Changelog
+
+All notable changes to Baton will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Every PR should update the ` + "`[Unreleased]`" + ` section with a short entry describing the change.
+
+## [0.1.0] — 2026-04-18
+
+Initial public release.
+
+[Unreleased]: https://github.com/devenjarvis/baton/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/devenjarvis/baton/releases/tag/v0.1.0
+`


### PR DESCRIPTION
## Summary

- Replaces the single `[Unreleased]` section in `CHANGELOG.md` (a merge conflict hotspot when multiple agents work in parallel) with a fragment-based system
- Each PR now drops a small `.md` file under `changelog.d/` using standard Keep a Changelog section headers (`### Added`, `### Fixed`, etc.)
- New `scripts/changelog/main.go` CLI assembles fragments into `CHANGELOG.md` at release time: groups entries in canonical section order (Added→Changed→Deprecated→Removed→Fixed→Security), inserts the new versioned section before existing versions, and generates correctly-ordered comparison links
- `CHANGELOG.md` `[Unreleased]` section removed — existing unreleased entries migrated to 16 individual fragment files in `changelog.d/`
- Release workflow gains an "Assemble changelog" step that runs `go run ./scripts/changelog --version $VERSION` before GoReleaser
- `CLAUDE.md` PR convention updated to describe the `changelog.d/` fragment workflow

## Test plan

- [ ] `go test ./scripts/changelog/...` passes
- [ ] `go vet ./scripts/changelog/...` is clean
- [ ] `go run ./scripts/changelog --version 0.2.0` assembles `changelog.d/` into `CHANGELOG.md` with `## [0.2.0]` before `## [0.1.0]`, correct section ordering, and links `[Unreleased]: .../compare/v0.2.0...HEAD`, `[0.2.0]: .../compare/v0.1.0...v0.2.0`, `[0.1.0]: .../releases/tag/v0.1.0`
- [ ] `changelog.d/` is empty after assembly (`.gitkeep` remains)
- [ ] `go run ./scripts/changelog --version X.Y.Z` exits non-zero when no fragments exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)