### PR TITLE
Fix focus mode: fullscreen terminal size and active session list

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -531,7 +531,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Set initial dimensions before any output arrives. The alt-screen
 		// transition detector in the tick handler will fire a follow-up resize
 		// once Claude's TUI enters alternate screen mode.
-		a.resizeSelectedForDashboard()
+		// Skip the bulk resize when focusLaunch is active — the agent was already
+		// resized to fullscreen above and resizeSelectedForDashboard would shrink it.
+		if a.dashboard.panelFocus != focusLaunch {
+			a.resizeSelectedForDashboard()
+		}
 		return a, nil
 
 	case killResultMsg:

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -764,6 +764,18 @@ func (d dashboardModel) reviewQueueSessions() []listItem {
 	return result
 }
 
+// inProgressSessions returns listItems for sessions in InProgress phase with agents still running.
+func (d dashboardModel) inProgressSessions() []listItem {
+	var result []listItem
+	for _, item := range d.items {
+		if item.kind == listItemSession && item.session != nil &&
+			item.session.LifecyclePhase() == agent.LifecycleInProgress && item.session.DoneAt().IsZero() {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
 // attentionAgents returns agents in StatusWaiting or StatusError (non-shell only).
 func (d dashboardModel) attentionAgents() []*agent.Agent {
 	var result []*agent.Agent
@@ -1037,6 +1049,31 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 	// Pipeline widget
 	lines = append(lines, d.renderPipelineWidget(width))
 	lines = append(lines, "")
+
+	// Active sessions
+	activeSessions := d.inProgressSessions()
+	if len(activeSessions) > 0 {
+		lines = append(lines, StyleSubtle.Render("ACTIVE"))
+		for _, item := range activeSessions {
+			sess := item.session
+			name := sess.GetDisplayName()
+			var activeCount, idleCount int
+			for _, ag := range d.items {
+				if ag.kind != listItemAgent || ag.agent == nil || ag.agent.IsShell || ag.session != sess {
+					continue
+				}
+				switch ag.agent.Status() {
+				case agent.StatusActive:
+					activeCount++
+				case agent.StatusIdle:
+					idleCount++
+				}
+			}
+			summary := fmt.Sprintf("%d active, %d idle", activeCount, idleCount)
+			lines = append(lines, fmt.Sprintf("  %s  %s", name, StyleSubtle.Render(summary)))
+		}
+		lines = append(lines, "")
+	}
 
 	// Review queue
 	reviewSessions := d.reviewQueueSessions()


### PR DESCRIPTION
## Summary
- **Bug 1 (fullscreen):** Guard `resizeSelectedForDashboard()` in `createResultMsg` to skip when `panelFocus == focusLaunch`. Previously the unconditional call overrode the correct fullscreen resize with split-panel dimensions immediately after it was applied.
- **Bug 2 (active sessions):** Add an ACTIVE section to the focus screen listing each in-progress session (LifecycleInProgress + DoneAt.IsZero()) with live agent status counts, between the pipeline widget and the review queue.

## Test plan
- Enable focus mode (`f`), press `n` → agent terminal should be fullscreen (not split-panel sized)
- Start 2+ sessions → focus screen shows ACTIVE section with each session name and active/idle agent counts
- `go build -o baton . && go test -race ./...`