### PR TITLE
Fix Claude Code reviewer not posting PR reviews in GHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
- Grant `pull-requests: write` permission in the `claude-code-review.yml` workflow
- The action was running and generating a review, but the GitHub API rejected the POST to submit it because `GITHUB_TOKEN` only had `read` permission on pull requests

## Test plan
- Open a new PR and confirm the Claude Code reviewer job runs and posts a review comment