### PR TITLE
Detect external branch renames and reconcile session state

### DIFF
--- a/changelog.d/detect-external-branch-renames.md
+++ b/changelog.d/detect-external-branch-renames.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Detect when a branch is renamed outside baton (e.g. `git branch -m`) and reconcile the in-memory session state within ~2 seconds, preventing a stale branch name from breaking sidebar labels and PR polling.

--- a/internal/agent/external_rename_test.go
+++ b/internal/agent/external_rename_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestReconcileExternalBranchRename(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origBranch := sess.Branch()
+	newBranch := origBranch + "-renamed"
+
+	mgr.ReconcileExternalBranchRename(sess.ID, newBranch)
+
+	if got := sess.Branch(); got != newBranch {
+		t.Errorf("sess.Branch() = %q, want %q", got, newBranch)
+	}
+
+	// Drain events until we see EventBranchRenamed or timeout.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-mgr.Events():
+			if ev.Type == EventBranchRenamed && ev.SessionID == sess.ID && ev.Branch == newBranch {
+				return // success
+			}
+		case <-deadline:
+			t.Error("timed out waiting for EventBranchRenamed")
+			return
+		}
+	}
+}
+
+func TestReconcileExternalBranchRename_UnknownSession(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	// Should not panic on unknown session ID.
+	mgr.ReconcileExternalBranchRename("nonexistent-id", "baton/new-branch")
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -366,6 +366,23 @@ func (m *Manager) emitBranchRenamed(sess *Session, _ *Agent, newBranch string) {
 	})
 }
 
+// ReconcileExternalBranchRename updates the in-memory branch name for a session
+// after the user has renamed the branch outside baton (e.g. `git branch -m`),
+// then fires EventBranchRenamed so the burst-polling window arms and the sidebar
+// label refreshes. No git operations are performed.
+func (m *Manager) ReconcileExternalBranchRename(sessionID, newBranch string) {
+	m.mu.RLock()
+	sess := m.sessions[sessionID]
+	m.mu.RUnlock()
+
+	if sess == nil {
+		return
+	}
+
+	sess.UpdateBranch(newBranch)
+	m.emitBranchRenamed(sess, nil, newBranch)
+}
+
 // findAgentAndSession locates an agent across all sessions and returns it
 // alongside its containing session.
 func (m *Manager) findAgentAndSession(agentID string) (*Agent, *Session) {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -415,6 +415,22 @@ func (s *Session) RenameBranch(repoPath, newBranch string) (string, error) {
 	return actual, nil
 }
 
+// UpdateBranch updates the in-memory branch name and session display name to
+// match an externally applied git branch rename. This is the no-git-ops
+// counterpart to RenameBranch: it reconciles state after the user has already
+// run `git branch -m` outside baton. Setting hasClaudeName prevents the Haiku
+// namer from overwriting the externally-set name on the next user prompt.
+func (s *Session) UpdateBranch(newBranch string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Worktree.Branch = newBranch
+	if last := lastBranchSegment(newBranch); last != "" {
+		s.Name = last
+	}
+	s.hasClaudeName = true
+}
+
 // Branch returns the session's current git branch, safe for concurrent reads
 // while RenameBranch may be mutating it.
 func (s *Session) Branch() string {

--- a/internal/agent/session_name_test.go
+++ b/internal/agent/session_name_test.go
@@ -178,3 +178,53 @@ func TestSessionRenameBranch_FailureLeavesStateUnchanged(t *testing.T) {
 		t.Error("HasClaudeName() should stay false on failure")
 	}
 }
+
+func TestUpdateBranch(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	wt, err := git.CreateWorktree(repo, "warm-ibis", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	s := newSession("session-1", "warm-ibis", wt)
+
+	if s.HasClaudeName() {
+		t.Error("HasClaudeName() should be false before UpdateBranch")
+	}
+
+	s.UpdateBranch("baton/fix-login-bug")
+
+	if s.Branch() != "baton/fix-login-bug" {
+		t.Errorf("Branch() = %q, want %q", s.Branch(), "baton/fix-login-bug")
+	}
+	if s.CurrentName() != "fix-login-bug" {
+		t.Errorf("CurrentName() = %q, want %q", s.CurrentName(), "fix-login-bug")
+	}
+	if !s.HasClaudeName() {
+		t.Error("HasClaudeName() should be true after UpdateBranch")
+	}
+}
+
+func TestUpdateBranch_PreventsHaikuOverwrite(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	wt, err := git.CreateWorktree(repo, "warm-ibis", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	s := newSession("session-1", "warm-ibis", wt)
+
+	s.UpdateBranch("baton/external-name")
+
+	// RenameBranch must be a no-op because hasClaudeName is now true.
+	actual, err := s.RenameBranch(repo, "baton/haiku-would-set-this")
+	if err != nil {
+		t.Fatalf("RenameBranch: %v", err)
+	}
+	if actual != "baton/external-name" {
+		t.Errorf("RenameBranch should no-op, got %q, want %q", actual, "baton/external-name")
+	}
+	if s.Branch() != "baton/external-name" {
+		t.Errorf("Branch() should stay %q after no-op, got %q", "baton/external-name", s.Branch())
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1790,6 +1790,17 @@ outer:
 					continue
 				}
 				ps.lastSHACheck = now
+
+				// Detect external branch renames (e.g. `git branch -m`) before
+				// querying the remote — a stale in-memory branch name causes
+				// getRemoteSHA to always return "" and drops the 30s stable poll.
+				if actualBranch := getCurrentHeadBranch(sess.Worktree.Path); actualBranch != "" && actualBranch != sess.Branch() {
+					mgr.ReconcileExternalBranchRename(sess.ID, actualBranch)
+					// Skip remote SHA check this tick; EventBranchRenamed will
+					// arm the burst and the next tick has the correct branch.
+					continue
+				}
+
 				sha := getRemoteSHA(repo.Path, sess.Branch())
 				if sha == "" || sha == ps.lastRemoteSHA {
 					continue
@@ -1840,6 +1851,24 @@ func getRemoteSHA(repoPath, branch string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// getCurrentHeadBranch returns the branch name that HEAD points to in the given
+// worktree. Returns "" on any error or when HEAD is detached (rev-parse returns
+// "HEAD"). Mirrors the getLocalHeadSHA pattern.
+func getCurrentHeadBranch(worktreePath string) string {
+	if worktreePath == "" {
+		return ""
+	}
+	out, err := exec.Command("git", "-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "HEAD" {
+		return ""
+	}
+	return branch
 }
 
 // getLocalHeadSHA returns the local HEAD SHA for a worktree. Used as a


### PR DESCRIPTION
## Summary

- When a user runs `git branch -m <old> <new>` outside baton (common when the Haiku timeout fires and they fix the name manually), `Session.Worktree.Branch` was stale forever, causing: wrong sidebar label, `getRemoteSHA` always returning `""` for the stale name (burst never arms), and every 30s poll re-traversing the SHA fallback path
- Adds `Session.UpdateBranch(newBranch string)` — the in-memory-only counterpart to `RenameBranch`: acquires write lock, updates `Worktree.Branch` and `Name`, sets `hasClaudeName=true` so the Haiku namer won't overwrite the externally-set name on the next prompt
- Adds `Manager.ReconcileExternalBranchRename(sessionID, newBranch string)` — looks up session, calls `UpdateBranch`, fires `EventBranchRenamed` to arm the burst-polling window and refresh the sidebar
- Adds `getCurrentHeadBranch(worktreePath)` helper in `app.go` (mirrors `getLocalHeadSHA` pattern) and a mismatch check inside `pollAllSessions`' 2s SHA-check cadence: if the actual HEAD branch differs from `sess.Branch()`, reconcile and skip the remote SHA query for that tick

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] Manual TUI: N/A (no UI layout changes; behavior verified via unit tests)
- [x] `TestUpdateBranch` — verifies `Branch()`, `CurrentName()`, and `HasClaudeName()` update correctly
- [x] `TestUpdateBranch_PreventsHaikuOverwrite` — verifies `RenameBranch` no-ops after `UpdateBranch`
- [x] `TestReconcileExternalBranchRename` — spins up a test manager, calls reconcile, drains events, asserts `EventBranchRenamed` with correct session ID and branch
- [x] `TestReconcileExternalBranchRename_UnknownSession` — verifies no panic on unknown session ID

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description