### PR TITLE
Add per-repo alias and configurable sidebar width

### DIFF
--- a/changelog.d/add-repo-alias-and-sidebar-width.md
+++ b/changelog.d/add-repo-alias-and-sidebar-width.md
@@ -1,0 +1,8 @@
+### Added
+
+- Per-repo `Alias` override so long repo names (e.g. ones sharing a long common prefix) can be rendered as a short nickname in the dashboard sidebar. Set it from the repo config form ("Alias"); leave blank to keep using the registered name.
+- Global `SidebarWidth` setting (default 30, clamped to 20..60) to widen or narrow the dashboard's left panel. Set it from the global config form ("Sidebar Width").
+
+### Fixed
+
+- Dashboard repo/session/agent name truncation now uses display-width (ANSI/UTF-8 aware) instead of byte length, so multi-byte names no longer get cut mid-rune.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,17 @@ import (
 type Repo struct {
 	Path    string    `json:"path"`
 	Name    string    `json:"name"`
+	Alias   string    `json:"alias,omitempty"`
 	AddedAt time.Time `json:"added_at"`
+}
+
+// DisplayName returns Alias when set, otherwise Name. Callers that render
+// repos in the UI should prefer this over Name directly.
+func (r Repo) DisplayName() string {
+	if r.Alias != "" {
+		return r.Alias
+	}
+	return r.Name
 }
 
 // Config is the top-level config structure persisted to disk.
@@ -186,6 +196,27 @@ func AddRepo(cfg *Config, path string) error {
 		AddedAt: time.Now(),
 	})
 	return nil
+}
+
+// SetRepoAlias updates the Alias on the registered repo matching path and
+// persists the registry. An empty alias clears the override. Returns an error
+// if the repo is not registered.
+func SetRepoAlias(path, alias string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("config: resolving path %q: %w", path, err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		return err
+	}
+	for i, r := range cfg.Repos {
+		if r.Path == absPath {
+			cfg.Repos[i].Alias = alias
+			return Save(cfg)
+		}
+	}
+	return fmt.Errorf("config: repo %q is not registered", absPath)
 }
 
 // RemoveRepo removes the repo with the given path (resolved to absolute) from

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -313,3 +313,74 @@ func TestGetBypassPermissions_NilPointer_ReturnsTrue(t *testing.T) {
 		t.Error("GetBypassPermissions() should return true when BypassPermissions is nil")
 	}
 }
+
+// ---- Repo.DisplayName ----
+
+func TestRepo_DisplayName_NoAlias(t *testing.T) {
+	r := config.Repo{Name: "my-company-super-long-repo-name", Path: "/x"}
+	if got := r.DisplayName(); got != r.Name {
+		t.Errorf("DisplayName() = %q, want %q", got, r.Name)
+	}
+}
+
+func TestRepo_DisplayName_AliasWins(t *testing.T) {
+	r := config.Repo{Name: "my-company-super-long-repo-name", Alias: "svc", Path: "/x"}
+	if got := r.DisplayName(); got != "svc" {
+		t.Errorf("DisplayName() = %q, want %q", got, "svc")
+	}
+}
+
+// ---- SetRepoAlias ----
+
+func TestSetRepoAlias_PersistsAndRoundTrips(t *testing.T) {
+	configDirInTmp(t)
+	repoPath := initTestRepo(t)
+
+	cfg := &config.Config{}
+	if err := config.AddRepo(cfg, repoPath); err != nil {
+		t.Fatalf("AddRepo() error = %v", err)
+	}
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	if err := config.SetRepoAlias(repoPath, "svc"); err != nil {
+		t.Fatalf("SetRepoAlias() error = %v", err)
+	}
+
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Repos) != 1 {
+		t.Fatalf("got %d repos, want 1", len(loaded.Repos))
+	}
+	if loaded.Repos[0].Alias != "svc" {
+		t.Errorf("Alias = %q, want %q", loaded.Repos[0].Alias, "svc")
+	}
+	if got := loaded.Repos[0].DisplayName(); got != "svc" {
+		t.Errorf("DisplayName() after reload = %q, want %q", got, "svc")
+	}
+
+	// Clearing should revert DisplayName to Name.
+	if err := config.SetRepoAlias(repoPath, ""); err != nil {
+		t.Fatalf("SetRepoAlias(\"\") error = %v", err)
+	}
+	loaded, err = config.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded.Repos[0].Alias != "" {
+		t.Errorf("Alias = %q, want empty after clear", loaded.Repos[0].Alias)
+	}
+	if got := loaded.Repos[0].DisplayName(); got != loaded.Repos[0].Name {
+		t.Errorf("DisplayName() after clear = %q, want %q", got, loaded.Repos[0].Name)
+	}
+}
+
+func TestSetRepoAlias_UnregisteredReturnsError(t *testing.T) {
+	configDirInTmp(t)
+	if err := config.SetRepoAlias(t.TempDir(), "x"); err == nil {
+		t.Error("SetRepoAlias() expected error for unregistered repo, got nil")
+	}
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -16,7 +16,21 @@ const (
 	DefaultBranchPrefix      = "baton/"
 	DefaultAgentProgram      = "claude"
 	DefaultWorktreeDir       = ".baton/worktrees"
+	DefaultSidebarWidth      = 30
+	MinSidebarWidth          = 20
+	MaxSidebarWidth          = 60
 )
+
+// ClampSidebarWidth returns w constrained to [MinSidebarWidth, MaxSidebarWidth].
+func ClampSidebarWidth(w int) int {
+	if w < MinSidebarWidth {
+		return MinSidebarWidth
+	}
+	if w > MaxSidebarWidth {
+		return MaxSidebarWidth
+	}
+	return w
+}
 
 // GlobalSettings holds user-wide settings stored at ~/.baton/config.json.
 // All fields are pointers so nil means "not set, use default."
@@ -28,6 +42,7 @@ type GlobalSettings struct {
 	BranchPrefix      *string `json:"branch_prefix,omitempty"`
 	AgentProgram      *string `json:"agent_program,omitempty"`
 	IDECommand        *string `json:"ide_command,omitempty"`
+	SidebarWidth      *int    `json:"sidebar_width,omitempty"`
 }
 
 // RepoSettings holds per-repo overrides stored at <repo>/.baton/config.json.
@@ -53,6 +68,7 @@ type ResolvedSettings struct {
 	AgentProgram      string
 	IDECommand        string
 	WorktreeDir       string
+	SidebarWidth      int
 }
 
 // Resolve merges global and repo settings over built-in defaults.
@@ -65,6 +81,7 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		BranchPrefix:      DefaultBranchPrefix,
 		AgentProgram:      DefaultAgentProgram,
 		WorktreeDir:       DefaultWorktreeDir,
+		SidebarWidth:      DefaultSidebarWidth,
 	}
 
 	if global != nil {
@@ -88,6 +105,9 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		}
 		if global.IDECommand != nil {
 			r.IDECommand = *global.IDECommand
+		}
+		if global.SidebarWidth != nil {
+			r.SidebarWidth = ClampSidebarWidth(*global.SidebarWidth)
 		}
 	}
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -11,6 +11,7 @@ import (
 
 func boolPtr(v bool) *bool    { return &v }
 func strPtr(v string) *string { return &v }
+func intPtr(v int) *int       { return &v }
 
 // ---- Resolve ----
 
@@ -428,5 +429,51 @@ func TestLoad_MigratesFromLegacyXDGPath(t *testing.T) {
 	oldPath := filepath.Join(oldDir, "repos.json")
 	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
 		t.Errorf("old path %s should be removed after migration", oldPath)
+	}
+}
+
+// ---- SidebarWidth ----
+
+func TestResolve_SidebarWidth_Default(t *testing.T) {
+	r := config.Resolve(nil, nil)
+	if r.SidebarWidth != config.DefaultSidebarWidth {
+		t.Errorf("SidebarWidth = %d, want %d", r.SidebarWidth, config.DefaultSidebarWidth)
+	}
+}
+
+func TestResolve_SidebarWidth_GlobalOverride(t *testing.T) {
+	r := config.Resolve(&config.GlobalSettings{SidebarWidth: intPtr(42)}, nil)
+	if r.SidebarWidth != 42 {
+		t.Errorf("SidebarWidth = %d, want 42", r.SidebarWidth)
+	}
+}
+
+func TestResolve_SidebarWidth_ClampedOnLoad(t *testing.T) {
+	cases := []struct {
+		in, want int
+	}{
+		{0, config.MinSidebarWidth},
+		{5, config.MinSidebarWidth},
+		{config.MinSidebarWidth, config.MinSidebarWidth},
+		{config.MaxSidebarWidth, config.MaxSidebarWidth},
+		{999, config.MaxSidebarWidth},
+	}
+	for _, c := range cases {
+		r := config.Resolve(&config.GlobalSettings{SidebarWidth: intPtr(c.in)}, nil)
+		if r.SidebarWidth != c.want {
+			t.Errorf("Resolve(SidebarWidth=%d).SidebarWidth = %d, want %d", c.in, r.SidebarWidth, c.want)
+		}
+	}
+}
+
+func TestClampSidebarWidth(t *testing.T) {
+	if got := config.ClampSidebarWidth(10); got != config.MinSidebarWidth {
+		t.Errorf("ClampSidebarWidth(10) = %d, want %d", got, config.MinSidebarWidth)
+	}
+	if got := config.ClampSidebarWidth(100); got != config.MaxSidebarWidth {
+		t.Errorf("ClampSidebarWidth(100) = %d, want %d", got, config.MaxSidebarWidth)
+	}
+	if got := config.ClampSidebarWidth(35); got != 35 {
+		t.Errorf("ClampSidebarWidth(35) = %d, want 35", got)
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -216,6 +216,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.globalSettings = globalSettings
 			_ = config.MigrateBypassPermissions(a.cfg)
 		}
+		a.dashboard.sidebarWidth = config.Resolve(a.globalSettings, nil).SidebarWidth
 
 		// Load per-repo settings and build resolved cache.
 		for _, repo := range msg.cfg.Repos {
@@ -580,6 +581,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Repo config form saved.
 		if a.dashboard.repoConfigForm != nil && a.dashboard.configRepoPath != "" {
 			repoPath := a.dashboard.configRepoPath
+			alias := strings.TrimSpace(a.dashboard.repoConfigForm.textValue("Alias"))
 			settings := a.extractRepoSettings()
 			if err := config.SaveRepoSettings(repoPath, settings); err != nil {
 				a.setError(err.Error())
@@ -588,6 +590,16 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.resolvedCache[repoPath] = config.Resolve(a.globalSettings, settings)
 				if mgr := a.managers[repoPath]; mgr != nil {
 					mgr.UpdateSettings(a.resolvedCache[repoPath])
+				}
+			}
+			for i, r := range a.cfg.Repos {
+				if r.Path == repoPath && r.Alias != alias {
+					a.cfg.Repos[i].Alias = alias
+					if err := config.Save(a.cfg); err != nil {
+						a.setError(err.Error())
+					}
+					a.refreshAgentList()
+					break
 				}
 			}
 		}
@@ -1141,9 +1153,17 @@ func (a *App) initRepoConfigForm(repoPath string) {
 	if rs.WorktreeDir != nil {
 		worktreeDir = *rs.WorktreeDir
 	}
+	alias := ""
+	for _, r := range a.cfg.Repos {
+		if r.Path == repoPath {
+			alias = r.Alias
+			break
+		}
+	}
 
 	inputWidth := 30
 	var fields []formField
+	fields = addTextInput(fields, "Alias", alias, "short nickname", inputWidth)
 	fields = addToggle(fields, "Bypass Permissions", bypassPerms)
 	fields = addTextInput(fields, "Default Branch", defaultBranch, "auto-detect", inputWidth)
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
@@ -1202,6 +1222,11 @@ func (a App) updateGlobalConfig(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if mgr := a.managers[repoPath]; mgr != nil {
 				mgr.UpdateSettings(a.resolvedCache[repoPath])
 			}
+		}
+		newSidebarWidth := config.Resolve(a.globalSettings, nil).SidebarWidth
+		if newSidebarWidth != a.dashboard.sidebarWidth {
+			a.dashboard.sidebarWidth = newSidebarWidth
+			a.resizeAllForDashboard()
 		}
 		a.view = ViewDashboard
 		return a, nil
@@ -1339,7 +1364,7 @@ func (a *App) refreshAgentList() {
 		items = append(items, listItem{
 			kind:     listItemRepo,
 			repoPath: repo.Path,
-			repoName: repo.Name,
+			repoName: repo.DisplayName(),
 		})
 		mgr := a.managers[repo.Path]
 		if mgr != nil {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -10,10 +10,25 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	xvt "github.com/charmbracelet/x/vt"
 	"github.com/devenjarvis/baton/internal/agent"
+	"github.com/devenjarvis/baton/internal/config"
 	"github.com/devenjarvis/baton/internal/github"
 )
+
+// truncateVisible returns s truncated to n display cells with an ellipsis.
+// ANSI-aware; avoids the naive byte-slice truncation that can cut multi-byte
+// runes in half or miscount ANSI escape sequences.
+func truncateVisible(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if ansi.StringWidth(s) <= n {
+		return s
+	}
+	return ansi.Truncate(s, n, "…")
+}
 
 // ColorWaiting is the accent used for agents in StatusWaiting (permission
 // prompts, input blocks). Scoped to the dashboard because no other view
@@ -63,6 +78,7 @@ type dashboardModel struct {
 	selected        int
 	width           int
 	height          int
+	sidebarWidth    int // resolved global SidebarWidth; 0 means use DefaultSidebarWidth
 	panelFocus      panelFocus
 	scrollOffset    int
 	diffStats       *diffSummaryData           // nil when no session selected or no data
@@ -183,12 +199,23 @@ func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 	return d, nil
 }
 
+// listWidth returns the configured sidebar width, falling back to the default
+// when sidebarWidth has not yet been plumbed in. Both View() and
+// fixedTermWidth() must return the same value on any given frame, otherwise
+// the sidebar and the agent VT will disagree about column counts.
+func (d dashboardModel) listWidth() int {
+	if d.sidebarWidth > 0 {
+		return d.sidebarWidth
+	}
+	return config.DefaultSidebarWidth
+}
+
 func (d dashboardModel) View() string {
 	if len(d.items) == 0 {
 		return d.emptyView()
 	}
 
-	listWidth := 30
+	listWidth := d.listWidth()
 	previewWidth := d.previewTermWidth()
 
 	list := d.renderList(listWidth)
@@ -235,8 +262,7 @@ func (d dashboardModel) contentHeight() int {
 // This is always the focusTerminal width (deducting the border) regardless of
 // the current panelFocus, so that focus switches never trigger a resize.
 func (d dashboardModel) fixedTermWidth() int {
-	listWidth := 30
-	return d.width - listWidth - 1 - 2 // list border + focusTerminal border
+	return d.width - d.listWidth() - 1 - 2 // list border + focusTerminal border
 }
 
 // fixedTermHeight returns the terminal row count that all agents should use.
@@ -304,11 +330,7 @@ func (d dashboardModel) renderList(width int) string {
 		switch item.kind {
 		case listItemRepo:
 			// Repo header row.
-			name := item.repoName
-			maxLen := width - 4
-			if len(name) > maxLen {
-				name = name[:maxLen-1] + "…"
-			}
+			name := truncateVisible(item.repoName, width-4)
 			var repoStyle lipgloss.Style
 			if isSelected {
 				repoStyle = lipgloss.NewStyle().Foreground(ColorText).Bold(true)
@@ -377,9 +399,7 @@ func (d dashboardModel) renderList(width int) string {
 			if maxNameLen < 5 {
 				maxNameLen = 5
 			}
-			if len(displayName) > maxNameLen {
-				displayName = displayName[:maxNameLen-1] + "…"
-			}
+			displayName = truncateVisible(displayName, maxNameLen)
 
 			nameStyle := lipgloss.NewStyle()
 			if closing {
@@ -390,7 +410,7 @@ func (d dashboardModel) renderList(width int) string {
 				label += StyleSubtle.Render(closingTag)
 			}
 			label += " "
-			labelLen := len(symbol) + 1 + len(displayName) + 2 + prSuffixLen + closingTagLen
+			labelLen := ansi.StringWidth(symbol) + 1 + ansi.StringWidth(displayName) + 2 + prSuffixLen + closingTagLen
 			padLen := width - 4 - labelLen
 			if padLen < 0 {
 				padLen = 0
@@ -460,10 +480,7 @@ func (d dashboardModel) renderList(width int) string {
 			if nameWidth < 1 {
 				nameWidth = 1
 			}
-			name := ag.GetDisplayName()
-			if len(name) > nameWidth {
-				name = name[:nameWidth-1] + "…"
-			}
+			name := truncateVisible(ag.GetDisplayName(), nameWidth)
 
 			agentPrefix := "      "
 			if isSelected {
@@ -478,7 +495,7 @@ func (d dashboardModel) renderList(width int) string {
 			if closing {
 				nameRendered = StyleSubtle.Render(name)
 			}
-			padName := nameWidth - len(name)
+			padName := nameWidth - ansi.StringWidth(name)
 			if padName < 0 {
 				padName = 0
 			}

--- a/internal/tui/globalconfig.go
+++ b/internal/tui/globalconfig.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"strconv"
+
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/baton/internal/config"
@@ -55,6 +57,10 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	if gs.IDECommand != nil {
 		ideCommand = *gs.IDECommand
 	}
+	sidebarWidth := ""
+	if gs.SidebarWidth != nil {
+		sidebarWidth = strconv.Itoa(*gs.SidebarWidth)
+	}
 
 	inputWidth := 30
 
@@ -66,6 +72,7 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
 	fields = addEditorFields(fields, ideCommand, inputWidth)
+	fields = addTextInput(fields, "Sidebar Width", sidebarWidth, strconv.Itoa(config.DefaultSidebarWidth), inputWidth)
 
 	return globalConfigModel{
 		form:   newConfigForm(fields, width),
@@ -134,6 +141,12 @@ func (m globalConfigModel) extractSettings() *config.GlobalSettings {
 	}
 	if v := extractIDECommand(m.form); v != "" {
 		s.IDECommand = &v
+	}
+	if v := m.form.textValue("Sidebar Width"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			clamped := config.ClampSidebarWidth(n)
+			s.SidebarWidth = &clamped
+		}
 	}
 
 	return s


### PR DESCRIPTION
Long repo names that share a common prefix were truncated to indistinguishable strings in the dashboard sidebar. Users can now set a per-repo Alias in the repo config form and a global SidebarWidth in the global config form. Dashboard truncation is now display-width aware (ansi.Truncate) so multi-byte names no longer get cut mid-rune.

https://claude.ai/code/session_018v5fDdhap6k4tGjy7nZLuu