### PR TITLE
Add Wellness Focus Mode to reduce multi-agent monitoring fatigue

### DIFF
--- a/changelog.d/add-wellness-focus-mode.md
+++ b/changelog.d/add-wellness-focus-mode.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Wellness Focus Mode** (`f` to toggle): shifts the dashboard from per-agent monitoring to a silent aggregate view, reducing multi-agent fatigue. Grounded in BCG/2026 research (n=1,488) showing 33% more decision fatigue and 39% more errors when overseeing 4+ parallel AI agents simultaneously.
+  - Focus panel shows session progress bar, status counts, attention rows for agents needing input, and last-review timestamp
+  - Idle chimes suppressed in focus mode; Waiting (permission prompt) chimes still fire
+  - Soft concurrent-agent limit: first `n` press at the configured limit shows a warning, second press overrides
+  - Break hint appears in the statusbar after the configured session duration (default 90m)
+  - Wellness log appended to `.baton/logs/wellness.log` on quit (date, duration, agent/session counts, focus switches)
+  - Three new global settings: `Focus Mode`, `Focus Session (min)`, `Max Concurrent Agents` — accessible via `s`

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -19,6 +19,11 @@ const (
 	MinSidebarWidth          = 20
 	MaxSidebarWidth          = 60
 
+	// Wellness defaults.
+	DefaultFocusModeEnabled    = false
+	DefaultFocusSessionMinutes = 90
+	DefaultMaxConcurrentAgents = 3
+
 	// DefaultBranchNamePrompt is the instruction sent to Haiku to summarize
 	// the user's first prompt into a branch slug. Users can override via the
 	// branch_name_prompt key in global or per-repo config; the {prompt} token
@@ -48,6 +53,11 @@ type GlobalSettings struct {
 	AgentProgram      *string `json:"agent_program,omitempty"`
 	IDECommand        *string `json:"ide_command,omitempty"`
 	SidebarWidth      *int    `json:"sidebar_width,omitempty"`
+
+	// Wellness settings — global preferences, not per-repo.
+	FocusModeEnabled    *bool `json:"focus_mode_enabled,omitempty"`
+	FocusSessionMinutes *int  `json:"focus_session_minutes,omitempty"`
+	MaxConcurrentAgents *int  `json:"max_concurrent_agents,omitempty"`
 }
 
 // RepoSettings holds per-repo overrides stored at <repo>/.baton/config.json.
@@ -74,19 +84,27 @@ type ResolvedSettings struct {
 	IDECommand        string
 	WorktreeDir       string
 	SidebarWidth      int
+
+	// Wellness settings.
+	FocusModeEnabled    bool
+	FocusSessionMinutes int
+	MaxConcurrentAgents int
 }
 
 // Resolve merges global and repo settings over built-in defaults.
 // Global overrides defaults; repo overrides global.
 func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 	r := ResolvedSettings{
-		AudioEnabled:      DefaultAudioEnabled,
-		BypassPermissions: DefaultBypassPermissions,
-		BranchPrefix:      DefaultBranchPrefix,
-		BranchNamePrompt:  DefaultBranchNamePrompt,
-		AgentProgram:      DefaultAgentProgram,
-		WorktreeDir:       DefaultWorktreeDir,
-		SidebarWidth:      DefaultSidebarWidth,
+		AudioEnabled:        DefaultAudioEnabled,
+		BypassPermissions:   DefaultBypassPermissions,
+		BranchPrefix:        DefaultBranchPrefix,
+		BranchNamePrompt:    DefaultBranchNamePrompt,
+		AgentProgram:        DefaultAgentProgram,
+		WorktreeDir:         DefaultWorktreeDir,
+		SidebarWidth:        DefaultSidebarWidth,
+		FocusModeEnabled:    DefaultFocusModeEnabled,
+		FocusSessionMinutes: DefaultFocusSessionMinutes,
+		MaxConcurrentAgents: DefaultMaxConcurrentAgents,
 	}
 
 	if global != nil {
@@ -113,6 +131,15 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		}
 		if global.SidebarWidth != nil {
 			r.SidebarWidth = ClampSidebarWidth(*global.SidebarWidth)
+		}
+		if global.FocusModeEnabled != nil {
+			r.FocusModeEnabled = *global.FocusModeEnabled
+		}
+		if global.FocusSessionMinutes != nil {
+			r.FocusSessionMinutes = *global.FocusSessionMinutes
+		}
+		if global.MaxConcurrentAgents != nil {
+			r.MaxConcurrentAgents = *global.MaxConcurrentAgents
 		}
 	}
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -478,3 +478,53 @@ func TestClampSidebarWidth(t *testing.T) {
 		t.Errorf("ClampSidebarWidth(35) = %d, want 35", got)
 	}
 }
+
+// ---- Wellness defaults ----
+
+func TestResolve_WellnessDefaults(t *testing.T) {
+	r := config.Resolve(nil, nil)
+
+	if r.FocusModeEnabled != config.DefaultFocusModeEnabled {
+		t.Errorf("FocusModeEnabled = %v, want %v", r.FocusModeEnabled, config.DefaultFocusModeEnabled)
+	}
+	if r.FocusSessionMinutes != config.DefaultFocusSessionMinutes {
+		t.Errorf("FocusSessionMinutes = %d, want %d", r.FocusSessionMinutes, config.DefaultFocusSessionMinutes)
+	}
+	if r.MaxConcurrentAgents != config.DefaultMaxConcurrentAgents {
+		t.Errorf("MaxConcurrentAgents = %d, want %d", r.MaxConcurrentAgents, config.DefaultMaxConcurrentAgents)
+	}
+}
+
+func TestResolve_WellnessGlobalOverride(t *testing.T) {
+	enabled := true
+	minutes := 60
+	maxAgents := 5
+	g := &config.GlobalSettings{
+		FocusModeEnabled:    &enabled,
+		FocusSessionMinutes: &minutes,
+		MaxConcurrentAgents: &maxAgents,
+	}
+	r := config.Resolve(g, nil)
+
+	if !r.FocusModeEnabled {
+		t.Error("FocusModeEnabled should be true (global override)")
+	}
+	if r.FocusSessionMinutes != 60 {
+		t.Errorf("FocusSessionMinutes = %d, want 60", r.FocusSessionMinutes)
+	}
+	if r.MaxConcurrentAgents != 5 {
+		t.Errorf("MaxConcurrentAgents = %d, want 5", r.MaxConcurrentAgents)
+	}
+}
+
+func TestResolve_WellnessNotInRepoSettings(t *testing.T) {
+	// Wellness fields are global-only; repo settings should not override them.
+	g := &config.GlobalSettings{
+		FocusSessionMinutes: intPtr(45),
+	}
+	// RepoSettings has no wellness fields by design.
+	r := config.Resolve(g, &config.RepoSettings{})
+	if r.FocusSessionMinutes != 45 {
+		t.Errorf("FocusSessionMinutes = %d, want 45 (from global)", r.FocusSessionMinutes)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2088,11 +2088,11 @@ func (a *App) activeAgentCount() int {
 
 // wellnessLogEntry is the JSON structure written on session end.
 type wellnessLogEntry struct {
-	Date             string `json:"date"`
-	DurationMin      int    `json:"duration_min"`
-	AgentsCreated    int    `json:"agents_created"`
-	SessionsCreated  int    `json:"sessions_created"`
-	FocusSwitches    int    `json:"focus_switches"`
+	Date            string `json:"date"`
+	DurationMin     int    `json:"duration_min"`
+	AgentsCreated   int    `json:"agents_created"`
+	SessionsCreated int    `json:"sessions_created"`
+	FocusSwitches   int    `json:"focus_switches"`
 }
 
 // writeWellnessLog appends a single JSON line to <repoPath>/.baton/logs/wellness.log.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -111,6 +113,18 @@ type App struct {
 	lastKnownStatus map[string]agent.Status
 	audioPlayer     *audio.Player
 
+	// Wellness / focus mode state.
+	focusModeActive     bool
+	sessionStart        time.Time
+	lastReviewAt        time.Time
+	newAgentPending     bool
+	focusSessionMinutes int // cached from resolved global settings
+
+	// Wellness counters (written to log on quit).
+	agentsCreatedCount   int
+	sessionsCreatedCount int
+	focusModeSwitches    int
+
 	// closingAgents and closingSessions track in-flight kill requests so the
 	// dashboard can render a "closing…" indicator while the async teardown runs.
 	// Lives in the TUI because it's purely a UI concern.
@@ -211,6 +225,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		a.cfg = msg.cfg
+		a.sessionStart = time.Now()
 
 		// Load global settings and run one-time migration.
 		globalSettings, err := config.LoadGlobalSettings()
@@ -220,7 +235,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.globalSettings = globalSettings
 			_ = config.MigrateBypassPermissions(a.cfg)
 		}
-		a.dashboard.sidebarWidth = config.Resolve(a.globalSettings, nil).SidebarWidth
+		resolved := config.Resolve(a.globalSettings, nil)
+		a.dashboard.sidebarWidth = resolved.SidebarWidth
+		a.focusModeActive = resolved.FocusModeEnabled
+		a.focusSessionMinutes = resolved.FocusSessionMinutes
 
 		// Load per-repo settings and build resolved cache.
 		for _, repo := range msg.cfg.Repos {
@@ -401,12 +419,15 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// (Claude needs user input). ChimedForTurn is the shared gate:
 			// whichever fires first in a turn wins, and the other is
 			// silently skipped. The flag resets on Enter or UserPromptSubmit.
+			// In focus mode, StatusIdle chimes are suppressed — only
+			// StatusWaiting (permission prompts) still fires.
 			if msg.event.Status == agent.StatusIdle || msg.event.Status == agent.StatusWaiting {
 				if mgr := a.managers[msg.repoPath]; mgr != nil {
 					if ag := mgr.Get(msg.event.AgentID); ag != nil && !ag.IsShell {
 						if ag.HasReceivedInput() && !ag.ChimedForTurn() {
 							resolved := a.resolvedCache[msg.repoPath]
-							if resolved.AudioEnabled && a.audioPlayer != nil {
+							chimeAllowed := !a.focusModeActive || msg.event.Status == agent.StatusWaiting
+							if resolved.AudioEnabled && a.audioPlayer != nil && chimeAllowed {
 								a.audioPlayer.Play()
 								ag.MarkChimedForTurn()
 							}
@@ -445,6 +466,21 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			a.setError(msg.err.Error())
 			return a, nil
+		}
+		a.agentsCreatedCount++
+		if msg.sessionID != "" && msg.agentID != "" {
+			// Count new sessions (agentID present means a session was also created).
+			// Distinguish new session (sessionID returned fresh from CreateSession)
+			// vs AddAgent (sessionID pre-existing) by checking if agentID is the
+			// first agent in the session.
+			if mgr := a.managers[a.activeRepo]; mgr != nil {
+				for _, sess := range mgr.ListSessions() {
+					if sess.ID == msg.sessionID && sess.AgentCount() == 1 {
+						a.sessionsCreatedCount++
+						break
+					}
+				}
+			}
 		}
 		a.refreshAgentList()
 		// Find the new agent by ID, select it, and auto-focus its terminal.
@@ -710,12 +746,28 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.audioPlayer != nil {
 				a.audioPlayer.Close()
 			}
+			a.writeWellnessLog()
 			return a, tea.Quit
 		default:
 			a.confirmQuit = false
 		}
 
+		// Clear the agent-limit pending flag on any key that isn't n.
+		if a.newAgentPending && msg.String() != "n" {
+			a.newAgentPending = false
+		}
+
 		switch msg.String() {
+		case "f":
+			// Toggle focus mode. When exiting focus mode (entering review),
+			// record the review time.
+			if a.focusModeActive {
+				a.lastReviewAt = time.Now()
+			}
+			a.focusModeActive = !a.focusModeActive
+			a.focusModeSwitches++
+			return a, nil
+
 		case "n":
 			// Create a new session in the repo of the currently selected item.
 			repoPath := a.dashboard.selectedRepoPath()
@@ -726,6 +778,21 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			}
 			a.activeRepo = repoPath
+
+			// Soft agent-count guidance in focus mode.
+			if a.focusModeActive {
+				resolved := a.resolvedCache[repoPath]
+				if resolved.MaxConcurrentAgents > 0 && a.activeAgentCount() >= resolved.MaxConcurrentAgents {
+					if !a.newAgentPending {
+						a.newAgentPending = true
+						a.setError(fmt.Sprintf("n again to override — %d+ agents shown to reduce productivity", resolved.MaxConcurrentAgents))
+						return a, nil
+					}
+					// Second press: proceed, clear pending flag.
+					a.newAgentPending = false
+				}
+			}
+
 			fixedW := a.dashboard.fixedTermWidth()
 			fixedH := a.dashboard.fixedTermHeight()
 			if fixedW <= 0 || fixedH <= 0 {
@@ -1372,11 +1439,14 @@ func (a App) updateGlobalConfig(msg tea.Msg) (tea.Model, tea.Cmd) {
 				mgr.UpdateSettings(a.resolvedCache[repoPath])
 			}
 		}
-		newSidebarWidth := config.Resolve(a.globalSettings, nil).SidebarWidth
-		if newSidebarWidth != a.dashboard.sidebarWidth {
-			a.dashboard.sidebarWidth = newSidebarWidth
+		newResolved := config.Resolve(a.globalSettings, nil)
+		if newResolved.SidebarWidth != a.dashboard.sidebarWidth {
+			a.dashboard.sidebarWidth = newResolved.SidebarWidth
 			a.resizeAllForDashboard()
 		}
+		// Refresh wellness settings from updated global config.
+		a.focusSessionMinutes = newResolved.FocusSessionMinutes
+		a.focusModeActive = newResolved.FocusModeEnabled
 		a.view = ViewDashboard
 		return a, nil
 	case globalConfigCancelMsg:
@@ -1486,6 +1556,10 @@ func (a *App) forwardWheelToAgent(ag *agent.Agent, msg tea.MouseWheelMsg) {
 func (a *App) refreshAgentList() {
 	a.dashboard.closingAgents = a.closingAgents
 	a.dashboard.closingSessions = a.closingSessions
+	a.dashboard.focusModeActive = a.focusModeActive
+	a.dashboard.sessionElapsed = time.Since(a.sessionStart)
+	a.dashboard.lastReviewAt = a.lastReviewAt
+	a.dashboard.focusSessionMinutes = a.focusSessionMinutes
 	if a.cfg == nil {
 		// Fallback used in tests that set up managers directly without cfg.
 		if mgr := a.managers[a.activeRepo]; mgr != nil {
@@ -1585,6 +1659,18 @@ func (a App) View() tea.View {
 			hints = focusTerminalHints
 		case focusConfig:
 			hints = repoConfigHints
+		}
+		// Prepend a break hint when focus mode is active and the session
+		// duration has exceeded the configured threshold.
+		if a.focusModeActive && a.focusSessionMinutes > 0 {
+			elapsed := time.Since(a.sessionStart)
+			if elapsed >= time.Duration(a.focusSessionMinutes)*time.Minute {
+				breakHint := keyHint{
+					key:  "⌛",
+					desc: fmt.Sprintf("%dm — take a break before reviewing", a.focusSessionMinutes),
+				}
+				hints = append([]keyHint{breakHint}, hints...)
+			}
 		}
 		statusbar := renderStatusBar(hints, a.width)
 		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)
@@ -1982,6 +2068,68 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 			stack:     stack,
 		}
 	}
+}
+
+// activeAgentCount returns the count of live non-shell agents across all repos.
+// Used to enforce the soft concurrent-agent limit in focus mode.
+func (a *App) activeAgentCount() int {
+	count := 0
+	for _, mgr := range a.managers {
+		for _, sess := range mgr.ListSessions() {
+			for _, ag := range sess.Agents() {
+				if !ag.IsShell {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+// wellnessLogEntry is the JSON structure written on session end.
+type wellnessLogEntry struct {
+	Date             string `json:"date"`
+	DurationMin      int    `json:"duration_min"`
+	AgentsCreated    int    `json:"agents_created"`
+	SessionsCreated  int    `json:"sessions_created"`
+	FocusSwitches    int    `json:"focus_switches"`
+}
+
+// writeWellnessLog appends a single JSON line to <repoPath>/.baton/logs/wellness.log.
+// Best-effort: any error is silently dropped so it never blocks shutdown.
+func (a *App) writeWellnessLog() {
+	repoPath := a.activeRepo
+	if repoPath == "" && a.cfg != nil && len(a.cfg.Repos) > 0 {
+		repoPath = a.cfg.Repos[0].Path
+	}
+	if repoPath == "" {
+		return
+	}
+
+	logPath := filepath.Join(repoPath, ".baton", "logs", "wellness.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return
+	}
+
+	elapsed := time.Since(a.sessionStart)
+	entry := wellnessLogEntry{
+		Date:            time.Now().UTC().Format(time.RFC3339),
+		DurationMin:     int(elapsed.Minutes()),
+		AgentsCreated:   a.agentsCreatedCount,
+		SessionsCreated: a.sessionsCreatedCount,
+		FocusSwitches:   a.focusModeSwitches,
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = f.WriteString(string(data) + "\n")
 }
 
 // ensureGitignore adds .baton/ to .gitignore in the given path if not already present.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	xvt "github.com/charmbracelet/x/vt"
 	"github.com/devenjarvis/baton/internal/agent"
+	"github.com/devenjarvis/baton/internal/audio"
 	"github.com/devenjarvis/baton/internal/config"
 )
 
@@ -1393,5 +1395,247 @@ func TestPreviewCursorHiddenWhenAgentHidesIt(t *testing.T) {
 	v := app.View()
 	if v.Cursor != nil {
 		t.Fatalf("expected view.Cursor nil when agent hid cursor, got %+v", v.Cursor)
+	}
+}
+
+// TestFocusModeToggle verifies that pressing 'f' toggles focusModeActive and
+// increments focusModeSwitches. Toggling off (focus→review) also sets lastReviewAt.
+func TestFocusModeToggle(t *testing.T) {
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+
+	if app.focusModeActive {
+		t.Fatal("Expected focusModeActive=false initially")
+	}
+
+	// First toggle: off → on.
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	app = model.(App)
+	if !app.focusModeActive {
+		t.Fatal("Expected focusModeActive=true after first f press")
+	}
+	if app.focusModeSwitches != 1 {
+		t.Errorf("Expected focusModeSwitches=1, got %d", app.focusModeSwitches)
+	}
+	// lastReviewAt should not be set when entering focus mode.
+	if !app.lastReviewAt.IsZero() {
+		t.Error("Expected lastReviewAt unset when entering focus mode")
+	}
+
+	// Second toggle: on → off (entering review). lastReviewAt should be set.
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	app = model.(App)
+	if app.focusModeActive {
+		t.Fatal("Expected focusModeActive=false after second f press")
+	}
+	if app.focusModeSwitches != 2 {
+		t.Errorf("Expected focusModeSwitches=2, got %d", app.focusModeSwitches)
+	}
+	if app.lastReviewAt.IsZero() {
+		t.Error("Expected lastReviewAt set when exiting focus mode (entering review)")
+	}
+}
+
+// TestFocusModeChimeSuppression verifies that in focus mode StatusIdle events
+// do not mark chime-for-turn, but StatusWaiting events still do.
+// When an audio player is available, the test asserts ChimedForTurn state
+// directly; otherwise it still validates the gate logic runs without error.
+func TestFocusModeChimeSuppression(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-chime-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+
+	sess, ag, err := mgr.CreateSessionWithCommand(agent.Config{
+		Name: "chime-test", Task: "test", RepoPath: dir, Rows: 24, Cols: 80,
+	}, func(_ string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 10")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate that the agent has received input, then reset ChimedForTurn so
+	// the gate logic can fire in the expected direction.
+	ag.SendKey(xvt.KeyPressEvent{Code: tea.KeyEnter})
+
+	resolved := config.Resolve(nil, nil)
+	resolved.AudioEnabled = true
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.resolvedCache[dir] = resolved
+	app.dashboard.items = []listItem{
+		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
+	}
+
+	// Try to wire up a real audio player so MarkChimedForTurn() can actually
+	// fire. Best-effort — if the environment has no audio device the player
+	// will be nil and we fall back to the structural assertion below.
+	if p, playerErr := audio.NewPlayer(); playerErr == nil {
+		app.audioPlayer = p
+		defer p.Close()
+	}
+
+	app.focusModeActive = true
+
+	// Case 1: StatusIdle in focus mode — chime should be suppressed.
+	// Reset chimed flag by simulating Enter (which resets ChimedForTurn).
+	ag.SendKey(xvt.KeyPressEvent{Code: tea.KeyEnter})
+	idleEvent := agentEventMsg{
+		event: agent.Event{
+			Type:    agent.EventStatusChanged,
+			AgentID: ag.ID,
+			Status:  agent.StatusIdle,
+		},
+		repoPath: dir,
+	}
+	model, _ := app.Update(idleEvent)
+	app = model.(App)
+	if !app.focusModeActive {
+		t.Error("Expected focusModeActive unchanged after idle event")
+	}
+	if app.audioPlayer != nil && ag.ChimedForTurn() {
+		t.Error("Expected ChimedForTurn=false after idle event in focus mode (chime suppressed)")
+	}
+
+	// Case 2: StatusWaiting in focus mode — chime should fire.
+	ag.SendKey(xvt.KeyPressEvent{Code: tea.KeyEnter}) // reset ChimedForTurn
+	waitEvent := agentEventMsg{
+		event: agent.Event{
+			Type:    agent.EventStatusChanged,
+			AgentID: ag.ID,
+			Status:  agent.StatusWaiting,
+		},
+		repoPath: dir,
+	}
+	model, _ = app.Update(waitEvent)
+	app = model.(App)
+	if !app.focusModeActive {
+		t.Error("Expected focusModeActive unchanged after waiting event")
+	}
+	if app.audioPlayer != nil && !ag.ChimedForTurn() {
+		t.Error("Expected ChimedForTurn=true after waiting event in focus mode (chime allowed)")
+	}
+}
+
+// TestSoftAgentLimitGuard verifies the two-press 'n' guard in focus mode:
+// first press shows a warning and sets newAgentPending; second press proceeds.
+func TestSoftAgentLimitGuard(t *testing.T) {
+	requireClaude(t)
+	dir, err := os.MkdirTemp("", "baton-softlimit-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.ResolvedSettings{
+		BypassPermissions:   true,
+		AgentProgram:        "claude",
+		MaxConcurrentAgents: 1, // limit to 1 so we hit it immediately
+	})
+	defer mgr.Shutdown()
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.resolvedCache[dir] = config.ResolvedSettings{
+		BypassPermissions:   true,
+		AgentProgram:        "claude",
+		MaxConcurrentAgents: 1,
+	}
+
+	// Create the first agent to reach the limit.
+	app = createAgent(t, app)
+	if app.err != "" {
+		t.Fatalf("Error creating first agent: %s", app.err)
+	}
+	if mgr.AgentCount() != 1 {
+		t.Fatalf("Expected 1 agent, got %d", mgr.AgentCount())
+	}
+
+	// Return to list focus so 'n' reaches the app-level handler.
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
+	app = model.(App)
+	if app.dashboard.panelFocus != focusList {
+		t.Fatalf("Expected focusList after ctrl+e, got %v", app.dashboard.panelFocus)
+	}
+
+	// Enable focus mode.
+	app.focusModeActive = true
+
+	// First 'n' press: should set newAgentPending and show error, not create agent.
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	app = model.(App)
+	if cmd != nil {
+		// If a cmd was returned, execute it to check if it created an agent.
+		// We don't expect this in the first press.
+		msg := cmd()
+		if _, ok := msg.(createResultMsg); ok {
+			t.Fatal("Expected no agent creation on first 'n' press at limit")
+		}
+	}
+	if !app.newAgentPending {
+		t.Fatal("Expected newAgentPending=true after first 'n' at limit")
+	}
+	if app.err == "" {
+		t.Fatal("Expected warning message after first 'n' at limit")
+	}
+
+	// Second 'n' press: should clear pending and proceed with creation.
+	model, cmd = app.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	app = model.(App)
+	if app.newAgentPending {
+		t.Fatal("Expected newAgentPending=false after second 'n'")
+	}
+	// cmd should be non-nil (agent creation is dispatched).
+	if cmd == nil {
+		t.Fatal("Expected non-nil cmd from second 'n' press (agent creation)")
+	}
+
+	// Any other key press should clear newAgentPending.
+	app.newAgentPending = true
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	app = model.(App)
+	if app.newAgentPending {
+		t.Fatal("Expected newAgentPending cleared by non-n key press")
 	}
 }

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -743,7 +743,7 @@ func (d dashboardModel) renderFocusPanel(width int) string {
 	}
 	separator := StyleSubtle.Render(strings.Repeat("─", sepWidth))
 
-	var lines []string
+	lines := make([]string, 0, 8)
 	lines = append(lines, title, separator)
 
 	// Progress bar: sessionElapsed vs focusSessionMinutes.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -113,6 +113,12 @@ type dashboardModel struct {
 	closingAgents   map[string]bool            // keyed by agent ID, passed from App
 	closingSessions map[string]bool            // keyed by session ID, passed from App
 
+	// Focus mode state, synced from App on every refresh.
+	focusModeActive     bool
+	sessionElapsed      time.Duration
+	lastReviewAt        time.Time
+	focusSessionMinutes int
+
 	// prSectionY is the content-relative row index (0-indexed, after the AGENTS
 	// title and separator) where the PR checks summary begins, or -1 when absent.
 	prSectionY int
@@ -330,7 +336,12 @@ func (d dashboardModel) View() string {
 	listWidth := d.listWidth()
 	previewWidth := d.previewTermWidth()
 
-	list := d.renderList(listWidth)
+	var list string
+	if d.focusModeActive {
+		list = d.renderFocusPanel(listWidth)
+	} else {
+		list = d.renderList(listWidth)
+	}
 	preview := d.renderPreview(previewWidth)
 
 	listStyle := lipgloss.NewStyle().
@@ -717,6 +728,167 @@ func (d dashboardModel) renderList(width int) string {
 		}
 		lines = append(lines, bottomLines...)
 	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderFocusPanel renders the aggregate left panel shown in focus mode.
+// It shows session progress, status counts, waiting-agent attention rows,
+// last review time, and minimal key hints.
+func (d dashboardModel) renderFocusPanel(width int) string {
+	title := StyleTitle.Render("FOCUS")
+	sepWidth := width - 2
+	if sepWidth < 0 {
+		sepWidth = 0
+	}
+	separator := StyleSubtle.Render(strings.Repeat("─", sepWidth))
+
+	var lines []string
+	lines = append(lines, title, separator)
+
+	// Progress bar: sessionElapsed vs focusSessionMinutes.
+	if d.focusSessionMinutes > 0 {
+		threshold := time.Duration(d.focusSessionMinutes) * time.Minute
+		elapsed := d.sessionElapsed
+		if elapsed > threshold {
+			elapsed = threshold
+		}
+		pct := float64(elapsed) / float64(threshold)
+		barWidth := width - 20
+		if barWidth < 5 {
+			barWidth = 5
+		}
+		filled := int(pct * float64(barWidth))
+		if filled > barWidth {
+			filled = barWidth
+		}
+		bar := strings.Repeat("=", filled)
+		if filled < barWidth {
+			bar += ">"
+			bar += strings.Repeat(" ", barWidth-filled-1)
+		}
+
+		elapsedMin := int(d.sessionElapsed.Minutes())
+		barStr := fmt.Sprintf("[%s] %dm / %dm", bar, elapsedMin, d.focusSessionMinutes)
+
+		var barStyle lipgloss.Style
+		switch {
+		case pct >= 1.0:
+			barStyle = lipgloss.NewStyle().Foreground(ColorError)
+		case pct >= 0.75:
+			barStyle = lipgloss.NewStyle().Foreground(ColorWarning)
+		default:
+			barStyle = lipgloss.NewStyle().Foreground(ColorMuted)
+		}
+		lines = append(lines, barStyle.Render(barStr))
+	}
+
+	// Status counts row.
+	var running, idle, done, waiting, errCount int
+	for _, item := range d.items {
+		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell {
+			continue
+		}
+		switch item.agent.Status() {
+		case agent.StatusActive:
+			running++
+		case agent.StatusIdle:
+			idle++
+		case agent.StatusDone:
+			done++
+		case agent.StatusWaiting:
+			waiting++
+		case agent.StatusError:
+			errCount++
+		}
+	}
+	statusLine := ""
+	if running > 0 {
+		statusLine += lipgloss.NewStyle().Foreground(ColorSecondary).Render(fmt.Sprintf("● %d running", running))
+	}
+	if waiting > 0 {
+		if statusLine != "" {
+			statusLine += "  "
+		}
+		statusLine += lipgloss.NewStyle().Foreground(ColorWaiting).Render(fmt.Sprintf("⏸ %d waiting", waiting))
+	}
+	if idle > 0 {
+		if statusLine != "" {
+			statusLine += "  "
+		}
+		statusLine += StyleSubtle.Render(fmt.Sprintf("⏸ %d idle", idle))
+	}
+	if done > 0 {
+		if statusLine != "" {
+			statusLine += "  "
+		}
+		statusLine += lipgloss.NewStyle().Foreground(ColorSuccess).Render(fmt.Sprintf("✓ %d done", done))
+	}
+	if errCount > 0 {
+		if statusLine != "" {
+			statusLine += "  "
+		}
+		statusLine += lipgloss.NewStyle().Foreground(ColorError).Render(fmt.Sprintf("✗ %d error", errCount))
+	}
+	if statusLine == "" {
+		statusLine = StyleSubtle.Render("no agents")
+	}
+	lines = append(lines, statusLine)
+
+	// Attention rows: agents needing input (Waiting or Error).
+	for _, item := range d.items {
+		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell {
+			continue
+		}
+		status := item.agent.Status()
+		if status != agent.StatusWaiting && status != agent.StatusError {
+			continue
+		}
+		label := item.agent.GetDisplayName()
+		if item.session != nil {
+			label = item.session.GetDisplayName()
+		}
+		var attnStyle lipgloss.Style
+		var attnSuffix string
+		if status == agent.StatusWaiting {
+			attnStyle = lipgloss.NewStyle().Foreground(ColorWaiting)
+			attnSuffix = "needs input"
+		} else {
+			attnStyle = lipgloss.NewStyle().Foreground(ColorError)
+			attnSuffix = "error"
+		}
+		nameWidth := width - 4 - len(attnSuffix)
+		if nameWidth < 4 {
+			nameWidth = 4
+		}
+		label = truncateVisible(label, nameWidth)
+		lines = append(lines, attnStyle.Render("⏺ "+label+"  "+attnSuffix))
+	}
+
+	// Last reviewed row.
+	if !d.lastReviewAt.IsZero() {
+		ago := time.Since(d.lastReviewAt)
+		var agoStr string
+		switch {
+		case ago < time.Minute:
+			agoStr = fmt.Sprintf("%ds ago", int(ago.Seconds()))
+		case ago < time.Hour:
+			agoStr = fmt.Sprintf("%dm ago", int(ago.Minutes()))
+		default:
+			agoStr = fmt.Sprintf("%dh ago", int(ago.Hours()))
+		}
+		lines = append(lines, StyleSubtle.Render("last review: "+agoStr))
+	} else {
+		lines = append(lines, StyleSubtle.Render("not yet reviewed"))
+	}
+
+	// Pad to content height before adding bottom hint.
+	contentH := d.contentHeight()
+	hintLine := StyleSubtle.Render("f review   n new agent")
+	for len(lines) < contentH-1 {
+		lines = append(lines, "")
+	}
+	lines = append(lines, hintLine)
 
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/globalconfig.go
+++ b/internal/tui/globalconfig.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	fieldFocusMode       = "Focus Mode"
-	fieldFocusSession    = "Focus Session (min)"
-	fieldMaxAgents       = "Max Concurrent Agents"
+	fieldFocusMode    = "Focus Mode"
+	fieldFocusSession = "Focus Session (min)"
+	fieldMaxAgents    = "Max Concurrent Agents"
 )
 
 // globalConfigSaveMsg is emitted when the global config form is saved.

--- a/internal/tui/globalconfig.go
+++ b/internal/tui/globalconfig.go
@@ -8,6 +8,12 @@ import (
 	"github.com/devenjarvis/baton/internal/config"
 )
 
+const (
+	fieldFocusMode       = "Focus Mode"
+	fieldFocusSession    = "Focus Session (min)"
+	fieldMaxAgents       = "Max Concurrent Agents"
+)
+
 // globalConfigSaveMsg is emitted when the global config form is saved.
 type globalConfigSaveMsg struct {
 	settings *config.GlobalSettings
@@ -58,6 +64,19 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 		sidebarWidth = strconv.Itoa(*gs.SidebarWidth)
 	}
 
+	focusModeEnabled := config.DefaultFocusModeEnabled
+	if gs.FocusModeEnabled != nil {
+		focusModeEnabled = *gs.FocusModeEnabled
+	}
+	focusSessionMinutes := ""
+	if gs.FocusSessionMinutes != nil {
+		focusSessionMinutes = strconv.Itoa(*gs.FocusSessionMinutes)
+	}
+	maxConcurrentAgents := ""
+	if gs.MaxConcurrentAgents != nil {
+		maxConcurrentAgents = strconv.Itoa(*gs.MaxConcurrentAgents)
+	}
+
 	inputWidth := 30
 
 	var fields []formField
@@ -68,6 +87,9 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
 	fields = addEditorFields(fields, ideCommand, inputWidth)
 	fields = addTextInput(fields, "Sidebar Width", sidebarWidth, strconv.Itoa(config.DefaultSidebarWidth), inputWidth)
+	fields = addToggle(fields, fieldFocusMode, focusModeEnabled)
+	fields = addTextInput(fields, fieldFocusSession, focusSessionMinutes, strconv.Itoa(config.DefaultFocusSessionMinutes), inputWidth)
+	fields = addTextInput(fields, fieldMaxAgents, maxConcurrentAgents, strconv.Itoa(config.DefaultMaxConcurrentAgents), inputWidth)
 
 	return globalConfigModel{
 		form:   newConfigForm(fields, width),
@@ -138,6 +160,20 @@ func (m globalConfigModel) extractSettings() *config.GlobalSettings {
 		if n, err := strconv.Atoi(v); err == nil {
 			clamped := config.ClampSidebarWidth(n)
 			s.SidebarWidth = &clamped
+		}
+	}
+
+	focusMode := m.form.toggleValue(fieldFocusMode)
+	s.FocusModeEnabled = &focusMode
+
+	if v := m.form.textValue(fieldFocusSession); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			s.FocusSessionMinutes = &n
+		}
+	}
+	if v := m.form.textValue(fieldMaxAgents); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			s.MaxConcurrentAgents = &n
 		}
 	}
 

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -21,6 +21,7 @@ var (
 		{"e", "open in IDE"},
 		{"p", "open PR"},
 		{"click PR#", "open"},
+		{"f", "focus mode"},
 		{"s", "settings"},
 		{"a", "add repo"},
 		{"o", "open branch"},


### PR DESCRIPTION
## Summary

- Introduces an opt-in **Focus Mode** (`f` to toggle) that shifts the left panel from per-agent monitoring to a silent aggregate view, grounded in BCG/2026 research (n=1,488) showing 33% more decision fatigue and 39% more errors when overseeing 4+ parallel AI streams simultaneously
- Focus panel shows session progress bar, per-status agent counts, attention rows for agents needing input (Waiting/Error), last-review timestamp, and minimal key hints
- **Chime suppression**: in focus mode, `StatusIdle` chimes are silenced; `StatusWaiting` (permission prompts) still fires so nothing blocks unattended
- **Soft agent limit**: first `n` press when at `MaxConcurrentAgents` shows a warning (`n again to override — 3+ agents shown to reduce productivity`); second press proceeds
- **Break hint**: `⌛ 90m — take a break before reviewing` prepended to the statusbar once `sessionElapsed ≥ FocusSessionMinutes`
- **Wellness log**: on quit, appends one JSON line to `.baton/logs/wellness.log` with date, duration, agents/sessions created, focus switches — raw data layer only
- **Three new global settings** exposed under `s`: Focus Mode (toggle), Focus Session (min), Max Concurrent Agents

All behavior is off-by-default (`FocusModeEnabled: false`) so existing workflows are unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` — all pass (pre-existing `TestLoad_MigratesFromLegacyXDGPath` failure unrelated)
- [x] Manual TUI:
  - Press `f` → left panel switches to FOCUS aggregate view
  - Press `f` again → returns to normal agent list
  - In focus mode with 3+ agents, press `n` → warning appears; press `n` again → new session created
  - In focus mode, agent completes → no idle chime; trigger permission prompt → chime fires
  - `s` → settings → Focus Mode, Focus Session, Max Concurrent Agents fields visible
  - Quit baton → `.baton/logs/wellness.log` contains one JSON line

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description