### PR TITLE
Mouse drag-to-select with auto-copy on the focused agent panel

### DIFF
--- a/changelog.d/feature-mouse-selection.md
+++ b/changelog.d/feature-mouse-selection.md
@@ -1,0 +1,7 @@
+### Added
+
+- Drag to select text in the focused agent panel; releases copy to the clipboard via OSC 52. Selection is performed in VT-cell coordinates so the lipgloss border can never appear inside a multi-line span. The highlight persists after release (matching iTerm2/Alacritty) and clears when you switch agents, lose terminal focus, click without dragging, or resize the window.
+
+### Fixed
+
+- Mouse-wheel coordinate translation no longer drifts by one row when the selected session has an open PR (the metadata-row count is computed from the dashboard rather than hardcoded).

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.23.1
 	github.com/bluekeyes/go-gitdiff v0.8.1
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/vt v0.0.0-20260413165052-6921c759c913
 	github.com/creack/pty v1.1.24
@@ -21,7 +22,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -531,6 +531,18 @@ func (a *Agent) RenderPadded(width, height int) string {
 	return a.terminal.RenderPadded(width, height)
 }
 
+// RenderPaddedWithSelection returns a width×height render with the cells inside
+// sel rendered in reverse video. See [vt.Terminal.RenderPaddedWithSelection].
+func (a *Agent) RenderPaddedWithSelection(width, height int, sel vt.SelectionRect) string {
+	return a.terminal.RenderPaddedWithSelection(width, height, sel)
+}
+
+// ExtractText returns the plain-text content of the cells inside rect.
+// See [vt.Terminal.ExtractText].
+func (a *Agent) ExtractText(rect vt.SelectionRect) string {
+	return a.terminal.ExtractText(rect)
+}
+
 // Snapshot returns a consistent (scrollback, viewport) pair for splice-safe
 // reads during pgup scrolling. See [vt.Terminal.Snapshot].
 func (a *Agent) Snapshot(width, height int) (scrollback []string, viewport string) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -22,6 +22,7 @@ import (
 	"github.com/devenjarvis/baton/internal/git"
 	"github.com/devenjarvis/baton/internal/github"
 	"github.com/devenjarvis/baton/internal/state"
+	"github.com/devenjarvis/baton/internal/vt"
 )
 
 // tickMsg triggers periodic re-renders.
@@ -195,6 +196,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.branchPicker.width = msg.Width
 		a.branchPicker.height = msg.Height - 1
 		a.recomputePRSectionY()
+		// A resize remaps the VT viewport — any in-flight selection is now
+		// pointing at stale cells. Drop it.
+		a.dashboard.clearSelection()
 
 		// Resize agent terminals to match their current display container.
 		if a.view == ViewDashboard {
@@ -1025,6 +1029,83 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if a.dashboard.panelFocus == focusList && a.dashboard.selectedAgent() != nil {
 					a.dashboard.panelFocus = focusTerminal
 				}
+				// Seed a fresh selection if the click landed inside the agent's
+				// VT viewport. dragSeen=false until a subsequent motion event
+				// confirms an actual drag — a click without drag should not
+				// produce a 1-cell selection.
+				if a.dashboard.panelFocus == focusTerminal {
+					if ag := a.dashboard.selectedAgent(); ag != nil {
+						if termX, termY, inVP := a.screenToTermCell(msg.X, msg.Y); inVP {
+							a.dashboard.selection = selection{
+								anchorX: termX,
+								anchorY: termY,
+								cursorX: termX,
+								cursorY: termY,
+								active:  true,
+								agentID: ag.ID,
+							}
+						} else {
+							// Click outside the viewport (e.g., on the border)
+							// drops any prior selection — matches what the user
+							// expects from "click somewhere else".
+							a.dashboard.clearSelection()
+						}
+					}
+				}
+			}
+		}
+		return a, nil
+	}
+
+	if msg, ok := msg.(tea.MouseMotionMsg); ok {
+		// Drag updates the cursor end of an in-flight selection. A motion
+		// event with the left button still held is the only signal we have
+		// that the user is dragging — bubbletea's MouseModeCellMotion gives
+		// us these while a button is down.
+		if a.dashboard.selection.active && msg.Button == tea.MouseLeft {
+			termX, termY, _ := a.screenToTermCell(msg.X, msg.Y)
+			if w := a.dashboard.fixedTermWidth(); w > 0 {
+				if termX < 0 {
+					termX = 0
+				} else if termX >= w {
+					termX = w - 1
+				}
+			}
+			if h := a.dashboard.fixedTermHeight(); h > 0 {
+				if termY < 0 {
+					termY = 0
+				} else if termY >= h {
+					termY = h - 1
+				}
+			}
+			a.dashboard.selection.cursorX = termX
+			a.dashboard.selection.cursorY = termY
+			if termX != a.dashboard.selection.anchorX || termY != a.dashboard.selection.anchorY {
+				a.dashboard.selection.dragSeen = true
+			}
+		}
+		return a, nil
+	}
+
+	if _, ok := msg.(tea.MouseReleaseMsg); ok {
+		if a.dashboard.selection.active {
+			if a.dashboard.selection.dragSeen {
+				// Real drag — copy the highlighted region. The highlight
+				// stays on screen until the next click clears or replaces it.
+				if ag := a.dashboard.selectedAgent(); ag != nil && ag.ID == a.dashboard.selection.agentID {
+					if sx, sy, ex, ey, ok := a.dashboard.selectionRect(); ok {
+						text := ag.ExtractText(vt.SelectionRect{
+							StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
+						})
+						if text != "" {
+							return a, tea.SetClipboard(text)
+						}
+					}
+				}
+			} else {
+				// Plain click — drop the seeded selection. Focus already moved
+				// in the click handler.
+				a.dashboard.clearSelection()
 			}
 		}
 		return a, nil
@@ -1074,6 +1155,15 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				diffCmd := a.refreshDiffStatsCmd()
 				return a, tea.Batch(cmd, diffCmd)
 			}
+		}
+	}
+	// Maintain the invariant: a text selection only persists while the user
+	// remains focused on the same agent's terminal. Any focus or agent change
+	// (sidebar nav, esc, click on the list, etc.) drops it.
+	if a.dashboard.selection.active {
+		ag := a.dashboard.selectedAgent()
+		if a.dashboard.panelFocus != focusTerminal || ag == nil || ag.ID != a.dashboard.selection.agentID {
+			a.dashboard.clearSelection()
 		}
 	}
 	return a, cmd
@@ -1305,18 +1395,16 @@ func (a *App) setError(msg string) {
 	a.errTicks = 30
 }
 
-// forwardWheelToAgent encodes a mouse wheel event and feeds it to the agent's
-// terminal. Coordinates are translated from dashboard-screen space to cells
-// relative to the agent's PTY viewport and clamped to [0,W)×[0,H). The
-// emulator only emits bytes when the running program has enabled mouse
-// reporting (DECSET 1000/1002/1003 + SGR 1006).
-func (a *App) forwardWheelToAgent(ag *agent.Agent, msg tea.MouseWheelMsg) {
-	// Row/col offsets to the terminal viewport's top-left cell in screen
-	// space. Mirrors the hardcoded layout assumed by fixedTermHeight
-	// (contentHeight − 4 metadata rows − 2 border rows) plus whatever banner
-	// rows the app layer has pushed the dashboard down by. Exact precision
-	// isn't critical — most alt-screen apps treat wheel events as
-	// direction-only — but translating keeps the coords inside the viewport.
+// screenToTermCell converts a screen-space mouse coordinate to a VT cell
+// coordinate inside the agent preview viewport. inViewport is false when the
+// point lies outside the viewport rectangle — callers that want clamping
+// should clamp to [0, fixedTermWidth) × [0, fixedTermHeight) themselves.
+//
+// The translation mirrors the dashboard layout: an optional error/confirm-quit
+// banner pushes content down, the list panel and its border occupy the first
+// 32 columns, and the preview's lipgloss frame plus the metadata rows above
+// the VT viewport offset the top-left cell.
+func (a *App) screenToTermCell(screenX, screenY int) (termX, termY int, inViewport bool) {
 	dashboardTopY := 0
 	if a.err != "" {
 		dashboardTopY++
@@ -1325,19 +1413,31 @@ func (a *App) forwardWheelToAgent(ag *agent.Agent, msg tea.MouseWheelMsg) {
 		dashboardTopY++
 	}
 	const (
-		previewColOffset    = 32 // list panel width + list-panel right border
-		previewLeftBorder   = 1
-		previewTopBorder    = 1
-		previewMetadataRows = 4 // title, sessionInfo, taskInfo, blank separator
+		previewColOffset  = 32 // list panel width + list-panel right border
+		previewLeftBorder = 1
+		previewTopBorder  = 1
 	)
-	termX := msg.X - previewColOffset - previewLeftBorder
+	w := a.dashboard.fixedTermWidth()
+	h := a.dashboard.fixedTermHeight()
+	termX = screenX - previewColOffset - previewLeftBorder
+	termY = screenY - dashboardTopY - previewTopBorder - a.dashboard.previewMetadataRows()
+	inViewport = w > 0 && h > 0 && termX >= 0 && termX < w && termY >= 0 && termY < h
+	return termX, termY, inViewport
+}
+
+// forwardWheelToAgent encodes a mouse wheel event and feeds it to the agent's
+// terminal. Coordinates are translated from dashboard-screen space to cells
+// relative to the agent's PTY viewport and clamped to [0,W)×[0,H). The
+// emulator only emits bytes when the running program has enabled mouse
+// reporting (DECSET 1000/1002/1003 + SGR 1006).
+func (a *App) forwardWheelToAgent(ag *agent.Agent, msg tea.MouseWheelMsg) {
+	termX, termY, _ := a.screenToTermCell(msg.X, msg.Y)
 	if termX < 0 {
 		termX = 0
 	}
 	if w := a.dashboard.fixedTermWidth(); w > 0 && termX >= w {
 		termX = w - 1
 	}
-	termY := msg.Y - dashboardTopY - previewTopBorder - previewMetadataRows
 	if termY < 0 {
 		termY = 0
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -15,6 +15,7 @@ import (
 	"github.com/devenjarvis/baton/internal/agent"
 	"github.com/devenjarvis/baton/internal/config"
 	"github.com/devenjarvis/baton/internal/github"
+	"github.com/devenjarvis/baton/internal/vt"
 )
 
 // truncateVisible returns s truncated to n display cells with an ellipsis.
@@ -94,6 +95,21 @@ type dashboardModel struct {
 	// Repo config form shown in the right panel when focusConfig is active.
 	repoConfigForm *configForm
 	configRepoPath string // path of the repo being configured
+
+	// Mouse text selection state in VT-cell coordinates, bound to a specific
+	// agent so a sidebar selection change clears it cleanly.
+	selection selection
+}
+
+// selection tracks an in-progress or completed mouse drag selection inside the
+// agent VT viewport. Coordinates are zero-based cell indices within the
+// agent's viewport (0..fixedTermWidth, 0..fixedTermHeight).
+type selection struct {
+	anchorX, anchorY int
+	cursorX, cursorY int
+	active           bool   // a click has seeded an in-flight or completed selection
+	dragSeen         bool   // mouse moved away from the anchor; distinguishes drag from plain click
+	agentID          string // agent.Agent.ID() the selection is bound to
 }
 
 func newDashboardModel() dashboardModel {
@@ -277,9 +293,9 @@ func (d dashboardModel) fixedTermHeight() int {
 // previewMetadataRows returns the number of non-VT rows rendered above the
 // terminal viewport in the preview panel: title, sessionInfo, taskInfo, and
 // the blank separator — plus one row for the PR info line when the selected
-// session has an open PR. Mouse coordinate translation in app.go uses a
-// hardcoded constant (see forwardWheelToAgent) and is explicitly out of scope
-// here.
+// session has an open PR. Mouse coordinate translation in app.go consumes
+// this via screenToTermCell so wheel/click/drag stay aligned with the
+// viewport when the PR row appears or disappears.
 func (d dashboardModel) previewMetadataRows() int {
 	rows := 4 // title, sessionInfo, taskInfo, blank
 	if sess := d.selectedSession(); sess != nil {
@@ -673,6 +689,11 @@ func (d dashboardModel) renderPreview(width int) string {
 			start = 0
 		}
 		render = strings.Join(allLines[start:end], "\n")
+	} else if d.selection.active && d.selection.dragSeen && d.selection.agentID == ag.ID {
+		sx, sy, ex, ey, _ := d.selectionRect()
+		render = ag.RenderPaddedWithSelection(vpWidth, vpHeight, vt.SelectionRect{
+			StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
+		})
 	} else {
 		render = ag.RenderPadded(vpWidth, vpHeight)
 	}
@@ -750,6 +771,33 @@ func (d *dashboardModel) clampToAgent() {
 			return
 		}
 	}
+}
+
+// clearSelection resets the mouse text-selection state. Safe to call when no
+// selection is active.
+func (d *dashboardModel) clearSelection() {
+	d.selection = selection{}
+}
+
+// selectionRect returns the active selection as a normalized rectangle in
+// VT-cell coordinates. Normalization is by row first, so for a multi-row
+// reverse drag (anchor row > cursor row) the returned startX/endX may be
+// "out of order" relative to a Cartesian rect — that asymmetry is intentional
+// and matches the per-line membership rule in vt.SelectionRect.inSelection:
+// startX picks where the start row begins, endX picks where the end row ends,
+// and the X axis is independent on each row. ok is false when there is no
+// drag-confirmed selection to render or copy from.
+func (d dashboardModel) selectionRect() (startX, startY, endX, endY int, ok bool) {
+	if !d.selection.active || !d.selection.dragSeen {
+		return 0, 0, 0, 0, false
+	}
+	startX, endX = d.selection.anchorX, d.selection.cursorX
+	startY, endY = d.selection.anchorY, d.selection.cursorY
+	if startY > endY || (startY == endY && startX > endX) {
+		startX, endX = endX, startX
+		startY, endY = endY, startY
+	}
+	return startX, startY, endX, endY, true
 }
 
 // agentItems returns all agent items from the list (for resize operations).

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -1,0 +1,104 @@
+package tui
+
+import "testing"
+
+func TestSelectionRect_Inactive(t *testing.T) {
+	d := dashboardModel{}
+	if _, _, _, _, ok := d.selectionRect(); ok {
+		t.Error("selectionRect on zero dashboard should report ok=false")
+	}
+
+	// active but no drag: still not a usable rect.
+	d.selection = selection{anchorX: 1, anchorY: 1, cursorX: 1, cursorY: 1, active: true}
+	if _, _, _, _, ok := d.selectionRect(); ok {
+		t.Error("selectionRect with dragSeen=false should report ok=false")
+	}
+}
+
+func TestSelectionRect_AnchorBeforeCursor(t *testing.T) {
+	d := dashboardModel{
+		selection: selection{
+			anchorX: 2, anchorY: 1,
+			cursorX: 7, cursorY: 4,
+			active: true, dragSeen: true,
+		},
+	}
+	sx, sy, ex, ey, ok := d.selectionRect()
+	if !ok {
+		t.Fatal("expected ok=true for drag-seen selection")
+	}
+	if sx != 2 || sy != 1 || ex != 7 || ey != 4 {
+		t.Errorf("anchor-before-cursor: got (%d,%d)-(%d,%d), want (2,1)-(7,4)", sx, sy, ex, ey)
+	}
+}
+
+func TestSelectionRect_AnchorAfterCursor(t *testing.T) {
+	d := dashboardModel{
+		selection: selection{
+			anchorX: 7, anchorY: 4,
+			cursorX: 2, cursorY: 1,
+			active: true, dragSeen: true,
+		},
+	}
+	sx, sy, ex, ey, ok := d.selectionRect()
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if sx != 2 || sy != 1 || ex != 7 || ey != 4 {
+		t.Errorf("anchor-after-cursor: got (%d,%d)-(%d,%d), want (2,1)-(7,4)", sx, sy, ex, ey)
+	}
+}
+
+func TestSelectionRect_SameRowAnchorAfterCursor(t *testing.T) {
+	// Drag right-to-left on the same row should still produce a normalized
+	// left-to-right rect.
+	d := dashboardModel{
+		selection: selection{
+			anchorX: 9, anchorY: 3,
+			cursorX: 4, cursorY: 3,
+			active: true, dragSeen: true,
+		},
+	}
+	sx, sy, ex, ey, ok := d.selectionRect()
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if sx != 4 || sy != 3 || ex != 9 || ey != 3 {
+		t.Errorf("same-row reverse drag: got (%d,%d)-(%d,%d), want (4,3)-(9,3)", sx, sy, ex, ey)
+	}
+}
+
+func TestSelectionRect_MultiRowReverseDrag(t *testing.T) {
+	// Drag bottom-up: anchor on a later row but cursor X to the right of anchor X.
+	// Normalization is by row first, so anchor's row becomes the bottom-right.
+	d := dashboardModel{
+		selection: selection{
+			anchorX: 2, anchorY: 5,
+			cursorX: 10, cursorY: 1,
+			active: true, dragSeen: true,
+		},
+	}
+	sx, sy, ex, ey, ok := d.selectionRect()
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if sx != 10 || sy != 1 || ex != 2 || ey != 5 {
+		t.Errorf("reverse multi-row drag: got (%d,%d)-(%d,%d), want (10,1)-(2,5)", sx, sy, ex, ey)
+	}
+}
+
+func TestClearSelection(t *testing.T) {
+	d := dashboardModel{
+		selection: selection{
+			anchorX: 1, anchorY: 1, cursorX: 5, cursorY: 5,
+			active: true, dragSeen: true, agentID: "abc",
+		},
+	}
+	d.clearSelection()
+	if d.selection.active || d.selection.dragSeen || d.selection.agentID != "" {
+		t.Errorf("clearSelection left residue: %+v", d.selection)
+	}
+	if _, _, _, _, ok := d.selectionRect(); ok {
+		t.Error("after clearSelection, selectionRect should report ok=false")
+	}
+}

--- a/internal/vt/bridge.go
+++ b/internal/vt/bridge.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	xvt "github.com/charmbracelet/x/vt"
 )
@@ -199,6 +200,201 @@ func (t *Terminal) RenderPadded(width, height int) string {
 	}
 	raw := t.emu.Render()
 	return padFrame(raw, width, height)
+}
+
+// SelectionRect is a viewport-local cell rectangle used by the selection-aware
+// render and extract helpers. Coordinates are zero-based cell indices, and
+// the rect is inclusive on both ends; per-row span is "from StartX on row
+// StartY through EndX on row EndY" — see RenderPaddedWithSelection for the
+// exact membership rule. When Active is false, the helpers behave as if no
+// selection were present.
+type SelectionRect struct {
+	StartX, StartY int
+	EndX, EndY     int
+	Active         bool
+}
+
+// inSelection reports whether (x, y) falls inside sel under the per-line rule:
+// rows strictly inside the [StartY, EndY] band are fully selected; the start
+// row is selected from StartX to end-of-row; the end row is selected from
+// start-of-row to EndX; a single-row selection uses [StartX, EndX].
+func (sel SelectionRect) inSelection(x, y int) bool {
+	if !sel.Active || y < sel.StartY || y > sel.EndY {
+		return false
+	}
+	if y > sel.StartY && y < sel.EndY {
+		return true
+	}
+	if sel.StartY == sel.EndY {
+		return x >= sel.StartX && x <= sel.EndX
+	}
+	if y == sel.StartY {
+		return x >= sel.StartX
+	}
+	return x <= sel.EndX
+}
+
+// RenderPaddedWithSelection returns a render identical in shape to RenderPadded
+// (width × height cells, lines separated by `\n`, each line ending with a
+// style reset) but with the cells inside sel rendered in reverse video so the
+// underlying foreground/background are preserved. When sel.Active is false,
+// this delegates to RenderPadded.
+//
+// Iteration goes cell-by-cell so the lipgloss border around the viewport is
+// excluded by construction — the selection rect lives in VT-cell coordinates,
+// not screen pixels, so the frame can never appear inside the highlight.
+func (t *Terminal) RenderPaddedWithSelection(width, height int, sel SelectionRect) string {
+	if width <= 0 || height <= 0 {
+		return ""
+	}
+	if !sel.Active {
+		return t.RenderPadded(width, height)
+	}
+
+	var b strings.Builder
+	b.Grow(height * (width + 16))
+	for y := 0; y < height; y++ {
+		t.renderLineWithSelection(&b, width, y, sel)
+		b.WriteString("\x1b[0m")
+		if y < height-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// renderLineWithSelection emits one row of width cells into b, honoring cell
+// styles and toggling SGR reverse video at selection boundaries. Wide cells
+// (Width == 2) emit their content once and consume two columns; if either
+// column is inside the selection, the cell is treated as selected.
+func (t *Terminal) renderLineWithSelection(b *strings.Builder, width, y int, sel SelectionRect) {
+	var (
+		pen     uv.Style
+		penSet  bool // false until we have written a real Style transition this line
+		reverse bool // SGR 7 currently on
+	)
+	for x := 0; x < width; x++ {
+		cell := t.emu.CellAt(x, y)
+		// Wide-cell trailing column: defensive skip. The lead branch below
+		// advances x past the trailing column, so this normally never fires
+		// — but if the emulator ever surfaces a stray Width==0 cell without
+		// a preceding lead, skipping it is the right behavior.
+		if cell != nil && cell.Width == 0 {
+			continue
+		}
+
+		var (
+			content string
+			cellW   int
+			style   uv.Style
+		)
+		if cell == nil {
+			content = " "
+			cellW = 1
+		} else {
+			content = cell.Content
+			if content == "" {
+				content = " "
+			}
+			cellW = cell.Width
+			if cellW < 1 {
+				cellW = 1
+			}
+			style = cell.Style
+		}
+
+		// Selection membership for this cell: a wide cell is "in" if either
+		// of its columns is in the selection.
+		inSel := sel.inSelection(x, y)
+		if cellW == 2 && !inSel {
+			inSel = sel.inSelection(x+1, y)
+		}
+
+		// Style transition. Always emit on the first cell of the line so any
+		// leftover SGR state from a prior line's reset is overwritten cleanly.
+		styleChanged := !penSet || !style.Equal(&pen)
+		if styleChanged {
+			diff := style.Diff(&pen)
+			if !penSet && diff == "" {
+				// First cell with zero style: still emit a reset so we don't
+				// inherit any pen the previous line might have left set.
+				b.WriteString("\x1b[0m")
+			} else {
+				b.WriteString(diff)
+			}
+			pen = style
+			penSet = true
+		}
+
+		// Reverse-video state. style.Diff may emit \x1b[0m, which clears all
+		// attributes including reverse — re-emit \x1b[7m after a style change
+		// while we're still inside the selection so the highlight survives.
+		switch {
+		case inSel && (!reverse || styleChanged):
+			b.WriteString("\x1b[7m")
+			reverse = true
+		case !inSel && reverse:
+			b.WriteString("\x1b[27m")
+			reverse = false
+		}
+
+		b.WriteString(content)
+		// Skip the trailing column of a wide cell so we don't double-emit.
+		if cellW == 2 {
+			x++
+		}
+	}
+	if reverse {
+		b.WriteString("\x1b[27m")
+	}
+}
+
+// ExtractText returns the plain text inside rect, joining rows with "\n" and
+// trimming trailing whitespace from each row. No styles or hyperlink metadata
+// are emitted. Wide cells contribute their content once (on the lead column)
+// and the trailing column is skipped; a wide cell is included if either of
+// its columns is inside the selection — matches RenderPaddedWithSelection.
+// An empty or inactive rect returns "".
+func (t *Terminal) ExtractText(rect SelectionRect) string {
+	if !rect.Active {
+		return ""
+	}
+	width := t.emu.Width()
+	var rows []string
+	for y := rect.StartY; y <= rect.EndY; y++ {
+		var line strings.Builder
+		for x := 0; x < width; x++ {
+			cell := t.emu.CellAt(x, y)
+			if cell != nil && cell.Width == 0 {
+				// Trailing column of a wide cell — handled at lead.
+				continue
+			}
+			cellW := 1
+			if cell != nil && cell.Width > 1 {
+				cellW = cell.Width
+			}
+			inSel := rect.inSelection(x, y)
+			if cellW == 2 && !inSel {
+				inSel = rect.inSelection(x+1, y)
+			}
+			if !inSel {
+				if cellW == 2 {
+					x++
+				}
+				continue
+			}
+			if cell == nil || cell.Content == "" {
+				line.WriteByte(' ')
+			} else {
+				line.WriteString(cell.Content)
+			}
+			if cellW == 2 {
+				x++
+			}
+		}
+		rows = append(rows, strings.TrimRight(line.String(), " \t"))
+	}
+	return strings.Join(rows, "\n")
 }
 
 // padFrame right-pads every line in `raw` (a `\n`-separated render) to `width`

--- a/internal/vt/bridge_test.go
+++ b/internal/vt/bridge_test.go
@@ -673,6 +673,258 @@ func TestSnapshotAtomic(t *testing.T) {
 	wg.Wait()
 }
 
+func TestRenderPaddedWithSelectionInactiveMatchesRenderPadded(t *testing.T) {
+	const w, h = 30, 4
+	term := New(w, h)
+	defer term.Close()
+	_, _ = term.Write([]byte("hello\r\nworld\r\nfoo bar\r\nbaz"))
+
+	want := term.RenderPadded(w, h)
+	got := term.RenderPaddedWithSelection(w, h, SelectionRect{Active: false})
+	if got != want {
+		t.Errorf("inactive selection should match RenderPadded byte-for-byte\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestRenderPaddedWithSelectionSingleCell(t *testing.T) {
+	const w, h = 10, 2
+	term := New(w, h)
+	defer term.Close()
+	_, _ = term.Write([]byte("ABCDE"))
+
+	// Select column 2 on row 0 → should invert exactly the 'C'.
+	out := term.RenderPaddedWithSelection(w, h, SelectionRect{
+		StartX: 2, StartY: 0, EndX: 2, EndY: 0, Active: true,
+	})
+	// The first row must contain "\x1b[7mC\x1b[27m" — reverse on, the cell, reverse off.
+	firstRow := strings.SplitN(out, "\n", 2)[0]
+	if !strings.Contains(firstRow, "\x1b[7mC\x1b[27m") {
+		t.Errorf("expected single-cell reverse around 'C', got %q", firstRow)
+	}
+	// 'B' and 'D' must not be wrapped in reverse video.
+	if strings.Contains(firstRow, "\x1b[7mB") || strings.Contains(firstRow, "\x1b[7mD") {
+		t.Errorf("expected only 'C' to be reversed, got %q", firstRow)
+	}
+	// Output shape must still be height rows, fully padded.
+	if got := strings.Count(out, "\n"); got != h-1 {
+		t.Errorf("expected %d newlines, got %d", h-1, got)
+	}
+}
+
+func TestRenderPaddedWithSelectionMultiLine(t *testing.T) {
+	const w, h = 10, 4
+	term := New(w, h)
+	defer term.Close()
+	_, _ = term.Write([]byte("ABCDE\r\nFGHIJ\r\nKLMNO\r\nPQRST"))
+
+	// Selection from (2,1) through (3,2): partial of row 1 (HIJ tail) and
+	// partial of row 2 (KLMN head).
+	out := term.RenderPaddedWithSelection(w, h, SelectionRect{
+		StartX: 2, StartY: 1, EndX: 3, EndY: 2, Active: true,
+	})
+	rows := strings.Split(out, "\n")
+	if len(rows) != h {
+		t.Fatalf("expected %d rows, got %d", h, len(rows))
+	}
+	// Row 0: no reverse video at all.
+	if strings.Contains(rows[0], "\x1b[7m") {
+		t.Errorf("row 0 should have no reverse video, got %q", rows[0])
+	}
+	// Row 1: reverse should turn on at H and span through end of row.
+	if !strings.Contains(rows[1], "\x1b[7m") {
+		t.Errorf("row 1 should contain reverse-on, got %q", rows[1])
+	}
+	// 'G' (col 1) must be before the reverse toggle.
+	idxG := strings.Index(rows[1], "G")
+	idxOn := strings.Index(rows[1], "\x1b[7m")
+	if idxG < 0 || idxOn < 0 || idxG > idxOn {
+		t.Errorf("row 1: 'G' should appear before reverse-on, got %q (G@%d, on@%d)", rows[1], idxG, idxOn)
+	}
+	// Row 2: reverse covers KLMN, then turns off before O.
+	if !strings.Contains(rows[2], "\x1b[27m") {
+		t.Errorf("row 2 should contain reverse-off, got %q", rows[2])
+	}
+	idxO := strings.Index(rows[2], "O")
+	idxOff := strings.Index(rows[2], "\x1b[27m")
+	if idxO < 0 || idxOff < 0 || idxOff > idxO {
+		t.Errorf("row 2: reverse-off should appear before 'O', got %q (off@%d, O@%d)", rows[2], idxOff, idxO)
+	}
+	// Row 3: no reverse video.
+	if strings.Contains(rows[3], "\x1b[7m") {
+		t.Errorf("row 3 should have no reverse video, got %q", rows[3])
+	}
+}
+
+func TestRenderPaddedWithSelectionDegenerateDims(t *testing.T) {
+	term := New(10, 5)
+	defer term.Close()
+	if got := term.RenderPaddedWithSelection(0, 5, SelectionRect{Active: true}); got != "" {
+		t.Errorf("expected empty for width=0, got %q", got)
+	}
+	if got := term.RenderPaddedWithSelection(5, 0, SelectionRect{Active: true}); got != "" {
+		t.Errorf("expected empty for height=0, got %q", got)
+	}
+}
+
+func TestRenderPaddedWithSelectionStyleTransitionInsideSelection(t *testing.T) {
+	const w, h = 10, 1
+	term := New(w, h)
+	defer term.Close()
+	// Red 'A', then plain 'BC'. Style.Diff from red→plain emits \x1b[0m which
+	// also clears reverse video — the bridge must re-emit \x1b[7m so the
+	// trailing 'BC' stays inverted.
+	_, _ = term.Write([]byte("\x1b[31mA\x1b[0mBC"))
+
+	out := term.RenderPaddedWithSelection(w, h, SelectionRect{
+		StartX: 0, StartY: 0, EndX: 2, EndY: 0, Active: true,
+	})
+	// Reverse-video must be in effect when 'B' and 'C' are emitted. We assert
+	// this structurally: every rendered glyph in the selection appears after
+	// a \x1b[7m and before the matching turn-off (or the trailing reset).
+	first := strings.SplitN(out, "\n", 2)[0]
+	idxA := strings.Index(first, "A")
+	idxB := strings.Index(first, "B")
+	idxC := strings.Index(first, "C")
+	if idxA < 0 || idxB < 0 || idxC < 0 {
+		t.Fatalf("expected A, B, C all present, got %q", first)
+	}
+	// Find the last \x1b[7m before each glyph and the first \x1b[27m or \x1b[0m
+	// after — assert the glyph is actually in reverse mode at emit time.
+	assertReverse := func(name string, idx int) {
+		t.Helper()
+		// last \x1b[7m before idx
+		on := strings.LastIndex(first[:idx], "\x1b[7m")
+		if on < 0 {
+			t.Errorf("%s at %d should be preceded by \\x1b[7m, got %q", name, idx, first)
+			return
+		}
+		// closest reverse-off after on
+		segment := first[on:idx]
+		if strings.Contains(segment, "\x1b[27m") || strings.Contains(segment, "\x1b[0m") {
+			// reverse was turned off between the last 7m and this glyph —
+			// must have been re-enabled. Look for another 7m closer to idx.
+			closer := strings.LastIndex(first[:idx], "\x1b[7m")
+			if closer == on {
+				t.Errorf("%s at %d: reverse turned off between \\x1b[7m@%d and glyph; not re-enabled. Frame=%q",
+					name, idx, on, first)
+			}
+		}
+	}
+	assertReverse("A", idxA)
+	assertReverse("B", idxB)
+	assertReverse("C", idxC)
+}
+
+func TestRenderPaddedWithSelectionWideCharNotSplit(t *testing.T) {
+	const w, h = 10, 1
+	term := New(w, h)
+	defer term.Close()
+	// Two CJK glyphs occupy 4 columns total; trailing ASCII fills the rest.
+	_, _ = term.Write([]byte("漢字hi"))
+
+	// Selection covers the trailing column of the first wide glyph only.
+	// The whole glyph should be inverted, and no second copy should appear.
+	out := term.RenderPaddedWithSelection(w, h, SelectionRect{
+		StartX: 1, StartY: 0, EndX: 1, EndY: 0, Active: true,
+	})
+	// "漢" must appear exactly once in the output.
+	if c := strings.Count(out, "漢"); c != 1 {
+		t.Errorf("wide glyph '漢' should appear exactly once, got %d in %q", c, out)
+	}
+	// And it should be inside the reverse-video bracket.
+	if !strings.Contains(out, "\x1b[7m漢\x1b[27m") {
+		t.Errorf("expected wide glyph to be wrapped in reverse video, got %q", out)
+	}
+}
+
+func TestExtractTextInactiveReturnsEmpty(t *testing.T) {
+	term := New(10, 2)
+	defer term.Close()
+	_, _ = term.Write([]byte("abc"))
+	if got := term.ExtractText(SelectionRect{Active: false}); got != "" {
+		t.Errorf("inactive rect should return empty, got %q", got)
+	}
+}
+
+func TestExtractTextSingleLine(t *testing.T) {
+	const w, h = 20, 2
+	term := New(w, h)
+	defer term.Close()
+	_, _ = term.Write([]byte("hello world"))
+
+	// Select cells 0..4 → "hello"
+	got := term.ExtractText(SelectionRect{StartX: 0, StartY: 0, EndX: 4, EndY: 0, Active: true})
+	if got != "hello" {
+		t.Errorf("expected 'hello', got %q", got)
+	}
+	// Select cells 6..10 → "world"
+	got = term.ExtractText(SelectionRect{StartX: 6, StartY: 0, EndX: 10, EndY: 0, Active: true})
+	if got != "world" {
+		t.Errorf("expected 'world', got %q", got)
+	}
+}
+
+func TestExtractTextMultiLine(t *testing.T) {
+	const w, h = 20, 4
+	term := New(w, h)
+	defer term.Close()
+	_, _ = term.Write([]byte("first line\r\nsecond\r\nthird"))
+
+	// Cover from (6, 0) to (5, 1) → " line" + "\n" + "second"
+	got := term.ExtractText(SelectionRect{StartX: 5, StartY: 0, EndX: 5, EndY: 1, Active: true})
+	want := " line\nsecond"
+	if got != want {
+		t.Errorf("multi-line: got %q, want %q", got, want)
+	}
+}
+
+func TestExtractTextTrimsTrailingWhitespace(t *testing.T) {
+	const w, h = 20, 2
+	term := New(w, h)
+	defer term.Close()
+	_, _ = term.Write([]byte("hi"))
+
+	// Selection extends past the actual content into blank cells; trailing
+	// whitespace must be trimmed.
+	got := term.ExtractText(SelectionRect{StartX: 0, StartY: 0, EndX: 19, EndY: 0, Active: true})
+	if got != "hi" {
+		t.Errorf("trailing blanks should be trimmed, got %q", got)
+	}
+
+	// Multi-line: each row trimmed independently. Row 1 is fully blank, so
+	// it should join in as an empty line — the join preserves rectangular
+	// shape across multi-line selections.
+	got = term.ExtractText(SelectionRect{StartX: 0, StartY: 0, EndX: 19, EndY: 1, Active: true})
+	if got != "hi\n" {
+		t.Errorf("multi-line trim should yield %q, got %q", "hi\n", got)
+	}
+}
+
+func TestExtractTextWideCharacter(t *testing.T) {
+	const w, h = 10, 1
+	term := New(w, h)
+	defer term.Close()
+	_, _ = term.Write([]byte("漢字hi"))
+
+	// Cells 0..3 cover both wide glyphs (each is 2 cells); content must
+	// not be duplicated by the trailing column.
+	got := term.ExtractText(SelectionRect{StartX: 0, StartY: 0, EndX: 3, EndY: 0, Active: true})
+	if got != "漢字" {
+		t.Errorf("expected '漢字', got %q", got)
+	}
+}
+
+func TestExtractTextEmptyRectOnBlankRow(t *testing.T) {
+	const w, h = 20, 2
+	term := New(w, h)
+	defer term.Close()
+	// Don't write anything — every cell is blank, so any rect trims to "".
+	got := term.ExtractText(SelectionRect{StartX: 0, StartY: 0, EndX: 5, EndY: 0, Active: true})
+	if got != "" {
+		t.Errorf("blank-row selection should yield empty string, got %q", got)
+	}
+}
+
 func TestCursorPosition(t *testing.T) {
 	term := New(80, 24)
 	defer term.Close()


### PR DESCRIPTION
## Summary

- Plain left-drag inside the focused agent VT viewport highlights cells in real time and copies the plain text to the clipboard via OSC 52 (`tea.SetClipboard`) on release. The highlight stays on screen until the next click clears or replaces it (matches iTerm2/Alacritty).
- Selection lives in VT-cell coordinates, not screen pixels — so the lipgloss border around the panel is excluded by construction even on multi-line spans, which was the workflow break that motivated this.
- Selection clears on agent change, focus leaving `focusTerminal`, click outside the viewport, and `WindowSizeMsg`.
- Drive-by fix: `forwardWheelToAgent` now uses the same `screenToTermCell` helper as the click/drag path, replacing a hardcoded `4`-row metadata constant with `dashboard.previewMetadataRows()`. Wheel coords no longer drift by a row when the selected session has an open PR.
- Plan + scope explicitly excludes scrollback selection, block selection, drag forwarding to the PTY, and modifier-bypass — all listed under Not in scope in the design.

The new `vt.SelectionRect` + `RenderPaddedWithSelection` + `ExtractText` helpers are unit-tested with the race detector for inactive-equivalence to `RenderPadded`, single-cell, multi-line, wide-character cells, blank-row trim, the empty rect, and an SGR transition mid-selection (`style.Diff` can emit `\x1b[0m`, which clears reverse — the bridge re-emits `\x1b[7m` so the highlight survives).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./...` — only `TestLoad_MigratesFromLegacyXDGPath` (internal/config) fails, confirmed pre-existing on `main`, unrelated
- [ ] Manual TUI:
  - Focus an agent, drag across multi-line output → live inverse-video rectangle, lipgloss border never inside the highlight.
  - Release → paste in another window, verify no `│` characters, no ANSI codes, no trailing whitespace.
  - Click without dragging → focuses the panel, no selection appears, prior selection clears.
  - Switch agents in the sidebar → highlight clears immediately.
  - Resize the terminal → highlight clears.
  - Mouse wheel still scrolls scrollback in non-alt-screen mode and forwards to alt-screen apps (regression check on the helper extraction).

## Checklist

- [x] Changelog fragment added at `changelog.d/feature-mouse-selection.md`
- [x] New behavior has tests (selection state helpers, render-with-selection across a style transition, extract-text edge cases)
- [x] New public API on `vt.Terminal` (`SelectionRect`, `RenderPaddedWithSelection`, `ExtractText`) and on `agent.Agent` (thin wrappers) — noted above