### PR TITLE
Fix PR detection inconsistency during branch rename

### DIFF
--- a/changelog.d/fix-pr-detection-inconsistency.md
+++ b/changelog.d/fix-pr-detection-inconsistency.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- PR indicator no longer blanks on a single nil poll result during branch-rename or rapid force-push windows; cache is now evicted only after 2 consecutive nil polls.
+- After a Haiku branch rename, PR tracking continues by falling back to the local worktree HEAD SHA when the remote branch hasn't been pushed under the new name yet.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -511,18 +511,30 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			return a, nil
 		}
-		// Lookup succeeded with no PR. If we had one before, the PR has been
-		// closed, merged, or its head branch was deleted — drop the stale entry
-		// so the UI reflects reality.
+		// Lookup succeeded with no PR. Apply a 2-consecutive-nil grace period
+		// before evicting the cache: a single nil is common during the rename
+		// gap (branch pushed under old name, remote SHA not yet updated) or a
+		// rapid force-push window. Two in a row means the PR is genuinely gone.
 		if msg.pr == nil {
 			if _, had := a.prCache[msg.sessionID]; had {
+				if ps != nil {
+					ps.consecutiveNilPolls++
+					if ps.consecutiveNilPolls < 2 {
+						return a, nil
+					}
+				}
 				delete(a.prCache, msg.sessionID)
 				if ps != nil {
 					ps.lastCheckState = ""
+					ps.consecutiveNilPolls = 0
 				}
 				a.updateDashboardPRCache()
 			}
 			return a, nil
+		}
+		// Successful poll: reset the nil counter.
+		if ps != nil {
+			ps.consecutiveNilPolls = 0
 		}
 		a.prCache[msg.sessionID] = &prCacheEntry{
 			pr:      msg.pr,
@@ -1780,7 +1792,7 @@ outer:
 			ps.lastPoll = now
 			ps.inFlight = true
 			a.prPollsInFlight++
-			cmds = append(cmds, a.refreshPRStatusForSession(sess.ID, sess.Branch(), repo.Path))
+			cmds = append(cmds, a.refreshPRStatusForSession(sess.ID, sess.Branch(), repo.Path, sess.Worktree.Path))
 		}
 	}
 	return cmds
@@ -1818,8 +1830,23 @@ func getRemoteSHA(repoPath, branch string) string {
 	return strings.TrimSpace(string(out))
 }
 
+// getLocalHeadSHA returns the local HEAD SHA for a worktree. Used as a
+// fallback when getRemoteSHA returns "" (branch not yet pushed under the
+// current name after a rename). Silent on error.
+func getLocalHeadSHA(worktreePath string) string {
+	if worktreePath == "" {
+		return ""
+	}
+	out, err := exec.Command("git", "-C", worktreePath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // refreshPRStatusForSession returns a Cmd that polls PR, check, and review status for a single session.
-func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath string) tea.Cmd {
+// worktreePath is used as a fallback SHA source when the branch hasn't been pushed under its current name.
+func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePath string) tea.Cmd {
 	ghClient := a.ghClient
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
@@ -1842,6 +1869,14 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath string) tea.
 		sha := getRemoteSHA(repoPath, branch)
 		if sha != "" {
 			pr, _ = ghClient.GetPRBySHA(ctx, owner, repo, sha)
+		}
+		// If the remote SHA is missing (branch not yet pushed under current name
+		// after a rename), try the local HEAD SHA — the commit may have been
+		// pushed before the rename and GitHub still associates the PR with it.
+		if pr == nil && sha == "" {
+			if localSHA := getLocalHeadSHA(worktreePath); localSHA != "" {
+				pr, _ = ghClient.GetPRBySHA(ctx, owner, repo, localSHA)
+			}
 		}
 		if pr == nil {
 			var err error

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -44,6 +44,11 @@ type prSessionState struct {
 	// up quickly. Writes happen only from the Bubble Tea Update goroutine;
 	// no locking required.
 	burstUntil time.Time
+	// consecutiveNilPolls counts how many back-to-back polls returned nil (no
+	// open PR). A cached entry is only evicted after 2 consecutive nils so a
+	// single nil during the rename-gap or a rapid force-push window does not
+	// blank the UI.
+	consecutiveNilPolls int
 }
 
 // isMergeReady returns true when all conditions for merge readiness are met.

--- a/internal/tui/pr_test.go
+++ b/internal/tui/pr_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/devenjarvis/baton/internal/agent"
+	"github.com/devenjarvis/baton/internal/github"
 )
 
 // TestPrPollInterval_BurstOverridesBaseline verifies the burst window shortens
@@ -85,22 +86,63 @@ func TestPrPollMsg_ErrorPreservesCache(t *testing.T) {
 	}
 }
 
-// TestPrPollMsg_NilClearsPreviouslyCachedEntry verifies that a successful
-// lookup with no PR drops a stale cached entry — e.g. when the PR is
-// closed, merged, or its head branch is deleted.
-func TestPrPollMsg_NilClearsPreviouslyCachedEntry(t *testing.T) {
+// TestPrPollMsg_NilGracePeriod verifies the 2-consecutive-nil grace period:
+// the first nil preserves the cache entry, the second nil evicts it.
+func TestPrPollMsg_NilGracePeriod(t *testing.T) {
 	a := NewApp()
 	a.prPollsInFlight = 1
 	a.prPollStates["sess-1"] = &prSessionState{inFlight: true, lastCheckState: "success"}
 	a.prCache["sess-1"] = &prCacheEntry{}
 
+	// First nil: cache should be preserved.
 	model, _ := a.Update(prPollMsg{sessionID: "sess-1"})
 	got := model.(App)
-	if _, ok := got.prCache["sess-1"]; ok {
-		t.Errorf("cache entry should be cleared when lookup returns (nil, nil)")
+	if _, ok := got.prCache["sess-1"]; !ok {
+		t.Errorf("cache entry should be preserved on first nil poll (grace period)")
 	}
-	if got.prPollStates["sess-1"].lastCheckState != "" {
-		t.Errorf("lastCheckState should reset, got %q", got.prPollStates["sess-1"].lastCheckState)
+	if got.prPollStates["sess-1"].consecutiveNilPolls != 1 {
+		t.Errorf("consecutiveNilPolls = %d, want 1", got.prPollStates["sess-1"].consecutiveNilPolls)
+	}
+
+	// Second nil: cache should be cleared.
+	got.prPollsInFlight = 1
+	got.prPollStates["sess-1"].inFlight = true
+	model2, _ := got.Update(prPollMsg{sessionID: "sess-1"})
+	got2 := model2.(App)
+	if _, ok := got2.prCache["sess-1"]; ok {
+		t.Errorf("cache entry should be cleared after second consecutive nil poll")
+	}
+	if got2.prPollStates["sess-1"].lastCheckState != "" {
+		t.Errorf("lastCheckState should reset, got %q", got2.prPollStates["sess-1"].lastCheckState)
+	}
+	if got2.prPollStates["sess-1"].consecutiveNilPolls != 0 {
+		t.Errorf("consecutiveNilPolls should reset to 0 after eviction, got %d", got2.prPollStates["sess-1"].consecutiveNilPolls)
+	}
+}
+
+// TestPrPollMsg_NilThenSuccessResetsCounter verifies that a successful poll
+// after a nil resets the consecutiveNilPolls counter so the grace period
+// starts fresh on the next nil.
+func TestPrPollMsg_NilThenSuccessResetsCounter(t *testing.T) {
+	a := NewApp()
+	a.prPollsInFlight = 1
+	a.prPollStates["sess-1"] = &prSessionState{inFlight: true}
+	a.prCache["sess-1"] = &prCacheEntry{}
+
+	// First nil: increments counter.
+	model, _ := a.Update(prPollMsg{sessionID: "sess-1"})
+	got := model.(App)
+	if got.prPollStates["sess-1"].consecutiveNilPolls != 1 {
+		t.Fatalf("consecutiveNilPolls after first nil = %d, want 1", got.prPollStates["sess-1"].consecutiveNilPolls)
+	}
+
+	// Successful poll: counter resets.
+	got.prPollsInFlight = 1
+	got.prPollStates["sess-1"].inFlight = true
+	model2, _ := got.Update(prPollMsg{sessionID: "sess-1", pr: &github.PRState{Number: 1}})
+	got2 := model2.(App)
+	if got2.prPollStates["sess-1"].consecutiveNilPolls != 0 {
+		t.Errorf("consecutiveNilPolls should reset to 0 after success, got %d", got2.prPollStates["sess-1"].consecutiveNilPolls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a 2-consecutive-nil grace period before evicting a cached PR entry: a single nil poll during the rename gap or rapid force-push window no longer blanks the sidebar PR indicator
- Fall back to local worktree HEAD SHA when `getRemoteSHA` returns "" (branch not yet pushed under current name after a Haiku rename) — GitHub can still find the PR via the SHA that was pushed before the rename

## Details

**Task 1 — Grace period:** `consecutiveNilPolls` field added to `prSessionState`. The `prPollMsg` handler only evicts the cache entry after 2 consecutive nils, resetting on any successful poll.

**Task 2 — HEAD SHA fallback:** `getLocalHeadSHA(worktreePath)` runs `git -C <worktree> rev-parse HEAD` silently. Used only in `refreshPRStatusForSession` (PR lookup path), not in the SHA-change detection path in `pollAllSessions` (which should only arm burst mode on actual remote pushes).

## Test plan

- [ ] All existing PR-polling tests updated and passing
- [ ] New tests: `TestPrPollMsg_NilGracePeriod`, `TestPrPollMsg_NilThenSuccessResetsCounter`
- [ ] `go test -race ./...` passes (pre-existing config test failure unrelated)
- [ ] Manual: start session, let Haiku rename branch — PR indicator stays visible before next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)