### PR TITLE
Show terminal cursor when preview panel is focused

### DIFF
--- a/changelog.d/fix-terminal-cursor.md
+++ b/changelog.d/fix-terminal-cursor.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Terminal cursor is now visible when the preview panel is focused, giving a clear indicator of where input will appear.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -515,6 +515,12 @@ func (a *Agent) IsAltScreen() bool {
 	return a.terminal.IsAltScreen()
 }
 
+// CursorPosition returns the current cursor position (x, y) where x is the
+// column and y is the row, both zero-indexed.
+func (a *Agent) CursorPosition() (x, y int) {
+	return a.terminal.CursorPosition()
+}
+
 // SendText forwards text input to the VT terminal.
 func (a *Agent) SendText(text string) {
 	a.mu.Lock()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1599,6 +1599,22 @@ func (a App) View() tea.View {
 	v.AltScreen = true
 	if a.view == ViewDashboard {
 		v.MouseMode = tea.MouseModeCellMotion
+		if a.dashboard.panelFocus == focusTerminal && a.dashboard.scrollOffset == 0 {
+			if item := a.dashboard.selectedItem(); item != nil && item.kind == listItemAgent && item.agent != nil {
+				cursorX, cursorY := item.agent.CursorPosition()
+				dashboardTopY := 0
+				if a.err != "" {
+					dashboardTopY++
+				}
+				if a.confirmQuit {
+					dashboardTopY++
+				}
+				const previewColOffset = 32 // mirrors screenToTermCell constant
+				screenX := cursorX + previewColOffset + 1
+				screenY := cursorY + dashboardTopY + 1 + a.dashboard.previewMetadataRows()
+				v.Cursor = tea.NewCursor(screenX, screenY)
+			}
+		}
 	}
 	return v
 }


### PR DESCRIPTION
## Summary

- `*agent.Agent` now exposes `CursorPosition() (x, y int)`, delegating to the existing `vt.Terminal.CursorPosition()` — no mutex needed since the VT emulator acquires its own RLock internally.
- `App.View()` sets `v.Cursor` on the returned `tea.View` when the dashboard is in `focusTerminal` mode, `scrollOffset == 0`, and an agent is selected. Bubble Tea then renders a blinking block cursor at the correct screen position.
- Cursor is automatically hidden when focus returns to the list, or when the user scrolls back into the scrollback buffer.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: launch Baton, create a session, press `Enter` to focus the terminal — blinking cursor appears at the agent's input prompt
- [ ] Manual TUI: press `Esc` — cursor disappears
- [ ] Manual TUI: press `PgUp` while in terminal focus — cursor disappears (scrollOffset > 0)

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — added `changelog.d/fix-terminal-cursor.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md` — manual TUI test only (cursor rendering can't be unit tested without a real TTY)
- [x] No new public API surface without a note in the PR description — `Agent.CursorPosition()` is new; it mirrors the existing `vt.Terminal.CursorPosition()` signature