### PR TITLE
Add unified row cursor to focus-mode fullscreen view

### DIFF
--- a/changelog.d/fix-focus-mode-selection.md
+++ b/changelog.d/fix-focus-mode-selection.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Focus mode: the fullscreen pipeline now has a visible row cursor that traverses the Active, Review Queue, and Attention sections in order. `j`/`k` move the cursor across sections instead of bouncing two indices in lockstep, and pressing `enter` on an active session jumps into its agent terminal — previously active sessions were listed but unselectable.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -118,7 +118,7 @@ type App struct {
 	sessionStart        time.Time
 	lastReviewAt        time.Time
 	newAgentPending     bool
-	focusSessionMinutes int // cached from resolved global settings
+	focusSessionMinutes int          // cached from resolved global settings
 	focusActiveIdx      int          // index into inProgressSessions
 	focusQueueIndex     int          // index into reviewQueueSessions
 	focusAttentionIdx   int          // index into attentionAgents

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -119,8 +119,10 @@ type App struct {
 	lastReviewAt        time.Time
 	newAgentPending     bool
 	focusSessionMinutes int // cached from resolved global settings
-	focusQueueIndex     int
-	focusAttentionIdx   int
+	focusActiveIdx      int          // index into inProgressSessions
+	focusQueueIndex     int          // index into reviewQueueSessions
+	focusAttentionIdx   int          // index into attentionAgents
+	focusCursorSection  focusSection // which section the focus-mode cursor is on
 	focusLaunchAgent    *agent.Agent
 	focusBacklogWarning bool // first n at backlog limit shows warning; second proceeds
 	repoPickerActive    bool
@@ -951,35 +953,18 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.focusModeActive && a.dashboard.panelFocus != focusReview {
 			switch msg.String() {
 			case "up", "k":
-				if a.focusQueueIndex > 0 {
-					a.focusQueueIndex--
-				}
-				if attAgents := a.dashboard.attentionAgents(); len(attAgents) > 0 && a.focusAttentionIdx > 0 {
-					a.focusAttentionIdx--
-				}
+				a.moveFocusCursorUp()
+				a.syncFocusCursorToDashboard()
 				return a, nil
 			case "down", "j":
-				if a.focusQueueIndex < len(a.dashboard.reviewQueueSessions())-1 {
-					a.focusQueueIndex++
-				}
-				if attAgents := a.dashboard.attentionAgents(); len(attAgents) > 0 && a.focusAttentionIdx < len(attAgents)-1 {
-					a.focusAttentionIdx++
-				}
+				a.moveFocusCursorDown()
+				a.syncFocusCursorToDashboard()
 				return a, nil
 			case "space", "enter":
-				attAgents := a.dashboard.attentionAgents()
-				if len(attAgents) > 0 {
-					idx := a.focusAttentionIdx
-					if idx >= len(attAgents) {
-						idx = len(attAgents) - 1
-					}
-					a.focusLaunchAgent = attAgents[idx]
-					a.dashboard.panelFocus = focusLaunch
-					a.dashboard.scrollOffset = 0
-					a.focusLaunchAgent.Resize(a.dashboard.height-1, a.dashboard.width)
-					return a, nil
+				if cmd, ok := a.activateFocusCursor(); ok {
+					return a, cmd
 				}
-				// No attention rows: fall through to normal enter handling.
+				// Cursor section had no actionable row: fall through to normal enter handling.
 			case "N":
 				if a.cfg != nil && len(a.cfg.Repos) > 0 {
 					currentIdx := -1
@@ -1102,6 +1087,12 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.focusModeSwitches++
 			if a.focusModeActive {
 				a.dashboard.clampToRepo()
+				// Park the cursor on the first non-empty section so the
+				// selection marker is visible the moment focus mode opens,
+				// rather than waiting for the next tick.
+				a.focusCursorSection = focusSectionActive
+				a.clampFocusCursor()
+				a.syncFocusCursorToDashboard()
 			}
 			return a, nil
 
@@ -2047,8 +2038,10 @@ func (a *App) refreshAgentList() {
 	a.dashboard.sessionElapsed = time.Since(a.sessionStart)
 	a.dashboard.lastReviewAt = a.lastReviewAt
 	a.dashboard.focusSessionMinutes = a.focusSessionMinutes
+	a.dashboard.focusActiveIdx = a.focusActiveIdx
 	a.dashboard.focusQueueIndex = a.focusQueueIndex
 	a.dashboard.focusAttentionIdx = a.focusAttentionIdx
+	a.dashboard.focusCursorSection = a.focusCursorSection
 	a.dashboard.activeRepoName = a.activeRepoDisplayName()
 	a.dashboard.activeRepoPath = a.activeRepo
 	a.dashboard.focusLaunchAgent = a.focusLaunchAgent
@@ -2142,14 +2135,215 @@ func (a *App) refreshAgentList() {
 			}
 		}
 	}
-	// Clamp focusAttentionIdx so the selection marker stays visible if agents
-	// leave the attention list (e.g. a permission prompt was just approved).
-	if n := len(a.dashboard.attentionAgents()); a.focusAttentionIdx >= n && n > 0 {
-		a.focusAttentionIdx = n - 1
-	} else if n == 0 {
-		a.focusAttentionIdx = 0
-	}
+	a.clampFocusCursor()
 	a.recomputePRSectionY()
+}
+
+// focusSectionCounts returns the number of rows in each fullscreen-focus section,
+// in the same order as the focusSection constants (active, review, attention).
+func (a *App) focusSectionCounts() (active, review, attention int) {
+	return len(a.dashboard.inProgressSessions()),
+		len(a.dashboard.reviewQueueSessions()),
+		len(a.dashboard.attentionAgents())
+}
+
+// clampFocusCursor keeps the per-section indices and the cursor section in
+// valid ranges as the underlying lists change (sessions transition phases,
+// agents leave the attention list, etc.). When the cursor's current section
+// becomes empty, it falls through to the next non-empty section in render
+// order so the cursor stays on a visible row.
+func (a *App) clampFocusCursor() {
+	actCount, revCount, attCount := a.focusSectionCounts()
+
+	clamp := func(idx, n int) int {
+		if n <= 0 {
+			return 0
+		}
+		if idx >= n {
+			return n - 1
+		}
+		if idx < 0 {
+			return 0
+		}
+		return idx
+	}
+	a.focusActiveIdx = clamp(a.focusActiveIdx, actCount)
+	a.focusQueueIndex = clamp(a.focusQueueIndex, revCount)
+	a.focusAttentionIdx = clamp(a.focusAttentionIdx, attCount)
+
+	counts := [3]int{actCount, revCount, attCount}
+	if counts[int(a.focusCursorSection)] > 0 {
+		return
+	}
+	for i, c := range counts {
+		if c > 0 {
+			a.focusCursorSection = focusSection(i)
+			return
+		}
+	}
+	a.focusCursorSection = focusSectionActive
+}
+
+// moveFocusCursorUp moves the fullscreen-focus cursor up one row. When at the
+// top of the current section, it transitions to the previous non-empty section.
+func (a *App) moveFocusCursorUp() {
+	actCount, revCount, _ := a.focusSectionCounts()
+
+	switch a.focusCursorSection {
+	case focusSectionActive:
+		if a.focusActiveIdx > 0 {
+			a.focusActiveIdx--
+		}
+	case focusSectionReview:
+		if a.focusQueueIndex > 0 {
+			a.focusQueueIndex--
+			return
+		}
+		if actCount > 0 {
+			a.focusCursorSection = focusSectionActive
+			a.focusActiveIdx = actCount - 1
+		}
+	case focusSectionAttention:
+		if a.focusAttentionIdx > 0 {
+			a.focusAttentionIdx--
+			return
+		}
+		if revCount > 0 {
+			a.focusCursorSection = focusSectionReview
+			a.focusQueueIndex = revCount - 1
+			return
+		}
+		if actCount > 0 {
+			a.focusCursorSection = focusSectionActive
+			a.focusActiveIdx = actCount - 1
+		}
+	}
+}
+
+// syncFocusCursorToDashboard mirrors the cursor-related App fields onto the
+// dashboard model so the next render reflects navigation immediately, without
+// waiting for the 100ms tick that drives refreshAgentList.
+func (a *App) syncFocusCursorToDashboard() {
+	a.dashboard.focusActiveIdx = a.focusActiveIdx
+	a.dashboard.focusQueueIndex = a.focusQueueIndex
+	a.dashboard.focusAttentionIdx = a.focusAttentionIdx
+	a.dashboard.focusCursorSection = a.focusCursorSection
+}
+
+// activateFocusCursor opens the row currently under the fullscreen-focus
+// cursor. Active sessions and attention agents jump into a focusLaunch
+// terminal; review-queue sessions open the review panel. Returns ok=false
+// when the cursor's section has no actionable row, so the caller can fall
+// through to other key handlers.
+func (a *App) activateFocusCursor() (tea.Cmd, bool) {
+	switch a.focusCursorSection {
+	case focusSectionActive:
+		sessions := a.dashboard.inProgressSessions()
+		if len(sessions) == 0 {
+			return nil, false
+		}
+		idx := a.focusActiveIdx
+		if idx >= len(sessions) {
+			idx = len(sessions) - 1
+		}
+		return nil, a.openSessionInFocusLaunch(sessions[idx].session)
+	case focusSectionReview:
+		reviewItems := a.dashboard.reviewQueueSessions()
+		if len(reviewItems) == 0 {
+			return nil, false
+		}
+		idx := a.focusQueueIndex
+		if idx >= len(reviewItems) {
+			idx = len(reviewItems) - 1
+		}
+		sess := reviewItems[idx].session
+		sess.SetLifecyclePhase(agent.LifecycleInReview)
+		a.reviewSession = sess
+		a.dashboard.panelFocus = focusReview
+		if _, ok := a.reviewDiffCache[sess.ID]; !ok {
+			return a.fetchReviewDiffCmd(sess), true
+		}
+		return nil, true
+	case focusSectionAttention:
+		attAgents := a.dashboard.attentionAgents()
+		if len(attAgents) == 0 {
+			return nil, false
+		}
+		idx := a.focusAttentionIdx
+		if idx >= len(attAgents) {
+			idx = len(attAgents) - 1
+		}
+		a.focusLaunchAgent = attAgents[idx]
+		a.dashboard.panelFocus = focusLaunch
+		a.dashboard.scrollOffset = 0
+		a.focusLaunchAgent.Resize(a.dashboard.height-1, a.dashboard.width)
+		return nil, true
+	}
+	return nil, false
+}
+
+// openSessionInFocusLaunch picks the first non-shell agent in sess and opens
+// it fullscreen in focusLaunch. Falls back to the first agent of any kind so
+// shell-only sessions remain reachable. Returns true if an agent was opened.
+func (a *App) openSessionInFocusLaunch(sess *agent.Session) bool {
+	if sess == nil {
+		return false
+	}
+	agents := sess.Agents()
+	var target *agent.Agent
+	for _, ag := range agents {
+		if !ag.IsShell {
+			target = ag
+			break
+		}
+	}
+	if target == nil && len(agents) > 0 {
+		target = agents[0]
+	}
+	if target == nil {
+		return false
+	}
+	a.focusLaunchAgent = target
+	a.dashboard.panelFocus = focusLaunch
+	a.dashboard.scrollOffset = 0
+	a.focusLaunchAgent.Resize(a.dashboard.height-1, a.dashboard.width)
+	return true
+}
+
+// moveFocusCursorDown moves the fullscreen-focus cursor down one row. When at
+// the bottom of the current section, it transitions to the next non-empty section.
+func (a *App) moveFocusCursorDown() {
+	actCount, revCount, attCount := a.focusSectionCounts()
+
+	switch a.focusCursorSection {
+	case focusSectionActive:
+		if a.focusActiveIdx < actCount-1 {
+			a.focusActiveIdx++
+			return
+		}
+		if revCount > 0 {
+			a.focusCursorSection = focusSectionReview
+			a.focusQueueIndex = 0
+			return
+		}
+		if attCount > 0 {
+			a.focusCursorSection = focusSectionAttention
+			a.focusAttentionIdx = 0
+		}
+	case focusSectionReview:
+		if a.focusQueueIndex < revCount-1 {
+			a.focusQueueIndex++
+			return
+		}
+		if attCount > 0 {
+			a.focusCursorSection = focusSectionAttention
+			a.focusAttentionIdx = 0
+		}
+	case focusSectionAttention:
+		if a.focusAttentionIdx < attCount-1 {
+			a.focusAttentionIdx++
+		}
+	}
 }
 
 func (a App) View() tea.View {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1772,3 +1772,220 @@ func TestFocusModeNavigationOnlyLandsOnRepos(t *testing.T) {
 		t.Fatalf("k from first repo: expected 0 (no-op), got %d", d.selected)
 	}
 }
+
+// makeFocusModeApp wires up an App in focus mode with two in-progress sessions
+// and one ready-for-review session, plus a single waiting agent. Used by the
+// tests below to exercise unified cursor navigation across the three sections.
+func makeFocusModeApp(t *testing.T) (App, *agent.Session, *agent.Session, *agent.Session) {
+	t.Helper()
+	sessA := &agent.Session{Name: "active-a"}
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessB := &agent.Session{Name: "active-b"}
+	sessB.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessR := &agent.Session{Name: "review-r"}
+	sessR.SetLifecyclePhase(agent.LifecycleReadyForReview)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sessA},
+		{kind: listItemSession, repoPath: "/r", session: sessB},
+		{kind: listItemSession, repoPath: "/r", session: sessR},
+	}
+	return app, sessA, sessB, sessR
+}
+
+// TestFocusModeNavigationCrossesSections verifies that j/k in focus mode
+// traverses Active → Review → Attention in render order, transitioning between
+// sections at the boundaries instead of bouncing two indices in lockstep.
+func TestFocusModeNavigationCrossesSections(t *testing.T) {
+	app, _, _, _ := makeFocusModeApp(t)
+	if app.focusCursorSection != focusSectionActive {
+		// clampFocusCursor only runs from refreshAgentList; here we drive the
+		// state directly. Make the starting condition explicit.
+		app.focusCursorSection = focusSectionActive
+	}
+
+	// Start at active[0].
+	if app.focusActiveIdx != 0 || app.focusCursorSection != focusSectionActive {
+		t.Fatalf("expected start at active[0], got section=%v active=%d", app.focusCursorSection, app.focusActiveIdx)
+	}
+
+	// j: active[0] → active[1].
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	app = model.(App)
+	if app.focusCursorSection != focusSectionActive || app.focusActiveIdx != 1 {
+		t.Fatalf("after 1st j: expected active[1], got section=%v active=%d", app.focusCursorSection, app.focusActiveIdx)
+	}
+
+	// j: active[1] (last) → review[0].
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	app = model.(App)
+	if app.focusCursorSection != focusSectionReview || app.focusQueueIndex != 0 {
+		t.Fatalf("after 2nd j: expected review[0], got section=%v review=%d", app.focusCursorSection, app.focusQueueIndex)
+	}
+
+	// j: review[0] (last review, no attention) → no-op.
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	app = model.(App)
+	if app.focusCursorSection != focusSectionReview || app.focusQueueIndex != 0 {
+		t.Fatalf("after 3rd j: expected review[0] (no-op), got section=%v review=%d", app.focusCursorSection, app.focusQueueIndex)
+	}
+
+	// k: review[0] → active[1].
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	app = model.(App)
+	if app.focusCursorSection != focusSectionActive || app.focusActiveIdx != 1 {
+		t.Fatalf("after k from review: expected active[1], got section=%v active=%d", app.focusCursorSection, app.focusActiveIdx)
+	}
+
+	// Verify the dashboard model received the synced state immediately.
+	if app.dashboard.focusCursorSection != focusSectionActive || app.dashboard.focusActiveIdx != 1 {
+		t.Fatalf("dashboard not synced: section=%v active=%d", app.dashboard.focusCursorSection, app.dashboard.focusActiveIdx)
+	}
+}
+
+// TestFocusModeEnterOnActiveOpensFocusLaunch verifies that pressing enter
+// while the cursor is on an active session selects the first non-shell agent
+// in that session and switches to focusLaunch.
+func TestFocusModeEnterOnActiveOpensFocusLaunch(t *testing.T) {
+	requireClaude(t)
+	dir, err := os.MkdirTemp("", "baton-focus-active-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+
+	sess, ag, err := mgr.CreateSessionWithCommand(agent.Config{
+		Name: "focus-active", Task: "test", RepoPath: dir, Rows: 24, Cols: 80,
+	}, func(_ string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 30")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: dir, repoName: "repo"},
+		{kind: listItemSession, repoPath: dir, session: sess},
+		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
+	}
+	app.focusCursorSection = focusSectionActive
+	app.focusActiveIdx = 0
+
+	// Press enter on the active section: should jump into focusLaunch on ag.
+	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Text: ""})
+	app = model.(App)
+	if app.dashboard.panelFocus != focusLaunch {
+		t.Fatalf("expected panelFocus=focusLaunch after enter on active, got %v", app.dashboard.panelFocus)
+	}
+	if app.focusLaunchAgent == nil || app.focusLaunchAgent.ID != ag.ID {
+		t.Fatalf("expected focusLaunchAgent=ag, got %v", app.focusLaunchAgent)
+	}
+}
+
+// TestFocusModeNavigationVisibleOnActiveOnly verifies that when only Active
+// rows exist (no review queue, no attention), j/k still move within the active
+// section and the dashboard sees the updated focusActiveIdx so the selection
+// marker can render. This is the bug the user reported: an invisible cursor.
+func TestFocusModeNavigationVisibleOnActiveOnly(t *testing.T) {
+	sessA := &agent.Session{Name: "active-a"}
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessB := &agent.Session{Name: "active-b"}
+	sessB.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sessA},
+		{kind: listItemSession, repoPath: "/r", session: sessB},
+	}
+	app.focusCursorSection = focusSectionActive
+
+	// j moves within active (active is the only non-empty section).
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	app = model.(App)
+	if app.dashboard.focusActiveIdx != 1 {
+		t.Fatalf("expected dashboard.focusActiveIdx=1 after j, got %d", app.dashboard.focusActiveIdx)
+	}
+
+	// j again at the bottom: no-op (no other section to fall through to).
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	app = model.(App)
+	if app.dashboard.focusActiveIdx != 1 {
+		t.Fatalf("expected dashboard.focusActiveIdx=1 (no-op at end), got %d", app.dashboard.focusActiveIdx)
+	}
+
+	// k moves back up.
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	app = model.(App)
+	if app.dashboard.focusActiveIdx != 0 {
+		t.Fatalf("expected dashboard.focusActiveIdx=0 after k, got %d", app.dashboard.focusActiveIdx)
+	}
+}
+
+// TestClampFocusCursorHopsToNonEmptySection verifies that when the cursor's
+// section becomes empty (e.g. all in-progress sessions transition to ready),
+// clampFocusCursor moves the cursor to the next non-empty section so the
+// selection marker stays visible.
+func TestClampFocusCursorHopsToNonEmptySection(t *testing.T) {
+	sessR := &agent.Session{Name: "review-r"}
+	sessR.SetLifecyclePhase(agent.LifecycleReadyForReview)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sessR},
+	}
+	app.focusCursorSection = focusSectionActive
+	app.focusActiveIdx = 0
+
+	app.clampFocusCursor()
+	if app.focusCursorSection != focusSectionReview {
+		t.Fatalf("expected hop to review section, got %v", app.focusCursorSection)
+	}
+	if app.focusQueueIndex != 0 {
+		t.Fatalf("expected review index 0, got %d", app.focusQueueIndex)
+	}
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -118,8 +118,10 @@ type dashboardModel struct {
 	sessionElapsed      time.Duration
 	lastReviewAt        time.Time
 	focusSessionMinutes int
+	focusActiveIdx      int          // index of highlighted in-progress session row
 	focusQueueIndex     int          // index into ReadyForReview sessions in fullscreen focus mode
 	focusAttentionIdx   int          // index of highlighted waiting/error agent row
+	focusCursorSection  focusSection // which fullscreen-focus section the cursor is on
 	activeRepoName      string       // display name of the active repo
 	activeRepoPath      string       // canonical path of the active repo (for pipeline filtering)
 	focusLaunchAgent    *agent.Agent // agent open in focusLaunch terminal; nil otherwise
@@ -820,7 +822,7 @@ func (d dashboardModel) renderAttentionRows() []string {
 			style = lipgloss.NewStyle().Foreground(ColorError)
 		}
 		prefix := "  "
-		if idx == d.focusAttentionIdx {
+		if d.focusCursorSection == focusSectionAttention && idx == d.focusAttentionIdx {
 			prefix = "> "
 		}
 		line := style.Render(fmt.Sprintf("%s⏸ %s", prefix, label))
@@ -1054,7 +1056,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 	activeSessions := d.inProgressSessions()
 	if len(activeSessions) > 0 {
 		lines = append(lines, StyleSubtle.Render("ACTIVE"))
-		for _, item := range activeSessions {
+		for i, item := range activeSessions {
 			sess := item.session
 			name := sess.GetDisplayName()
 			var activeCount, idleCount int
@@ -1070,7 +1072,14 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 				}
 			}
 			summary := fmt.Sprintf("%d active, %d idle", activeCount, idleCount)
-			lines = append(lines, fmt.Sprintf("  %s  %s", name, StyleSubtle.Render(summary)))
+			selected := d.focusCursorSection == focusSectionActive && i == d.focusActiveIdx
+			prefix := "  "
+			nameStyled := name
+			if selected {
+				prefix = StyleActive.Render("> ")
+				nameStyled = lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
+			}
+			lines = append(lines, fmt.Sprintf("%s%s  %s", prefix, nameStyled, StyleSubtle.Render(summary)))
 		}
 		lines = append(lines, "")
 	}
@@ -1081,7 +1090,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, StyleSubtle.Render("REVIEW QUEUE"))
 		for i, item := range reviewSessions {
 			sess := item.session
-			selected := i == d.focusQueueIndex
+			selected := d.focusCursorSection == focusSectionReview && i == d.focusQueueIndex
 			name := sess.GetDisplayName()
 			age := ""
 			if !sess.DoneAt().IsZero() {

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -1,0 +1,44 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/devenjarvis/baton/internal/agent"
+)
+
+// TestRenderFocusActiveCursor verifies that when the focus cursor is on an
+// active session, that row is rendered with the "> " selection prefix.
+func TestRenderFocusActiveCursor(t *testing.T) {
+	sessA := &agent.Session{Name: "active-a"}
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessB := &agent.Session{Name: "active-b"}
+	sessB.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	d := newDashboardModel()
+	d.width = 120
+	d.height = 39
+	d.focusModeActive = true
+	d.focusCursorSection = focusSectionActive
+	d.focusActiveIdx = 1
+	d.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sessA},
+		{kind: listItemSession, repoPath: "/r", session: sessB},
+	}
+
+	out := d.renderFullscreenFocus(120, 39)
+	lines := strings.Split(out, "\n")
+	var sawSelected bool
+	for _, line := range lines {
+		if strings.Contains(line, "active-b") && strings.Contains(line, "> ") {
+			sawSelected = true
+		}
+		if strings.Contains(line, "active-a") && strings.Contains(line, "> ") {
+			t.Fatalf("active-a should not be selected (focusActiveIdx=1):\n%s", line)
+		}
+	}
+	if !sawSelected {
+		t.Fatalf("expected selection marker on active-b, got:\n%s", out)
+	}
+}

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -21,3 +21,14 @@ const (
 	focusReview                     // preview: review panel (fullscreen focus mode)
 	focusLaunch                     // focus mode paused — viewing an agent terminal
 )
+
+// focusSection identifies which row group the fullscreen focus-mode cursor is
+// currently on. The cursor traverses Active → Review Queue → Attention in
+// render order, with j/k transitioning between sections at the boundaries.
+type focusSection int
+
+const (
+	focusSectionActive    focusSection = iota // in-progress sessions
+	focusSectionReview                        // ready-for-review sessions
+	focusSectionAttention                     // waiting/error agents
+)

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -74,11 +74,12 @@ var (
 	}
 
 	focusModeHints = []keyHint{
+		{"j/k", "navigate"},
+		{"⏎", "open"},
 		{"m", "mark ready"},
 		{"r", "review"},
 		{"n", "new"},
 		{"N", "change repo"},
-		{"space", "interact"},
 		{"f", "exit focus"},
 	}
 


### PR DESCRIPTION
The pipeline view listed active sessions, review queue items, and
attention agents but only showed a selection marker on review/attention
rows, and j/k bumped two independent indices in lockstep — so when the
only visible rows were active sessions, navigation produced no visible
change and pressing enter never opened a session terminal.

Track a focusCursorSection alongside per-section indices and have j/k
walk Active → Review → Attention in render order, transitioning at
boundaries. Render the "> " marker on whatever row the cursor is on,
make enter jump into the first non-shell agent of an active session,
and surface j/k + open in the focus-mode status bar hints.

https://claude.ai/code/session_01Rou5nZJNqxWk657rMQf2rp