### PR TITLE
Style PR numbers as clickable links in dashboard

### DIFF
--- a/changelog.d/style-pr-number-as-link.md
+++ b/changelog.d/style-pr-number-as-link.md
@@ -1,0 +1,4 @@
+### Changed
+
+- PR numbers (`#N`) now appear underlined in cyan throughout the dashboard (session row, checks section header, preview panel) to signal they are clickable.
+- Status bar in dashboard mode now shows a "click PR#  open" hint alongside the `p  open PR` keyboard shortcut.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -662,7 +662,7 @@ func (d dashboardModel) renderPreview(width int) string {
 					checkStr = fmt.Sprintf(" -- %d/%d checks "+StyleWarning.Render("\u25cb"), entry.checks.Passed, entry.checks.Total)
 				}
 			}
-			prInfo = StyleSubtle.Render(fmt.Sprintf(" PR: #%d (%s)%s  %s", pr.Number, pr.State, checkStr, pr.URL))
+			prInfo = StyleSubtle.Render(" PR: ") + StyleLink.Render(fmt.Sprintf("#%d", pr.Number)) + StyleSubtle.Render(fmt.Sprintf(" (%s)%s  %s", pr.State, checkStr, pr.URL))
 		}
 	}
 	var taskInfo string
@@ -919,7 +919,7 @@ func (d dashboardModel) renderChecksSummary(entry *prCacheEntry, width, maxHeigh
 	if padLen < 0 {
 		padLen = 0
 	}
-	header := StyleSubtle.Render(prLabel) + badge + StyleSubtle.Render(strings.Repeat("─", padLen))
+	header := StyleSubtle.Render("── PR ") + StyleLink.Render(fmt.Sprintf("#%d", pr.Number)) + StyleSubtle.Render(" ──") + badge + StyleSubtle.Render(strings.Repeat("─", padLen))
 
 	var lines []string
 	lines = append(lines, header)

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -68,7 +68,7 @@ func prIndicator(entry *prCacheEntry) string {
 	pr := entry.pr
 	checks := entry.checks
 
-	prNum := fmt.Sprintf("#%d", pr.Number)
+	prNum := StyleLink.Render(fmt.Sprintf("#%d", pr.Number))
 
 	if checks == nil {
 		return prNum

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -20,6 +20,7 @@ var (
 		{"t", "shell"},
 		{"e", "open in IDE"},
 		{"p", "open PR"},
+		{"click PR#", "open"},
 		{"s", "settings"},
 		{"a", "add repo"},
 		{"o", "open branch"},

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -31,6 +31,10 @@ var (
 	StyleActive = lipgloss.NewStyle().
 			Foreground(ColorSecondary)
 
+	StyleLink = lipgloss.NewStyle().
+			Underline(true).
+			Foreground(ColorSecondary)
+
 	StyleStatusBar = lipgloss.NewStyle().
 			Foreground(ColorText).
 			Background(lipgloss.Color("#1F2937")).


### PR DESCRIPTION
## Summary

- Add `StyleLink` (underlined cyan `#06B6D4`) to the theme for consistent link-style rendering across the TUI
- Apply `StyleLink` to `#N` in the session row's `prIndicator`, the checks section header (`── PR #N ──`), and the preview panel's PR info line
- Add a "click PR#  open" hint to the dashboard status bar alongside the existing `p  open PR` keyboard shortcut
- Width accounting in `renderChecksSummary` is unchanged — `padLen` still uses the plain string length, not the styled output

The PR number was previously plain/muted text with no visual signal that it's clickable. This makes the affordance discoverable without changing any underlying behavior.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: left sidebar `#N` underlined/cyan; `── PR #N ──` header with `#N` cyan; preview panel `#N` cyan; status bar shows "click PR#  open"
- [ ] Click PR section → opens browser (existing behavior preserved)
- [ ] `p` key → opens browser (existing behavior preserved)

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description