### PR TITLE
Make focusLaunch terminal fullscreen with focusTerminal UX parity

### DIFF
--- a/changelog.d/fullscreen-focus-launch.md
+++ b/changelog.d/fullscreen-focus-launch.md
@@ -1,0 +1,3 @@
+### Improved
+
+- Opening an agent from focus mode now renders fullscreen (matching the dashboard terminal view) instead of a small fixed box. Includes scroll (pgup/pgdn/mouse wheel), text selection, cursor positioning, and shift+esc to interrupt Claude. Typing `f` now goes to the agent rather than exiting focus mode.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1683,8 +1683,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// (sidebar nav, esc, click on the list, etc.) drops it.
 	if a.dashboard.selection.active {
 		ag := a.dashboard.selectedAgent()
-		if !((a.dashboard.panelFocus == focusTerminal && ag != nil && ag.ID == a.dashboard.selection.agentID) ||
-			(a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == a.dashboard.selection.agentID)) {
+		if (a.dashboard.panelFocus != focusTerminal || ag == nil || ag.ID != a.dashboard.selection.agentID) &&
+			(a.dashboard.panelFocus != focusLaunch || a.focusLaunchAgent == nil || a.focusLaunchAgent.ID != a.dashboard.selection.agentID) {
 			a.dashboard.clearSelection()
 		}
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -226,6 +226,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Resize agent terminals to match their current display container.
 		if a.view == ViewDashboard {
 			a.resizeAllForDashboard()
+			if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
+				a.focusLaunchAgent.Resize(a.dashboard.height-1, a.dashboard.width)
+			}
 		}
 
 	case initAppMsg:
@@ -516,6 +519,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if a.focusModeActive {
 						a.focusLaunchAgent = item.agent
 						a.dashboard.panelFocus = focusLaunch
+						a.dashboard.scrollOffset = 0
+						item.agent.Resize(a.dashboard.height-1, a.dashboard.width)
 					} else {
 						a.dashboard.panelFocus = focusTerminal
 					}
@@ -540,6 +545,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == msg.agentID {
 				a.focusLaunchAgent = nil
 				a.dashboard.panelFocus = focusList
+				a.dashboard.scrollOffset = 0
 			}
 		case killScopeSession:
 			delete(a.closingSessions, msg.sessionID)
@@ -549,6 +555,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == id {
 					a.focusLaunchAgent = nil
 					a.dashboard.panelFocus = focusList
+					a.dashboard.scrollOffset = 0
 				}
 			}
 			delete(a.diffStatsCache, msg.sessionID)
@@ -763,17 +770,36 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case tea.KeyPressMsg:
-		// focusLaunch: forward all keys to the launch agent; f/esc returns to focus pipeline.
+		// focusLaunch: forward all keys to the launch agent; esc/ctrl+e returns to focus pipeline.
 		if a.dashboard.panelFocus == focusLaunch {
 			a.confirmQuit = false
 			if a.focusLaunchAgent == nil {
 				a.dashboard.panelFocus = focusList
+				a.dashboard.scrollOffset = 0
 				return a, nil
 			}
 			switch msg.String() {
-			case "f", "esc":
+			case "esc", "ctrl+e":
+				a.resizeAgentForDashboard(a.focusLaunchAgent)
 				a.focusLaunchAgent = nil
 				a.dashboard.panelFocus = focusList
+				a.dashboard.scrollOffset = 0
+			case "shift+esc":
+				a.focusLaunchAgent.SendKey(xvt.KeyPressEvent{Code: tea.KeyEscape})
+			case "pgup":
+				sbLines := len(a.focusLaunchAgent.ScrollbackLines())
+				maxScroll := sbLines
+				a.dashboard.scrollOffset += a.dashboard.height / 2
+				if a.dashboard.scrollOffset > maxScroll {
+					a.dashboard.scrollOffset = maxScroll
+				}
+			case "pgdn":
+				a.dashboard.scrollOffset -= a.dashboard.height / 2
+				if a.dashboard.scrollOffset < 0 {
+					a.dashboard.scrollOffset = 0
+				}
+			case "home":
+				a.dashboard.scrollOffset = 0
 			default:
 				if msg.Text != "" {
 					a.focusLaunchAgent.SendText(msg.Text)
@@ -938,6 +964,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 					a.focusLaunchAgent = attAgents[idx]
 					a.dashboard.panelFocus = focusLaunch
+					a.dashboard.scrollOffset = 0
+					a.focusLaunchAgent.Resize(a.dashboard.height-1, a.dashboard.width)
 					return a, nil
 				}
 				// No attention rows: fall through to normal enter handling.
@@ -1458,6 +1486,19 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 							a.dashboard.clearSelection()
 						}
 					}
+				} else if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
+					if termX, termY, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y); inVP {
+						a.dashboard.selection = selection{
+							anchorX: termX,
+							anchorY: termY,
+							cursorX: termX,
+							cursorY: termY,
+							active:  true,
+							agentID: a.focusLaunchAgent.ID,
+						}
+					} else {
+						a.dashboard.clearSelection()
+					}
 				}
 			}
 		}
@@ -1470,25 +1511,34 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// that the user is dragging — bubbletea's MouseModeCellMotion gives
 		// us these while a button is down.
 		if a.dashboard.selection.active && msg.Button == tea.MouseLeft {
-			termX, termY, _ := a.screenToTermCell(msg.X, msg.Y)
-			if w := a.dashboard.fixedTermWidth(); w > 0 {
-				if termX < 0 {
-					termX = 0
-				} else if termX >= w {
-					termX = w - 1
+			if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
+				tx, ty, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
+				if inVP {
+					a.dashboard.selection.cursorX = tx
+					a.dashboard.selection.cursorY = ty
+					a.dashboard.selection.dragSeen = true
 				}
-			}
-			if h := a.dashboard.fixedTermHeight(); h > 0 {
-				if termY < 0 {
-					termY = 0
-				} else if termY >= h {
-					termY = h - 1
+			} else {
+				termX, termY, _ := a.screenToTermCell(msg.X, msg.Y)
+				if w := a.dashboard.fixedTermWidth(); w > 0 {
+					if termX < 0 {
+						termX = 0
+					} else if termX >= w {
+						termX = w - 1
+					}
 				}
-			}
-			a.dashboard.selection.cursorX = termX
-			a.dashboard.selection.cursorY = termY
-			if termX != a.dashboard.selection.anchorX || termY != a.dashboard.selection.anchorY {
-				a.dashboard.selection.dragSeen = true
+				if h := a.dashboard.fixedTermHeight(); h > 0 {
+					if termY < 0 {
+						termY = 0
+					} else if termY >= h {
+						termY = h - 1
+					}
+				}
+				a.dashboard.selection.cursorX = termX
+				a.dashboard.selection.cursorY = termY
+				if termX != a.dashboard.selection.anchorX || termY != a.dashboard.selection.anchorY {
+					a.dashboard.selection.dragSeen = true
+				}
 			}
 		}
 		return a, nil
@@ -1516,6 +1566,24 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 							return a, tea.SetClipboard(text)
 						}
 					}
+				} else if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == a.dashboard.selection.agentID {
+					if sx, sy, ex, ey, ok := a.dashboard.selectionRect(); ok {
+						rect := vt.SelectionRect{
+							StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
+						}
+						ag := a.focusLaunchAgent
+						var text string
+						if a.dashboard.scrollOffset > 0 {
+							vpWidth := a.dashboard.width
+							vpHeight := a.dashboard.height - 1
+							text = ag.ExtractTextFromSnapshot(vpWidth, vpHeight, a.dashboard.scrollOffset, rect)
+						} else {
+							text = ag.ExtractText(rect)
+						}
+						if text != "" {
+							return a, tea.SetClipboard(text)
+						}
+					}
 				}
 			} else {
 				// Plain click — drop the seeded selection. Focus already moved
@@ -1527,6 +1595,44 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if msg, ok := msg.(tea.MouseWheelMsg); ok {
+		if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
+			ag := a.focusLaunchAgent
+			if ag.IsAltScreen() {
+				termX, termY, _ := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
+				if termX < 0 {
+					termX = 0
+				}
+				if termX >= a.dashboard.width {
+					termX = a.dashboard.width - 1
+				}
+				if termY < 0 {
+					termY = 0
+				}
+				if termY >= a.dashboard.height-1 {
+					termY = a.dashboard.height - 2
+				}
+				ag.SendMouse(xvt.MouseWheel{
+					X:      termX,
+					Y:      termY,
+					Button: xvt.MouseButton(msg.Button),
+					Mod:    xvt.KeyMod(msg.Mod),
+				})
+				return a, nil
+			}
+			if msg.Button == tea.MouseWheelUp {
+				sbLines := len(ag.ScrollbackLines())
+				max := sbLines
+				a.dashboard.scrollOffset += 3
+				if a.dashboard.scrollOffset > max {
+					a.dashboard.scrollOffset = max
+				}
+			} else {
+				a.dashboard.scrollOffset -= 3
+				if a.dashboard.scrollOffset < 0 {
+					a.dashboard.scrollOffset = 0
+				}
+			}
+		}
 		if a.dashboard.panelFocus == focusTerminal {
 			ag := a.dashboard.selectedAgent()
 			if ag != nil {
@@ -1577,7 +1683,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// (sidebar nav, esc, click on the list, etc.) drops it.
 	if a.dashboard.selection.active {
 		ag := a.dashboard.selectedAgent()
-		if a.dashboard.panelFocus != focusTerminal || ag == nil || ag.ID != a.dashboard.selection.agentID {
+		if !((a.dashboard.panelFocus == focusTerminal && ag != nil && ag.ID == a.dashboard.selection.agentID) ||
+			(a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == a.dashboard.selection.agentID)) {
 			a.dashboard.clearSelection()
 		}
 	}
@@ -1794,6 +1901,18 @@ func (a *App) resizeSelectedForDashboard() {
 	}
 }
 
+// resizeAgentForDashboard resizes a specific agent to the dashboard preview dimensions.
+func (a *App) resizeAgentForDashboard(ag *agent.Agent) {
+	if ag == nil {
+		return
+	}
+	w := a.dashboard.fixedTermWidth()
+	h := a.dashboard.fixedTermHeight()
+	if w > 0 && h > 0 {
+		ag.Resize(h, w)
+	}
+}
+
 // resizeAllForDashboard resizes every agent to the dashboard preview dimensions.
 // Called on WindowSizeMsg so all agents match the new terminal size.
 func (a *App) resizeAllForDashboard() {
@@ -1803,6 +1922,9 @@ func (a *App) resizeAllForDashboard() {
 		return
 	}
 	for _, ag := range a.dashboard.agentItems() {
+		if a.focusLaunchAgent != nil && ag.ID == a.focusLaunchAgent.ID {
+			continue
+		}
 		ag.Resize(h, w)
 	}
 }
@@ -1860,6 +1982,24 @@ func (a *App) screenToTermCell(screenX, screenY int) (termX, termY int, inViewpo
 	termY = screenY - dashboardTopY - previewTopBorder - a.dashboard.previewMetadataRows()
 	inViewport = w > 0 && h > 0 && termX >= 0 && termX < w && termY >= 0 && termY < h
 	return termX, termY, inViewport
+}
+
+// screenToTermCellFocusLaunch converts a screen-space mouse coordinate to a VT
+// cell coordinate for the fullscreen focusLaunch agent terminal.
+func (a *App) screenToTermCellFocusLaunch(screenX, screenY int) (termX, termY int, inViewport bool) {
+	dashboardTopY := 0
+	if a.err != "" {
+		dashboardTopY++
+	}
+	if a.confirmQuit {
+		dashboardTopY++
+	}
+	termX = screenX
+	termY = screenY - dashboardTopY - 1
+	w := a.dashboard.width
+	h := a.dashboard.height - 1
+	inViewport = termX >= 0 && termX < w && termY >= 0 && termY < h
+	return
 }
 
 // forwardWheelToAgent encodes a mouse wheel event and feeds it to the agent's
@@ -2107,6 +2247,21 @@ func (a App) View() tea.View {
 				const previewColOffset = 31
 				screenX := cursorX + previewColOffset + 1
 				screenY := cursorY + dashboardTopY + 1 + a.dashboard.previewMetadataRows()
+				v.Cursor = tea.NewCursor(screenX, screenY)
+			}
+		} else if a.dashboard.panelFocus == focusLaunch && a.dashboard.scrollOffset == 0 && a.focusLaunchAgent != nil {
+			ag := a.focusLaunchAgent
+			if !ag.IsAltScreen() && ag.CursorVisible() {
+				cursorX, cursorY := ag.CursorPosition()
+				dashboardTopY := 0
+				if a.err != "" {
+					dashboardTopY++
+				}
+				if a.confirmQuit {
+					dashboardTopY++
+				}
+				screenX := cursorX
+				screenY := cursorY + dashboardTopY + 1
 				v.Cursor = tea.NewCursor(screenX, screenY)
 			}
 		}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -890,8 +890,6 @@ func (d dashboardModel) renderFocusLaunchView(width, height int) string {
 		return d.renderFullscreenFocus(width, height)
 	}
 
-	banner := StyleWarning.Render("Focus mode paused — press f to return")
-
 	agentName := ag.GetDisplayName()
 	var sessionBranch string
 	for _, item := range d.items {
@@ -906,17 +904,41 @@ func (d dashboardModel) renderFocusLaunchView(width, height int) string {
 	}
 	header := StyleSubtle.Render(strings.Join(headerParts, "  "))
 
-	termWidth := d.fixedTermWidth()
-	if termWidth < 1 {
-		termWidth = width
-	}
-	termHeight := d.fixedTermHeight()
-	if termHeight < 1 {
-		termHeight = height - 2
-	}
-	render := ag.RenderPadded(termWidth, termHeight)
+	vpWidth := width
+	vpHeight := height - 1
+	var render string
+	if d.scrollOffset > 0 {
+		sbLines, viewport := ag.Snapshot(vpWidth, vpHeight)
+		vpLines := strings.Split(viewport, "\n")
+		allLines := append(sbLines, vpLines...)
 
-	return strings.Join([]string{banner, header, render}, "\n")
+		end := len(allLines) - d.scrollOffset
+		if end < 0 {
+			end = 0
+		}
+		start := end - vpHeight
+		if start < 0 {
+			start = 0
+		}
+		visibleLines := vt.PadLines(allLines[start:end], vpWidth)
+		if d.selection.active && d.selection.dragSeen && d.selection.agentID == ag.ID {
+			sx, sy, ex, ey, _ := d.selectionRect()
+			render = applySelectionHighlight(visibleLines, vt.SelectionRect{
+				StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
+			})
+		} else {
+			render = strings.Join(visibleLines, "\n")
+		}
+	} else if d.selection.active && d.selection.dragSeen && d.selection.agentID == ag.ID {
+		sx, sy, ex, ey, _ := d.selectionRect()
+		render = ag.RenderPaddedWithSelection(vpWidth, vpHeight, vt.SelectionRect{
+			StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
+		})
+	} else {
+		render = ag.RenderPadded(vpWidth, vpHeight)
+	}
+
+	return header + "\n" + render
 }
 
 // renderFullscreenFocus renders the fullscreen pipeline view shown when focusModeActive is true.

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -83,8 +83,11 @@ var (
 	}
 
 	focusLaunchHints = []keyHint{
-		{"f/esc", "back to focus"},
 		{"enter", "send"},
+		{"pgup/pgdn", "scroll"},
+		{"home", "live"},
+		{"esc", "back"},
+		{"⇧esc", "interrupt"},
 	}
 
 	repoPickerHints = []keyHint{


### PR DESCRIPTION
## Summary

- Opening an agent from focus mode (space/enter on an attention row) now renders its terminal fullscreen instead of a small fixed box in the upper-left corner
- Typing `f` no longer exits focus mode — it goes to the agent like any other character; `esc`/`ctrl+e` exit
- `shift+esc` interrupts Claude (forwards ESC to the agent PTY)
- `pgup`/`pgdn` and mouse wheel scroll the terminal output; `home` snaps back to live output
- Click-drag text selection and clipboard copy now work in focusLaunch, matching the dashboard preview panel
- Cursor is positioned correctly at fullscreen coordinates when not scrolled
- Agent is resized to fullscreen on enter and back to split-pane dimensions on exit; window resize handled correctly
- Statusbar hints updated to show scroll/interrupt/home shortcuts

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] Manual TUI:
  - Launch baton, enable focus mode (`f`)
  - Create an agent and let it reach "waiting" status
  - Press space/enter on the attention row → terminal fills the screen with 1-line context header
  - Type "f" → goes to Claude, does NOT exit
  - Press esc → returns to focus pipeline
  - Re-enter agent, press shift+esc → interrupts Claude
  - Mouse wheel → scrolls output
  - Click-drag → highlights and copies text
  - Press pgup/pgdn → scrolls; home → snaps to live
  - Resize terminal window while in focusLaunch → agent resizes correctly

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description