### PR TITLE
Make Haiku branch namer reliably succeed for every session

### DIFF
--- a/changelog.d/fix-haiku-branch-namer-reliability.md
+++ b/changelog.d/fix-haiku-branch-namer-reliability.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- The Haiku-driven branch/session rename now succeeds reliably, where it previously failed for most sessions. Three issues compounded: (1) the Haiku subprocess inherited `BATON_HOOK_SOCKET` and `BATON_AGENT_ID`, which caused phantom hook events to fire back into the running TUI as the parent agent and added per-call socket roundtrips that inflated cold-start latency past the timeout — these vars are now stripped from the subprocess env; (2) the 15s overall timeout was too tight for `claude -p` cold starts (settings discovery, MCP probe, possible auth refresh routinely take 10–25s) — each attempt now gets 30s and the overall sequence gets 75s; (3) a single transient blip dropped the rename until the next user prompt — there are now up to 3 attempts per prompt with a 1s/3s backoff, classifying `claude not found` and empty-slug results as terminal so they don't waste retries.
+
+- Per-rename diagnostic logs land in `<repo>/.baton/logs/haiku.log` (one line per attempt + a final outcome line, truncated past 1 MiB) so failures that previously vanished silently — the TUI alt-screen makes stderr unreadable — can now be inspected after the fact.

--- a/internal/agent/haikulog.go
+++ b/internal/agent/haikulog.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// haikuLogPath returns the diagnostic log path for the given repo. The log
+// lives under <repoPath>/.baton/logs/ alongside the hook socket.
+func haikuLogPath(repoPath string) string {
+	return filepath.Join(repoPath, ".baton", "logs", "haiku.log")
+}
+
+// haikuLogMaxBytes is the size threshold past which haikuLog truncates the
+// file. The log is diagnostic, not audit; losing history on truncation is
+// acceptable in exchange for bounded disk use.
+const haikuLogMaxBytes int64 = 1 << 20 // 1 MiB
+
+var haikuLogMu sync.Mutex
+
+// haikuLog appends a single diagnostic line about the branch-namer flow to
+// <repoPath>/.baton/logs/haiku.log. Best-effort: any I/O error is silently
+// dropped so logging never disrupts the TUI. The line is suffixed with "\n"
+// if it doesn't already end in one.
+//
+// When the log exceeds haikuLogMaxBytes, the file is truncated before the
+// next write — the log is for diagnosing the most recent failures, not for
+// long-term audit, so a hard truncate is simpler than rotating files.
+func haikuLog(repoPath, line string) {
+	if repoPath == "" {
+		return
+	}
+	haikuLogMu.Lock()
+	defer haikuLogMu.Unlock()
+
+	path := haikuLogPath(repoPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+
+	if info, err := os.Stat(path); err == nil && info.Size() > haikuLogMaxBytes {
+		_ = os.Truncate(path, 0)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	if line == "" || line[len(line)-1] != '\n' {
+		line += "\n"
+	}
+	_, _ = f.WriteString(line)
+}
+
+// haikuLogAttempt formats and writes one per-attempt diagnostic line.
+func haikuLogAttempt(repoPath, sessionID string, attempt int, suffix string, err error, took time.Duration) {
+	status := "err"
+	detail := ""
+	switch {
+	case err != nil:
+		detail = fmt.Sprintf(" err=%q", err.Error())
+	case suffix == "":
+		detail = " err=\"empty suffix\""
+	default:
+		status = "ok"
+		detail = fmt.Sprintf(" suffix=%s", suffix)
+	}
+	haikuLog(repoPath, fmt.Sprintf(
+		"%s session=%s attempt=%d status=%s took=%s%s",
+		time.Now().UTC().Format(time.RFC3339),
+		sessionID, attempt, status, took.Round(time.Millisecond), detail,
+	))
+}
+
+// haikuLogOutcome formats and writes one final-outcome diagnostic line for
+// the whole rename sequence (across all retries).
+func haikuLogOutcome(repoPath, sessionID, suffix string, err error, took time.Duration) {
+	if err == nil && suffix != "" {
+		haikuLog(repoPath, fmt.Sprintf(
+			"%s session=%s status=ok suffix=%s took=%s",
+			time.Now().UTC().Format(time.RFC3339),
+			sessionID, suffix, took.Round(time.Millisecond),
+		))
+		return
+	}
+	detail := "unknown"
+	if err != nil {
+		detail = err.Error()
+	}
+	haikuLog(repoPath, fmt.Sprintf(
+		"%s session=%s status=fail err=%q took=%s",
+		time.Now().UTC().Format(time.RFC3339),
+		sessionID, detail, took.Round(time.Millisecond),
+	))
+}

--- a/internal/agent/haikulog_test.go
+++ b/internal/agent/haikulog_test.go
@@ -1,0 +1,134 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestHaikuLog_AppendsAndCreates(t *testing.T) {
+	repo := t.TempDir()
+	haikuLog(repo, "first")
+	haikuLog(repo, "second")
+
+	body, err := os.ReadFile(haikuLogPath(repo))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "first\n") || !strings.Contains(got, "second\n") {
+		t.Errorf("log missing entries: %q", got)
+	}
+}
+
+func TestHaikuLog_NoRepoIsNoOp(t *testing.T) {
+	// No path = no panic, no file. Just verify it doesn't crash.
+	haikuLog("", "anything")
+}
+
+func TestHaikuLog_TruncatesPastSizeLimit(t *testing.T) {
+	repo := t.TempDir()
+	path := haikuLogPath(repo)
+	if err := os.MkdirAll(strings.TrimSuffix(path, "/haiku.log"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Pre-seed a file larger than the truncation threshold.
+	huge := make([]byte, haikuLogMaxBytes+100)
+	for i := range huge {
+		huge[i] = 'X'
+	}
+	if err := os.WriteFile(path, huge, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	haikuLog(repo, "fresh-line")
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if int64(len(body)) >= haikuLogMaxBytes {
+		t.Errorf("log not truncated; size = %d, max = %d", len(body), haikuLogMaxBytes)
+	}
+	if !strings.Contains(string(body), "fresh-line") {
+		t.Errorf("log missing fresh entry after truncate: %q", string(body))
+	}
+	if strings.Contains(string(body), "XXXXXXXXXX") {
+		t.Errorf("log still contains pre-truncate content: %q", string(body)[:50])
+	}
+}
+
+func TestHaikuLog_ConcurrentWritesNoInterleaving(t *testing.T) {
+	repo := t.TempDir()
+	const goroutines = 16
+	const perGoroutine = 50
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				haikuLog(repo, "tag-XYZ-marker")
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	body, err := os.ReadFile(haikuLogPath(repo))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+	if got, want := len(lines), goroutines*perGoroutine; got != want {
+		t.Errorf("line count = %d, want %d", got, want)
+	}
+	for _, line := range lines {
+		if line != "tag-XYZ-marker" {
+			t.Errorf("interleaved/corrupt line: %q", line)
+			break
+		}
+	}
+}
+
+func TestHaikuLogAttempt_FormatsOkAndErr(t *testing.T) {
+	repo := t.TempDir()
+	haikuLogAttempt(repo, "sess-1", 1, "", errors.New("boom"), 100*time.Millisecond)
+	haikuLogAttempt(repo, "sess-1", 2, "good-slug", nil, 200*time.Millisecond)
+
+	body, err := os.ReadFile(haikuLogPath(repo))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "session=sess-1 attempt=1 status=err") {
+		t.Errorf("missing err line: %q", got)
+	}
+	if !strings.Contains(got, `err="boom"`) {
+		t.Errorf("missing quoted err detail: %q", got)
+	}
+	if !strings.Contains(got, "session=sess-1 attempt=2 status=ok took=200ms suffix=good-slug") {
+		t.Errorf("missing ok line: %q", got)
+	}
+}
+
+func TestHaikuLogOutcome_FormatsBothPaths(t *testing.T) {
+	repo := t.TempDir()
+	haikuLogOutcome(repo, "sess-2", "", errors.New("nope"), 500*time.Millisecond)
+	haikuLogOutcome(repo, "sess-2", "name", nil, 1500*time.Millisecond)
+
+	body, err := os.ReadFile(haikuLogPath(repo))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, `status=fail err="nope" took=500ms`) {
+		t.Errorf("missing fail line: %q", got)
+	}
+	if !strings.Contains(got, "status=ok suffix=name took=1.5s") {
+		t.Errorf("missing ok line: %q", got)
+	}
+}

--- a/internal/agent/haikuname.go
+++ b/internal/agent/haikuname.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -19,6 +21,25 @@ type BranchNamer func(ctx context.Context, instruction string) (string, error)
 
 const claudeHaikuModel = "claude-haiku-4-5"
 
+// ErrClaudeNotFound is returned when the `claude` binary is not on PATH.
+// The retry wrapper treats this as terminal — no amount of retrying will
+// produce the binary, so we fail fast and let the next user prompt re-attempt.
+var ErrClaudeNotFound = errors.New("claude not found on PATH")
+
+// ErrEmptySlug is returned when claude's response slugifies to the empty
+// string (e.g. punctuation-only output, or output that doesn't begin with
+// an alphanumeric character). Treated as terminal — retrying the same
+// instruction is unlikely to produce a different result.
+var ErrEmptySlug = errors.New("empty slug after slugify")
+
+// batonHookEnvVars lists env vars that wire a claude subprocess into baton's
+// running hook server. These must be stripped from the Haiku subprocess so
+// it doesn't fire phantom hook events back into the TUI as the parent agent.
+var batonHookEnvVars = []string{
+	"BATON_HOOK_SOCKET",
+	"BATON_AGENT_ID",
+}
+
 // DefaultBranchNamer returns a BranchNamer that shells out to
 // `claude -p --model claude-haiku-4-5` to summarize the user's first prompt.
 // The instruction is piped in on stdin so the argv stays bounded regardless
@@ -31,7 +52,7 @@ func DefaultBranchNamer() BranchNamer {
 	return func(ctx context.Context, instruction string) (string, error) {
 		claudePath, err := exec.LookPath("claude")
 		if err != nil {
-			return "", fmt.Errorf("claude not found on PATH: %w", err)
+			return "", fmt.Errorf("%w: %v", ErrClaudeNotFound, err)
 		}
 		return runClaudeHaiku(ctx, claudePath, instruction)
 	}
@@ -40,6 +61,12 @@ func DefaultBranchNamer() BranchNamer {
 func runClaudeHaiku(ctx context.Context, claudePath, instruction string) (string, error) {
 	cmd := exec.CommandContext(ctx, claudePath, "-p", "--model", claudeHaikuModel)
 	cmd.Stdin = strings.NewReader(instruction)
+	// Strip baton's hook-wiring env vars so the Haiku subprocess does not
+	// register hook callbacks against the running TUI's socket as the parent
+	// agent. Inheriting these caused phantom SessionStart/SessionEnd events
+	// to land on the parent agent and added per-call socket roundtrips that
+	// inflated cold-start latency past the rename timeout.
+	cmd.Env = sanitizedHaikuEnv(os.Environ())
 	// Bound how long Wait() blocks on pipe drain after the context kills the
 	// process — otherwise a descendant sleep can hold the stdout pipe open
 	// and keep Wait blocked long past cancellation.
@@ -55,7 +82,112 @@ func runClaudeHaiku(ctx context.Context, claudePath, instruction string) (string
 
 	slug := slugify(strings.TrimSpace(stdout.String()))
 	if slug == "" {
-		return "", fmt.Errorf("claude haiku: empty slug after slugify")
+		return "", ErrEmptySlug
 	}
 	return slug, nil
+}
+
+// sanitizedHaikuEnv returns env minus baton's hook-wiring vars. Everything
+// else (PATH, HOME, XDG_*, ANTHROPIC_*, etc.) is preserved — claude needs
+// auth and config to run.
+func sanitizedHaikuEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if shouldStripHaikuEnv(e) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func shouldStripHaikuEnv(entry string) bool {
+	for _, name := range batonHookEnvVars {
+		if strings.HasPrefix(entry, name+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+// callNamerWithRetry invokes namer up to maxAttempts times, each bounded by
+// perAttempt, returning early on success. Treats ErrClaudeNotFound and
+// ErrEmptySlug as terminal — retrying won't fix a missing binary or a model
+// that returned junk. Aborts immediately when done is closed (manager
+// shutdown) or when the outer ctx expires.
+//
+// perAttemptLog, if non-nil, is invoked with the attempt number (1-based),
+// the result/error, and the wall-clock duration. Used to write per-attempt
+// lines to the diagnostic log without coupling this wrapper to a file path.
+func callNamerWithRetry(
+	ctx context.Context,
+	namer BranchNamer,
+	instruction string,
+	done <-chan struct{},
+	maxAttempts int,
+	perAttempt time.Duration,
+	backoff []time.Duration,
+	perAttemptLog func(attempt int, suffix string, err error, took time.Duration),
+) (string, error) {
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		select {
+		case <-done:
+			return "", context.Canceled
+		default:
+		}
+
+		attemptCtx, cancel := context.WithTimeout(ctx, perAttempt)
+		start := time.Now()
+		suffix, err := namer(attemptCtx, instruction)
+		cancel()
+		took := time.Since(start)
+
+		if perAttemptLog != nil {
+			perAttemptLog(attempt, suffix, err, took)
+		}
+
+		if err == nil && suffix != "" {
+			return suffix, nil
+		}
+
+		// Terminal errors: don't retry.
+		if errors.Is(err, ErrClaudeNotFound) || errors.Is(err, ErrEmptySlug) {
+			return "", err
+		}
+		if err == nil && suffix == "" {
+			// Defensive: namer returned (\"\", nil). Treat as terminal.
+			return "", ErrEmptySlug
+		}
+
+		lastErr = err
+		if attempt == maxAttempts {
+			break
+		}
+
+		var wait time.Duration
+		if idx := attempt - 1; idx < len(backoff) {
+			wait = backoff[idx]
+		}
+		if wait > 0 {
+			timer := time.NewTimer(wait)
+			select {
+			case <-timer.C:
+			case <-done:
+				timer.Stop()
+				return "", context.Canceled
+			case <-ctx.Done():
+				timer.Stop()
+				return "", ctx.Err()
+			}
+		}
+	}
+	return "", lastErr
 }

--- a/internal/agent/haikuname_test.go
+++ b/internal/agent/haikuname_test.go
@@ -2,10 +2,13 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -218,5 +221,229 @@ func TestDefaultBranchNamer_ClaudeMissing(t *testing.T) {
 	_, err := namer(ctx, "hello")
 	if err == nil {
 		t.Fatal("expected error when claude is absent from PATH")
+	}
+	if !errors.Is(err, ErrClaudeNotFound) {
+		t.Errorf("err = %v, want errors.Is(err, ErrClaudeNotFound) == true", err)
+	}
+}
+
+// writeEnvDumpingClaude writes a fake claude that dumps its env into envFile
+// and prints stdout. Used to verify env-stripping in the Haiku subprocess.
+func writeEnvDumpingClaude(t *testing.T, dir, envFile, stdout string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake claude uses /bin/sh; skip on windows")
+	}
+	script := "#!/bin/sh\n" +
+		"cat >/dev/null\n" +
+		"env > " + shellSingleQuote(envFile) + "\n" +
+		"printf %s " + shellSingleQuote(stdout) + "\n"
+	path := filepath.Join(dir, "claude")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write env-dumping claude: %v", err)
+	}
+}
+
+func TestDefaultBranchNamer_StripsBatonHookEnv(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "env.txt")
+	writeEnvDumpingClaude(t, dir, envFile, "result-slug")
+	withPATH(t, dir)
+
+	t.Setenv("BATON_HOOK_SOCKET", "/should/not/leak.sock")
+	t.Setenv("BATON_AGENT_ID", "should-not-leak")
+	// Sentinel non-baton var should still be inherited.
+	t.Setenv("BATON_KEEPME_TESTONLY", "yes")
+
+	namer := DefaultBranchNamer()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := namer(ctx, "hello"); err != nil {
+		t.Fatalf("namer returned error: %v", err)
+	}
+
+	envContents, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	body := string(envContents)
+	for _, banned := range []string{"BATON_HOOK_SOCKET=", "BATON_AGENT_ID="} {
+		if strings.Contains(body, banned) {
+			t.Errorf("subprocess env contained %q; should have been stripped\n%s", banned, body)
+		}
+	}
+	if !strings.Contains(body, "BATON_KEEPME_TESTONLY=yes") {
+		t.Errorf("subprocess env missing non-baton sentinel var; env stripping was too aggressive\n%s", body)
+	}
+}
+
+func TestSanitizedHaikuEnv(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"BATON_HOOK_SOCKET=/sock",
+		"HOME=/home/u",
+		"BATON_AGENT_ID=abc",
+		"BATON_FOO=keepme",     // not in strip list
+		"BATON_HOOK_SOCKET_X=", // prefix-only similar key — must NOT be stripped
+	}
+	out := sanitizedHaikuEnv(in)
+	got := strings.Join(out, "\n")
+	for _, banned := range []string{"BATON_HOOK_SOCKET=/sock", "BATON_AGENT_ID=abc"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("sanitized env contained %q\n%s", banned, got)
+		}
+	}
+	for _, kept := range []string{"PATH=/usr/bin", "HOME=/home/u", "BATON_FOO=keepme", "BATON_HOOK_SOCKET_X="} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("sanitized env missing %q\n%s", kept, got)
+		}
+	}
+}
+
+// TestCallNamerWithRetry_SucceedsAfterTransientErrors verifies that a transient
+// error on attempts 1 and 2 is recovered by attempt 3.
+func TestCallNamerWithRetry_SucceedsAfterTransientErrors(t *testing.T) {
+	var calls atomic.Int32
+	stub := func(ctx context.Context, instruction string) (string, error) {
+		n := calls.Add(1)
+		if n < 3 {
+			return "", fmt.Errorf("transient failure %d", n)
+		}
+		return "good-slug", nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan struct{})
+
+	suffix, err := callNamerWithRetry(
+		ctx, stub, "x", done,
+		3, 1*time.Second, []time.Duration{10 * time.Millisecond, 10 * time.Millisecond},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected success after retry, got err=%v", err)
+	}
+	if suffix != "good-slug" {
+		t.Errorf("suffix = %q, want good-slug", suffix)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("namer called %d times, want 3", got)
+	}
+}
+
+// TestCallNamerWithRetry_StopsOnTerminalErrors verifies that terminal sentinel
+// errors short-circuit the retry loop.
+func TestCallNamerWithRetry_StopsOnTerminalErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"ClaudeNotFound", fmt.Errorf("wrap: %w", ErrClaudeNotFound)},
+		{"EmptySlug", ErrEmptySlug},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			stub := func(ctx context.Context, instruction string) (string, error) {
+				calls.Add(1)
+				return "", tc.err
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			done := make(chan struct{})
+
+			_, err := callNamerWithRetry(
+				ctx, stub, "x", done,
+				3, 100*time.Millisecond, []time.Duration{10 * time.Millisecond, 10 * time.Millisecond},
+				nil,
+			)
+			if !errors.Is(err, tc.err) && !errors.Is(err, ErrClaudeNotFound) && !errors.Is(err, ErrEmptySlug) {
+				t.Errorf("err = %v, want terminal", err)
+			}
+			if got := calls.Load(); got != 1 {
+				t.Errorf("namer called %d times for terminal error, want 1", got)
+			}
+		})
+	}
+}
+
+// TestCallNamerWithRetry_DoneAbortsBackoff verifies that closing the done
+// channel during the inter-attempt sleep aborts retries promptly.
+func TestCallNamerWithRetry_DoneAbortsBackoff(t *testing.T) {
+	var calls atomic.Int32
+	stub := func(ctx context.Context, instruction string) (string, error) {
+		calls.Add(1)
+		return "", fmt.Errorf("transient")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan struct{})
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(done)
+	}()
+
+	start := time.Now()
+	_, err := callNamerWithRetry(
+		ctx, stub, "x", done,
+		3, 1*time.Second, []time.Duration{2 * time.Second, 2 * time.Second},
+		nil,
+	)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("retry took %v after done close; expected ~50ms-ish", elapsed)
+	}
+	if got := calls.Load(); got > 2 {
+		t.Errorf("namer called %d times after done close, want <= 2", got)
+	}
+}
+
+// TestCallNamerWithRetry_LogsEachAttempt verifies the per-attempt logging
+// callback fires exactly once per attempt with the right metadata.
+func TestCallNamerWithRetry_LogsEachAttempt(t *testing.T) {
+	var calls atomic.Int32
+	stub := func(ctx context.Context, instruction string) (string, error) {
+		n := calls.Add(1)
+		if n < 2 {
+			return "", fmt.Errorf("blip")
+		}
+		return "ok-slug", nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan struct{})
+
+	type entry struct {
+		attempt int
+		suffix  string
+		err     error
+	}
+	var seen []entry
+	logFn := func(attempt int, suffix string, err error, took time.Duration) {
+		seen = append(seen, entry{attempt, suffix, err})
+	}
+
+	suffix, err := callNamerWithRetry(
+		ctx, stub, "x", done,
+		3, 100*time.Millisecond, []time.Duration{1 * time.Millisecond, 1 * time.Millisecond},
+		logFn,
+	)
+	if err != nil || suffix != "ok-slug" {
+		t.Fatalf("got suffix=%q err=%v, want ok-slug nil", suffix, err)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("len(seen) = %d, want 2", len(seen))
+	}
+	if seen[0].attempt != 1 || seen[0].err == nil {
+		t.Errorf("first log entry: %+v, want attempt=1 with err", seen[0])
+	}
+	if seen[1].attempt != 2 || seen[1].suffix != "ok-slug" || seen[1].err != nil {
+		t.Errorf("second log entry: %+v, want attempt=2 suffix=ok-slug err=nil", seen[1])
 	}
 }

--- a/internal/agent/main_test.go
+++ b/internal/agent/main_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestMain redirects $HOME to a per-process temp dir so tests that exercise
@@ -30,5 +31,15 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 	}
+
+	// Production retry config (30s per attempt, 75s overall, 1s+3s backoff)
+	// is realistic for a `claude -p` cold start but glacial in unit tests.
+	// Shrink to fast-but-still-realistic values so tests still exercise the
+	// retry path without padding wall-clock time. Unit tests of the wrapper
+	// itself (TestCallNamerWithRetry_*) override these inline as needed.
+	haikuNamePerAttemptTimeout = 500 * time.Millisecond
+	haikuNameOverallTimeout = 3 * time.Second
+	haikuNameBackoff = []time.Duration{}
+
 	os.Exit(m.Run())
 }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -68,10 +68,29 @@ type Manager struct {
 	branchNamer BranchNamer
 }
 
-// haikuNameTimeout bounds how long the Haiku summarization subprocess may run
-// before it's cancelled. On timeout the random branch persists and the next
+// haikuNamePerAttemptTimeout bounds how long a single Haiku summarization
+// subprocess may run before it's cancelled. Cold starts of `claude -p`
+// (settings discovery, MCP probe, possible auth refresh) routinely exceed
+// 15s in real-world repos, so each attempt gets a generous budget.
+//
+// Declared as var (not const) so tests can swap to fast values via
+// setHaikuRetryForTesting.
+var haikuNamePerAttemptTimeout = 30 * time.Second
+
+// haikuNameOverallTimeout caps the total wall-clock time spent across all
+// retry attempts. On timeout the random branch persists and the next
 // actionable prompt retries.
-const haikuNameTimeout = 15 * time.Second
+var haikuNameOverallTimeout = 75 * time.Second
+
+// haikuNameAttempts is the maximum number of times callNamerWithRetry will
+// invoke the namer per UserPromptSubmit. Each attempt is bounded by
+// haikuNamePerAttemptTimeout; the whole sequence is bounded by
+// haikuNameOverallTimeout.
+var haikuNameAttempts = 3
+
+// haikuNameBackoff is the wait between attempts N and N+1. Linear small
+// backoff is enough at this scale — exponential is overkill for 3 attempts.
+var haikuNameBackoff = []time.Duration{1 * time.Second, 3 * time.Second}
 
 // NewManager creates a new agent manager for the given repo.
 //
@@ -237,7 +256,7 @@ func (m *Manager) maybeRenameFromPrompt(sess *Session, a *Agent, prompt string) 
 		defer m.watchers.Done()
 		defer sess.finishRename()
 
-		ctx, cancel := context.WithTimeout(context.Background(), haikuNameTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), haikuNameOverallTimeout)
 		defer cancel()
 
 		// Cancel the Haiku subprocess if the manager shuts down mid-call.
@@ -251,15 +270,29 @@ func (m *Manager) maybeRenameFromPrompt(sess *Session, a *Agent, prompt string) 
 			}
 		}()
 
-		suffix, err := namer(ctx, instruction)
+		repoPath := m.repoPath
+		sessID := sess.ID
+		logAttempt := func(attempt int, s string, err error, took time.Duration) {
+			haikuLogAttempt(repoPath, sessID, attempt, s, err, took)
+		}
+
+		start := time.Now()
+		suffix, err := callNamerWithRetry(
+			ctx, namer, instruction, m.done,
+			haikuNameAttempts, haikuNamePerAttemptTimeout, haikuNameBackoff,
+			logAttempt,
+		)
 		if err != nil || suffix == "" {
+			haikuLogOutcome(repoPath, sessID, suffix, err, time.Since(start))
 			return
 		}
 
 		newBranch := config.ExpandBranchPrefix(prefix) + suffix
 		if !m.renameSessionBranch(sess, newBranch) {
+			haikuLogOutcome(repoPath, sessID, "", fmt.Errorf("git rename failed or session closed (target=%s)", newBranch), time.Since(start))
 			return
 		}
+		haikuLogOutcome(repoPath, sessID, suffix, nil, time.Since(start))
 		// The session display name updates to the Haiku-derived task name so
 		// the sidebar separator shows what the session is working on. Agents
 		// keep their stable track identities (Track 1, Track 2, ...) and are


### PR DESCRIPTION
Three issues compounded to make the rename fail more often than not:

1. The Haiku subprocess inherited BATON_HOOK_SOCKET and BATON_AGENT_ID
   because runClaudeHaiku did not set cmd.Env. The Haiku claude therefore
   registered hook callbacks against the running TUI's socket as the
   parent agent — phantom SessionStart/SessionEnd events landed on the
   parent and each Haiku call paid extra socket roundtrips that pushed
   cold-start latency past the timeout. Now stripped via sanitizedHaikuEnv.

2. The 15s overall timeout was too tight for `claude -p` cold starts
   (settings discovery, MCP probe, possible auth refresh routinely take
   10-25s). Replaced with 30s per attempt and 75s overall.

3. A single transient blip dropped the rename until the next user prompt;
   if the user fired one big prompt and walked away, no rename ever
   happened. callNamerWithRetry now runs up to 3 attempts with 1s/3s
   linear backoff. ErrClaudeNotFound and ErrEmptySlug are classified as
   terminal so they don't waste retries.

Also adds a per-rename diagnostic log at <repo>/.baton/logs/haiku.log
(one line per attempt + a final outcome line, hard-truncated past 1 MiB).
The TUI alt-screen made stderr unreadable, so failures previously vanished
silently — file-based logging keeps the surface non-disruptive while
giving users a way to see what actually failed.

https://claude.ai/code/session_017adDfqYpjbu1kVrHiYQKDk