### PR TITLE
Guard Stop/SessionStart hooks against resurrecting Done/Error agents

### DIFF
--- a/changelog.d/fix-late-hook-resurrection.md
+++ b/changelog.d/fix-late-hook-resurrection.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Late `Stop` and `SessionStart` hook events arriving after a Claude process exits no longer resurrect `Done`/`Error` agents back to `Idle`/`Active`. This eliminates spurious status indicators and potential phantom chimes caused by the race between the PTY close path and in-flight unix-socket hook events.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -374,6 +374,11 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 
 	switch e.Kind {
 	case hook.KindSessionStart:
+		// A late SessionStart after process exit must not resurrect a Done or
+		// Error agent — mirror the guard pattern on the other hook kinds.
+		if a.status == StatusDone || a.status == StatusError {
+			return false
+		}
 		if e.SessionID != "" {
 			a.claudeSessionID = e.SessionID
 		}
@@ -385,6 +390,14 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 		return false
 
 	case hook.KindStop:
+		// A late Stop after process exit must not resurrect a Done or Error
+		// agent. This race is common: the PTY closes (readLoop sets Done/Error)
+		// and Claude's in-flight Stop hook event lands a moment later on the
+		// unix socket. Without this guard the agent's status would flip back to
+		// Idle, showing a wrong indicator and potentially triggering a chime.
+		if a.status == StatusDone || a.status == StatusError {
+			return false
+		}
 		// Claude finished its turn; the user is now in control. Clear the
 		// composing flag so input-display logic returns to its idle baseline.
 		a.composing = false

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -207,6 +207,179 @@ func TestManagerUserPromptSubmitRearmsChime(t *testing.T) {
 	}
 }
 
+// TestDoneAgentIgnoresLateStop verifies that a Done agent stays Done when a
+// late Stop event arrives — the common race where the PTY closes (readLoop
+// sets StatusDone) while Claude's in-flight Stop hook is still in the socket
+// queue.  Without the guard, the agent's status would flip to Idle and the
+// dashboard would show the wrong indicator.
+func TestDoneAgentIgnoresLateStop(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "done-ignore-stop", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	ag.mu.Lock()
+	ag.status = StatusDone
+	ag.mu.Unlock()
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindStop,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent Stop: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	if got := ag.Status(); got != StatusDone {
+		t.Errorf("expected Done to be preserved after late Stop, got %s", got)
+	}
+}
+
+// TestErrorAgentIgnoresLateStop verifies that an Error agent stays Error when a
+// late Stop hook arrives after the process has already exited with an error.
+func TestErrorAgentIgnoresLateStop(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "error-ignore-stop", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	ag.mu.Lock()
+	ag.status = StatusError
+	ag.mu.Unlock()
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindStop,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent Stop: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	if got := ag.Status(); got != StatusError {
+		t.Errorf("expected Error to be preserved after late Stop, got %s", got)
+	}
+}
+
+// TestDoneAgentIgnoresLateSessionStart verifies that a Done agent stays Done
+// when a late SessionStart event arrives.  This mirrors the same scenario for
+// Stop: the process may exit before all hook events are drained from the socket.
+func TestDoneAgentIgnoresLateSessionStart(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "done-ignore-ss", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	ag.mu.Lock()
+	ag.status = StatusDone
+	ag.mu.Unlock()
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:      hook.KindSessionStart,
+		AgentID:   ag.ID,
+		SessionID: "stray-session-id",
+	}); err != nil {
+		t.Fatalf("SendEvent SessionStart: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	if got := ag.Status(); got != StatusDone {
+		t.Errorf("expected Done to be preserved after late SessionStart, got %s", got)
+	}
+}
+
+// TestNotificationIgnoredWhenIdle verifies that a Notification arriving after
+// Stop (when the agent is already Idle) does not flip the agent to Waiting.
+// This prevents a trailing Notification from re-attentioning a row that Claude
+// has already finished with.
+func TestNotificationIgnoredWhenIdle(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "idle-ignore-notif", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// Drive to Idle via Stop hook (normal end-of-turn path).
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindSessionStart,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent SessionStart: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
+	}
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindStop,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent Stop: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusIdle, 2*time.Second) {
+		t.Fatalf("expected Idle after Stop, got %s", ag.Status())
+	}
+
+	// A trailing Notification must not flip Idle → Waiting.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindNotification,
+		AgentID: ag.ID,
+		Message: "stray notification after turn ended",
+	}); err != nil {
+		t.Fatalf("SendEvent Notification: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	if got := ag.Status(); got != StatusIdle {
+		t.Errorf("expected Idle to be preserved after stray Notification, got %s", got)
+	}
+}
+
 // TestDoneAgentIgnoresLateNotification verifies a Done agent stays Done
 // when a late Notification event arrives (e.g. race between Claude emitting
 // a prompt and the agent process having already been killed/finished).


### PR DESCRIPTION
## Summary

- `KindStop` and `KindSessionStart` were missing the Done/Error guard that every other hook kind already has. A late Stop or SessionStart hook arriving after the Claude process exits (common race: PTY closes → `readLoop` sets `Done`/`Error`, but the hook event is still in the unix socket queue) would flip the agent back to `Idle`/`Active` — producing a wrong status indicator in the dashboard and potentially firing a spurious chime.
- Added the same `if a.status == StatusDone || a.status == StatusError { return false }` guard to both cases, matching the pattern already used by `Notification`, `UserPromptSubmit`, and `PreToolUse`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (all passing; pre-existing `TestLoad_MigratesFromLegacyXDGPath` failure in `internal/config` is unrelated)
- [x] Four new integration tests added: `TestDoneAgentIgnoresLateStop`, `TestErrorAgentIgnoresLateStop`, `TestDoneAgentIgnoresLateSessionStart`, `TestNotificationIgnoredWhenIdle`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] Manual TUI: verify Done/Error agents show correct final status after Claude exits

## Checklist

- [x] Updated `changelog.d/fix-late-hook-resurrection.md`
- [x] New behavior has tests
- [x] No new public API surface