### PR TITLE
Move worktree dir on first-prompt rename to keep session names congruent

### DIFF
--- a/changelog.d/unify-session-naming.md
+++ b/changelog.d/unify-session-naming.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Session name, git branch, and on-disk worktree directory now stay congruent after the first-prompt rename. Previously only the branch and the session's display name were updated to the Haiku-generated slug, while `.baton/worktrees/<random-name>` stayed frozen at the original adjective-noun. When the rename fires, `git worktree move` now relocates the directory to `.baton/worktrees/<slug>` so the dashboard's `Session / Branch / Worktree` line reads a single coherent identity. Best-effort: if the worktree move fails (destination occupied, worktree locked, etc.) the branch rename is kept and the path is left untouched, matching pre-change behavior. Existing sessions with already-divergent names are not migrated.

--- a/internal/agent/detach_resume_test.go
+++ b/internal/agent/detach_resume_test.go
@@ -439,7 +439,7 @@ func TestDetachResumePreservesHasClaudeName(t *testing.T) {
 	}
 
 	// Rename the branch before detaching.
-	if _, err := sess.RenameBranch(repo, "baton/add-feature"); err != nil {
+	if _, err := sess.RenameBranch(repo, "baton/add-feature", ""); err != nil {
 		t.Fatal(err)
 	}
 	if !sess.HasClaudeName() {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -256,6 +256,7 @@ func (m *Manager) applyRename(sess *Session, newBranch string) bool {
 	// EventStatusChanged would reference a session no longer in m.sessions.
 	m.mu.RLock()
 	_, stillOpen := m.sessions[sess.ID]
+	worktreeDir := m.settings.WorktreeDir
 	m.mu.RUnlock()
 	if !stillOpen {
 		return false
@@ -265,7 +266,7 @@ func (m *Manager) applyRename(sess *Session, newBranch string) bool {
 	// will retry. Writing to stderr during an active TUI alt-screen scrambles
 	// the rendered UI, so the error is swallowed here — users see the
 	// unchanged branch label in the preview as the implicit signal.
-	if _, err := sess.RenameBranch(m.repoPath, newBranch); err != nil {
+	if _, err := sess.RenameBranch(m.repoPath, newBranch, worktreeDir); err != nil {
 		return false
 	}
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -359,17 +359,29 @@ func (s *Session) finishRename() {
 	s.renaming = false
 }
 
-// RenameBranch renames the session's git branch to newBranch. If the rename
-// succeeds, Session.Worktree.Branch, Session.Name, and hasClaudeName are
-// updated atomically under the session mutex. The actual new name (which may
-// include a collision suffix from git.RenameBranch) is returned.
+// RenameBranch renames the session's git branch to newBranch and moves the
+// worktree directory to match, so the session's display name, branch, and
+// on-disk worktree path all stay congruent. If the rename succeeds,
+// Session.Worktree.Branch, Session.Worktree.Path, Session.Worktree.Name,
+// Session.Name, each agent's WorktreePath reference, and hasClaudeName are
+// updated atomically under the session mutex. The actual new branch name
+// (which may include a collision suffix from git.RenameBranch) is returned.
+//
+// worktreeDir is the configured worktree directory (e.g. ".baton/worktrees");
+// pass empty string to use the default.
+//
+// The worktree move is best-effort: if `git worktree move` fails (destination
+// occupied by an unrelated dir, locked worktree, etc.) the branch rename is
+// kept and the worktree path is left pointing at the old location, matching
+// pre-change behavior. The caller's hasClaudeName flip still fires so the
+// rename won't be retried on the next prompt.
 //
 // If the session already has a Claude-derived name, this is a no-op and
 // returns the current branch.
 //
-// The session mutex is held across the git subprocess call so concurrent
+// The session mutex is held across the git subprocess calls so concurrent
 // callers observe a consistent view and cannot both attempt a rename.
-func (s *Session) RenameBranch(repoPath, newBranch string) (string, error) {
+func (s *Session) RenameBranch(repoPath, newBranch, worktreeDir string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -383,8 +395,17 @@ func (s *Session) RenameBranch(repoPath, newBranch string) (string, error) {
 	}
 
 	s.Worktree.Branch = actual
-	if last := lastBranchSegment(actual); last != "" {
-		s.Name = last
+	newName := lastBranchSegment(actual)
+	if newName != "" {
+		s.Name = newName
+		// Best-effort: align the on-disk worktree dir with the new branch.
+		// Swallow errors — the branch rename already succeeded, and a failed
+		// move is no worse than today's behavior.
+		if err := git.MoveWorktree(repoPath, s.Worktree, newName, worktreeDir); err == nil {
+			for _, a := range s.agents {
+				a.WorktreePath = s.Worktree.Path
+			}
+		}
 	}
 	s.hasClaudeName = true
 

--- a/internal/agent/session_name_test.go
+++ b/internal/agent/session_name_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/devenjarvis/baton/internal/git"
@@ -62,6 +64,7 @@ func TestSessionRenameBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
+	oldPath := wt.Path
 
 	s := newSession("session-1", "warm-ibis", wt)
 
@@ -69,7 +72,7 @@ func TestSessionRenameBranch(t *testing.T) {
 		t.Error("HasClaudeName() should be false before rename")
 	}
 
-	actual, err := s.RenameBranch(repo, "baton/add-dark-mode")
+	actual, err := s.RenameBranch(repo, "baton/add-dark-mode", "")
 	if err != nil {
 		t.Fatalf("RenameBranch: %v", err)
 	}
@@ -86,8 +89,23 @@ func TestSessionRenameBranch(t *testing.T) {
 		t.Error("HasClaudeName() should be true after rename")
 	}
 
+	// The on-disk worktree directory is moved to match the new branch name so
+	// Session/Branch/Worktree all stay congruent.
+	if got := filepath.Base(s.Worktree.Path); got != "add-dark-mode" {
+		t.Errorf("Worktree.Path basename = %q, want %q", got, "add-dark-mode")
+	}
+	if s.Worktree.Name != "add-dark-mode" {
+		t.Errorf("Worktree.Name = %q, want %q", s.Worktree.Name, "add-dark-mode")
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old worktree path %q should not exist after rename (err=%v)", oldPath, err)
+	}
+	if _, err := os.Stat(s.Worktree.Path); err != nil {
+		t.Errorf("new worktree path %q should exist after rename: %v", s.Worktree.Path, err)
+	}
+
 	// Second rename is a no-op.
-	second, err := s.RenameBranch(repo, "baton/second-attempt")
+	second, err := s.RenameBranch(repo, "baton/second-attempt", "")
 	if err != nil {
 		t.Fatalf("second RenameBranch: %v", err)
 	}
@@ -96,6 +114,48 @@ func TestSessionRenameBranch(t *testing.T) {
 	}
 	if s.Name != "add-dark-mode" {
 		t.Errorf("second rename should not change Name, got %q", s.Name)
+	}
+}
+
+// TestSessionRenameBranch_WorktreeCollision verifies that when the target
+// worktree directory is already occupied on disk, Session.RenameBranch still
+// relocates the worktree — falling back to a "-2" suffix — so the session
+// name, branch, and on-disk directory remain congruent.
+func TestSessionRenameBranch_WorktreeCollision(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	wt, err := git.CreateWorktree(repo, "warm-ibis", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	oldPath := wt.Path
+
+	// Occupy the primary destination with a non-empty unrelated directory.
+	blockerPath := filepath.Join(repo, ".baton", "worktrees", "add-dark-mode")
+	if err := os.MkdirAll(blockerPath, 0o755); err != nil {
+		t.Fatalf("mkdir blocker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blockerPath, "sentinel"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	s := newSession("session-1", "warm-ibis", wt)
+
+	actual, err := s.RenameBranch(repo, "baton/add-dark-mode", "")
+	if err != nil {
+		t.Fatalf("RenameBranch: %v", err)
+	}
+	if actual != "baton/add-dark-mode" {
+		t.Errorf("branch rename should still succeed, got %q", actual)
+	}
+	if !s.HasClaudeName() {
+		t.Error("HasClaudeName should be true after rename")
+	}
+	if filepath.Base(s.Worktree.Path) != "add-dark-mode-2" {
+		t.Errorf("worktree path basename = %q, want %q", filepath.Base(s.Worktree.Path), "add-dark-mode-2")
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old worktree path %q should be gone (err=%v)", oldPath, err)
 	}
 }
 
@@ -112,7 +172,7 @@ func TestSessionRenameBranch_FailureLeavesStateUnchanged(t *testing.T) {
 
 	// Pin git config so rename would otherwise succeed, then sabotage via an
 	// empty target which RenameBranch rejects without touching state.
-	_, err = s.RenameBranch(repo, "")
+	_, err = s.RenameBranch(repo, "", "")
 	if err == nil {
 		t.Fatal("expected error for empty target")
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -653,6 +653,99 @@ func TestRenameBranch_Idempotent(t *testing.T) {
 	}
 }
 
+func TestMoveWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+
+	wt, err := git.CreateWorktree(repo, "warm-ibis", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	oldPath := wt.Path
+
+	// Seed a file inside the worktree so we can confirm it made the trip.
+	sentinel := filepath.Join(oldPath, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	if err := git.MoveWorktree(repo, wt, "add-dark-mode", ""); err != nil {
+		t.Fatalf("MoveWorktree: %v", err)
+	}
+
+	if wt.Name != "add-dark-mode" {
+		t.Errorf("wt.Name = %q, want %q", wt.Name, "add-dark-mode")
+	}
+	if filepath.Base(wt.Path) != "add-dark-mode" {
+		t.Errorf("wt.Path basename = %q, want %q", filepath.Base(wt.Path), "add-dark-mode")
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old path %q should be gone (err=%v)", oldPath, err)
+	}
+	if _, err := os.Stat(filepath.Join(wt.Path, "sentinel.txt")); err != nil {
+		t.Errorf("sentinel file should exist at new path: %v", err)
+	}
+
+	// Git admin metadata should still recognise the worktree — running any
+	// git command from inside it confirms the gitdir file was updated.
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = wt.Path
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse in moved worktree: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), filepath.Base(wt.Path)) {
+		t.Errorf("git rev-parse should return new path, got %q", string(out))
+	}
+}
+
+func TestMoveWorktree_NoOpWhenAlreadyNamed(t *testing.T) {
+	repo := initTestRepo(t)
+
+	wt, err := git.CreateWorktree(repo, "already-named", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	origPath := wt.Path
+
+	if err := git.MoveWorktree(repo, wt, "already-named", ""); err != nil {
+		t.Fatalf("MoveWorktree no-op: %v", err)
+	}
+	if wt.Path != origPath {
+		t.Errorf("wt.Path changed on no-op move: got %q, want %q", wt.Path, origPath)
+	}
+}
+
+func TestMoveWorktree_CollisionFallback(t *testing.T) {
+	repo := initTestRepo(t)
+
+	wt, err := git.CreateWorktree(repo, "warm-ibis", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	// Occupy the primary destination with an unrelated directory. Git
+	// worktree move silently succeeds into an empty dir, so populate it
+	// with a file to force a real collision that triggers the "-2"
+	// fallback path.
+	blocker := filepath.Join(repo, ".baton", "worktrees", "add-dark-mode")
+	if err := os.MkdirAll(blocker, 0o755); err != nil {
+		t.Fatalf("mkdir blocker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blocker, "sentinel"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker sentinel: %v", err)
+	}
+
+	if err := git.MoveWorktree(repo, wt, "add-dark-mode", ""); err != nil {
+		t.Fatalf("MoveWorktree with collision: %v", err)
+	}
+	if wt.Name != "add-dark-mode-2" {
+		t.Errorf("wt.Name = %q, want %q", wt.Name, "add-dark-mode-2")
+	}
+	if filepath.Base(wt.Path) != "add-dark-mode-2" {
+		t.Errorf("wt.Path basename = %q, want %q", filepath.Base(wt.Path), "add-dark-mode-2")
+	}
+}
+
 func TestCreateWorktreeWithStartPoint(t *testing.T) {
 	work, bare := initTestRepoWithRemote(t)
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -329,3 +329,58 @@ func isBranchCollisionErr(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "already exists") || strings.Contains(msg, "already used")
 }
+
+// MoveWorktree renames wt's on-disk directory to <worktreeDir>/<newName> under
+// repoPath via `git worktree move`. Git updates the admin `gitdir` file so the
+// worktree remains valid, and processes cwd'd inside keep working via inode
+// (their PWD env may go stale — cosmetic only; getcwd() resolves to the new
+// path). On success, wt.Path and wt.Name are updated in place.
+//
+// If the destination directory already exists (orphaned worktree, unrelated
+// dir), the function retries with "-2", "-3", ... suffixes up to "-9" before
+// giving up. Non-collision errors (source missing, locked worktree, git
+// refuses) are returned immediately without retrying.
+//
+// No-op when the current basename already equals newName.
+func MoveWorktree(repoPath string, wt *WorktreeInfo, newName, worktreeDir string) error {
+	if wt == nil {
+		return fmt.Errorf("worktree is nil")
+	}
+	if newName == "" {
+		return fmt.Errorf("new worktree name is empty")
+	}
+	if worktreeDir == "" {
+		worktreeDir = ".baton/worktrees"
+	}
+	if filepath.Base(wt.Path) == newName {
+		return nil
+	}
+
+	// Pre-check the destination filesystem slot. Some versions of
+	// `git worktree move` silently nest the source into a pre-existing
+	// directory rather than erroring, so we can't rely on git's exit status
+	// to detect collisions. Stepping through candidates until we find an
+	// empty slot gives uniform behavior across git versions.
+	candidate := newName
+	absNewPath := ""
+	for i := 1; i <= 9; i++ {
+		absNewPath = filepath.Join(repoPath, worktreeDir, candidate)
+		if abs, err := filepath.Abs(absNewPath); err == nil {
+			absNewPath = abs
+		}
+		if _, err := os.Stat(absNewPath); os.IsNotExist(err) {
+			break
+		}
+		if i == 9 {
+			return fmt.Errorf("move worktree %q: all destinations up to %q are taken", wt.Path, absNewPath)
+		}
+		candidate = fmt.Sprintf("%s-%d", newName, i+1)
+	}
+
+	if _, err := runGit(repoPath, "worktree", "move", wt.Path, absNewPath); err != nil {
+		return fmt.Errorf("move worktree %q -> %q: %w", wt.Path, absNewPath, err)
+	}
+	wt.Path = absNewPath
+	wt.Name = candidate
+	return nil
+}


### PR DESCRIPTION
When the Haiku-generated branch rename fires on the first user prompt, also
move the on-disk worktree via `git worktree move` so `.baton/worktrees/<slug>`
matches the new branch and display name. With many sessions open, the
dashboard's Session / Branch / Worktree line now reads as one coherent
identity instead of documenting three diverging names.

Best-effort: if the worktree move fails the branch rename is kept and the
path stays at its old location. Pre-existing divergent sessions are left
alone; only new renames from this release forward get the aligned layout.