### PR TITLE
Polish focus mode UX: pipeline fix, repo counts, picker

### DIFF
--- a/changelog.d/focus-mode-polish.md
+++ b/changelog.d/focus-mode-polish.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Pipeline cards no longer overflow terminal width at 80 columns; width formula corrected and minimum cell width raised to fit all labels.
+
+### Changed
+
+- Pressing `N` in focus mode now updates both the header label and the pipeline counts to reflect only the active repo's sessions.
+- Focus header shows a compact per-repo agent summary (e.g. `my-app(2⚡) | backend(1⏸)`) when multiple repos are configured.
+- Attention rows now display `session-name › Track N` so the session context is visible alongside the agent name.
+- Review queue rows now show the PR number and CI check status badge when a PR exists.
+- Pressing `n` in focus mode with 2+ repos opens a repo picker overlay (`< my-app >`) before creating the session; single-repo setups are unchanged.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -122,7 +122,7 @@ type App struct {
 	focusQueueIndex     int
 	focusAttentionIdx   int
 	focusLaunchAgent    *agent.Agent
-	focusBacklogWarning bool                        // first n at backlog limit shows warning; second proceeds
+	focusBacklogWarning bool // first n at backlog limit shows warning; second proceeds
 	repoPickerActive    bool
 	repoPickerForm      *configForm
 	reviewDiffCache     map[string]*reviewDiffEntry // keyed by session ID

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -123,6 +123,8 @@ type App struct {
 	focusAttentionIdx   int
 	focusLaunchAgent    *agent.Agent
 	focusBacklogWarning bool                        // first n at backlog limit shows warning; second proceeds
+	repoPickerActive    bool
+	repoPickerForm      *configForm
 	reviewDiffCache     map[string]*reviewDiffEntry // keyed by session ID
 	reviewSession       *agent.Session              // session currently open in review panel
 
@@ -859,6 +861,55 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
+		// Repo picker overlay: intercept all keys when active.
+		if a.repoPickerActive && a.repoPickerForm != nil {
+			switch msg.String() {
+			case "enter":
+				selectedIdx := a.repoPickerForm.selectIndex("Repo")
+				a.repoPickerActive = false
+				a.repoPickerForm = nil
+				if a.cfg != nil && selectedIdx >= 0 && selectedIdx < len(a.cfg.Repos) {
+					a.activeRepo = a.cfg.Repos[selectedIdx].Path
+					a.refreshAgentList()
+				}
+				repoPath := a.activeRepo
+				if repoPath == "" {
+					return a, nil
+				}
+				fixedW := a.dashboard.fixedTermWidth()
+				fixedH := a.dashboard.fixedTermHeight()
+				if fixedW <= 0 || fixedH <= 0 {
+					a.setError("Terminal size not yet known; try again")
+					return a, nil
+				}
+				resolved := a.resolvedCache[repoPath]
+				mgr := a.managers[repoPath]
+				if mgr == nil {
+					return a, nil
+				}
+				pickerCfg := agent.Config{
+					Rows:              fixedH,
+					Cols:              fixedW,
+					BypassPermissions: resolved.BypassPermissions,
+					AgentProgram:      resolved.AgentProgram,
+				}
+				return a, func() tea.Msg {
+					sess, ag, err := mgr.CreateSession(pickerCfg)
+					if err != nil {
+						return createResultMsg{err: err}
+					}
+					return createResultMsg{sessionID: sess.ID, agentID: ag.ID}
+				}
+			case "esc":
+				a.repoPickerActive = false
+				a.repoPickerForm = nil
+				return a, nil
+			default:
+				cmd := a.repoPickerForm.Update(msg)
+				return a, cmd
+			}
+		}
+
 		// Focus-mode key handling (fullscreen pipeline view).
 		if a.focusModeActive && a.dashboard.panelFocus != focusReview {
 			switch msg.String() {
@@ -934,6 +985,28 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return a, a.fetchReviewDiffCmd(sess)
 				}
 				return a, nil
+			case "n":
+				if a.cfg != nil && len(a.cfg.Repos) > 1 {
+					var options []string
+					activeIdx := 0
+					for i, repo := range a.cfg.Repos {
+						options = append(options, repo.DisplayName())
+						if repo.Path == a.activeRepo {
+							activeIdx = i
+						}
+					}
+					fields := addSelect(nil, "Repo", options, activeIdx)
+					form := newConfigForm(fields, 40)
+					a.repoPickerActive = true
+					a.repoPickerForm = &form
+					return a, nil
+				}
+				// Single repo: exits this case without returning, so control
+				// continues past this switch to the general "n" handler below
+				// (which includes the agent-count / backlog soft-limit checks).
+				// Multi-repo path skips those checks intentionally: picker
+				// navigation clears the pending flags anyway, and the user's
+				// explicit repo selection signals clear intent.
 			}
 		}
 
@@ -1826,6 +1899,7 @@ func (a *App) refreshAgentList() {
 	a.dashboard.focusQueueIndex = a.focusQueueIndex
 	a.dashboard.focusAttentionIdx = a.focusAttentionIdx
 	a.dashboard.activeRepoName = a.activeRepoDisplayName()
+	a.dashboard.activeRepoPath = a.activeRepo
 	a.dashboard.focusLaunchAgent = a.focusLaunchAgent
 	if a.cfg == nil {
 		// Fallback used in tests that set up managers directly without cfg.
@@ -1960,6 +2034,28 @@ func (a App) View() tea.View {
 				}
 				hints = append([]keyHint{breakHint}, hints...)
 			}
+		}
+		// Repo picker overlay: replace body with centered picker when active.
+		if a.repoPickerActive && a.repoPickerForm != nil {
+			hints = repoPickerHints
+			pickerW := a.width / 2
+			if pickerW > 50 {
+				pickerW = 50
+			}
+			if pickerW < 30 {
+				pickerW = 30
+			}
+			overlayContent := lipgloss.JoinVertical(lipgloss.Left,
+				StyleTitle.Render("New session in..."),
+				"",
+				a.repoPickerForm.View(),
+			)
+			overlay := lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				Padding(0, 1).
+				Width(pickerW).
+				Render(overlayContent)
+			body = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, overlay)
 		}
 		statusbar := renderStatusBar(hints, a.width)
 		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -261,3 +261,13 @@ func (f configForm) selectValue(label string) string {
 	}
 	return ""
 }
+
+// selectIndex returns the index of the currently selected option for a select field.
+func (f configForm) selectIndex(label string) int {
+	for _, field := range f.fields {
+		if field.label == label && field.kind == fieldSelect {
+			return field.selected
+		}
+	}
+	return 0
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -121,6 +121,7 @@ type dashboardModel struct {
 	focusQueueIndex     int          // index into ReadyForReview sessions in fullscreen focus mode
 	focusAttentionIdx   int          // index of highlighted waiting/error agent row
 	activeRepoName      string       // display name of the active repo
+	activeRepoPath      string       // canonical path of the active repo (for pipeline filtering)
 	focusLaunchAgent    *agent.Agent // agent open in focusLaunch terminal; nil otherwise
 
 	// prSectionY is the content-relative row index (0-indexed, after the AGENTS
@@ -790,9 +791,15 @@ func (d dashboardModel) renderAttentionRows() []string {
 		if status != agent.StatusWaiting && status != agent.StatusError {
 			continue
 		}
-		label := item.agent.GetDisplayName()
+		agentName := item.agent.GetDisplayName()
+		label := agentName
 		if item.session != nil {
-			label = item.session.GetDisplayName()
+			sessName := item.session.GetDisplayName()
+			if sessName != agentName {
+				label = sessName + " › " + agentName
+			} else {
+				label = sessName
+			}
 		}
 		var style lipgloss.Style
 		if status == agent.StatusWaiting {
@@ -837,6 +844,9 @@ func (d dashboardModel) renderPipelineWidget(width int) string {
 		if item.kind != listItemSession || item.session == nil {
 			continue
 		}
+		if d.focusModeActive && d.activeRepoPath != "" && item.repoPath != d.activeRepoPath {
+			continue
+		}
 		switch item.session.LifecyclePhase() {
 		case agent.LifecycleInProgress:
 			inProgress++
@@ -849,14 +859,14 @@ func (d dashboardModel) renderPipelineWidget(width int) string {
 		}
 	}
 
-	cellWidth := (width - 6) / 4
-	if cellWidth < 12 {
-		cellWidth = 12
+	cellWidth := (width - 8) / 4
+	if cellWidth < 18 {
+		cellWidth = 18
 	}
 
 	cell := func(label string, count int, color lipgloss.Color, highlight bool) string {
 		cnt := lipgloss.NewStyle().Foreground(color).Bold(true).Render(fmt.Sprintf("%d", count))
-		lbl := StyleSubtle.Render(label)
+		lbl := StyleSubtle.Render(truncateVisible(label, cellWidth-2))
 		inner := fmt.Sprintf("%s\n%s", lbl, cnt)
 		style := lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(0, 1).Width(cellWidth)
 		if highlight {
@@ -952,6 +962,53 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 	if d.activeRepoName != "" {
 		headerLine += "  " + StyleSubtle.Render("repo: "+d.activeRepoName)
 	}
+	// Cross-repo summary: collect repo names and per-repo agent status counts.
+	type repoStat struct {
+		name    string
+		path    string
+		active  int
+		waiting int
+	}
+	var repoOrder []string
+	repoStats := make(map[string]*repoStat)
+	for _, item := range d.items {
+		if item.kind == listItemRepo {
+			if _, ok := repoStats[item.repoPath]; !ok {
+				repoOrder = append(repoOrder, item.repoPath)
+				repoStats[item.repoPath] = &repoStat{name: item.repoName, path: item.repoPath}
+			}
+		} else if item.kind == listItemAgent && item.agent != nil && !item.agent.IsShell {
+			if rs, ok := repoStats[item.repoPath]; ok {
+				switch item.agent.Status() {
+				case agent.StatusActive:
+					rs.active++
+				case agent.StatusWaiting:
+					rs.waiting++
+				}
+			}
+		}
+	}
+	if len(repoOrder) > 1 {
+		var parts []string
+		for _, path := range repoOrder {
+			rs := repoStats[path]
+			var sym string
+			if rs.active > 0 {
+				sym = fmt.Sprintf("%d⚡", rs.active)
+			} else if rs.waiting > 0 {
+				sym = fmt.Sprintf("%d⏸", rs.waiting)
+			} else {
+				sym = "0"
+			}
+			entry := rs.name + "(" + sym + ")"
+			if path == d.activeRepoPath {
+				parts = append(parts, StyleActive.Render(entry))
+			} else {
+				parts = append(parts, StyleSubtle.Render(entry))
+			}
+		}
+		headerLine += "  " + strings.Join(parts, StyleSubtle.Render(" | "))
+	}
 	lines = append(lines, headerLine)
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
 
@@ -983,6 +1040,11 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 				cardStyle = StyleSubtle
 			}
 			line := cardStyle.Render(fmt.Sprintf("%s%s", prefix, name))
+			if prEntry := d.prCache[sess.ID]; prEntry != nil {
+				if ind := prIndicator(prEntry); ind != "" {
+					line += "  " + ind
+				}
+			}
 			if age != "" {
 				line += StyleSubtle.Render("  " + age)
 			}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -86,6 +86,12 @@ var (
 		{"f/esc", "back to focus"},
 		{"enter", "send"},
 	}
+
+	repoPickerHints = []keyHint{
+		{"←/→", "cycle repo"},
+		{"enter", "confirm"},
+		{"esc", "cancel"},
+	}
 )
 
 func renderStatusBar(hints []keyHint, width int) string {


### PR DESCRIPTION
## Summary

- **Pipeline card overflow fixed** — width formula corrected to `(width-8)/4`, minimum cell width raised to 18 so "READY TO REVIEW" fits; `truncateVisible` added as a safety net on all labels. All 4 cards render cleanly at ≥80 columns.
- **Pipeline counts now filter by active repo** — pressing `N` to cycle repos updates both the header label and the IN PROGRESS / READY TO REVIEW / IN REVIEW / SHIPPING counts to reflect only that repo's sessions.
- **Per-repo agent summary in focus header** — when 2+ repos are configured, the header appends `my-app(2⚡) | backend(1⏸) | frontend(0)` built from live agent status; the active repo's count is highlighted.
- **Session context in attention rows** — rows now read `session-name › Track N  ⏸ reason` instead of just the agent name, making it clear which task needs action without switching views.
- **PR badge in review queue** — review queue rows show the PR number and CI check status (e.g. `add-dark-mode  #42 ✓`) when a PR exists, sourced from the existing `prCache`.
- **Repo picker for new sessions** — pressing `n` in focus mode with 2+ repos shows a small centered overlay (`< my-app >`) to choose the target repo before creating the session; `←/→` cycles, `enter` confirms, `esc` cancels. Single-repo setups are unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI:
  - Launch baton with 2+ repos, press `f` → focus mode
  - Press `N` — verify header label AND all 4 pipeline counts change together
  - Verify header shows per-repo agent summary (e.g. `my-app(0) | backend(1⚡)`)
  - Start an agent that enters waiting state — confirm attention row shows `session › Track N  ⏸ reason`
  - If a session has an open PR, confirm review queue row shows PR badge
  - Press `n` — verify repo picker overlay appears with active repo pre-selected; confirm/cancel both work
  - Resize terminal to 80 cols — verify all 4 pipeline cards render without overflow

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (changelog fragment at `changelog.d/focus-mode-polish.md`)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description