### PR TITLE
Fix doubled/misaligned preview-panel cursor

### DIFF
--- a/changelog.d/fix-doubled-preview-cursor.md
+++ b/changelog.d/fix-doubled-preview-cursor.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Focused preview panel no longer renders a doubled or misaligned host-terminal cursor. The host cursor used `previewColOffset = 32` instead of `31`, drawing it one column right of the agent's VT cursor; the host cursor was also unconditionally shown even after the inner program emitted DECRST 25 (`\e[?25l`), so full-screen TUIs like Claude Code drew an extra blinking block on top of their own cursor. `vt.Terminal` now tracks DECTCEM via the `CursorVisibility` callback and `App.View()` only places `tea.NewCursor` when the agent reports the cursor visible.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -521,6 +521,13 @@ func (a *Agent) CursorPosition() (x, y int) {
 	return a.terminal.CursorPosition()
 }
 
+// CursorVisible reports whether the inner program wants the cursor shown
+// (DECTCEM, mode 25). Used by the TUI to suppress the host-terminal cursor
+// while a full-screen app draws its own.
+func (a *Agent) CursorVisible() bool {
+	return a.terminal.CursorVisible()
+}
+
 // SendText forwards text input to the VT terminal.
 func (a *Agent) SendText(text string) {
 	a.mu.Lock()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1428,9 +1428,10 @@ func (a *App) setError(msg string) {
 // should clamp to [0, fixedTermWidth) × [0, fixedTermHeight) themselves.
 //
 // The translation mirrors the dashboard layout: an optional error/confirm-quit
-// banner pushes content down, the list panel and its border occupy the first
-// 32 columns, and the preview's lipgloss frame plus the metadata rows above
-// the VT viewport offset the top-left cell.
+// banner pushes content down, the list panel and its border occupy columns
+// 0..30 (the preview's left border lives at column 31), and the preview's
+// lipgloss frame plus the metadata rows above the VT viewport offset the
+// top-left cell.
 func (a *App) screenToTermCell(screenX, screenY int) (termX, termY int, inViewport bool) {
 	dashboardTopY := 0
 	if a.err != "" {
@@ -1440,7 +1441,10 @@ func (a *App) screenToTermCell(screenX, screenY int) (termX, termY int, inViewpo
 		dashboardTopY++
 	}
 	const (
-		previewColOffset  = 32 // list panel width + list-panel right border
+		// previewColOffset is the screen column of the preview's left border
+		// (= listWidth + list-panel right border = 30 + 1). The preview's left
+		// border occupies that column; VT cell 0 sits at previewColOffset + 1.
+		previewColOffset  = 31
 		previewLeftBorder = 1
 		previewTopBorder  = 1
 	)
@@ -1617,7 +1621,7 @@ func (a App) View() tea.View {
 	if a.view == ViewDashboard {
 		v.MouseMode = tea.MouseModeCellMotion
 		if a.dashboard.panelFocus == focusTerminal && a.dashboard.scrollOffset == 0 {
-			if item := a.dashboard.selectedItem(); item != nil && item.kind == listItemAgent && item.agent != nil {
+			if item := a.dashboard.selectedItem(); item != nil && item.kind == listItemAgent && item.agent != nil && item.agent.CursorVisible() {
 				cursorX, cursorY := item.agent.CursorPosition()
 				dashboardTopY := 0
 				if a.err != "" {
@@ -1626,7 +1630,10 @@ func (a App) View() tea.View {
 				if a.confirmQuit {
 					dashboardTopY++
 				}
-				const previewColOffset = 32 // mirrors screenToTermCell constant
+				// previewColOffset is the column of the preview's left border;
+				// VT cell 0 lives one column to its right. Mirrors the constant
+				// in screenToTermCell — the two formulas must move in lockstep.
+				const previewColOffset = 31
 				screenX := cursorX + previewColOffset + 1
 				screenY := cursorY + dashboardTopY + 1 + a.dashboard.previewMetadataRows()
 				v.Cursor = tea.NewCursor(screenX, screenY)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1246,3 +1246,152 @@ func TestRefreshAgentListRepoAffinity(t *testing.T) {
 		t.Errorf("expected cursor on repo header, got kind=%v", selected.kind)
 	}
 }
+
+// waitForCursorAt polls ag.CursorPosition() until it reports (wantX, wantY)
+// or the deadline expires. Used by the preview-cursor placement test to wait
+// for a positioning escape sequence to be processed by the emulator.
+func waitForCursorAt(t *testing.T, ag *agent.Agent, wantX, wantY int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if x, y := ag.CursorPosition(); x == wantX && y == wantY {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	x, y := ag.CursorPosition()
+	t.Fatalf("cursor did not reach (%d, %d) within timeout; got (%d, %d)", wantX, wantY, x, y)
+}
+
+// waitForCursorHidden polls ag.CursorVisible() until it reports false or the
+// deadline expires.
+func waitForCursorHidden(t *testing.T, ag *agent.Agent) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !ag.CursorVisible() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("cursor did not hide within timeout")
+}
+
+// TestPreviewCursorPlacement verifies that App.View() places the host cursor
+// on the screen cell the agent's VT cursor occupies. Regression test for the
+// off-by-one introduced in PR #95 (previewColOffset = 32 placed it one column
+// too far right) — with previewColOffset = 31 the host cursor lands exactly
+// on top of VT cell 0's screen column.
+func TestPreviewCursorPlacement(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-cursorpos-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+
+	// Position cursor at row 10, col 15 (1-indexed CUP) — that is VT cell
+	// (14, 9) in 0-indexed coordinates. Sleeping keeps the bash process alive
+	// so the agent stays in StatusActive.
+	sess, ag, err := mgr.CreateSessionWithCommand(agent.Config{
+		Name: "cursor-pos", Task: "test", RepoPath: dir, Rows: 24, Cols: 80,
+	}, func(_ string) *exec.Cmd {
+		return exec.Command("bash", "-c", `printf '\033[10;15H'; sleep 10`)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForCursorAt(t, ag, 14, 9)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.dashboard.items = []listItem{
+		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
+	}
+	app.dashboard.panelFocus = focusTerminal
+
+	v := app.View()
+	if v.Cursor == nil {
+		t.Fatal("expected non-nil view.Cursor in focusTerminal with visible cursor")
+	}
+	// Expected screen position:
+	//   X = previewColOffset(31) + previewLeftBorder(1) + cursorX(14) = 46
+	//   Y = dashboardTopY(0) + previewTopBorder(1) + previewMetadataRows(2) + cursorY(9) = 12
+	// With the pre-fix off-by-one (previewColOffset=32) X would be 47, which
+	// is the visible "shifted one to the right" symptom the user reported.
+	if v.Cursor.X != 46 || v.Cursor.Y != 12 {
+		t.Fatalf("expected cursor at screen (46, 12), got (%d, %d)", v.Cursor.X, v.Cursor.Y)
+	}
+}
+
+// TestPreviewCursorHiddenWhenAgentHidesIt verifies that App.View() leaves
+// view.Cursor nil after the inner program emits DECRST 25 (\e[?25l). Regression
+// test for the doubled-cursor symptom: full-screen TUIs (Claude Code) draw
+// their own visual cursor and hide the host terminal's — without this gate
+// baton would draw an extra blinking block on top.
+func TestPreviewCursorHiddenWhenAgentHidesIt(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-cursorhide-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+
+	sess, ag, err := mgr.CreateSessionWithCommand(agent.Config{
+		Name: "cursor-hide", Task: "test", RepoPath: dir, Rows: 24, Cols: 80,
+	}, func(_ string) *exec.Cmd {
+		return exec.Command("bash", "-c", `printf '\033[?25l'; sleep 10`)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForCursorHidden(t, ag)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.dashboard.items = []listItem{
+		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
+	}
+	app.dashboard.panelFocus = focusTerminal
+
+	v := app.View()
+	if v.Cursor != nil {
+		t.Fatalf("expected view.Cursor nil when agent hid cursor, got %+v", v.Cursor)
+	}
+}

--- a/internal/vt/bridge.go
+++ b/internal/vt/bridge.go
@@ -60,6 +60,16 @@ type Terminal struct {
 	// Written by Write() (agent.readLoop), read by AltScreenEntered() (Bubble Tea).
 	// Protected by historyMu.
 	altScreenEntered bool
+
+	// cursorVisible mirrors the emulator's DECTCEM (mode 25) state. Updated by
+	// the CursorVisibility callback registered in New() — which fires from
+	// inside emu.Write() (agent.readLoop goroutine) — and read by
+	// CursorVisible() (Bubble Tea main goroutine). Default is true (DECTCEM
+	// defaults on); the callback only fires on transitions, so a never-toggled
+	// terminal stays visible. Guarded by its own mutex to avoid lock-order
+	// coupling with historyMu / stableRenderMu.
+	cursorVisible   bool
+	cursorVisibleMu sync.Mutex
 }
 
 // New creates a new Terminal with the given dimensions.
@@ -67,10 +77,23 @@ func New(width, height int) *Terminal {
 	emu := xvt.NewSafeEmulator(width, height)
 	pr, pw := io.Pipe()
 	t := &Terminal{
-		emu: emu,
-		pr:  pr,
-		pw:  pw,
+		emu:           emu,
+		pr:            pr,
+		pw:            pw,
+		cursorVisible: true, // DECTCEM defaults on; callback fires on transitions only.
 	}
+	// Register a CursorVisibility callback so we can answer CursorVisible()
+	// without reaching into emulator internals. The callback fires from inside
+	// emu.Write() (agent.readLoop), so cursorVisibleMu must stay independent
+	// of historyMu / stableRenderMu — never call back into Write while holding
+	// it.
+	emu.SetCallbacks(xvt.Callbacks{
+		CursorVisibility: func(visible bool) {
+			t.cursorVisibleMu.Lock()
+			t.cursorVisible = visible
+			t.cursorVisibleMu.Unlock()
+		},
+	})
 	go t.bridgeRead()
 	return t
 }
@@ -611,6 +634,16 @@ func (t *Terminal) Read(buf []byte) (int, error) {
 func (t *Terminal) CursorPosition() (x, y int) {
 	pos := t.emu.CursorPosition()
 	return pos.X, pos.Y
+}
+
+// CursorVisible reports whether the inner program currently wants the cursor
+// shown (DECTCEM, mode 25). Default is true; flips to false on `\e[?25l` and
+// back to true on `\e[?25h`. Used by the TUI to suppress the host-terminal
+// cursor when a full-screen app (e.g. Claude Code) draws its own.
+func (t *Terminal) CursorVisible() bool {
+	t.cursorVisibleMu.Lock()
+	defer t.cursorVisibleMu.Unlock()
+	return t.cursorVisible
 }
 
 // Width returns the terminal width in columns.


### PR DESCRIPTION
## Summary

Two bugs introduced (or made user-visible) by PR #95:

- **Off-by-one in `previewColOffset`** — `internal/tui/app.go` used `32` in both `screenToTermCell` and `App.View()`, but the preview's left border sits at column `31` (`listWidth=30` + right border `1`). The host cursor was rendering one column right of the agent's drawn cursor (the "single space in front" symptom). Both call sites now use `31`.
- **Host cursor shown when inner program hid it** — Full-screen TUIs (Claude Code) emit DECRST 25 (`\e[?25l`) and draw their own visual cursor. `vt.SafeEmulator` honored that, but `vt.Terminal` did not expose visibility, so `App.View()` unconditionally drew a host cursor on top — the doubled-cursor symptom. `vt.Terminal` now registers a `CursorVisibility` callback (default visible per DECTCEM), `agent.Agent` exposes a `CursorVisible()` passthrough, and `App.View()` only sets `v.Cursor` when the agent reports the cursor visible.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./internal/tui/ ./internal/vt/ ./internal/agent/`
- [x] Confirmed each new test catches its bug under reverted source: `TestPreviewCursorPlacement` fails with cursor X=47 when `previewColOffset=32`; `TestPreviewCursorHiddenWhenAgentHidesIt` fails with non-nil cursor when the `CursorVisible()` gate is removed.
- [ ] Manual TUI: with `./baton`, focus a Claude Code session preview — exactly one cursor (Claude's own); focus a shell session — exactly one cursor sitting on the next-character cell; press `Esc` → host cursor hides; page-up to scroll → host cursor hides (existing `scrollOffset == 0` gate, unchanged).

## Checklist

- [x] Added a `changelog.d/` fragment (`fix-doubled-preview-cursor.md`) per the repo convention in `CLAUDE.md` — `CHANGELOG.md` itself is assembled from fragments at release time.
- [x] New behavior has unit tests in `internal/tui/app_test.go`.
- [x] Public API surface change: `vt.Terminal.CursorVisible() bool` and `agent.Agent.CursorVisible() bool` added (mirrors the existing `CursorPosition()` shape).