### PR TITLE
Make focus mode repo navigation visible and correct

### DIFF
--- a/changelog.d/feat-focus-mode-repo-nav.md
+++ b/changelog.d/feat-focus-mode-repo-nav.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Focus mode arrow-key navigation now moves between repo rows only (skips sessions and agents), making the selected repo visible in the panel
+- Focus panel shows a compact per-repo agent-status summary with a selection cursor so you can see which repo `n` will target
+- Bottom hint in focus mode now reads "n new agent in <reponame>" to confirm the target repo

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -766,6 +766,9 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			a.focusModeActive = !a.focusModeActive
 			a.focusModeSwitches++
+			if a.focusModeActive {
+				a.dashboard.clampToRepo()
+			}
 			return a, nil
 
 		case "n":
@@ -1632,15 +1635,21 @@ func (a *App) refreshAgentList() {
 		a.dashboard.selected = len(items) - 1
 	}
 	a.dashboard.items = items
-	a.dashboard.clampToAgent()
+	if a.focusModeActive {
+		a.dashboard.clampToRepo()
+	} else {
+		a.dashboard.clampToAgent()
+	}
 
 	// If the selection landed in a different repo, search backward for the
 	// nearest item in the original repo (an agent or the repo header).
 	if prevRepo != "" && len(items) > 0 && items[a.dashboard.selected].repoPath != prevRepo {
 		for i := a.dashboard.selected; i >= 0; i-- {
 			if items[i].repoPath == prevRepo && items[i].kind != listItemSession {
-				a.dashboard.selected = i
-				break
+				if !a.focusModeActive || items[i].kind == listItemRepo {
+					a.dashboard.selected = i
+					break
+				}
 			}
 		}
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1639,3 +1639,98 @@ func TestSoftAgentLimitGuard(t *testing.T) {
 		t.Fatal("Expected newAgentPending cleared by non-n key press")
 	}
 }
+
+// TestClampToRepo verifies that clampToRepo always lands on a listItemRepo row.
+func TestClampToRepo(t *testing.T) {
+	sess := &agent.Session{Name: "s"}
+	ag := &agent.Agent{Name: "a"}
+
+	items := []listItem{
+		{kind: listItemRepo, repoPath: "/r1", repoName: "repo1"},   // 0
+		{kind: listItemSession, repoPath: "/r1", session: sess},     // 1
+		{kind: listItemAgent, repoPath: "/r1", session: sess, agent: ag}, // 2
+		{kind: listItemRepo, repoPath: "/r2", repoName: "repo2"},   // 3
+		{kind: listItemAgent, repoPath: "/r2", session: sess, agent: ag}, // 4
+	}
+
+	// Already on a repo row: no-op.
+	d := newDashboardModel()
+	d.items = items
+	d.selected = 0
+	d.clampToRepo()
+	if d.selected != 0 {
+		t.Fatalf("no-op case: expected 0, got %d", d.selected)
+	}
+
+	// On an agent row: should find the owning repo header above (backward search).
+	d.selected = 2
+	d.clampToRepo()
+	if d.selected != 0 {
+		t.Fatalf("agent in repo1: expected 0 (repo1 header), got %d", d.selected)
+	}
+
+	// On the session row: should find the repo header above.
+	d.selected = 1
+	d.clampToRepo()
+	if d.selected != 0 {
+		t.Fatalf("session row: expected 0 (repo1 header), got %d", d.selected)
+	}
+
+	// On agent in repo2 (index 4): repo2 header is at index 3, above.
+	d.selected = 4
+	d.clampToRepo()
+	if d.selected != 3 {
+		t.Fatalf("agent in repo2: expected 3 (repo2 header), got %d", d.selected)
+	}
+
+	// Out-of-range selected: should clamp down and then find a repo.
+	d.selected = 99
+	d.clampToRepo()
+	if d.items[d.selected].kind != listItemRepo {
+		t.Fatalf("out-of-range: expected listItemRepo, got kind=%d at selected=%d", d.items[d.selected].kind, d.selected)
+	}
+}
+
+// TestFocusModeNavigationOnlyLandsOnRepos verifies that j/k in focus mode only
+// move between listItemRepo rows, skipping sessions and agents entirely.
+func TestFocusModeNavigationOnlyLandsOnRepos(t *testing.T) {
+	sess := &agent.Session{Name: "s"}
+	ag := &agent.Agent{Name: "a"}
+
+	d := newDashboardModel()
+	d.width = 120
+	d.height = 39
+	d.focusModeActive = true
+	d.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r1", repoName: "repo1"},        // 0
+		{kind: listItemSession, repoPath: "/r1", session: sess},          // 1
+		{kind: listItemAgent, repoPath: "/r1", session: sess, agent: ag}, // 2
+		{kind: listItemRepo, repoPath: "/r2", repoName: "repo2"},        // 3
+		{kind: listItemAgent, repoPath: "/r2", session: sess, agent: ag}, // 4
+	}
+	d.selected = 0
+
+	// j from repo1 should skip session and agent, land on repo2.
+	d, _ = d.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	if d.selected != 3 {
+		t.Fatalf("j from repo1: expected 3 (repo2), got %d", d.selected)
+	}
+
+	// j from repo2 (last repo): no-op, stays at 3.
+	d, _ = d.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	if d.selected != 3 {
+		t.Fatalf("j from last repo: expected 3 (no-op), got %d", d.selected)
+	}
+
+	// k from repo2 should land on repo1.
+	d, _ = d.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if d.selected != 0 {
+		t.Fatalf("k from repo2: expected 0 (repo1), got %d", d.selected)
+	}
+
+	// k from repo1 (first repo): no-op, stays at 0.
+	d, _ = d.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if d.selected != 0 {
+		t.Fatalf("k from first repo: expected 0 (no-op), got %d", d.selected)
+	}
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1646,10 +1646,10 @@ func TestClampToRepo(t *testing.T) {
 	ag := &agent.Agent{Name: "a"}
 
 	items := []listItem{
-		{kind: listItemRepo, repoPath: "/r1", repoName: "repo1"},   // 0
-		{kind: listItemSession, repoPath: "/r1", session: sess},     // 1
+		{kind: listItemRepo, repoPath: "/r1", repoName: "repo1"},         // 0
+		{kind: listItemSession, repoPath: "/r1", session: sess},          // 1
 		{kind: listItemAgent, repoPath: "/r1", session: sess, agent: ag}, // 2
-		{kind: listItemRepo, repoPath: "/r2", repoName: "repo2"},   // 3
+		{kind: listItemRepo, repoPath: "/r2", repoName: "repo2"},         // 3
 		{kind: listItemAgent, repoPath: "/r2", session: sess, agent: ag}, // 4
 	}
 
@@ -1702,10 +1702,10 @@ func TestFocusModeNavigationOnlyLandsOnRepos(t *testing.T) {
 	d.height = 39
 	d.focusModeActive = true
 	d.items = []listItem{
-		{kind: listItemRepo, repoPath: "/r1", repoName: "repo1"},        // 0
+		{kind: listItemRepo, repoPath: "/r1", repoName: "repo1"},         // 0
 		{kind: listItemSession, repoPath: "/r1", session: sess},          // 1
 		{kind: listItemAgent, repoPath: "/r1", session: sess, agent: ag}, // 2
-		{kind: listItemRepo, repoPath: "/r2", repoName: "repo2"},        // 3
+		{kind: listItemRepo, repoPath: "/r2", repoName: "repo2"},         // 3
 		{kind: listItemAgent, repoPath: "/r2", session: sess, agent: ag}, // 4
 	}
 	d.selected = 0

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -292,7 +292,13 @@ func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 		switch msg.String() {
 		case "j", "down":
 			for next := d.selected + 1; next < len(d.items); next++ {
-				if d.items[next].kind != listItemSession {
+				if d.focusModeActive {
+					if d.items[next].kind == listItemRepo {
+						d.selected = next
+						d.scrollOffset = 0
+						break
+					}
+				} else if d.items[next].kind != listItemSession {
 					d.selected = next
 					d.scrollOffset = 0
 					break
@@ -300,7 +306,13 @@ func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 			}
 		case "k", "up":
 			for next := d.selected - 1; next >= 0; next-- {
-				if d.items[next].kind != listItemSession {
+				if d.focusModeActive {
+					if d.items[next].kind == listItemRepo {
+						d.selected = next
+						d.scrollOffset = 0
+						break
+					}
+				} else if d.items[next].kind != listItemSession {
 					d.selected = next
 					d.scrollOffset = 0
 					break
@@ -835,6 +847,73 @@ func (d dashboardModel) renderFocusPanel(width int) string {
 	}
 	lines = append(lines, statusLine)
 
+	// Compact per-repo summary list.
+	type repoCounts struct {
+		index   int // index into d.items for this repo's listItemRepo
+		name    string
+		running int
+		waiting int
+		done    int
+		errC    int
+	}
+	var repos []repoCounts
+	repoIdx := -1
+	for i, item := range d.items {
+		switch item.kind {
+		case listItemRepo:
+			repos = append(repos, repoCounts{index: i, name: item.repoName})
+			repoIdx = len(repos) - 1
+		case listItemAgent:
+			if repoIdx < 0 || item.agent == nil || item.agent.IsShell {
+				continue
+			}
+			switch item.agent.Status() {
+			case agent.StatusActive:
+				repos[repoIdx].running++
+			case agent.StatusWaiting:
+				repos[repoIdx].waiting++
+			case agent.StatusDone:
+				repos[repoIdx].done++
+			case agent.StatusError:
+				repos[repoIdx].errC++
+			}
+		}
+	}
+	for _, rc := range repos {
+		cursor := " "
+		if d.selected == rc.index {
+			cursor = ">"
+		}
+		var counts string
+		if rc.running > 0 {
+			counts += lipgloss.NewStyle().Foreground(ColorSecondary).Render(fmt.Sprintf("● %d", rc.running)) + " "
+		}
+		if rc.waiting > 0 {
+			counts += lipgloss.NewStyle().Foreground(ColorWaiting).Render(fmt.Sprintf("⏸ %d", rc.waiting)) + " "
+		}
+		if rc.done > 0 {
+			counts += lipgloss.NewStyle().Foreground(ColorSuccess).Render(fmt.Sprintf("✓ %d", rc.done)) + " "
+		}
+		if rc.errC > 0 {
+			counts += lipgloss.NewStyle().Foreground(ColorError).Render(fmt.Sprintf("✗ %d", rc.errC)) + " "
+		}
+		counts = strings.TrimRight(counts, " ")
+		countsWidth := ansi.StringWidth(counts)
+		nameWidth := width - 2 - 1 - countsWidth // border(2) + cursor(1)
+		if countsWidth > 0 {
+			nameWidth-- // space between name and counts
+		}
+		if nameWidth < 4 {
+			nameWidth = 4
+		}
+		name := truncateVisible(rc.name, nameWidth)
+		row := cursor + " " + name
+		if countsWidth > 0 {
+			row += " " + counts
+		}
+		lines = append(lines, row)
+	}
+
 	// Attention rows: agents needing input (Waiting or Error).
 	for _, item := range d.items {
 		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell {
@@ -884,7 +963,11 @@ func (d dashboardModel) renderFocusPanel(width int) string {
 
 	// Pad to content height before adding bottom hint.
 	contentH := d.contentHeight()
-	hintLine := StyleSubtle.Render("f review   n new agent")
+	hintText := "f review   n new agent"
+	if d.selected >= 0 && d.selected < len(d.items) && d.items[d.selected].kind == listItemRepo {
+		hintText = "f review   n new agent in " + d.items[d.selected].repoName
+	}
+	hintLine := StyleSubtle.Render(hintText)
 	for len(lines) < contentH-1 {
 		lines = append(lines, "")
 	}
@@ -1099,6 +1182,37 @@ func (d dashboardModel) selectedRepoPath() string {
 		return ""
 	}
 	return item.repoPath
+}
+
+// clampToRepo adjusts selected to the nearest listItemRepo row.
+// Searches backward first (repo headers appear above their agents), then forward.
+func (d *dashboardModel) clampToRepo() {
+	if len(d.items) == 0 {
+		return
+	}
+	if d.selected >= len(d.items) {
+		d.selected = len(d.items) - 1
+	}
+	if d.selected < 0 {
+		d.selected = 0
+	}
+	if d.items[d.selected].kind == listItemRepo {
+		return
+	}
+	// Search backward first: repo headers appear above their agents.
+	for i := d.selected - 1; i >= 0; i-- {
+		if d.items[i].kind == listItemRepo {
+			d.selected = i
+			return
+		}
+	}
+	// Fall forward if no repo header above (shouldn't happen in a valid list).
+	for i := d.selected + 1; i < len(d.items); i++ {
+		if d.items[i].kind == listItemRepo {
+			d.selected = i
+			return
+		}
+	}
 }
 
 // clampToAgent adjusts selected to the nearest non-session row.


### PR DESCRIPTION
## Summary

- Add `clampToRepo()` that snaps selection to the nearest `listItemRepo` row (searches backward first since repo headers sit above their agents); wired into the focus-mode toggle and `refreshAgentList()` in place of `clampToAgent()` when focus mode is active
- Restrict j/k arrow keys in focus mode to `listItemRepo` items only — previously they'd invisibly navigate agents/sessions with no feedback
- Render a compact per-repo agent-count summary in `renderFocusPanel()` with a `>` cursor so the selected repo is always visible; counts show running/waiting/done/error agents per repo
- Update the bottom hint from `"n new agent"` to `"n new agent in <reponame>"` so the target repo is confirmed before pressing n
- Guard the same-repo re-anchor in `refreshAgentList()` so a post-rebuild repo migration can't land on an agent row and bypass the focus-mode invariant

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `TestClampToRepo` — verifies backward-first search, no-op on repo row, out-of-range clamp
- [x] `TestFocusModeNavigationOnlyLandsOnRepos` — verifies j/k skip sessions/agents, no-op at list boundaries
- [ ] Manual TUI: start baton with two repos, toggle focus mode with `f`, verify compact repo list appears, arrow keys move between repos only, hint shows "n new agent in <reponame>", pressing `n` creates agent in the indicated repo

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description