### PR TITLE
Keep focusLaunch agent fullscreen on alt-screen entry

### DIFF
--- a/changelog.d/fix-focus-launch-fullscreen.md
+++ b/changelog.d/fix-focus-launch-fullscreen.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Focus mode: when creating or opening a Claude Code session from the focus pipeline, the agent terminal now fills the screen instead of being shrunk to the dashboard preview size when Claude's TUI enters alt-screen mode.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -371,7 +371,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					continue
 				}
 				if item.agent.AltScreenEntered() {
-					item.agent.Resize(fixedH, fixedW)
+					// The focusLaunch agent renders fullscreen, so resize it
+					// to the fullscreen dimensions instead of shrinking it
+					// back to the preview size.
+					if a.focusLaunchAgent != nil && item.agent.ID == a.focusLaunchAgent.ID {
+						item.agent.Resize(a.dashboard.height-1, a.dashboard.width)
+					} else {
+						item.agent.Resize(fixedH, fixedW)
+					}
 					// VT history is cleared on alt-screen entry; any prior
 					// scrollOffset now indexes into an empty buffer and would
 					// leave the preview visually frozen until the user hits


### PR DESCRIPTION
When a session was created in focus mode, the agent was correctly
resized to fullscreen on createResultMsg, but the alt-screen transition
detector in the tick handler then unconditionally shrank every agent
back to the preview dimensions — leaving Claude Code rendering at ~3/4
of the screen until the next manual resize.

Skip focusLaunchAgent in that resize loop and re-resize it to fullscreen
instead, mirroring the existing carve-out in resizeAllForDashboard.