### PR TITLE
Fix PR tracking disappearance and delays

### DIFF
--- a/changelog.d/fix-pr-tracking.md
+++ b/changelog.d/fix-pr-tracking.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- PR tracking is now robust across branch renames, closed/merged PRs, and transient GitHub API failures. The session PR panel now appears reliably within ~2s after a push, even when the PR was opened while the smart-branch-name Haiku rename was still in flight.
+
+### Changed
+
+- GitHub PR lookups now resolve by commit SHA first (with branch-name fallback), so a `git branch -m` or async rename no longer hides an open PR.
+- The GitHub client retries transient 5xx and rate-limit responses (max 2 retries with server-honored `Retry-After`); transient failures no longer blank the PR panel.
+- The PR poller arms a 60s burst of 2s-interval polls after any branch rename or remote-SHA change — force-pushes and new commits on branches with an open PR now refresh promptly instead of waiting the full 30s adaptive interval.
+- Closed or merged PRs are cleared from the panel on the next successful poll; they previously lingered forever because of a cache-update gate.
+- The PR checks panel in the left sidebar now reserves a minimum height even when the agent list is long, truncating the list with a "+N more" marker so the panel remains visible.

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -1224,3 +1224,65 @@ func TestSmartBranchRename_ShutdownCancelsInflight(t *testing.T) {
 		t.Fatal("Shutdown did not return — rename goroutine likely leaked")
 	}
 }
+
+// TestSmartBranchRename_EmitsBranchRenamedEvent asserts that a successful
+// rename via applyRename emits an EventBranchRenamed carrying the new branch
+// name. The TUI scheduler uses this event to burst-refresh PR state and
+// recover from the rename/PR race.
+func TestSmartBranchRename_EmitsBranchRenamedEvent(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, smartBranchTestSettings())
+	defer mgr.Shutdown()
+
+	stub := &stubNamer{result: "add-dark-mode"}
+	mgr.SetBranchNamer(stub.fn())
+
+	cfg := Config{Name: "rename-event", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drain EventCreated.
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	original := sess.Branch()
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "add dark mode to dashboard",
+	}); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+
+	got := waitForBranchChanged(t, sess, original, 2*time.Second)
+	if got != "baton/add-dark-mode" {
+		t.Fatalf("branch = %q, want baton/add-dark-mode", got)
+	}
+
+	// Drain events until we see EventBranchRenamed. Other events
+	// (EventStatusChanged, etc.) may interleave; skip them.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-mgr.Events():
+			if ev.Type == EventBranchRenamed {
+				if ev.SessionID != sess.ID {
+					t.Errorf("SessionID = %q, want %q", ev.SessionID, sess.ID)
+				}
+				if ev.Branch != got {
+					t.Errorf("Branch = %q, want %q", ev.Branch, got)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("did not receive EventBranchRenamed within 2s")
+		}
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -28,6 +28,11 @@ const (
 	EventDone
 	EventError
 	EventSessionClosed
+	// EventBranchRenamed fires after a session's branch has been renamed
+	// (e.g. by the smart-branch-name Haiku flow). Consumers should refresh
+	// any state keyed by branch name — notably PR lookups — since GitHub
+	// may still have the PR indexed under the old name until the next push.
+	EventBranchRenamed
 )
 
 // Event represents something that happened to an agent.
@@ -36,6 +41,9 @@ type Event struct {
 	AgentID   string
 	SessionID string
 	Status    Status
+	// Branch is populated only for EventBranchRenamed and carries the new
+	// branch name. Zero-value for all other event types.
+	Branch string
 }
 
 // Manager manages the lifecycle of all sessions and their agents.
@@ -278,6 +286,11 @@ func (m *Manager) applyRename(sess *Session, newBranch string) bool {
 			Status:    lead.Status(),
 		})
 	}
+	m.emit(Event{
+		Type:      EventBranchRenamed,
+		SessionID: sess.ID,
+		Branch:    newBranch,
+	})
 	return true
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -2,7 +2,11 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
 	"time"
 
 	gh "github.com/google/go-github/v69/github"
@@ -11,6 +15,9 @@ import (
 // Client wraps the GitHub API client with methods for PR and check operations.
 type Client struct {
 	gh *gh.Client
+	// sleep is injected for testability. Defaults to time.After-based sleep
+	// that honors ctx cancellation.
+	sleep func(ctx context.Context, d time.Duration) error
 }
 
 // NewClient creates a new GitHub API client using a token from GetToken().
@@ -21,18 +28,134 @@ func NewClient() (*Client, error) {
 	}
 
 	client := gh.NewClient(nil).WithAuthToken(token)
-	return &Client{gh: client}, nil
+	return &Client{gh: client, sleep: ctxSleep}, nil
+}
+
+// ctxSleep blocks for d or until ctx is cancelled, whichever is first.
+func ctxSleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// retry budget: 1 initial attempt + up to 2 retries.
+var defaultRetryBackoffs = []time.Duration{500 * time.Millisecond, 2 * time.Second}
+
+// maxRetryWait caps server-suggested Retry-After values so an egregious
+// Retry-After header can't hang a poll for minutes.
+const maxRetryWait = 30 * time.Second
+
+// doWithRetry invokes op, retrying on 5xx, 429, and typed rate-limit errors.
+// It honors Retry-After for 429 responses and the typed errors' hints,
+// applies a small jitter to backoff, and respects ctx cancellation.
+// 4xx (other than 429) and 422 are not retried.
+func (c *Client) doWithRetry(ctx context.Context, op func() (*gh.Response, error)) error {
+	var lastErr error
+	for attempt := 0; attempt <= len(defaultRetryBackoffs); attempt++ {
+		resp, err := op()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		retriable, wait := classifyRetry(resp, err)
+		if !retriable || attempt == len(defaultRetryBackoffs) {
+			return err
+		}
+
+		if wait == 0 {
+			wait = defaultRetryBackoffs[attempt]
+		}
+		// ±100ms jitter (bounded to wait).
+		jitter := time.Duration(rand.Int64N(int64(200*time.Millisecond))) - 100*time.Millisecond
+		wait += jitter
+		if wait < 0 {
+			wait = 0
+		}
+		if wait > maxRetryWait {
+			wait = maxRetryWait
+		}
+		if err := c.sleep(ctx, wait); err != nil {
+			return err
+		}
+	}
+	return lastErr
+}
+
+// classifyRetry returns whether the error is retriable and an optional
+// server-suggested wait duration.
+func classifyRetry(resp *gh.Response, err error) (retriable bool, wait time.Duration) {
+	var rate *gh.RateLimitError
+	if errors.As(err, &rate) {
+		if !rate.Rate.Reset.IsZero() {
+			wait = time.Until(rate.Rate.Reset.Time)
+			if wait < 0 {
+				wait = 0
+			}
+		}
+		return true, wait
+	}
+	var abuse *gh.AbuseRateLimitError
+	if errors.As(err, &abuse) {
+		if abuse.RetryAfter != nil {
+			wait = *abuse.RetryAfter
+		}
+		return true, wait
+	}
+	if resp == nil || resp.Response == nil {
+		// Transport-level failure (no HTTP response) — retry once.
+		return true, 0
+	}
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests:
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, perr := strconv.Atoi(ra); perr == nil {
+				wait = time.Duration(secs) * time.Second
+			}
+		}
+		return true, wait
+	case http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true, 0
+	}
+	return false, 0
+}
+
+// isNotFoundOrUnprocessable returns true for 404/422 responses — used by
+// SHA-based PR lookup to treat a pre-push SHA as "no PR", not an error.
+func isNotFoundOrUnprocessable(resp *gh.Response) bool {
+	if resp == nil || resp.Response == nil {
+		return false
+	}
+	return resp.StatusCode == http.StatusNotFound ||
+		resp.StatusCode == http.StatusUnprocessableEntity
 }
 
 // GetPR finds an open pull request for the given head branch.
 // Returns nil (not an error) if no open PR exists for the branch.
 func (c *Client) GetPR(ctx context.Context, owner, repo, branch string) (*PRState, error) {
-	prs, _, err := c.gh.PullRequests.List(ctx, owner, repo, &gh.PullRequestListOptions{
-		Head:  owner + ":" + branch,
-		State: "open",
-		ListOptions: gh.ListOptions{
-			PerPage: 1,
-		},
+	var prs []*gh.PullRequest
+	err := c.doWithRetry(ctx, func() (*gh.Response, error) {
+		var resp *gh.Response
+		var err error
+		prs, resp, err = c.gh.PullRequests.List(ctx, owner, repo, &gh.PullRequestListOptions{
+			Head:  owner + ":" + branch,
+			State: "open",
+			ListOptions: gh.ListOptions{
+				PerPage: 1,
+			},
+		})
+		return resp, err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing PRs: %w", err)
@@ -45,13 +168,74 @@ func (c *Client) GetPR(ctx context.Context, owner, repo, branch string) (*PRStat
 	return prToState(prs[0]), nil
 }
 
+// GetPRBySHA finds the PR associated with a commit SHA. This is invariant to
+// branch renames: after a local `git branch -m`, the commit's association with
+// its PR on GitHub is preserved, so SHA lookup still finds it.
+//
+// Semantics:
+//   - fork PRs (head repo != owner/repo) are filtered out.
+//   - prefers open PRs; if none are open, returns the most recent (closed/merged).
+//   - 404/422 (commit not yet pushed to GitHub) return (nil, nil), not an error.
+func (c *Client) GetPRBySHA(ctx context.Context, owner, repo, sha string) (*PRState, error) {
+	if sha == "" {
+		return nil, nil
+	}
+	var prs []*gh.PullRequest
+	var finalResp *gh.Response
+	err := c.doWithRetry(ctx, func() (*gh.Response, error) {
+		var resp *gh.Response
+		var err error
+		prs, resp, err = c.gh.PullRequests.ListPullRequestsWithCommit(ctx, owner, repo, sha, &gh.ListOptions{
+			PerPage: 10,
+		})
+		finalResp = resp
+		return resp, err
+	})
+	if err != nil {
+		if isNotFoundOrUnprocessable(finalResp) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing PRs for commit: %w", err)
+	}
+
+	headRepo := owner + "/" + repo
+	var openPR *gh.PullRequest
+	var mostRecent *gh.PullRequest
+	for _, pr := range prs {
+		// Drop PRs whose head is in a fork repo sharing the SHA.
+		if pr.GetHead().GetRepo().GetFullName() != headRepo {
+			continue
+		}
+		if openPR == nil && pr.GetState() == "open" {
+			openPR = pr
+		}
+		if mostRecent == nil ||
+			pr.GetUpdatedAt().After(mostRecent.GetUpdatedAt().Time) {
+			mostRecent = pr
+		}
+	}
+	if openPR != nil {
+		return prToState(openPR), nil
+	}
+	if mostRecent != nil {
+		return prToState(mostRecent), nil
+	}
+	return nil, nil
+}
+
 // ListPRs returns open pull requests for the given repository (up to 100).
 func (c *Client) ListPRs(ctx context.Context, owner, repo string) ([]*PRState, error) {
-	prs, _, err := c.gh.PullRequests.List(ctx, owner, repo, &gh.PullRequestListOptions{
-		State: "open",
-		ListOptions: gh.ListOptions{
-			PerPage: 100,
-		},
+	var prs []*gh.PullRequest
+	err := c.doWithRetry(ctx, func() (*gh.Response, error) {
+		var resp *gh.Response
+		var err error
+		prs, resp, err = c.gh.PullRequests.List(ctx, owner, repo, &gh.PullRequestListOptions{
+			State: "open",
+			ListOptions: gh.ListOptions{
+				PerPage: 100,
+			},
+		})
+		return resp, err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing PRs: %w", err)
@@ -66,10 +250,16 @@ func (c *Client) ListPRs(ctx context.Context, owner, repo string) ([]*PRState, e
 
 // GetChecks returns the combined check status for the given git ref (SHA or branch).
 func (c *Client) GetChecks(ctx context.Context, owner, repo, ref string) (*CheckStatus, error) {
-	result, _, err := c.gh.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, &gh.ListCheckRunsOptions{
-		ListOptions: gh.ListOptions{
-			PerPage: 100,
-		},
+	var result *gh.ListCheckRunsResults
+	err := c.doWithRetry(ctx, func() (*gh.Response, error) {
+		var resp *gh.Response
+		var err error
+		result, resp, err = c.gh.Checks.ListCheckRunsForRef(ctx, owner, repo, ref, &gh.ListCheckRunsOptions{
+			ListOptions: gh.ListOptions{
+				PerPage: 100,
+			},
+		})
+		return resp, err
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing check runs: %w", err)
@@ -124,7 +314,13 @@ func (c *Client) GetReviews(ctx context.Context, owner, repo string, number int)
 	var allReviews []*gh.PullRequestReview
 	opts := &gh.ListOptions{PerPage: 100}
 	for {
-		reviews, resp, err := c.gh.PullRequests.ListReviews(ctx, owner, repo, number, opts)
+		var reviews []*gh.PullRequestReview
+		var resp *gh.Response
+		err := c.doWithRetry(ctx, func() (*gh.Response, error) {
+			var err error
+			reviews, resp, err = c.gh.PullRequests.ListReviews(ctx, owner, repo, number, opts)
+			return resp, err
+		})
 		if err != nil {
 			return nil, fmt.Errorf("listing reviews: %w", err)
 		}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,360 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v69/github"
+)
+
+// newTestClient returns a Client whose underlying go-github client is pointed
+// at the given test server. sleep is replaced with a no-op so tests do not
+// actually wait for backoff intervals.
+func newTestClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	ghc := gh.NewClient(nil)
+	base, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse base url: %v", err)
+	}
+	ghc.BaseURL = base
+	return &Client{
+		gh: ghc,
+		sleep: func(ctx context.Context, d time.Duration) error {
+			return nil
+		},
+	}
+}
+
+func TestGetPR_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/o/r/pulls" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = fmt.Fprintln(w, `[{"number":42,"title":"t","html_url":"u","state":"open","head":{"ref":"feat"},"base":{"ref":"main"}}]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPR(context.Background(), "o", "r", "feat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil || pr.Number != 42 {
+		t.Fatalf("expected PR #42, got %+v", pr)
+	}
+}
+
+func TestGetPR_NoPR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, `[]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPR(context.Background(), "o", "r", "feat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr != nil {
+		t.Fatalf("expected nil PR, got %+v", pr)
+	}
+}
+
+func TestGetPR_Retry503ThenSuccess(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			http.Error(w, "down", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = fmt.Fprintln(w, `[{"number":1,"title":"","state":"open","head":{"ref":"f"},"base":{"ref":"main"}}]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPR(context.Background(), "o", "r", "f")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil {
+		t.Fatalf("expected PR, got nil")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+}
+
+func TestGetPR_ExhaustRetries(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.GetPR(context.Background(), "o", "r", "f")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("expected 3 attempts (1 + 2 retries), got %d", got)
+	}
+}
+
+func TestGetPR_NoRetryOn4xx(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.GetPR(context.Background(), "o", "r", "f")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected 1 attempt (no retry on 4xx), got %d", got)
+	}
+}
+
+func TestGetPR_RetryOn429WithRetryAfter(t *testing.T) {
+	var calls atomic.Int32
+	var waitsCaptured []time.Duration
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "2")
+			http.Error(w, "slow down", http.StatusTooManyRequests)
+			return
+		}
+		_, _ = fmt.Fprintln(w, `[]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	// Capture the wait duration passed to sleep.
+	c.sleep = func(ctx context.Context, d time.Duration) error {
+		waitsCaptured = append(waitsCaptured, d)
+		return nil
+	}
+	_, err := c.GetPR(context.Background(), "o", "r", "f")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+	if len(waitsCaptured) != 1 {
+		t.Fatalf("expected 1 sleep, got %d: %v", len(waitsCaptured), waitsCaptured)
+	}
+	// Wait should be ~2s (jitter ±100ms, clamped to maxRetryWait).
+	if waitsCaptured[0] < 1900*time.Millisecond || waitsCaptured[0] > 2100*time.Millisecond {
+		t.Fatalf("expected ~2s wait, got %v", waitsCaptured[0])
+	}
+}
+
+func TestGetPR_CtxCancelledDuringBackoff(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	// Make sleep return ctx error.
+	cancelErr := errors.New("cancelled")
+	c.sleep = func(ctx context.Context, d time.Duration) error {
+		return cancelErr
+	}
+	_, err := c.GetPR(context.Background(), "o", "r", "f")
+	if !errors.Is(err, cancelErr) && err == nil {
+		// doWithRetry returns the sleep error directly, but callers wrap it.
+		// Just ensure we got *some* error and didn't loop forever.
+		t.Fatalf("expected error from cancelled sleep, got nil")
+	}
+}
+
+func TestGetPRBySHA_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/o/r/commits/deadbeef/pulls" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = fmt.Fprintln(w, `[{"number":7,"state":"open","head":{"ref":"feat","repo":{"full_name":"o/r"}},"base":{"ref":"main"}}]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPRBySHA(context.Background(), "o", "r", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil || pr.Number != 7 {
+		t.Fatalf("expected PR #7, got %+v", pr)
+	}
+}
+
+func TestGetPRBySHA_ForkFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Two PRs for this commit — one from a fork, one from the owner's repo.
+		_, _ = fmt.Fprintln(w, `[
+			{"number":9,"state":"open","head":{"ref":"feat","repo":{"full_name":"fork/r"}}},
+			{"number":7,"state":"open","head":{"ref":"feat","repo":{"full_name":"o/r"}}}
+		]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPRBySHA(context.Background(), "o", "r", "deadbeef")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil {
+		t.Fatalf("expected PR, got nil")
+	}
+	if pr.Number != 7 {
+		t.Fatalf("expected fork PR filtered out; got #%d", pr.Number)
+	}
+}
+
+func TestGetPRBySHA_422ReturnsNoPR(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, `{"message":"No commit found for SHA"}`, http.StatusUnprocessableEntity)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPRBySHA(context.Background(), "o", "r", "notpushed")
+	if err != nil {
+		t.Fatalf("expected no error for 422, got %v", err)
+	}
+	if pr != nil {
+		t.Fatalf("expected nil PR, got %+v", pr)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected 1 attempt (no retry on 422), got %d", got)
+	}
+}
+
+func TestGetPRBySHA_EmptySHAReturnsNil(t *testing.T) {
+	c := &Client{gh: gh.NewClient(nil), sleep: func(context.Context, time.Duration) error { return nil }}
+	pr, err := c.GetPRBySHA(context.Background(), "o", "r", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr != nil {
+		t.Fatalf("expected nil PR, got %+v", pr)
+	}
+}
+
+func TestGetPRBySHA_AllClosedReturnsMostRecent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, `[
+			{"number":1,"state":"closed","updated_at":"2024-01-01T00:00:00Z","head":{"ref":"a","repo":{"full_name":"o/r"}}},
+			{"number":2,"state":"closed","updated_at":"2024-06-01T00:00:00Z","head":{"ref":"b","repo":{"full_name":"o/r"}}}
+		]`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPRBySHA(context.Background(), "o", "r", "sha")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil || pr.Number != 2 {
+		t.Fatalf("expected most-recent PR #2, got %+v", pr)
+	}
+}
+
+func TestGetChecks_RetryThenSuccess(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			http.Error(w, "down", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = fmt.Fprintln(w, `{"total_count":1,"check_runs":[{"name":"ci","status":"completed","conclusion":"success"}]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	checks, err := c.GetChecks(context.Background(), "o", "r", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if checks.Passed != 1 || checks.State != "success" {
+		t.Fatalf("unexpected check status: %+v", checks)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+}
+
+func TestClassifyRetry(t *testing.T) {
+	t.Run("nil_response_transport_error", func(t *testing.T) {
+		retry, wait := classifyRetry(nil, errors.New("transport failed"))
+		if !retry {
+			t.Errorf("expected retry=true for transport error")
+		}
+		if wait != 0 {
+			t.Errorf("expected wait=0, got %v", wait)
+		}
+	})
+	t.Run("5xx_retriable", func(t *testing.T) {
+		resp := &gh.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}}
+		retry, _ := classifyRetry(resp, errors.New("500"))
+		if !retry {
+			t.Errorf("expected retry=true for 500")
+		}
+	})
+	t.Run("4xx_not_retriable", func(t *testing.T) {
+		resp := &gh.Response{Response: &http.Response{StatusCode: http.StatusForbidden}}
+		retry, _ := classifyRetry(resp, errors.New("forbidden"))
+		if retry {
+			t.Errorf("expected retry=false for plain 403")
+		}
+	})
+	t.Run("422_not_retriable", func(t *testing.T) {
+		resp := &gh.Response{Response: &http.Response{StatusCode: http.StatusUnprocessableEntity}}
+		retry, _ := classifyRetry(resp, errors.New("422"))
+		if retry {
+			t.Errorf("expected retry=false for 422")
+		}
+	})
+	t.Run("429_retriable_with_retry_after", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("Retry-After", "5")
+		resp := &gh.Response{Response: &http.Response{StatusCode: http.StatusTooManyRequests, Header: h}}
+		retry, wait := classifyRetry(resp, errors.New("429"))
+		if !retry {
+			t.Errorf("expected retry=true for 429")
+		}
+		if wait != 5*time.Second {
+			t.Errorf("expected wait=5s, got %v", wait)
+		}
+	})
+	t.Run("abuse_rate_limit_honors_retry_after", func(t *testing.T) {
+		d := 3 * time.Second
+		err := &gh.AbuseRateLimitError{RetryAfter: &d}
+		retry, wait := classifyRetry(nil, err)
+		if !retry {
+			t.Errorf("expected retry=true")
+		}
+		if wait != 3*time.Second {
+			t.Errorf("expected wait=3s, got %v", wait)
+		}
+	})
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -409,6 +409,24 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			a.lastKnownStatus[msg.event.AgentID] = msg.event.Status
 		}
+		// Branch rename invalidates any PR-by-branch lookup. Schedule a burst of
+		// short-interval polls so the SHA-based lookup can rediscover the PR
+		// quickly — do NOT clear the cache here; that happens only when the
+		// next poll confirms the PR is gone (handled in prPollMsg).
+		if msg.event.Type == agent.EventBranchRenamed && msg.event.SessionID != "" {
+			ps := a.prPollStates[msg.event.SessionID]
+			if ps == nil {
+				ps = &prSessionState{}
+				a.prPollStates[msg.event.SessionID] = ps
+			}
+			ps.burstUntil = time.Now().Add(60 * time.Second)
+			ps.lastPoll = time.Time{}
+			// Clearing lastRemoteSHA forces getRemoteSHA to re-check against
+			// the new branch name on the next tick instead of comparing against
+			// the SHA it read under the old branch.
+			ps.lastRemoteSHA = ""
+			ps.lastSHACheck = time.Time{}
+		}
 		// Refresh list on any agent event — all repos are visible in the dashboard.
 		a.refreshAgentList()
 		if mgr := a.managers[msg.repoPath]; mgr != nil {
@@ -482,38 +500,52 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if ps != nil {
 			ps.inFlight = false
 		}
-		// Only update cache if we got data; preserve existing cache on errors.
-		if msg.pr != nil {
-			a.prCache[msg.sessionID] = &prCacheEntry{
-				pr:      msg.pr,
-				checks:  msg.checks,
-				reviews: msg.reviews,
+		// Fetch failed: preserve cache so a transient error doesn't blank the UI.
+		if msg.err != nil {
+			return a, nil
+		}
+		// Lookup succeeded with no PR. If we had one before, the PR has been
+		// closed, merged, or its head branch was deleted — drop the stale entry
+		// so the UI reflects reality.
+		if msg.pr == nil {
+			if _, had := a.prCache[msg.sessionID]; had {
+				delete(a.prCache, msg.sessionID)
+				if ps != nil {
+					ps.lastCheckState = ""
+				}
+				a.updateDashboardPRCache()
 			}
-			// Detect check state transitions and fire notifications.
-			if ps != nil && msg.checks != nil {
-				prevState := ps.lastCheckState
-				newState := msg.checks.State
-				if prevState == "pending" && (newState == "success" || newState == "failure") {
-					// Flash the session row.
-					ps.flashUntil = time.Now().Add(2 * time.Second)
-					if newState == "success" {
-						ps.flashColor = "success"
-					} else {
-						ps.flashColor = "error"
-					}
-					// Play audio notification, gated by the session's repo AudioEnabled setting
-					// (same gate as the idle-transition notification above).
-					if a.audioPlayer != nil {
-						repoPath := a.repoPathForSession(msg.sessionID)
-						if repoPath != "" && a.resolvedCache[repoPath].AudioEnabled {
-							a.audioPlayer.Play()
-						}
+			return a, nil
+		}
+		a.prCache[msg.sessionID] = &prCacheEntry{
+			pr:      msg.pr,
+			checks:  msg.checks,
+			reviews: msg.reviews,
+		}
+		// Detect check state transitions and fire notifications.
+		if ps != nil && msg.checks != nil {
+			prevState := ps.lastCheckState
+			newState := msg.checks.State
+			if prevState == "pending" && (newState == "success" || newState == "failure") {
+				// Flash the session row.
+				ps.flashUntil = time.Now().Add(2 * time.Second)
+				if newState == "success" {
+					ps.flashColor = "success"
+				} else {
+					ps.flashColor = "error"
+				}
+				// Play audio notification, gated by the session's repo AudioEnabled setting
+				// (same gate as the idle-transition notification above).
+				if a.audioPlayer != nil {
+					repoPath := a.repoPathForSession(msg.sessionID)
+					if repoPath != "" && a.resolvedCache[repoPath].AudioEnabled {
+						a.audioPlayer.Play()
 					}
 				}
-				ps.lastCheckState = newState
 			}
-			a.updateDashboardPRCache()
+			ps.lastCheckState = newState
 		}
+		a.updateDashboardPRCache()
 		return a, nil
 
 	case resumeDoneMsg:
@@ -1574,24 +1606,24 @@ outer:
 			// Determine adaptive polling interval.
 			interval := a.prPollInterval(sess.ID, ps)
 			if now.Sub(ps.lastPoll) < interval {
-				// Check for push detection: if no PR yet, see if the remote SHA changed.
-				// Throttle git rev-parse calls to at most once every shaCheckInterval per
-				// session to avoid blocking the Bubble Tea main goroutine on every tick.
-				if a.prCache[sess.ID] == nil || a.prCache[sess.ID].pr == nil {
-					if now.Sub(ps.lastSHACheck) < shaCheckInterval {
-						continue
-					}
-					ps.lastSHACheck = now
-					sha := getRemoteSHA(repo.Path, sess.Branch())
-					if sha != "" && sha != ps.lastRemoteSHA {
-						ps.lastRemoteSHA = sha
-						// Push detected — fall through to schedule an immediate poll.
-					} else {
-						continue
-					}
-				} else {
+				// Push detection runs for every session — including those with a
+				// cached PR — so new commits, force-pushes, and rewrites get
+				// picked up promptly instead of waiting the 30s stable interval.
+				// Throttled to once per shaCheckInterval so git rev-parse does
+				// not block the Bubble Tea main goroutine on every tick.
+				if now.Sub(ps.lastSHACheck) < shaCheckInterval {
 					continue
 				}
+				ps.lastSHACheck = now
+				sha := getRemoteSHA(repo.Path, sess.Branch())
+				if sha == "" || sha == ps.lastRemoteSHA {
+					continue
+				}
+				ps.lastRemoteSHA = sha
+				// SHA changed — arm a burst so the next minute of polls runs
+				// on the short (2s) cadence, then fall through to schedule an
+				// immediate poll.
+				ps.burstUntil = now.Add(60 * time.Second)
 			}
 
 			ps.lastPoll = now
@@ -1605,6 +1637,11 @@ outer:
 
 // prPollInterval returns the adaptive polling interval for a session.
 func (a *App) prPollInterval(sessionID string, ps *prSessionState) time.Duration {
+	// Event-driven burst (branch rename, new push): poll aggressively for a
+	// short window so state transitions become visible within ~2s.
+	if ps != nil && time.Now().Before(ps.burstUntil) {
+		return 2 * time.Second
+	}
 	entry := a.prCache[sessionID]
 	// No PR found yet but branch may have been pushed.
 	if entry == nil || entry.pr == nil {
@@ -1634,24 +1671,51 @@ func getRemoteSHA(repoPath, branch string) string {
 func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath string) tea.Cmd {
 	ghClient := a.ghClient
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
 
 		rawURL, err := git.GetRemoteURL(repoPath)
 		if err != nil {
-			return prPollMsg{sessionID: sessionID}
+			return prPollMsg{sessionID: sessionID, err: err}
 		}
 		owner, repo, err := github.ParseRemoteURL(rawURL)
 		if err != nil {
-			return prPollMsg{sessionID: sessionID}
+			return prPollMsg{sessionID: sessionID, err: err}
 		}
 
-		pr, _ := ghClient.GetPR(ctx, owner, repo, branch)
+		// Prefer SHA-based lookup: invariant to branch renames, so a PR opened
+		// under a random baton/<adj>-<noun> name (before Haiku rename finishes)
+		// is still discovered after the rename. Fall back to branch lookup when
+		// the commit hasn't been pushed or SHA lookup returns no PR.
+		var pr *github.PRState
+		sha := getRemoteSHA(repoPath, branch)
+		if sha != "" {
+			pr, _ = ghClient.GetPRBySHA(ctx, owner, repo, sha)
+		}
+		if pr == nil {
+			var err error
+			pr, err = ghClient.GetPR(ctx, owner, repo, branch)
+			if err != nil {
+				return prPollMsg{sessionID: sessionID, err: err}
+			}
+		}
 		var checks *github.CheckStatus
 		var reviews *github.ReviewStatus
 		if pr != nil {
-			checks, _ = ghClient.GetChecks(ctx, owner, repo, branch)
-			reviews, _ = ghClient.GetReviews(ctx, owner, repo, pr.Number)
+			var err error
+			// Prefer SHA for checks when available — matches what CI ran against.
+			checkRef := branch
+			if sha != "" {
+				checkRef = sha
+			}
+			checks, err = ghClient.GetChecks(ctx, owner, repo, checkRef)
+			if err != nil {
+				return prPollMsg{sessionID: sessionID, err: err}
+			}
+			reviews, err = ghClient.GetReviews(ctx, owner, repo, pr.Number)
+			if err != nil {
+				return prPollMsg{sessionID: sessionID, err: err}
+			}
 		}
 
 		return prPollMsg{
@@ -1712,6 +1776,8 @@ func openURL(url string) error {
 // recomputePRSectionY updates d.prSectionY with the content-relative row index
 // (0-indexed, after the AGENTS title and separator) where the PR checks section
 // begins, or -1 when no PR section is rendered. Call after any layout change.
+// Must mirror the truncation logic in dashboardModel.renderList so mouse clicks
+// map to the correct visual rows.
 func (a *App) recomputePRSectionY() {
 	d := &a.dashboard
 	d.prSectionY = -1
@@ -1726,10 +1792,28 @@ func (a *App) recomputePRSectionY() {
 	}
 
 	contentH := d.contentHeight()
+	// Budget for the PR panel, matching renderList.
+	prBudget := 6
+	if half := contentH / 2; prBudget > half {
+		prBudget = half
+	}
+	if prBudget < 2 {
+		return
+	}
+
 	agentListHeight := len(d.items)
+	// Apply the same list truncation renderList performs, so availCheckHeight
+	// reflects the post-truncation list length.
+	if agentListHeight > contentH-prBudget {
+		maxList := contentH - prBudget
+		if maxList < 1 {
+			maxList = 1
+		}
+		agentListHeight = maxList
+	}
 	maxCheckHeight := contentH / 3
 	availCheckHeight := contentH - agentListHeight
-	if availCheckHeight > maxCheckHeight {
+	if availCheckHeight > maxCheckHeight && maxCheckHeight >= prBudget {
 		availCheckHeight = maxCheckHeight
 	}
 	if availCheckHeight < 2 {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -495,23 +495,68 @@ func (d dashboardModel) renderList(width int) string {
 	}
 
 	// Render PR checks summary and diff stats at the bottom of the left panel.
+	// Guarantee a minimum height for the PR panel so it stays visible even
+	// when the agent list is long — truncating the list with a "+N more"
+	// indicator if necessary.
+	contentH := d.contentHeight()
 	var bottomLines []string
+
+	var prEntry *prCacheEntry
 	if sess := d.selectedSession(); sess != nil {
-		if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
-			contentH := d.contentHeight()
-			agentListHeight := len(lines)
-			maxCheckHeight := contentH / 3
-			availCheckHeight := contentH - agentListHeight
-			if availCheckHeight > maxCheckHeight {
-				availCheckHeight = maxCheckHeight
+		if e := d.prCache[sess.ID]; e != nil && e.pr != nil {
+			prEntry = e
+		}
+	}
+
+	// Reserve height for the PR panel up front so it survives a crowded
+	// agent list. Capped at half of contentH on narrow terminals to avoid
+	// starving the agent list entirely.
+	prBudget := 0
+	if prEntry != nil {
+		prBudget = 6
+		if half := contentH / 2; prBudget > half {
+			prBudget = half
+		}
+	}
+
+	// If the agent list + reserved PR budget would exceed contentH, truncate
+	// the list and replace the overflow with a "+N more" marker so the PR
+	// panel still renders.
+	if prBudget > 0 && len(lines) > contentH-prBudget {
+		maxList := contentH - prBudget
+		if maxList < 1 {
+			maxList = 1
+		}
+		// Keep room for the "+N more" marker itself.
+		if maxList < len(lines) {
+			kept := maxList - 1
+			if kept < 0 {
+				kept = 0
 			}
-			if availCheckHeight >= 2 {
-				bottomLines = append(bottomLines, d.renderChecksSummary(entry, width, availCheckHeight)...)
+			hidden := len(lines) - kept
+			truncated := make([]string, 0, kept+1)
+			truncated = append(truncated, lines[:kept]...)
+			truncated = append(truncated, StyleSubtle.Render(fmt.Sprintf("  +%d more", hidden)))
+			lines = truncated
+		}
+	}
+
+	if prEntry != nil {
+		avail := contentH - len(lines)
+		if avail > prBudget && prBudget > 0 {
+			// Cap at the reserved budget so diffStats has room below.
+			if avail > prBudget*2 {
+				avail = prBudget * 2
 			}
+		}
+		if maxCheck := contentH / 3; avail > maxCheck && maxCheck >= prBudget {
+			avail = maxCheck
+		}
+		if avail >= 2 {
+			bottomLines = append(bottomLines, d.renderChecksSummary(prEntry, width, avail)...)
 		}
 	}
 	if d.diffStats != nil {
-		contentH := d.contentHeight()
 		agentListHeight := len(lines) + len(bottomLines)
 		maxDiffHeight := contentH / 3
 		availHeight := contentH - agentListHeight
@@ -524,7 +569,6 @@ func (d dashboardModel) renderList(width int) string {
 		}
 	}
 	if len(bottomLines) > 0 {
-		contentH := d.contentHeight()
 		padding := contentH - len(lines) - len(bottomLines)
 		for i := 0; i < padding; i++ {
 			lines = append(lines, "")

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -9,11 +9,18 @@ import (
 )
 
 // prPollMsg carries the result of an async PR status poll.
+//
+// Three result shapes are possible and must be distinguished by the handler:
+//   - err != nil: the fetch failed (transient). Preserve cache; shorten next poll.
+//   - err == nil, pr == nil: the lookup succeeded and no open PR exists
+//     (newly opened session, or PR was closed/merged).
+//   - err == nil, pr != nil: update cache.
 type prPollMsg struct {
 	sessionID string
 	pr        *github.PRState
 	checks    *github.CheckStatus
 	reviews   *github.ReviewStatus
+	err       error
 }
 
 // prCacheEntry holds cached PR and check status for a session.
@@ -32,6 +39,11 @@ type prSessionState struct {
 	flashUntil     time.Time
 	flashColor     string // "success" or "error"
 	inFlight       bool
+	// burstUntil, when set in the future, causes prPollInterval to return a
+	// short (~2s) cadence so events like branch rename or new push are picked
+	// up quickly. Writes happen only from the Bubble Tea Update goroutine;
+	// no locking required.
+	burstUntil time.Time
 }
 
 // isMergeReady returns true when all conditions for merge readiness are met.

--- a/internal/tui/pr_test.go
+++ b/internal/tui/pr_test.go
@@ -1,0 +1,126 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/devenjarvis/baton/internal/agent"
+)
+
+// TestPrPollInterval_BurstOverridesBaseline verifies the burst window shortens
+// the poll interval to 2s regardless of the adaptive baseline.
+func TestPrPollInterval_BurstOverridesBaseline(t *testing.T) {
+	a := NewApp()
+	ps := &prSessionState{burstUntil: time.Now().Add(30 * time.Second)}
+	a.prPollStates["s1"] = ps
+	if got := a.prPollInterval("s1", ps); got != 2*time.Second {
+		t.Fatalf("burst interval = %v, want 2s", got)
+	}
+}
+
+func TestPrPollInterval_ExpiredBurstFallsBackToBaseline(t *testing.T) {
+	a := NewApp()
+	ps := &prSessionState{burstUntil: time.Now().Add(-5 * time.Second)}
+	a.prPollStates["s1"] = ps
+	if got := a.prPollInterval("s1", ps); got != 30*time.Second {
+		t.Fatalf("expired burst should use 30s baseline, got %v", got)
+	}
+}
+
+// TestBranchRenamedEventArmsBurst verifies that feeding an EventBranchRenamed
+// via agentEventMsg sets burstUntil in the future and resets SHA/poll state
+// so the next tick re-queries immediately.
+func TestBranchRenamedEventArmsBurst(t *testing.T) {
+	a := NewApp()
+	// Seed prior state so we can verify the handler resets it.
+	a.prPollStates["sess-1"] = &prSessionState{
+		lastPoll:      time.Now(),
+		lastSHACheck:  time.Now(),
+		lastRemoteSHA: "oldsha",
+	}
+
+	model, _ := a.Update(agentEventMsg{
+		event: agent.Event{
+			Type:      agent.EventBranchRenamed,
+			SessionID: "sess-1",
+			Branch:    "baton/new-name",
+		},
+	})
+	got := model.(App).prPollStates["sess-1"]
+	if got == nil {
+		t.Fatal("prPollStates missing after event")
+	}
+	if !got.burstUntil.After(time.Now().Add(50 * time.Second)) {
+		t.Errorf("burstUntil should be ~60s in the future, got %v", got.burstUntil)
+	}
+	if !got.lastPoll.IsZero() {
+		t.Errorf("lastPoll should be reset, got %v", got.lastPoll)
+	}
+	if got.lastRemoteSHA != "" {
+		t.Errorf("lastRemoteSHA should be cleared, got %q", got.lastRemoteSHA)
+	}
+}
+
+// TestPrPollMsg_ErrorPreservesCache verifies that a fetch error does not
+// clobber a previously-cached PR entry.
+func TestPrPollMsg_ErrorPreservesCache(t *testing.T) {
+	a := NewApp()
+	a.prPollsInFlight = 1
+	a.prPollStates["sess-1"] = &prSessionState{inFlight: true}
+	prev := &prCacheEntry{}
+	a.prCache["sess-1"] = prev
+
+	model, _ := a.Update(prPollMsg{sessionID: "sess-1", err: errors.New("boom")})
+	got := model.(App)
+	if got.prCache["sess-1"] != prev {
+		t.Errorf("cache entry was clobbered on error")
+	}
+	if got.prPollStates["sess-1"].inFlight {
+		t.Errorf("inFlight should be cleared after poll result")
+	}
+	if got.prPollsInFlight != 0 {
+		t.Errorf("prPollsInFlight = %d, want 0", got.prPollsInFlight)
+	}
+}
+
+// TestPrPollMsg_NilClearsPreviouslyCachedEntry verifies that a successful
+// lookup with no PR drops a stale cached entry — e.g. when the PR is
+// closed, merged, or its head branch is deleted.
+func TestPrPollMsg_NilClearsPreviouslyCachedEntry(t *testing.T) {
+	a := NewApp()
+	a.prPollsInFlight = 1
+	a.prPollStates["sess-1"] = &prSessionState{inFlight: true, lastCheckState: "success"}
+	a.prCache["sess-1"] = &prCacheEntry{}
+
+	model, _ := a.Update(prPollMsg{sessionID: "sess-1"})
+	got := model.(App)
+	if _, ok := got.prCache["sess-1"]; ok {
+		t.Errorf("cache entry should be cleared when lookup returns (nil, nil)")
+	}
+	if got.prPollStates["sess-1"].lastCheckState != "" {
+		t.Errorf("lastCheckState should reset, got %q", got.prPollStates["sess-1"].lastCheckState)
+	}
+}
+
+// TestPrPollMsg_NilWithNoPriorCacheIsNoop verifies that a successful empty
+// lookup for a session that never had a PR doesn't create spurious state.
+func TestPrPollMsg_NilWithNoPriorCacheIsNoop(t *testing.T) {
+	a := NewApp()
+	a.prPollsInFlight = 1
+	a.prPollStates["sess-1"] = &prSessionState{inFlight: true}
+
+	model, _ := a.Update(prPollMsg{sessionID: "sess-1"})
+	got := model.(App)
+	if _, ok := got.prCache["sess-1"]; ok {
+		t.Errorf("no cache entry should exist")
+	}
+	if got.prPollStates["sess-1"].inFlight {
+		t.Errorf("inFlight should be cleared")
+	}
+}
+
+// Ensure the test file participates in the package even when the above tests
+// are filtered out via -run.
+var _ = tea.Batch


### PR DESCRIPTION
Look up PRs by commit SHA (rename-invariant), clear stale cache on close/
merge, add retries to the GitHub client, always watch the remote SHA, and
burst-poll for 60s after a branch rename or SHA change. Also guarantee a
minimum height for the PR checks panel in the left sidebar.

https://claude.ai/code/session_01AwN7je9qXAhXbFgPvnGMR8