### PR TITLE
Add marquee ticker for overflowing session names

### DIFF
--- a/changelog.d/session-name-ticker.md
+++ b/changelog.d/session-name-ticker.md
@@ -1,0 +1,3 @@
+### Added
+
+- Marquee ticker for long session names in the sidebar. Names that overflow the available width now pause at the start (2s), scroll left at a steady pace (250ms/step) to reveal the full name ending with a `·` dot, pause briefly at the end (1s), then snap back and repeat. Separator dashes stay stable width throughout the scroll. Fits the Baton radio/audio theme.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -369,6 +369,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				diffCmd = a.refreshDiffStatsCmd()
 			}
 		}
+		// Advance sidebar marquee tickers for overflowing session names.
+		a.dashboard.advanceTickers(time.Now())
 		// Adaptive per-session PR polling.
 		var prCmds []tea.Cmd
 		if a.ghClient != nil {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -31,6 +31,31 @@ func truncateVisible(s string, n int) string {
 	return ansi.Truncate(s, n, "…")
 }
 
+// tickerSlice returns a maxWidth-wide window of s starting at rune offset.
+// Returns "" when offset >= len(runes).
+func tickerSlice(s string, offset, maxWidth int) string {
+	runes := []rune(s)
+	if offset >= len(runes) {
+		return ""
+	}
+	return truncateVisible(string(runes[offset:]), maxWidth)
+}
+
+// Timing constants for the sidebar session-name marquee ticker.
+const (
+	tickerPauseStart = 2 * time.Second
+	tickerPauseEnd   = time.Second
+	tickerInterval   = 250 * time.Millisecond
+)
+
+// sessionTicker tracks the scroll state for one session's name in the sidebar.
+type sessionTicker struct {
+	offset      int
+	pauseUntil  time.Time
+	nextAdvance time.Time
+	atEnd       bool
+}
+
 // ColorWaiting is the accent used for agents in StatusWaiting (permission
 // prompts, input blocks). Scoped to the dashboard because no other view
 // needs it today — add to theme.go if another view ever surfaces waiting.
@@ -92,6 +117,9 @@ type dashboardModel struct {
 	// title and separator) where the PR checks summary begins, or -1 when absent.
 	prSectionY int
 
+	// tickers tracks marquee scroll state for session names that overflow the sidebar.
+	tickers map[string]*sessionTicker
+
 	// Repo config form shown in the right panel when focusConfig is active.
 	repoConfigForm *configForm
 	configRepoPath string // path of the repo being configured
@@ -113,7 +141,81 @@ type selection struct {
 }
 
 func newDashboardModel() dashboardModel {
-	return dashboardModel{prSectionY: -1}
+	return dashboardModel{prSectionY: -1, tickers: make(map[string]*sessionTicker)}
+}
+
+// advanceTickers steps the marquee scroll state for all sessions whose names
+// overflow the sidebar. Must be called once per tick before rendering.
+func (d *dashboardModel) advanceTickers(now time.Time) {
+	width := d.listWidth()
+	for _, item := range d.items {
+		if item.kind != listItemSession || item.session == nil {
+			continue
+		}
+		sess := item.session
+		displayName := sess.GetDisplayName()
+
+		closing := d.closingSessions != nil && d.closingSessions[sess.ID]
+		prSuffixLen := 0
+		if !closing {
+			if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
+				prSuffixLen = 1 + len(fmt.Sprintf("#%d", entry.pr.Number))
+				if entry.checks != nil {
+					prSuffixLen += 2
+				}
+				if isMergeReady(entry) {
+					prSuffixLen += 6
+				}
+			}
+		}
+		closingTagLen := 0
+		if closing {
+			closingTagLen = 9
+		}
+		maxNameLen := width - 10 - prSuffixLen - closingTagLen
+		if maxNameLen < 5 {
+			maxNameLen = 5
+		}
+
+		if ansi.StringWidth(displayName) <= maxNameLen {
+			delete(d.tickers, sess.ID)
+			continue
+		}
+
+		fullName := displayName + " ·"
+		fullRunes := []rune(fullName)
+
+		t, exists := d.tickers[sess.ID]
+		if !exists {
+			t = &sessionTicker{pauseUntil: now.Add(tickerPauseStart)}
+			d.tickers[sess.ID] = t
+		}
+
+		if now.Before(t.pauseUntil) {
+			continue
+		}
+		if now.Before(t.nextAdvance) {
+			continue
+		}
+
+		t.offset++
+		t.nextAdvance = now.Add(tickerInterval)
+
+		if ansi.StringWidth(string(fullRunes[t.offset:])) <= maxNameLen {
+			if !t.atEnd {
+				// First time reaching the end: brief pause before snapping.
+				t.atEnd = true
+				t.pauseUntil = now.Add(tickerPauseEnd)
+				t.nextAdvance = time.Time{}
+			} else {
+				// End pause expired: snap back to start.
+				t.offset = 0
+				t.atEnd = false
+				t.pauseUntil = now.Add(tickerPauseStart)
+				t.nextAdvance = time.Time{}
+			}
+		}
+	}
 }
 
 func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
@@ -423,18 +525,25 @@ func (d dashboardModel) renderList(width int) string {
 			if maxNameLen < 5 {
 				maxNameLen = 5
 			}
-			displayName = truncateVisible(displayName, maxNameLen)
+			var renderedName string
+			if ansi.StringWidth(displayName) <= maxNameLen {
+				renderedName = displayName
+			} else if t := d.tickers[sess.ID]; t != nil && t.offset > 0 {
+				renderedName = tickerSlice(displayName+" ·", t.offset, maxNameLen)
+			} else {
+				renderedName = truncateVisible(displayName, maxNameLen)
+			}
 
 			nameStyle := lipgloss.NewStyle()
 			if closing {
 				nameStyle = StyleSubtle
 			}
-			label := fmt.Sprintf(" %s %s", symbolStyle.Render(symbol), nameStyle.Render(displayName))
+			label := fmt.Sprintf(" %s %s", symbolStyle.Render(symbol), nameStyle.Render(renderedName))
 			if closing {
 				label += StyleSubtle.Render(closingTag)
 			}
 			label += renameSuffix + " "
-			labelLen := ansi.StringWidth(symbol) + 1 + ansi.StringWidth(displayName) + 2 + renameSuffixLen + prSuffixLen + closingTagLen
+			labelLen := ansi.StringWidth(symbol) + 1 + ansi.StringWidth(renderedName) + 2 + renameSuffixLen + prSuffixLen + closingTagLen
 			padLen := width - 4 - labelLen
 			if padLen < 0 {
 				padLen = 0

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -1,6 +1,12 @@
 package tui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devenjarvis/baton/internal/agent"
+)
 
 func TestSelectionRect_Inactive(t *testing.T) {
 	d := dashboardModel{}
@@ -100,5 +106,155 @@ func TestClearSelection(t *testing.T) {
 	}
 	if _, _, _, _, ok := d.selectionRect(); ok {
 		t.Error("after clearSelection, selectionRect should report ok=false")
+	}
+}
+
+// tickerDashboard builds a minimal dashboardModel for ticker tests.
+func tickerDashboard(sidebarW int, sessions ...*agent.Session) dashboardModel {
+	d := newDashboardModel()
+	d.sidebarWidth = sidebarW
+	d.prCache = make(map[string]*prCacheEntry)
+	d.closingSessions = make(map[string]bool)
+	for _, s := range sessions {
+		d.items = append(d.items, listItem{kind: listItemSession, session: s})
+	}
+	return d
+}
+
+// past returns a time in the past so ticker pause/advance checks pass immediately.
+func past() time.Time { return time.Now().Add(-time.Hour) }
+
+func TestTickerSlice_Basic(t *testing.T) {
+	got := tickerSlice("hello world", 6, 5)
+	if got != "world" {
+		t.Errorf("got %q, want %q", got, "world")
+	}
+}
+
+func TestTickerSlice_OffsetAtEnd(t *testing.T) {
+	got := tickerSlice("hello", 5, 10)
+	if got != "" {
+		t.Errorf("offset=len: got %q, want %q", got, "")
+	}
+}
+
+func TestTickerSlice_OffsetPastEnd(t *testing.T) {
+	got := tickerSlice("hello", 10, 5)
+	if got != "" {
+		t.Errorf("offset>len: got %q, want %q", got, "")
+	}
+}
+
+func TestTickerSlice_MultibyteRunes(t *testing.T) {
+	// "日本語" — 3 runes, each 2 display cells wide; offset=1 skips "日".
+	got := tickerSlice("日本語", 1, 10)
+	if got != "本語" {
+		t.Errorf("multibyte: got %q, want %q", got, "本語")
+	}
+}
+
+func TestAdvanceTickers_NameFits_NoTickerCreated(t *testing.T) {
+	// sidebarW=30 → maxNameLen=20; "short" (5 chars) fits easily.
+	sess := &agent.Session{ID: "s1", Name: "short"}
+	d := tickerDashboard(30, sess)
+	d.advanceTickers(time.Now())
+	if _, exists := d.tickers["s1"]; exists {
+		t.Error("ticker should not be created for a name that fits")
+	}
+}
+
+func TestAdvanceTickers_NameFits_ClearsStale(t *testing.T) {
+	// Stale ticker entry from a previous long name should be removed.
+	sess := &agent.Session{ID: "s1", Name: "short"}
+	d := tickerDashboard(30, sess)
+	d.tickers["s1"] = &sessionTicker{offset: 5}
+	d.advanceTickers(time.Now())
+	if _, exists := d.tickers["s1"]; exists {
+		t.Error("stale ticker should be removed when name fits")
+	}
+}
+
+func TestAdvanceTickers_OverflowCreatesTickerWithPause(t *testing.T) {
+	// sidebarW=30 → maxNameLen=20; long name (26 chars) overflows.
+	longName := "abcdefghijklmnopqrstuvwxyz"
+	sess := &agent.Session{ID: "s1", Name: longName}
+	d := tickerDashboard(30, sess)
+	now := time.Now()
+	d.advanceTickers(now)
+	tk := d.tickers["s1"]
+	if tk == nil {
+		t.Fatal("expected ticker to be created for overflowing name")
+	}
+	if tk.offset != 0 {
+		t.Errorf("offset: got %d, want 0", tk.offset)
+	}
+	if !tk.pauseUntil.After(now) {
+		t.Error("ticker should start in paused state")
+	}
+}
+
+func TestAdvanceTickers_AdvancePastPause_IncrementsOffset(t *testing.T) {
+	longName := "abcdefghijklmnopqrstuvwxyz"
+	sess := &agent.Session{ID: "s1", Name: longName}
+	d := tickerDashboard(30, sess)
+	// Pre-seed expired ticker so initial pause is already over.
+	d.tickers["s1"] = &sessionTicker{pauseUntil: past(), nextAdvance: past()}
+	d.advanceTickers(time.Now())
+	tk := d.tickers["s1"]
+	if tk.offset != 1 {
+		t.Errorf("offset after advance: got %d, want 1", tk.offset)
+	}
+}
+
+func TestAdvanceTickers_WideCharName_ScrollsNotStuck(t *testing.T) {
+	// 12 CJK runes = 24 display cells, overflows maxNameLen=20.
+	// len(fullRunes) = 14. Old rune-count check (offset+20 >= 14) would fire at
+	// offset=0 (0+20=20 >= 14), preventing the name from ever scrolling.
+	wideName := strings.Repeat("日", 12)
+	sess := &agent.Session{ID: "s1", Name: wideName}
+	d := tickerDashboard(30, sess)
+	d.tickers["s1"] = &sessionTicker{pauseUntil: past(), nextAdvance: past()}
+	d.advanceTickers(time.Now())
+	tk := d.tickers["s1"]
+	if tk.atEnd {
+		t.Error("wide-char name: atEnd should not fire on first advance")
+	}
+	if tk.offset != 1 {
+		t.Errorf("wide-char name: offset after first advance: got %d, want 1", tk.offset)
+	}
+}
+
+func TestAdvanceTickers_EndReached_SnapsBack(t *testing.T) {
+	// sidebarW=30 → maxNameLen=20
+	// longName=26 chars → fullName "…" + " ·" = 28 runes
+	// end condition: offset+20 >= 28 → offset >= 8
+	longName := "12345678901234567890123456"
+	sess := &agent.Session{ID: "s1", Name: longName}
+	d := tickerDashboard(30, sess)
+
+	// Set offset to 7 (one step before end); advance once → hits 8 → atEnd=true.
+	d.tickers["s1"] = &sessionTicker{offset: 7, pauseUntil: past(), nextAdvance: past()}
+	d.advanceTickers(time.Now())
+	tk := d.tickers["s1"]
+	if !tk.atEnd {
+		t.Fatal("expected atEnd=true after reaching end")
+	}
+	if tk.offset != 8 {
+		t.Errorf("offset at end: got %d, want 8", tk.offset)
+	}
+
+	// Simulate end-pause expiry and advance again → snap back.
+	tk.pauseUntil = past()
+	tk.nextAdvance = past()
+	beforeSnap := time.Now()
+	d.advanceTickers(time.Now())
+	if tk.offset != 0 {
+		t.Errorf("offset after snap: got %d, want 0", tk.offset)
+	}
+	if tk.atEnd {
+		t.Error("atEnd should be false after snap")
+	}
+	if !tk.pauseUntil.After(beforeSnap) {
+		t.Error("snap should set a fresh start pause")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a radio-style marquee ticker to session names in the sidebar that overflow the available width
- Long names pause at the start (2s), scroll left at 250ms/step revealing the full name ending with a `·` dot, pause at the end (1s), then snap back and repeat — fitting the Baton radio/audio theme
- Separator dashes stay stable width during scrolling (`labelLen` uses `ansi.StringWidth(renderedName)` so dash count is invariant)
- Wide-character (CJK, emoji) names handled correctly: end condition uses `ansi.StringWidth` of remaining tail rather than rune count, so names with multi-cell characters scroll properly

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] Manual TUI: launch `baton`, create a session with a long name (40+ chars), observe: name starts truncated, pauses ~2s, scrolls left steadily, shows `·` at end, pauses ~1s, snaps back and repeats
- [x] Manual TUI: verify separator dashes don't shift width during scroll
- [x] Manual TUI: verify PR flash color still works alongside ticker

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — added `changelog.d/session-name-ticker.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description