### PR TITLE
Fix text selection and copy when agent preview is scrolled up

### DIFF
--- a/changelog.d/fix-scrolled-selection-copy.md
+++ b/changelog.d/fix-scrolled-selection-copy.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Text selection and copy now work correctly when the agent preview pane is scrolled up. Previously, dragging over scrolled content showed no highlight and copied text from the wrong (live viewport) rows. Now the selection highlight is rendered correctly in scrollback, and releasing the drag copies the text that was actually highlighted.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -556,6 +556,13 @@ func (a *Agent) ExtractText(rect vt.SelectionRect) string {
 	return a.terminal.ExtractText(rect)
 }
 
+// ExtractTextFromSnapshot extracts plain text from the correct visible window
+// in the combined scrollback+viewport content, accounting for scroll offset.
+// See [vt.Terminal.ExtractTextFromSnapshot].
+func (a *Agent) ExtractTextFromSnapshot(width, height, scrollOffset int, rect vt.SelectionRect) string {
+	return a.terminal.ExtractTextFromSnapshot(width, height, scrollOffset, rect)
+}
+
 // Snapshot returns a consistent (scrollback, viewport) pair for splice-safe
 // reads during pgup scrolling. See [vt.Terminal.Snapshot].
 func (a *Agent) Snapshot(width, height int) (scrollback []string, viewport string) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1096,9 +1096,17 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// stays on screen until the next click clears or replaces it.
 				if ag := a.dashboard.selectedAgent(); ag != nil && ag.ID == a.dashboard.selection.agentID {
 					if sx, sy, ex, ey, ok := a.dashboard.selectionRect(); ok {
-						text := ag.ExtractText(vt.SelectionRect{
+						rect := vt.SelectionRect{
 							StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
-						})
+						}
+						var text string
+						if a.dashboard.scrollOffset > 0 {
+							vpWidth := a.dashboard.previewTermWidth()
+							vpHeight := a.dashboard.previewTermHeight()
+							text = ag.ExtractTextFromSnapshot(vpWidth, vpHeight, a.dashboard.scrollOffset, rect)
+						} else {
+							text = ag.ExtractText(rect)
+						}
 						if text != "" {
 							return a, tea.SetClipboard(text)
 						}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -805,7 +805,15 @@ func (d dashboardModel) renderPreview(width int) string {
 		if start < 0 {
 			start = 0
 		}
-		render = strings.Join(allLines[start:end], "\n")
+		visibleLines := allLines[start:end]
+		if d.selection.active && d.selection.dragSeen && d.selection.agentID == ag.ID {
+			sx, sy, ex, ey, _ := d.selectionRect()
+			render = applySelectionHighlight(visibleLines, vt.SelectionRect{
+				StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
+			})
+		} else {
+			render = strings.Join(visibleLines, "\n")
+		}
 	} else if d.selection.active && d.selection.dragSeen && d.selection.agentID == ag.ID {
 		sx, sy, ex, ey, _ := d.selectionRect()
 		render = ag.RenderPaddedWithSelection(vpWidth, vpHeight, vt.SelectionRect{
@@ -821,6 +829,66 @@ func (d dashboardModel) renderPreview(width int) string {
 	}
 	previewParts = append(previewParts, taskInfo, "", render)
 	return lipgloss.JoinVertical(lipgloss.Left, previewParts...)
+}
+
+// applySelectionHighlight inserts reverse-video SGR codes around selected column
+// ranges in each line of lines. ANSI is stripped first so column positions are
+// reliable; the non-selected text is emitted as plain. Active must be true on
+// rect for any highlight to be applied.
+func applySelectionHighlight(lines []string, rect vt.SelectionRect) string {
+	inSel := func(x, y int) bool {
+		if !rect.Active || y < rect.StartY || y > rect.EndY {
+			return false
+		}
+		if y > rect.StartY && y < rect.EndY {
+			return true
+		}
+		if rect.StartY == rect.EndY {
+			return x >= rect.StartX && x <= rect.EndX
+		}
+		if y == rect.StartY {
+			return x >= rect.StartX
+		}
+		return x <= rect.EndX
+	}
+	result := make([]string, len(lines))
+	for y, line := range lines {
+		if !rect.Active || y < rect.StartY || y > rect.EndY {
+			result[y] = line
+			continue
+		}
+		stripped := ansi.Strip(line)
+		var b strings.Builder
+		col := 0
+		inRev := false
+		for _, r := range stripped {
+			rw := ansi.StringWidth(string(r))
+			if rw == 0 {
+				continue // combining marks / zero-width chars have no column position
+			}
+			sel := false
+			for c := col; c < col+rw; c++ {
+				if inSel(c, y) {
+					sel = true
+					break
+				}
+			}
+			if sel && !inRev {
+				b.WriteString("\x1b[7m")
+				inRev = true
+			} else if !sel && inRev {
+				b.WriteString("\x1b[27m")
+				inRev = false
+			}
+			b.WriteRune(r)
+			col += rw
+		}
+		if inRev {
+			b.WriteString("\x1b[27m")
+		}
+		result[y] = b.String()
+	}
+	return strings.Join(result, "\n")
 }
 
 // selectedItem returns the currently selected list item, or nil if the list is empty.

--- a/internal/vt/bridge.go
+++ b/internal/vt/bridge.go
@@ -397,6 +397,58 @@ func (t *Terminal) ExtractText(rect SelectionRect) string {
 	return strings.Join(rows, "\n")
 }
 
+// ExtractTextFromSnapshot extracts plain text from the correct visible window
+// in the combined scrollback+viewport content, accounting for scroll offset.
+// Calls Snapshot() for an atomic read to avoid TOCTOU races between the two reads.
+// rect coordinates are viewport-local (row 0 = topmost visible line).
+func (t *Terminal) ExtractTextFromSnapshot(width, height, scrollOffset int, rect SelectionRect) string {
+	if !rect.Active {
+		return ""
+	}
+	scrollback, viewport := t.Snapshot(width, height)
+	vpLines := strings.Split(viewport, "\n")
+	allLines := append(scrollback, vpLines...)
+
+	end := len(allLines) - scrollOffset
+	if end < 0 {
+		end = 0
+	}
+	start := end - height
+	if start < 0 {
+		start = 0
+	}
+	visibleLines := allLines[start:end]
+
+	var rows []string
+	for y := rect.StartY; y <= rect.EndY; y++ {
+		if y >= len(visibleLines) {
+			break
+		}
+		stripped := ansi.Strip(visibleLines[y])
+		var line strings.Builder
+		col := 0
+		for _, r := range stripped {
+			rw := ansi.StringWidth(string(r))
+			if rw == 0 {
+				continue // combining marks / zero-width chars have no column position
+			}
+			inSel := false
+			for c := col; c < col+rw; c++ {
+				if rect.inSelection(c, y) {
+					inSel = true
+					break
+				}
+			}
+			if inSel {
+				line.WriteRune(r)
+			}
+			col += rw
+		}
+		rows = append(rows, strings.TrimRight(line.String(), " \t"))
+	}
+	return strings.Join(rows, "\n")
+}
+
 // padFrame right-pads every line in `raw` (a `\n`-separated render) to `width`
 // cells and forces the output to exactly `height` lines.
 func padFrame(raw string, width, height int) string {

--- a/internal/vt/bridge_test.go
+++ b/internal/vt/bridge_test.go
@@ -925,6 +925,65 @@ func TestExtractTextEmptyRectOnBlankRow(t *testing.T) {
 	}
 }
 
+func TestExtractTextFromSnapshotInactiveReturnsEmpty(t *testing.T) {
+	term := New(20, 2)
+	defer term.Close()
+	_, _ = term.Write([]byte("abc"))
+	if got := term.ExtractTextFromSnapshot(20, 2, 0, SelectionRect{Active: false}); got != "" {
+		t.Errorf("inactive rect should return empty, got %q", got)
+	}
+}
+
+func TestExtractTextFromSnapshotScrollbackRow(t *testing.T) {
+	// 20-wide, 2-row terminal: "FirstLine" scrolls off into scrollback.
+	term := New(20, 2)
+	defer term.Close()
+	_, _ = term.Write([]byte("FirstLine\r\nSecondLine\r\nThirdLine"))
+
+	// allLines = [scrollback[0]="FirstLine...", vpLine0="SecondLine...", vpLine1="ThirdLine..."]
+	// scrollOffset=1: end=2, start=0 → visible=["FirstLine...", "SecondLine..."]
+	// Select row 0, cols 0..8 → "FirstLine"
+	got := term.ExtractTextFromSnapshot(20, 2, 1, SelectionRect{
+		StartX: 0, StartY: 0, EndX: 8, EndY: 0, Active: true,
+	})
+	if got != "FirstLine" {
+		t.Errorf("expected 'FirstLine' from scrollback, got %q", got)
+	}
+}
+
+func TestExtractTextFromSnapshotViewportRowWhenScrolled(t *testing.T) {
+	// 20-wide, 2-row terminal: visible[1] = "SecondLine..." when scrollOffset=1.
+	term := New(20, 2)
+	defer term.Close()
+	_, _ = term.Write([]byte("FirstLine\r\nSecondLine\r\nThirdLine"))
+
+	// scrollOffset=1: visible=["FirstLine...", "SecondLine..."]
+	// Select row 1, cols 0..9 → "SecondLine"
+	got := term.ExtractTextFromSnapshot(20, 2, 1, SelectionRect{
+		StartX: 0, StartY: 1, EndX: 9, EndY: 1, Active: true,
+	})
+	if got != "SecondLine" {
+		t.Errorf("expected 'SecondLine', got %q", got)
+	}
+}
+
+func TestExtractTextFromSnapshotMultiRowCrossesScrollback(t *testing.T) {
+	// Selection spanning both a scrollback row and a viewport row.
+	term := New(20, 2)
+	defer term.Close()
+	_, _ = term.Write([]byte("FirstLine\r\nSecondLine\r\nThirdLine"))
+
+	// scrollOffset=1: visible=["FirstLine...", "SecondLine..."]
+	// Select from (5,0) to (5,1) → "Line" + "\n" + "Second"
+	got := term.ExtractTextFromSnapshot(20, 2, 1, SelectionRect{
+		StartX: 5, StartY: 0, EndX: 5, EndY: 1, Active: true,
+	})
+	want := "Line\nSecond"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
 func TestCursorPosition(t *testing.T) {
 	term := New(80, 24)
 	defer term.Close()


### PR DESCRIPTION
## Summary

- **Visual bug fixed**: dragging over scrolled-up content now shows the selection highlight. The `scrollOffset > 0` render branch previously never called `RenderPaddedWithSelection`; a new `applySelectionHighlight` helper applies reverse-video SGR around selected column ranges of the ANSI-stripped visible lines.
- **Functional bug fixed**: releasing a drag while scrolled now copies the correct text. `ag.ExtractText` reads from emulator cells at row Y, but visual row Y when scrolled maps to `allLines[start+Y]` (scrollback + viewport combined). The mouse-release handler now calls `ag.ExtractTextFromSnapshot` when `scrollOffset > 0`, which atomically snapshots the combined content via `Snapshot()` and uses the identical coordinate math as the render.
- New `ExtractTextFromSnapshot` on `vt.Terminal` and `agent.Agent` for scroll-aware text extraction; existing `ExtractText` path (offset 0) is unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI:
  1. Start baton with an active agent producing enough output to fill scrollback (PgUp shows history)
  2. Press PgUp to scroll up several screens
  3. Click-drag over text in the scrolled view — confirm selection highlight appears
  4. Release — paste into terminal and confirm the correct text was copied (matches the highlighted content, not the live viewport)
  5. Press PgDown back to live view, drag-select — confirm existing path still works

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — fragment added at `changelog.d/fix-scrolled-selection-copy.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description — `ExtractTextFromSnapshot` documented in summary above