### PR TITLE
Simplify preview panel header to branch/worktree only

### DIFF
--- a/changelog.d/simplify-preview-header.md
+++ b/changelog.d/simplify-preview-header.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Preview panel header now shows only `Branch` and `Worktree` fields; removed the agent title row and task row. The scroll-offset indicator `[↑N]` moves to the branch/worktree line when scrolling.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -389,17 +389,17 @@ func (d dashboardModel) fixedTermWidth() int {
 // accepting 1 row of clipping when PR is visible is better than per-session
 // resize churn.
 func (d dashboardModel) fixedTermHeight() int {
-	return d.contentHeight() - 4 - 2 // metadata rows + focusTerminal border
+	return d.contentHeight() - 2 - 2 // 2 metadata rows (sessionInfo + blank) + 2 border rows
 }
 
 // previewMetadataRows returns the number of non-VT rows rendered above the
-// terminal viewport in the preview panel: title, sessionInfo, taskInfo, and
-// the blank separator — plus one row for the PR info line when the selected
-// session has an open PR. Mouse coordinate translation in app.go consumes
-// this via screenToTermCell so wheel/click/drag stay aligned with the
-// viewport when the PR row appears or disappears.
+// terminal viewport in the preview panel: sessionInfo and the blank separator
+// — plus one row for the PR info line when the selected session has an open
+// PR. Mouse coordinate translation in app.go consumes this via screenToTermCell
+// so wheel/click/drag stay aligned with the viewport when the PR row appears
+// or disappears.
 func (d dashboardModel) previewMetadataRows() int {
-	rows := 4 // title, sessionInfo, taskInfo, blank
+	rows := 2 // sessionInfo + blank; assumes agents always have a non-nil session
 	if sess := d.selectedSession(); sess != nil {
 		if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
 			rows++
@@ -753,16 +753,16 @@ func (d dashboardModel) renderPreview(width int) string {
 
 	// Agent selected — show terminal preview with session context.
 	ag := item.agent
-	titleText := " " + ag.GetDisplayName() + " "
-	if d.scrollOffset > 0 {
-		titleText = fmt.Sprintf(" %s [↑%d] ", ag.GetDisplayName(), d.scrollOffset)
-	}
-	title := StyleTitle.Render(titleText)
 
 	sessionInfo := ""
 	if item.session != nil {
-		sessionInfo = StyleSubtle.Render(fmt.Sprintf(" Session: %s  Branch: %s  Worktree: %s",
-			item.session.GetDisplayName(), item.session.Branch(), item.session.Worktree.Path))
+		if d.scrollOffset > 0 {
+			sessionInfo = StyleSubtle.Render(fmt.Sprintf(" Branch: %s  Worktree: %s  [↑%d]",
+				item.session.Branch(), item.session.Worktree.Path, d.scrollOffset))
+		} else {
+			sessionInfo = StyleSubtle.Render(fmt.Sprintf(" Branch: %s  Worktree: %s",
+				item.session.Branch(), item.session.Worktree.Path))
+		}
 	}
 	var prInfo string
 	if item.session != nil {
@@ -782,13 +782,6 @@ func (d dashboardModel) renderPreview(width int) string {
 			prInfo = StyleSubtle.Render(" PR: ") + StyleLink.Render(fmt.Sprintf("#%d", pr.Number)) + StyleSubtle.Render(fmt.Sprintf(" (%s)%s  %s", pr.State, checkStr, pr.URL))
 		}
 	}
-	var taskInfo string
-	if ag.IsShell {
-		taskInfo = StyleSubtle.Render(" Shell — " + ag.WorktreePath)
-	} else {
-		taskInfo = StyleSubtle.Render(" Task: " + ag.Task)
-	}
-
 	var render string
 	vpWidth := d.previewTermWidth()
 	vpHeight := d.previewTermHeight()
@@ -815,11 +808,14 @@ func (d dashboardModel) renderPreview(width int) string {
 		render = ag.RenderPadded(vpWidth, vpHeight)
 	}
 
-	previewParts := []string{title, sessionInfo}
+	previewParts := []string{}
+	if sessionInfo != "" {
+		previewParts = append(previewParts, sessionInfo)
+	}
 	if prInfo != "" {
 		previewParts = append(previewParts, prInfo)
 	}
-	previewParts = append(previewParts, taskInfo, "", render)
+	previewParts = append(previewParts, "", render)
 	return lipgloss.JoinVertical(lipgloss.Left, previewParts...)
 }
 


### PR DESCRIPTION
## Summary

- Removes the agent title row and task info row from the preview panel header — the session name is already visible in the sidebar, and the task string adds visual noise without actionable value
- `sessionInfo` line now shows only `Branch: <branch>  Worktree: <path>`
- The scroll-offset indicator `[↑N]` moves to the end of the branch/worktree line when scrolling into scrollback
- Corrects `previewMetadataRows()` (4 → 2) and `fixedTermHeight()` row count to keep mouse click/wheel/drag coordinates aligned with the viewport

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: select an agent — confirm header shows only `Branch: …  Worktree: …` with no title or task row
- [ ] Manual TUI: scroll into scrollback — confirm `[↑N]` appears on the branch/worktree line
- [ ] Manual TUI: click/drag inside the focused terminal — confirm mouse coordinates are correctly aligned (not shifted)
- [ ] Manual TUI: session with a PR — confirm PR row still appears below the branch/worktree line

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description