### PR TITLE
Focus mode: show green 'finished — awaiting prompt' when all agents idle

### DIFF
--- a/changelog.d/focus-idle-session-indicator.md
+++ b/changelog.d/focus-idle-session-indicator.md
@@ -1,0 +1,3 @@
+### Added
+
+- Focus mode ACTIVE section now shows a green "finished — awaiting prompt" label when all agents in a session are idle, replacing the muted gray "N active, M idle" text — gives a clear visual signal that Claude has finished and is ready for the next prompt.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1071,7 +1071,6 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 					idleCount++
 				}
 			}
-			summary := fmt.Sprintf("%d active, %d idle", activeCount, idleCount)
 			selected := d.focusCursorSection == focusSectionActive && i == d.focusActiveIdx
 			prefix := "  "
 			nameStyled := name
@@ -1079,7 +1078,13 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 				prefix = StyleActive.Render("> ")
 				nameStyled = lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
 			}
-			lines = append(lines, fmt.Sprintf("%s%s  %s", prefix, nameStyled, StyleSubtle.Render(summary)))
+			var summaryStyled string
+			if activeCount == 0 && idleCount > 0 {
+				summaryStyled = lipgloss.NewStyle().Foreground(ColorSuccess).Render("finished — awaiting prompt")
+			} else {
+				summaryStyled = StyleSubtle.Render(fmt.Sprintf("%d active, %d idle", activeCount, idleCount))
+			}
+			lines = append(lines, fmt.Sprintf("%s%s  %s", prefix, nameStyled, summaryStyled))
 		}
 		lines = append(lines, "")
 	}


### PR DESCRIPTION
## Summary

- In focus mode's fullscreen ACTIVE section, the per-session summary line previously always showed \"N active, M idle\" in muted gray regardless of state
- When all agents in a session reach `StatusIdle`, the summary now shows **\"finished — awaiting prompt\"** styled in green (`ColorSuccess`, `#10B981`), giving the user a clear visual signal that Claude has completed its response and is ready for the next prompt
- When any agent is still active, the unchanged gray \"N active, M idle\" text is shown

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: launch baton, enter focus mode (`f`), start an agent and give it a prompt. While responding: ACTIVE section shows gray \"N active, M idle\". After Claude finishes: line changes to green \"finished — awaiting prompt\". Give another prompt: flips back to gray.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description