### PR TITLE
Fix focus mode agent interaction: launch terminal, attention rows, repo cycling

### DIFF
--- a/changelog.d/focus-mode-agent-interaction.md
+++ b/changelog.d/focus-mode-agent-interaction.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Focus mode: pressing `n` to create a new agent now opens a "focus paused" terminal so you can give the initial prompt, then press `f` to return to the pipeline view.
+- Focus mode: attention rows (waiting agents) now show the notification reason text (e.g. "Claude needs your permission to use Bash") and can be navigated with `j`/`k`. Press `space`/`enter` to open that agent's terminal.
+- Focus mode: header now shows the active repo name. Press `N` to cycle through repos without leaving focus mode.
+- Focus mode: status bar shows context-sensitive hints (`[f/esc] back to focus`) when a launch terminal is open.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -33,6 +33,7 @@ type Agent struct {
 	claudeSessionID  string
 	hasClaudeName    bool
 	status           Status
+	waitingReason    string
 	lastOutput       time.Time
 	lastInput        time.Time
 	composing        bool
@@ -398,6 +399,7 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 		if a.status == StatusDone || a.status == StatusError {
 			return false
 		}
+		a.waitingReason = ""
 		// Claude finished its turn; the user is now in control. Clear the
 		// composing flag so input-display logic returns to its idle baseline.
 		a.composing = false
@@ -419,6 +421,7 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 		// Done or Error agent, and don't clobber Idle either — if Claude sent
 		// Stop already, a trailing Notification shouldn't re-attention the row.
 		if a.status == StatusActive || a.status == StatusWaiting {
+			a.waitingReason = e.Message
 			if a.status != StatusWaiting {
 				a.status = StatusWaiting
 				return true
@@ -435,6 +438,7 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 		if a.status == StatusDone || a.status == StatusError {
 			return false
 		}
+		a.waitingReason = ""
 		a.chimedForTurn = false
 		if a.status != StatusActive {
 			a.status = StatusActive
@@ -453,6 +457,7 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 		if a.status == StatusDone || a.status == StatusError {
 			return false
 		}
+		a.waitingReason = ""
 		if a.status != StatusActive {
 			a.status = StatusActive
 			return true
@@ -593,6 +598,16 @@ func (a *Agent) Status() Status {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.status
+}
+
+// WaitingReason returns the message from the most recent KindNotification event
+// that drove the agent to StatusWaiting, or "" if the agent is not waiting.
+// The reason is cleared when the agent transitions away from StatusWaiting via
+// KindPreToolUse, KindStop, or KindUserPromptSubmit.
+func (a *Agent) WaitingReason() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.waitingReason
 }
 
 // SetDisplayName sets the human-readable display name for this agent.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -413,6 +413,7 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 		// Flag a clean exit for observability. Actual teardown still goes
 		// through the PTY close path (readLoop -> close(done)).
 		a.cleanExit = true
+		a.waitingReason = ""
 		return false
 
 	case hook.KindNotification:

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -705,6 +705,68 @@ func TestUserPromptSubmitSlashWithArgRenamesBranch(t *testing.T) {
 	}
 }
 
+// TestWaitingReasonStoredAndCleared verifies that WaitingReason() is set when a
+// KindNotification event fires and cleared when KindPreToolUse follows.
+func TestWaitingReasonStoredAndCleared(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "waiting-reason", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// SessionStart → Active.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindSessionStart,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent SessionStart: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
+	}
+
+	// Notification → Waiting; reason must be stored.
+	const wantReason = "Claude needs permission"
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindNotification,
+		AgentID: ag.ID,
+		Message: wantReason,
+	}); err != nil {
+		t.Fatalf("SendEvent Notification: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusWaiting, 2*time.Second) {
+		t.Fatalf("expected Waiting after Notification, got %s", ag.Status())
+	}
+	if got := ag.WaitingReason(); got != wantReason {
+		t.Errorf("WaitingReason() = %q, want %q", got, wantReason)
+	}
+
+	// PreToolUse → Active; reason must be cleared.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindPreToolUse,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent PreToolUse: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+		t.Fatalf("expected Active after PreToolUse, got %s", ag.Status())
+	}
+	if got := ag.WaitingReason(); got != "" {
+		t.Errorf("WaitingReason() = %q after PreToolUse, want empty", got)
+	}
+}
+
 // waitForStatus polls the agent status up to d for the desired value.
 func waitForStatus(t *testing.T, a *Agent, want Status, d time.Duration) bool {
 	t.Helper()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -120,8 +120,8 @@ type App struct {
 	newAgentPending     bool
 	focusSessionMinutes int // cached from resolved global settings
 	focusQueueIndex     int
-	focusAttentionIdx   int          // index of highlighted waiting/error agent row
-	focusLaunchAgent    *agent.Agent // agent open in focusLaunch terminal; nil otherwise
+	focusAttentionIdx   int
+	focusLaunchAgent    *agent.Agent
 	focusBacklogWarning bool                        // first n at backlog limit shows warning; second proceeds
 	reviewDiffCache     map[string]*reviewDiffEntry // keyed by session ID
 	reviewSession       *agent.Session              // session currently open in review panel

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -120,6 +120,8 @@ type App struct {
 	newAgentPending     bool
 	focusSessionMinutes int // cached from resolved global settings
 	focusQueueIndex     int
+	focusAttentionIdx   int          // index of highlighted waiting/error agent row
+	focusLaunchAgent    *agent.Agent // agent open in focusLaunch terminal; nil otherwise
 	focusBacklogWarning bool                        // first n at backlog limit shows warning; second proceeds
 	reviewDiffCache     map[string]*reviewDiffEntry // keyed by session ID
 	reviewSession       *agent.Session              // session currently open in review panel
@@ -509,7 +511,12 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			for i, item := range a.dashboard.items {
 				if item.kind == listItemAgent && item.agent != nil && item.agent.ID == msg.agentID {
 					a.dashboard.selected = i
-					a.dashboard.panelFocus = focusTerminal
+					if a.focusModeActive {
+						a.focusLaunchAgent = item.agent
+						a.dashboard.panelFocus = focusLaunch
+					} else {
+						a.dashboard.panelFocus = focusTerminal
+					}
 					break
 				}
 			}
@@ -527,11 +534,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case killScopeAgent:
 			delete(a.closingAgents, msg.agentID)
 			delete(a.lastKnownStatus, msg.agentID)
+			// Exit focusLaunch if the killed agent is the one being viewed.
+			if a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == msg.agentID {
+				a.focusLaunchAgent = nil
+				a.dashboard.panelFocus = focusList
+			}
 		case killScopeSession:
 			delete(a.closingSessions, msg.sessionID)
 			for _, id := range msg.agentIDs {
 				delete(a.closingAgents, id)
 				delete(a.lastKnownStatus, id)
+				if a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == id {
+					a.focusLaunchAgent = nil
+					a.dashboard.panelFocus = focusList
+				}
 			}
 			delete(a.diffStatsCache, msg.sessionID)
 		}
@@ -745,6 +761,27 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case tea.KeyPressMsg:
+		// focusLaunch: forward all keys to the launch agent; f/esc returns to focus pipeline.
+		if a.dashboard.panelFocus == focusLaunch {
+			a.confirmQuit = false
+			if a.focusLaunchAgent == nil {
+				a.dashboard.panelFocus = focusList
+				return a, nil
+			}
+			switch msg.String() {
+			case "f", "esc":
+				a.focusLaunchAgent = nil
+				a.dashboard.panelFocus = focusList
+			default:
+				if msg.Text != "" {
+					a.focusLaunchAgent.SendText(msg.Text)
+				} else {
+					a.focusLaunchAgent.SendKey(xvt.KeyPressEvent(msg))
+				}
+			}
+			return a, nil
+		}
+
 		// When the terminal or config panel has focus, skip all app-level bindings.
 		if a.dashboard.panelFocus == focusTerminal || a.dashboard.panelFocus == focusConfig {
 			a.confirmQuit = false
@@ -829,10 +866,42 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if a.focusQueueIndex > 0 {
 					a.focusQueueIndex--
 				}
+				if attAgents := a.dashboard.attentionAgents(); len(attAgents) > 0 && a.focusAttentionIdx > 0 {
+					a.focusAttentionIdx--
+				}
 				return a, nil
 			case "down", "j":
 				if a.focusQueueIndex < len(a.dashboard.reviewQueueSessions())-1 {
 					a.focusQueueIndex++
+				}
+				if attAgents := a.dashboard.attentionAgents(); len(attAgents) > 0 && a.focusAttentionIdx < len(attAgents)-1 {
+					a.focusAttentionIdx++
+				}
+				return a, nil
+			case "space", "enter":
+				attAgents := a.dashboard.attentionAgents()
+				if len(attAgents) > 0 {
+					idx := a.focusAttentionIdx
+					if idx >= len(attAgents) {
+						idx = len(attAgents) - 1
+					}
+					a.focusLaunchAgent = attAgents[idx]
+					a.dashboard.panelFocus = focusLaunch
+					return a, nil
+				}
+				// No attention rows: fall through to normal enter handling.
+			case "N":
+				if a.cfg != nil && len(a.cfg.Repos) > 0 {
+					currentIdx := -1
+					for i, repo := range a.cfg.Repos {
+						if repo.Path == a.activeRepo {
+							currentIdx = i
+							break
+						}
+					}
+					nextIdx := (currentIdx + 1) % len(a.cfg.Repos)
+					a.activeRepo = a.cfg.Repos[nextIdx].Path
+					a.refreshAgentList()
 				}
 				return a, nil
 			case "m":
@@ -1670,6 +1739,21 @@ func (a *App) setError(msg string) {
 	a.errTicks = 30
 }
 
+// activeRepoDisplayName returns the display name for the active repo (alias or base path).
+func (a App) activeRepoDisplayName() string {
+	if a.activeRepo == "" {
+		return ""
+	}
+	if a.cfg != nil {
+		for _, repo := range a.cfg.Repos {
+			if repo.Path == a.activeRepo {
+				return repo.DisplayName()
+			}
+		}
+	}
+	return filepath.Base(a.activeRepo)
+}
+
 // screenToTermCell converts a screen-space mouse coordinate to a VT cell
 // coordinate inside the agent preview viewport. inViewport is false when the
 // point lies outside the viewport rectangle — callers that want clamping
@@ -1739,6 +1823,9 @@ func (a *App) refreshAgentList() {
 	a.dashboard.lastReviewAt = a.lastReviewAt
 	a.dashboard.focusSessionMinutes = a.focusSessionMinutes
 	a.dashboard.focusQueueIndex = a.focusQueueIndex
+	a.dashboard.focusAttentionIdx = a.focusAttentionIdx
+	a.dashboard.activeRepoName = a.activeRepoDisplayName()
+	a.dashboard.focusLaunchAgent = a.focusLaunchAgent
 	if a.cfg == nil {
 		// Fallback used in tests that set up managers directly without cfg.
 		if mgr := a.managers[a.activeRepo]; mgr != nil {
@@ -1829,6 +1916,13 @@ func (a *App) refreshAgentList() {
 			}
 		}
 	}
+	// Clamp focusAttentionIdx so the selection marker stays visible if agents
+	// leave the attention list (e.g. a permission prompt was just approved).
+	if n := len(a.dashboard.attentionAgents()); a.focusAttentionIdx >= n && n > 0 {
+		a.focusAttentionIdx = n - 1
+	} else if n == 0 {
+		a.focusAttentionIdx = 0
+	}
 	a.recomputePRSectionY()
 }
 
@@ -1851,6 +1945,8 @@ func (a App) View() tea.View {
 			hints = focusTerminalHints
 		case focusConfig:
 			hints = repoConfigHints
+		case focusLaunch:
+			hints = focusLaunchHints
 		}
 		// Prepend a break hint when focus mode is active and the session
 		// duration has exceeded the configured threshold.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -984,6 +984,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// record the review time.
 			if a.focusModeActive {
 				a.lastReviewAt = time.Now()
+				a.focusLaunchAgent = nil
 			}
 			a.focusModeActive = !a.focusModeActive
 			a.focusModeSwitches++

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -118,7 +118,10 @@ type dashboardModel struct {
 	sessionElapsed      time.Duration
 	lastReviewAt        time.Time
 	focusSessionMinutes int
-	focusQueueIndex     int // index into ReadyForReview sessions in fullscreen focus mode
+	focusQueueIndex     int          // index into ReadyForReview sessions in fullscreen focus mode
+	focusAttentionIdx   int          // index of highlighted waiting/error agent row
+	activeRepoName      string       // display name of the active repo
+	focusLaunchAgent    *agent.Agent // agent open in focusLaunch terminal; nil otherwise
 
 	// prSectionY is the content-relative row index (0-indexed, after the AGENTS
 	// title and separator) where the PR checks summary begins, or -1 when absent.
@@ -344,6 +347,10 @@ func (d dashboardModel) listWidth() int {
 func (d dashboardModel) View() string {
 	if len(d.items) == 0 {
 		return d.emptyView()
+	}
+
+	if d.focusModeActive && d.panelFocus == focusLaunch {
+		return d.renderFocusLaunchView(d.width, d.height)
 	}
 
 	if d.focusModeActive {
@@ -756,9 +763,25 @@ func (d dashboardModel) reviewQueueSessions() []listItem {
 	return result
 }
 
-// renderAttentionRows renders Waiting/Error agents (same as current focus panel attention section).
+// attentionAgents returns agents in StatusWaiting or StatusError (non-shell only).
+func (d dashboardModel) attentionAgents() []*agent.Agent {
+	var result []*agent.Agent
+	for _, item := range d.items {
+		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell {
+			continue
+		}
+		status := item.agent.Status()
+		if status == agent.StatusWaiting || status == agent.StatusError {
+			result = append(result, item.agent)
+		}
+	}
+	return result
+}
+
+// renderAttentionRows renders Waiting/Error agents with selection marker and waiting reason.
 func (d dashboardModel) renderAttentionRows() []string {
 	lines := make([]string, 0, len(d.items))
+	idx := 0
 	for _, item := range d.items {
 		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell {
 			continue
@@ -777,7 +800,16 @@ func (d dashboardModel) renderAttentionRows() []string {
 		} else {
 			style = lipgloss.NewStyle().Foreground(ColorError)
 		}
-		lines = append(lines, style.Render(fmt.Sprintf("⏸ %s", label)))
+		prefix := "  "
+		if idx == d.focusAttentionIdx {
+			prefix = "> "
+		}
+		line := style.Render(fmt.Sprintf("%s⏸ %s", prefix, label))
+		if reason := item.agent.WaitingReason(); reason != "" {
+			line += StyleSubtle.Render(" — " + truncateVisible(reason, 50))
+		}
+		lines = append(lines, line)
+		idx++
 	}
 	return lines
 }
@@ -841,6 +873,42 @@ func (d dashboardModel) renderPipelineWidget(width int) string {
 	)
 }
 
+// renderFocusLaunchView renders the "focus mode paused" view with a single agent terminal.
+func (d dashboardModel) renderFocusLaunchView(width, height int) string {
+	ag := d.focusLaunchAgent
+	if ag == nil {
+		return d.renderFullscreenFocus(width, height)
+	}
+
+	banner := StyleWarning.Render("Focus mode paused — press f to return")
+
+	agentName := ag.GetDisplayName()
+	var sessionBranch string
+	for _, item := range d.items {
+		if item.kind == listItemAgent && item.agent == ag && item.session != nil {
+			sessionBranch = item.session.Branch()
+			break
+		}
+	}
+	headerParts := []string{fmt.Sprintf("agent: %s", agentName)}
+	if sessionBranch != "" {
+		headerParts = append(headerParts, fmt.Sprintf("branch: %s", sessionBranch))
+	}
+	header := StyleSubtle.Render(strings.Join(headerParts, "  "))
+
+	termWidth := d.fixedTermWidth()
+	if termWidth < 1 {
+		termWidth = width
+	}
+	termHeight := d.fixedTermHeight()
+	if termHeight < 1 {
+		termHeight = height - 2
+	}
+	render := ag.RenderPadded(termWidth, termHeight)
+
+	return strings.Join([]string{banner, header, render}, "\n")
+}
+
 // renderFullscreenFocus renders the fullscreen pipeline view shown when focusModeActive is true.
 func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 	var lines []string
@@ -881,6 +949,9 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		timerStr = barStyle.Render(fmt.Sprintf("[%s] %dm/%dm", bar, elapsedMin, d.focusSessionMinutes))
 	}
 	headerLine := title + "  " + timerStr
+	if d.activeRepoName != "" {
+		headerLine += "  " + StyleSubtle.Render("repo: "+d.activeRepoName)
+	}
 	lines = append(lines, headerLine)
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
 

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -19,4 +19,5 @@ const (
 	focusTerminal                   // preview: keys forwarded to agent
 	focusConfig                     // preview: repo config form
 	focusReview                     // preview: review panel (fullscreen focus mode)
+	focusLaunch                     // focus mode paused — viewing an agent terminal
 )

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -77,7 +77,14 @@ var (
 		{"m", "mark ready"},
 		{"r", "review"},
 		{"n", "new"},
+		{"N", "change repo"},
+		{"space", "interact"},
 		{"f", "exit focus"},
+	}
+
+	focusLaunchHints = []keyHint{
+		{"f/esc", "back to focus"},
+		{"enter", "send"},
 	}
 )
 


### PR DESCRIPTION
## Summary

- **New agent in focus mode opens an interactive terminal** instead of silently creating in the background. Pressing \`n\` while in focus mode now sets \`panelFocus = focusLaunch\` so the developer can give the initial prompt. Pressing \`f\` or \`esc\` returns to the pipeline view.
- **Waiting agents show why they're waiting.** The \`Agent\` struct now stores the notification message from \`KindNotification\` hook events as \`waitingReason\`. Attention rows in the focus pipeline display this text (truncated to 50 chars) alongside the agent name. Navigating with \`j\`/\`k\` and pressing \`space\`/\`enter\` opens that agent's terminal.
- **Active repo visible in focus header.** The focus mode header now renders \`repo: <name>\`. Pressing \`N\` (shift+N) cycles through registered repos without leaving focus mode.
- **Context-sensitive status bar in launch terminal.** When a launch terminal is open, the status bar shows \`[f/esc] back to focus\` instead of the general focus mode hints.
- **Cleanup:** \`focusLaunchAgent\` is nil-guarded everywhere, cleared on agent/session kill, and cleared when toggling focus mode off. \`waitingReason\` is now also cleared on \`KindSessionEnd\`.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [ ] \`gofumpt -l .\` (clean)
- [ ] \`golangci-lint run ./...\`
- [x] \`go test -race ./...\`
- [ ] Manual TUI:
  - Enter focus mode (\`f\`), press \`n\` → terminal opens with "Focus mode paused — press f to return" banner; type a prompt; press \`f\` → back to pipeline view
  - Focus header shows \`repo: <name>\`; press \`N\` → repo name updates
  - Let an agent reach a permission prompt → attention row shows notification text; press \`j\`/\`k\` to navigate; press \`space\` → launch terminal opens for that agent; respond; press \`f\` → back to pipeline

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — changelog fragment added at `changelog.d/focus-mode-agent-interaction.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md` — `TestWaitingReasonStoredAndCleared` added for `WaitingReason()` lifecycle; focus mode TUI paths are manual-test-only per project convention
- [x] No new public API surface without a note in the PR description — `WaitingReason() string` added to `agent.Agent` (used internally by TUI)