### PR TITLE
Music-themed playback controls + Haiku rename indicator

### DIFF
--- a/changelog.d/redesign-playback-controls.md
+++ b/changelog.d/redesign-playback-controls.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Agent status symbols now use playback-control glyphs: `▷` (starting), `▶` (active), `⏺` (waiting/on-mic), `⏸` (idle), `⏭` (done), `⏹` (error), reinforcing Baton's music identity.
+- Session rows display a `⏏` suffix while Haiku is composing a branch name, disappearing automatically once the rename completes or fails.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -338,6 +338,13 @@ func (s *Session) HasClaudeName() bool {
 	return s.hasClaudeName
 }
 
+// IsRenaming reports whether a Haiku rename goroutine is currently in flight.
+func (s *Session) IsRenaming() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.renaming
+}
+
 // SetClaudeName marks whether this session has a Claude-derived branch name.
 func (s *Session) SetClaudeName(v bool) {
 	s.mu.Lock()

--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -35,17 +35,17 @@ func (s Status) String() string {
 func (s Status) Symbol() string {
 	switch s {
 	case StatusStarting:
-		return "◎"
+		return "▷"
 	case StatusActive:
-		return "●"
+		return "▶"
 	case StatusWaiting:
-		return "◐"
+		return "⏺"
 	case StatusIdle:
-		return "○"
+		return "⏸"
 	case StatusDone:
-		return "✓"
+		return "⏭"
 	case StatusError:
-		return "✗"
+		return "⏹"
 	default:
 		return "?"
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -383,6 +383,14 @@ func (d dashboardModel) renderList(width int) string {
 
 			displayName := sess.GetDisplayName()
 
+			// Build rename-in-flight indicator suffix. Skipped while closing.
+			var renameSuffix string
+			var renameSuffixLen int
+			if !closing && sess.IsRenaming() {
+				renameSuffix = " ⏏"
+				renameSuffixLen = 2 // space + glyph
+			}
+
 			// Build PR indicator suffix for the session row. Skipped while
 			// closing so the " closing…" tag doesn't fight with a PR badge
 			// for limited header width.
@@ -411,7 +419,7 @@ func (d dashboardModel) renderList(width int) string {
 			}
 
 			// 4 for "  ──", 3 for " symbol ", 1 trailing space, plus some padding chars
-			maxNameLen := width - 10 - prSuffixLen - closingTagLen
+			maxNameLen := width - 10 - renameSuffixLen - prSuffixLen - closingTagLen
 			if maxNameLen < 5 {
 				maxNameLen = 5
 			}
@@ -425,8 +433,8 @@ func (d dashboardModel) renderList(width int) string {
 			if closing {
 				label += StyleSubtle.Render(closingTag)
 			}
-			label += " "
-			labelLen := ansi.StringWidth(symbol) + 1 + ansi.StringWidth(displayName) + 2 + prSuffixLen + closingTagLen
+			label += renameSuffix + " "
+			labelLen := ansi.StringWidth(symbol) + 1 + ansi.StringWidth(displayName) + 2 + renameSuffixLen + prSuffixLen + closingTagLen
 			padLen := width - 4 - labelLen
 			if padLen < 0 {
 				padLen = 0


### PR DESCRIPTION
## Summary

- Replace generic status symbols (circles, checkmarks) with playback-control glyphs that map semantically to agent lifecycle states: `▷` starting, `▶` active, `⏺` waiting/on-mic, `⏸` idle, `⏭` done, `⏹` error — reinforcing Baton's music identity.
- Add `IsRenaming() bool` getter on `Session` (thread-safe, reads `s.renaming` under `RLock`) so the TUI can observe rename-in-flight state without package coupling.
- Render a `⏏` suffix on session rows while Haiku is composing a branch name, disappearing automatically once the rename completes or fails. Follows the existing `prSuffix`/`prSuffixLen` width-budget pattern exactly; suppressed when `closing` is true.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: launch baton, create a session, submit a prompt — observe `▷`→`▶`→`⏸` transitions; `⏏` appears briefly during Haiku rename then disappears once branch name is set; `⏹` on agent kill.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — added `changelog.d/redesign-playback-controls.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description — `IsRenaming()` added, noted above