### PR TITLE
Name new sessions after songs and log them to a setlist

### DIFF
--- a/changelog.d/change-song-name-worktrees.md
+++ b/changelog.d/change-song-name-worktrees.md
@@ -1,0 +1,4 @@
+### Changed
+
+- New sessions are now named after a randomly chosen song from a hardcoded catalog (e.g. `baton/wonderwall`, `baton/karma-police`) instead of the previous adjective-noun pairs. In-session secondary agents still get adjective-noun names. The first-prompt Haiku rename is unchanged — it still replaces the song slug with a task-derived branch name.
+- Each new session also appends a JSON line to `~/.baton/setlist.jsonl` recording the song that played for it (name, artist, ISRC, slug, repo, session id, timestamp). This is the persistence foundation for a future setlist view.

--- a/internal/agent/main_test.go
+++ b/internal/agent/main_test.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain redirects $HOME to a per-process temp dir so tests that exercise
+// session creation never touch the real ~/.baton/setlist.jsonl (or any other
+// global baton state). Without this, every CreateSession in the test suite
+// appends a row to the user's real setlist file.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "baton-agent-tests-*")
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+	if err := os.Setenv("HOME", tmp); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config")); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/agent/main_test.go
+++ b/internal/agent/main_test.go
@@ -7,20 +7,28 @@ import (
 )
 
 // TestMain redirects $HOME to a per-process temp dir so tests that exercise
-// session creation never touch the real ~/.baton/setlist.jsonl (or any other
-// global baton state). Without this, every CreateSession in the test suite
-// appends a row to the user's real setlist file.
+// session creation never touch the real ~/.baton/setlist.jsonl. We also set
+// explicit git author/committer env vars so the HOME redirect does not break
+// tests that run `git commit` (which would otherwise fail with "Author
+// identity unknown" when no global gitconfig is reachable, e.g. on CI
+// runners).
 func TestMain(m *testing.M) {
 	tmp, err := os.MkdirTemp("", "baton-agent-tests-*")
 	if err != nil {
 		panic(err)
 	}
 	defer func() { _ = os.RemoveAll(tmp) }()
-	if err := os.Setenv("HOME", tmp); err != nil {
-		panic(err)
-	}
-	if err := os.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config")); err != nil {
-		panic(err)
+	for k, v := range map[string]string{
+		"HOME":                tmp,
+		"XDG_CONFIG_HOME":     filepath.Join(tmp, ".config"),
+		"GIT_AUTHOR_NAME":     "Baton Test",
+		"GIT_AUTHOR_EMAIL":    "baton-test@example.com",
+		"GIT_COMMITTER_NAME":  "Baton Test",
+		"GIT_COMMITTER_EMAIL": "baton-test@example.com",
+	} {
+		if err := os.Setenv(k, v); err != nil {
+			panic(err)
+		}
 	}
 	os.Exit(m.Run())
 }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -15,6 +15,8 @@ import (
 	"github.com/devenjarvis/baton/internal/config"
 	"github.com/devenjarvis/baton/internal/git"
 	"github.com/devenjarvis/baton/internal/hook"
+	"github.com/devenjarvis/baton/internal/setlist"
+	"github.com/devenjarvis/baton/internal/songs"
 	"github.com/devenjarvis/baton/internal/state"
 )
 
@@ -540,7 +542,8 @@ func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
 	for _, s := range m.sessions {
 		existing = append(existing, s.CurrentName())
 	}
-	name := RandomName(existing)
+	track := songs.Pick(existing)
+	name := track.Slug()
 	m.nextID++
 	id := fmt.Sprintf("session-%d", m.nextID)
 	settings := m.settings
@@ -580,6 +583,19 @@ func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
 	m.mu.Lock()
 	m.sessions[id] = sess
 	m.mu.Unlock()
+
+	// Best-effort: record the song that "played" for this session. Failure
+	// must not block session creation, and we don't surface the error since
+	// stderr writes would corrupt the TUI.
+	_ = setlist.Append(setlist.Entry{
+		PlayedAt:  time.Now(),
+		Name:      track.Name,
+		Artist:    track.Artist,
+		ISRC:      track.ISRC,
+		Slug:      name,
+		Repo:      m.repoPath,
+		SessionID: id,
+	})
 
 	return sess, nil
 }

--- a/internal/setlist/setlist.go
+++ b/internal/setlist/setlist.go
@@ -1,0 +1,107 @@
+// Package setlist persists a JSONL log of songs that have "played" for
+// Baton sessions. Each newly created session appends one entry to
+// ~/.baton/setlist.jsonl so the user can later browse a setlist of past
+// sessions.
+package setlist
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/devenjarvis/baton/internal/config"
+)
+
+// Entry is a single record in the setlist log.
+type Entry struct {
+	PlayedAt  time.Time `json:"playedAt"`
+	Name      string    `json:"name"`
+	Artist    string    `json:"artist"`
+	ISRC      string    `json:"isrc"`
+	Slug      string    `json:"slug"`
+	Repo      string    `json:"repo,omitempty"`
+	SessionID string    `json:"sessionId,omitempty"`
+}
+
+// Path returns the absolute path to the setlist JSONL file inside ~/.baton.
+func Path() (string, error) {
+	dir, err := config.BatonDir()
+	if err != nil {
+		return "", fmt.Errorf("setlist: resolving baton dir: %w", err)
+	}
+	return filepath.Join(dir, "setlist.jsonl"), nil
+}
+
+// Append serialises e as JSON and appends it as a new line to the setlist
+// file, creating the parent directory and file if needed.
+func Append(e Entry) error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("setlist: creating parent dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("setlist: opening file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("setlist: marshalling entry: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("setlist: writing entry: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("setlist: closing file: %w", err)
+	}
+	return nil
+}
+
+// Load reads all entries from the setlist file. Malformed JSON lines are
+// skipped silently so a partially written or hand-edited file does not
+// surface as an error. If the file does not exist, Load returns (nil, nil).
+func Load() ([]Entry, error) {
+	path, err := Path()
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("setlist: opening file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var entries []Entry
+	scanner := bufio.NewScanner(f)
+	// Allow long lines just in case an entry grows past the default 64KiB.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal(line, &e); err != nil {
+			// Tolerate malformed lines silently.
+			continue
+		}
+		entries = append(entries, e)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("setlist: scanning file: %w", err)
+	}
+	return entries, nil
+}

--- a/internal/setlist/setlist_test.go
+++ b/internal/setlist/setlist_test.go
@@ -1,0 +1,157 @@
+package setlist_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/devenjarvis/baton/internal/setlist"
+)
+
+// setlistDirInTmp redirects $HOME into a temp directory so tests never touch
+// the real ~/.baton/. Returns the ~/.baton directory.
+func setlistDirInTmp(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	t.Setenv("HOME", base)
+	return filepath.Join(base, ".baton")
+}
+
+func TestAppend_RoundTrip(t *testing.T) {
+	setlistDirInTmp(t)
+
+	entries := []setlist.Entry{
+		{
+			PlayedAt:  time.Now().UTC().Truncate(time.Second),
+			Name:      "Song One",
+			Artist:    "Artist A",
+			ISRC:      "USRC11111111",
+			Slug:      "song-one",
+			Repo:      "repo-a",
+			SessionID: "sess-1",
+		},
+		{
+			PlayedAt: time.Now().UTC().Add(time.Minute).Truncate(time.Second),
+			Name:     "Song Two",
+			Artist:   "Artist B",
+			ISRC:     "USRC22222222",
+			Slug:     "song-two",
+		},
+		{
+			PlayedAt:  time.Now().UTC().Add(2 * time.Minute).Truncate(time.Second),
+			Name:      "Song Three",
+			Artist:    "Artist C",
+			ISRC:      "USRC33333333",
+			Slug:      "song-three",
+			Repo:      "repo-c",
+			SessionID: "sess-3",
+		},
+	}
+
+	for _, e := range entries {
+		if err := setlist.Append(e); err != nil {
+			t.Fatalf("Append(%q) error = %v", e.Name, err)
+		}
+	}
+
+	loaded, err := setlist.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded) != len(entries) {
+		t.Fatalf("Load() len = %d, want %d", len(loaded), len(entries))
+	}
+	for i, want := range entries {
+		got := loaded[i]
+		if !got.PlayedAt.Equal(want.PlayedAt) {
+			t.Errorf("entry[%d] PlayedAt = %v, want %v", i, got.PlayedAt, want.PlayedAt)
+		}
+		if got.Name != want.Name {
+			t.Errorf("entry[%d] Name = %q, want %q", i, got.Name, want.Name)
+		}
+		if got.Artist != want.Artist {
+			t.Errorf("entry[%d] Artist = %q, want %q", i, got.Artist, want.Artist)
+		}
+		if got.ISRC != want.ISRC {
+			t.Errorf("entry[%d] ISRC = %q, want %q", i, got.ISRC, want.ISRC)
+		}
+		if got.Slug != want.Slug {
+			t.Errorf("entry[%d] Slug = %q, want %q", i, got.Slug, want.Slug)
+		}
+		if got.Repo != want.Repo {
+			t.Errorf("entry[%d] Repo = %q, want %q", i, got.Repo, want.Repo)
+		}
+		if got.SessionID != want.SessionID {
+			t.Errorf("entry[%d] SessionID = %q, want %q", i, got.SessionID, want.SessionID)
+		}
+	}
+}
+
+func TestLoad_MissingFile_ReturnsNil(t *testing.T) {
+	setlistDirInTmp(t)
+
+	entries, err := setlist.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+	if entries != nil {
+		t.Fatalf("Load() = %v, want nil", entries)
+	}
+}
+
+func TestLoad_MalformedLineTolerated(t *testing.T) {
+	dir := setlistDirInTmp(t)
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, "setlist.jsonl")
+
+	content := `{"playedAt":"2026-01-01T00:00:00Z","name":"First","artist":"A","isrc":"X","slug":"first"}
+this is not json at all {{{
+{"playedAt":"2026-01-02T00:00:00Z","name":"Second","artist":"B","isrc":"Y","slug":"second"}
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	entries, err := setlist.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("Load() len = %d, want 2", len(entries))
+	}
+	if entries[0].Name != "First" {
+		t.Errorf("entries[0].Name = %q, want %q", entries[0].Name, "First")
+	}
+	if entries[1].Name != "Second" {
+		t.Errorf("entries[1].Name = %q, want %q", entries[1].Name, "Second")
+	}
+}
+
+func TestAppend_CreatesParentDir(t *testing.T) {
+	dir := setlistDirInTmp(t)
+
+	// Confirm ~/.baton does not exist yet.
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to not exist, got err=%v", dir, err)
+	}
+
+	e := setlist.Entry{
+		PlayedAt: time.Now().UTC().Truncate(time.Second),
+		Name:     "Only Song",
+		Artist:   "Some Artist",
+		ISRC:     "USRC44444444",
+		Slug:     "only-song",
+	}
+	if err := setlist.Append(e); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	path := filepath.Join(dir, "setlist.jsonl")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+}

--- a/internal/songs/catalog.json
+++ b/internal/songs/catalog.json
@@ -1,0 +1,22 @@
+[
+  {"name": "Bohemian Rhapsody", "artist": "Queen", "isrc": "GBUM71029604"},
+  {"name": "Smells Like Teen Spirit", "artist": "Nirvana", "isrc": "USGF19920005"},
+  {"name": "Wonderwall", "artist": "Oasis", "isrc": "GBARL9500504"},
+  {"name": "1979", "artist": "The Smashing Pumpkins", "isrc": "XXXXX0000001"},
+  {"name": "Take On Me", "artist": "a-ha", "isrc": "XXXXX0000002"},
+  {"name": "Hey Ya!", "artist": "OutKast", "isrc": "USAR10300012"},
+  {"name": "Mr. Brightside", "artist": "The Killers", "isrc": "USIR20301070"},
+  {"name": "Karma Police", "artist": "Radiohead", "isrc": "GBAYE9700216"},
+  {"name": "Lose Yourself", "artist": "Eminem", "isrc": "USIR10211570"},
+  {"name": "Crazy In Love", "artist": "Beyonce", "isrc": "USSM10307164"},
+  {"name": "Hotel California", "artist": "Eagles", "isrc": "USEE10076201"},
+  {"name": "Billie Jean", "artist": "Michael Jackson", "isrc": "USSM18300407"},
+  {"name": "Sweet Child O Mine", "artist": "Guns N Roses", "isrc": "USGF18750007"},
+  {"name": "Imagine", "artist": "John Lennon", "isrc": "USCA29500016"},
+  {"name": "Seven Nation Army", "artist": "The White Stripes", "isrc": "USXTH0301201"},
+  {"name": "Rolling In The Deep", "artist": "Adele", "isrc": "GBBKS1000349"},
+  {"name": "Uptown Funk", "artist": "Mark Ronson", "isrc": "GBARL1401524"},
+  {"name": "Skinny Love", "artist": "Bon Iver", "isrc": "XXXXX0000003"},
+  {"name": "Float On", "artist": "Modest Mouse", "isrc": "USEP40400142"},
+  {"name": "Juicy", "artist": "The Notorious B.I.G.", "isrc": "XXXXX0000004"}
+]

--- a/internal/songs/songs.go
+++ b/internal/songs/songs.go
@@ -1,0 +1,82 @@
+// Package songs provides a small embedded catalog of well-known tracks used to
+// generate human-friendly session names (e.g. "bohemian-rhapsody"). It exposes
+// a Track type with a Slug() helper and a Pick function that returns a random
+// track whose slug is not already taken.
+package songs
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"math/rand/v2"
+	"regexp"
+	"strings"
+)
+
+// Track is a single entry in the songs catalog.
+type Track struct {
+	Name   string `json:"name"`
+	Artist string `json:"artist"`
+	ISRC   string `json:"isrc"`
+}
+
+var nonAlnumRe = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// Slug returns a URL-friendly slug derived from t.Name. The rules mirror
+// internal/agent.slugify: lowercase, collapse non-alphanumeric runs to "-",
+// trim leading/trailing "-", truncate to 40 chars, and require the first
+// character to be [a-z0-9]. Returns "" if no valid slug can be produced.
+func (t Track) Slug() string {
+	slug := nonAlnumRe.ReplaceAllString(strings.ToLower(t.Name), "-")
+	slug = strings.Trim(slug, "-")
+	if len(slug) > 40 {
+		slug = slug[:40]
+		slug = strings.TrimRight(slug, "-")
+	}
+	if slug == "" {
+		return ""
+	}
+	if slug[0] < 'a' || slug[0] > 'z' {
+		if slug[0] < '0' || slug[0] > '9' {
+			return ""
+		}
+	}
+	return slug
+}
+
+//go:embed catalog.json
+var catalogJSON []byte
+
+var catalog []Track
+
+func init() {
+	if err := json.Unmarshal(catalogJSON, &catalog); err != nil {
+		panic(fmt.Sprintf("songs: failed to parse embedded catalog.json: %v", err))
+	}
+	if len(catalog) == 0 {
+		panic("songs: embedded catalog.json is empty")
+	}
+}
+
+// Pick returns a random track from the catalog whose Slug() is not present in
+// existing. It retries up to 100 times to avoid collisions; if all attempts
+// collide it returns the last attempt anyway. Panics if the catalog is empty.
+func Pick(existing []string) Track {
+	if len(catalog) == 0 {
+		panic("songs: catalog is empty")
+	}
+
+	existingSet := make(map[string]struct{}, len(existing))
+	for _, e := range existing {
+		existingSet[e] = struct{}{}
+	}
+
+	var tr Track
+	for i := 0; i < 100; i++ {
+		tr = catalog[rand.IntN(len(catalog))]
+		if _, found := existingSet[tr.Slug()]; !found {
+			return tr
+		}
+	}
+	return tr
+}

--- a/internal/songs/songs_test.go
+++ b/internal/songs/songs_test.go
@@ -1,0 +1,82 @@
+package songs
+
+import (
+	"regexp"
+	"testing"
+)
+
+var validNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+func TestSlug_MatchesValidNameRegex(t *testing.T) {
+	for _, tr := range catalog {
+		slug := tr.Slug()
+		if !validNameRe.MatchString(slug) {
+			t.Errorf("Track %q.Slug() = %q which does not match validName regex", tr.Name, slug)
+		}
+	}
+}
+
+func TestSlug_NonEmpty(t *testing.T) {
+	for _, tr := range catalog {
+		if tr.Slug() == "" {
+			t.Errorf("Track %q has empty Slug()", tr.Name)
+		}
+	}
+}
+
+func TestCatalog_AllFieldsNonEmpty(t *testing.T) {
+	if len(catalog) == 0 {
+		t.Fatal("catalog is empty")
+	}
+	for i, tr := range catalog {
+		if tr.Name == "" {
+			t.Errorf("catalog[%d].Name is empty", i)
+		}
+		if tr.Artist == "" {
+			t.Errorf("catalog[%d].Artist is empty (track %q)", i, tr.Name)
+		}
+		if tr.ISRC == "" {
+			t.Errorf("catalog[%d].ISRC is empty (track %q)", i, tr.Name)
+		}
+	}
+}
+
+func TestPick_NonEmpty(t *testing.T) {
+	tr := Pick(nil)
+	if tr.Name == "" {
+		t.Fatal("Pick(nil) returned a track with empty Name")
+	}
+}
+
+func TestPick_AvoidsCollision(t *testing.T) {
+	// Run up to len(catalog) rounds — once we've picked every track the
+	// catalog naturally exhausts, so we cap there.
+	rounds := 200
+	if rounds > len(catalog) {
+		rounds = len(catalog)
+	}
+	existing := make([]string, 0, rounds)
+	for i := 0; i < rounds; i++ {
+		tr := Pick(existing)
+		slug := tr.Slug()
+		for _, e := range existing {
+			if e == slug {
+				t.Errorf("Pick returned slug %q which already exists in the existing list", slug)
+			}
+		}
+		existing = append(existing, slug)
+	}
+}
+
+func TestPick_WithExistingAvoidsDuplicate(t *testing.T) {
+	first := Pick(nil)
+	existing := []string{first.Slug()}
+
+	for i := 0; i < 50; i++ {
+		tr := Pick(existing)
+		if tr.Slug() != first.Slug() {
+			return // success
+		}
+	}
+	t.Errorf("Pick kept returning %q even with it in the existing list", first.Slug())
+}

--- a/internal/tui/main_test.go
+++ b/internal/tui/main_test.go
@@ -9,18 +9,27 @@ import (
 // TestMain redirects $HOME to a per-process temp dir so tests that exercise
 // session creation (via agent.Manager) never touch the real ~/.baton/ —
 // otherwise every CreateSession call appends a row to the user's real
-// setlist file.
+// setlist file. We also set explicit git author/committer env vars so the
+// HOME redirect does not break tests that run `git commit` (which would
+// otherwise fail with "Author identity unknown" when no global gitconfig
+// is reachable, e.g. on CI runners).
 func TestMain(m *testing.M) {
 	tmp, err := os.MkdirTemp("", "baton-tui-tests-*")
 	if err != nil {
 		panic(err)
 	}
 	defer func() { _ = os.RemoveAll(tmp) }()
-	if err := os.Setenv("HOME", tmp); err != nil {
-		panic(err)
-	}
-	if err := os.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config")); err != nil {
-		panic(err)
+	for k, v := range map[string]string{
+		"HOME":                tmp,
+		"XDG_CONFIG_HOME":     filepath.Join(tmp, ".config"),
+		"GIT_AUTHOR_NAME":     "Baton Test",
+		"GIT_AUTHOR_EMAIL":    "baton-test@example.com",
+		"GIT_COMMITTER_NAME":  "Baton Test",
+		"GIT_COMMITTER_EMAIL": "baton-test@example.com",
+	} {
+		if err := os.Setenv(k, v); err != nil {
+			panic(err)
+		}
 	}
 	os.Exit(m.Run())
 }

--- a/internal/tui/main_test.go
+++ b/internal/tui/main_test.go
@@ -1,0 +1,26 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain redirects $HOME to a per-process temp dir so tests that exercise
+// session creation (via agent.Manager) never touch the real ~/.baton/ —
+// otherwise every CreateSession call appends a row to the user's real
+// setlist file.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "baton-tui-tests-*")
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+	if err := os.Setenv("HOME", tmp); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config")); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary

- New sessions are named after a randomly chosen song from a small embedded catalog (e.g. `baton/wonderwall`, `baton/karma-police`) instead of adjective-noun pairs. Catalog lives in `internal/songs/catalog.json` (~20 well-known tracks); the user can replace contents later or, eventually, sync from Spotify.
- Each new session appends a JSON line to `~/.baton/setlist.jsonl` capturing the song that played for it (name, artist, ISRC, slug, repo, session id, timestamp). This is the persistence foundation for a future setlist view.
- In-session secondary agents still get adjective-noun names. Existing-branch attach (`CreateSessionOnBranch*`) does not pick a song or write to the setlist. The first-prompt Haiku rename is unchanged — the song slug is the *initial* worktree name, the renamed branch is what the rest of the flow operates on.
- `internal/agent/` and `internal/tui/` tests redirect `$HOME` via `TestMain` so the test suite no longer pollutes the user's real `~/.baton/setlist.jsonl`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` (one pre-existing failure in `internal/config/TestLoad_MigratesFromLegacyXDGPath` reproduces on `main`; unrelated to this PR)
- [ ] Manual TUI: create two sessions, confirm they get distinct song slugs; check `~/.baton/setlist.jsonl` has two lines; attach to an existing branch and confirm no new setlist line; type a real prompt and confirm Haiku rename overwrites the song slug while the setlist line for that session is unchanged.

## Checklist

- [x] Added a fragment under `changelog.d/` (`change-song-name-worktrees.md`)
- [x] New behavior has tests (`internal/songs`, `internal/setlist`); the manager wiring is exercised by existing `internal/agent` and `internal/tui` tests via `TestMain`
- [x] No new public API surface beyond `internal/songs` and `internal/setlist`, both internal packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)