### PR TITLE
Fix five e2e tests after status-symbol change

### DIFF
--- a/changelog.d/fix-e2e-status-symbols.md
+++ b/changelog.d/fix-e2e-status-symbols.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Five e2e tests (`TestHookPipeline`, `TestSessionCreation`, `TestAgentAddition`, `TestAgentKill`, `TestSessionKill`) were failing because their helpers still looked for the pre-PR-#89 status glyphs (`◎ ● ◐ ○ ✓ ✗`) instead of the music-themed playback controls now produced by `agent.Status.Symbol()` (`▷ ▶ ⏺ ⏸ ⏭ ⏹`). The agent rows were rendered correctly all along; only the assertion side was stale. Updated `countAgentRows` and the `TestHookPipeline` symbol expectations to match the current symbols.

--- a/internal/e2e/hooks_test.go
+++ b/internal/e2e/hooks_test.go
@@ -83,31 +83,31 @@ func TestHookPipeline(t *testing.T) {
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
-	// Active (●) — session-start fires at t≈0.3s.
-	if !waitForAgentSymbol(s, "●", 5000) {
-		t.Fatalf("never observed Active (●) symbol\nScreen:\n%s", s.Screenshot())
+	// Active (▶) — session-start fires at t≈0.3s.
+	if !waitForAgentSymbol(s, "▶", 5000) {
+		t.Fatalf("never observed Active (▶) symbol\nScreen:\n%s", s.Screenshot())
 	}
-	// Waiting (◐) — notification fires at t≈1.5s.
-	if !waitForAgentSymbol(s, "◐", 5000) {
-		t.Fatalf("never observed Waiting (◐) symbol\nScreen:\n%s", s.Screenshot())
+	// Waiting (⏺) — notification fires at t≈1.5s.
+	if !waitForAgentSymbol(s, "⏺", 5000) {
+		t.Fatalf("never observed Waiting (⏺) symbol\nScreen:\n%s", s.Screenshot())
 	}
-	// Idle (○) — stop fires at t≈3.5s.
-	if !waitForAgentSymbol(s, "○", 5000) {
-		t.Fatalf("never observed Idle (○) after Stop\nScreen:\n%s", s.Screenshot())
+	// Idle (⏸) — stop fires at t≈3.5s.
+	if !waitForAgentSymbol(s, "⏸", 5000) {
+		t.Fatalf("never observed Idle (⏸) after Stop\nScreen:\n%s", s.Screenshot())
 	}
-	// Active (●) again — user-prompt-submit fires at t≈5.5s and re-arms.
+	// Active (▶) again — user-prompt-submit fires at t≈5.5s and re-arms.
 	// This is the observable signal that UserPromptSubmit transitioned the
 	// bubble back to Active. (The chime re-arm flag is not visible on
 	// screen; the second Idle below confirms the manager saw the transition
 	// and emitted a status-change event.)
-	if !waitForAgentSymbol(s, "●", 5000) {
-		t.Fatalf("never observed re-armed Active (●) after UserPromptSubmit\nScreen:\n%s", s.Screenshot())
+	if !waitForAgentSymbol(s, "▶", 5000) {
+		t.Fatalf("never observed re-armed Active (▶) after UserPromptSubmit\nScreen:\n%s", s.Screenshot())
 	}
-	// Idle (○) again — stop fires at t≈7.5s. This doubles as a re-arm check:
+	// Idle (⏸) again — stop fires at t≈7.5s. This doubles as a re-arm check:
 	// if UserPromptSubmit hadn't re-armed, there'd be no intermediate Active
 	// and the second Stop would be a no-op status-wise.
-	if !waitForAgentSymbol(s, "○", 5000) {
-		t.Fatalf("never observed final Idle (○) after second Stop\nScreen:\n%s", s.Screenshot())
+	if !waitForAgentSymbol(s, "⏸", 5000) {
+		t.Fatalf("never observed final Idle (⏸) after second Stop\nScreen:\n%s", s.Screenshot())
 	}
 }
 

--- a/internal/e2e/lifecycle_test.go
+++ b/internal/e2e/lifecycle_test.go
@@ -157,10 +157,10 @@ func TestSessionKill(t *testing.T) {
 
 // countAgentRows counts agent rows in the dashboard sidebar.
 // Agent rows are indented under sessions and start with a status symbol from
-// agent.Status.Symbol(): ◎ ● ◐ ○ ✓ ✗ (or "$" for shell agents). Session header
+// agent.Status.Symbol(): ▷ ▶ ⏺ ⏸ ⏭ ⏹ (or "$" for shell agents). Session header
 // rows contain box-drawing dashes "──", so we skip those.
 func countAgentRows(screen string) int {
-	statusSymbols := []string{"◎ ", "● ", "◐ ", "○ ", "✓ ", "✗ ", "$ "}
+	statusSymbols := []string{"▷ ", "▶ ", "⏺ ", "⏸ ", "⏭ ", "⏹ ", "$ "}
 	count := 0
 	for _, line := range strings.Split(screen, "\n") {
 		// Strip leading whitespace and the optional selection arrow.


### PR DESCRIPTION
## Summary

- Five e2e tests (`TestHookPipeline`, `TestSessionCreation`, `TestAgentAddition`, `TestAgentKill`, `TestSessionKill`) were failing because their assertion helpers still looked for the pre-PR-#89 status glyphs (`◎ ● ◐ ○ ✓ ✗`).
- PR #89 ("Music-themed playback controls + Haiku rename indicator") changed `agent.Status.Symbol()` to `▷ ▶ ⏺ ⏸ ⏭ ⏹` but left the test helpers behind. The dashboard rendered correctly all along — failure screenshots in CI showed `▸ ▶ Track 1` agent rows on screen while the helpers reported zero rows.
- Pure test-side fix: updated `countAgentRows` in `internal/e2e/lifecycle_test.go` and the five `waitForAgentSymbol` calls (plus their `t.Fatalf` glyphs and surrounding comments) in `internal/e2e/hooks_test.go`. No production code touched.

## Test plan

- [x] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [x] `go test -race ./...` — only failure is `TestLoad_MigratesFromLegacyXDGPath` in `internal/config`, which reproduces identically on `main` (pre-existing, unrelated to this PR)
- [x] `go test -tags e2e -timeout 300s -v ./internal/e2e/` — all 14 tests pass, including the 5 previously failing ones
- [ ] Manual TUI: not needed — purely test-side string updates

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` — added `changelog.d/fix-e2e-status-symbols.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md` — N/A, this is a test-only fix
- [x] No new public API surface without a note in the PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)