### PR TITLE
Add tab bar to focus launch view for multi-agent navigation

### DIFF
--- a/changelog.d/focus-launch-tab-bar.md
+++ b/changelog.d/focus-launch-tab-bar.md
@@ -1,0 +1,8 @@
+### Added
+
+- Tab bar above the agent terminal in focus launch view showing all session agents; active tab is highlighted with bold/accent style and a status dot (`●` active/waiting, `○` idle, `×` error/done)
+- `⌘[`/`⌘]` keyboard shortcuts to cycle between agent tabs in focus launch
+- `⌘j` to open a new shell tab in the current session's worktree
+- `⌘a` to open a new Claude agent tab in the current session
+- Mouse click on tab bar to switch the active agent
+- Auto-selects the most-active agent (Active > Waiting > Idle > Starting) when entering focus launch

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -16,6 +16,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	xvt "github.com/charmbracelet/x/vt"
 	"github.com/devenjarvis/baton/internal/agent"
 	"github.com/devenjarvis/baton/internal/audio"
@@ -124,6 +125,7 @@ type App struct {
 	focusAttentionIdx   int          // index into attentionAgents
 	focusCursorSection  focusSection // which section the focus-mode cursor is on
 	focusLaunchAgent    *agent.Agent
+	focusLaunchSession  *agent.Session
 	focusBacklogWarning bool // first n at backlog limit shows warning; second proceeds
 	repoPickerActive    bool
 	repoPickerForm      *configForm
@@ -229,7 +231,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.view == ViewDashboard {
 			a.resizeAllForDashboard()
 			if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
-				a.focusLaunchAgent.Resize(a.dashboard.height-1, a.dashboard.width)
+				a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 			}
 		}
 
@@ -377,7 +379,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// to the fullscreen dimensions instead of shrinking it
 					// back to the preview size.
 					if a.focusLaunchAgent != nil && item.agent.ID == a.focusLaunchAgent.ID {
-						item.agent.Resize(a.dashboard.height-1, a.dashboard.width)
+						item.agent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 					} else {
 						item.agent.Resize(fixedH, fixedW)
 					}
@@ -527,9 +529,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.dashboard.selected = i
 					if a.focusModeActive {
 						a.focusLaunchAgent = item.agent
+						a.focusLaunchSession = item.session
 						a.dashboard.panelFocus = focusLaunch
 						a.dashboard.scrollOffset = 0
-						item.agent.Resize(a.dashboard.height-1, a.dashboard.width)
+						item.agent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 					} else {
 						a.dashboard.panelFocus = focusTerminal
 					}
@@ -557,6 +560,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Exit focusLaunch if the killed agent is the one being viewed.
 			if a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == msg.agentID {
 				a.focusLaunchAgent = nil
+				a.focusLaunchSession = nil
 				a.dashboard.panelFocus = focusList
 				a.dashboard.scrollOffset = 0
 			}
@@ -567,6 +571,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				delete(a.lastKnownStatus, id)
 				if a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == id {
 					a.focusLaunchAgent = nil
+					a.focusLaunchSession = nil
 					a.dashboard.panelFocus = focusList
 					a.dashboard.scrollOffset = 0
 				}
@@ -795,6 +800,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "esc", "ctrl+e":
 				a.resizeAgentForDashboard(a.focusLaunchAgent)
 				a.focusLaunchAgent = nil
+				a.focusLaunchSession = nil
 				a.dashboard.panelFocus = focusList
 				a.dashboard.scrollOffset = 0
 			case "shift+esc":
@@ -813,6 +819,64 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case "home":
 				a.dashboard.scrollOffset = 0
+			case "super+]", "super+[":
+				if a.focusLaunchSession != nil {
+					agents := a.focusLaunchSession.Agents()
+					idx := 0
+					for i, ag := range agents {
+						if ag.ID == a.focusLaunchAgent.ID {
+							idx = i
+							break
+						}
+					}
+					if msg.String() == "super+]" {
+						idx = (idx + 1) % len(agents)
+					} else {
+						idx = (idx - 1 + len(agents)) % len(agents)
+					}
+					a.focusLaunchAgent = agents[idx]
+					a.dashboard.scrollOffset = 0
+					a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+				}
+			case "super+j":
+				if a.focusLaunchSession != nil {
+					repoPath := a.repoPathForSession(a.focusLaunchSession.ID)
+					mgr := a.managers[repoPath]
+					if mgr != nil {
+						resolved := a.resolvedCache[repoPath]
+						cfg := agent.Config{
+							Rows:              a.focusLaunchTermHeight(),
+							Cols:              a.dashboard.width,
+							BypassPermissions: resolved.BypassPermissions,
+						}
+						if newAg, err := mgr.AddShell(a.focusLaunchSession.ID, cfg); err == nil {
+							a.focusLaunchAgent = newAg
+							a.dashboard.scrollOffset = 0
+						} else {
+							a.setError(err.Error())
+						}
+					}
+				}
+			case "super+a":
+				if a.focusLaunchSession != nil {
+					repoPath := a.repoPathForSession(a.focusLaunchSession.ID)
+					mgr := a.managers[repoPath]
+					if mgr != nil {
+						resolved := a.resolvedCache[repoPath]
+						cfg := agent.Config{
+							Rows:              a.focusLaunchTermHeight(),
+							Cols:              a.dashboard.width,
+							BypassPermissions: resolved.BypassPermissions,
+							AgentProgram:      resolved.AgentProgram,
+						}
+						if newAg, err := mgr.AddAgent(a.focusLaunchSession.ID, cfg); err == nil {
+							a.focusLaunchAgent = newAg
+							a.dashboard.scrollOffset = 0
+						} else {
+							a.setError(err.Error())
+						}
+					}
+				}
 			default:
 				if msg.Text != "" {
 					a.focusLaunchAgent.SendText(msg.Text)
@@ -1082,6 +1146,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.focusModeActive {
 				a.lastReviewAt = time.Now()
 				a.focusLaunchAgent = nil
+				a.focusLaunchSession = nil
 			}
 			a.focusModeActive = !a.focusModeActive
 			a.focusModeSwitches++
@@ -1439,6 +1504,20 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		a.confirmQuit = false
 		if msg.Button == tea.MouseLeft {
+			// focusLaunch tab bar click — handled before list/preview panel checks
+			// because focusLaunch is fullscreen and occupies all columns.
+			if a.dashboard.panelFocus == focusLaunch && a.focusLaunchSession != nil {
+				tabBarY := dashboardTopY + 1
+				if msg.Y == tabBarY {
+					if idx := a.focusLaunchTabIndexAt(msg.X); idx >= 0 {
+						agents := a.focusLaunchSession.Agents()
+						a.focusLaunchAgent = agents[idx]
+						a.dashboard.scrollOffset = 0
+						a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+					}
+					return a, nil
+				}
+			}
 			if msg.X < 31 {
 				// List panel click — map Y to item index.
 				// Subtract 2 for the SESSIONS title row and separator row.
@@ -1577,7 +1656,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 						var text string
 						if a.dashboard.scrollOffset > 0 {
 							vpWidth := a.dashboard.width
-							vpHeight := a.dashboard.height - 1
+							vpHeight := a.focusLaunchTermHeight()
 							text = ag.ExtractTextFromSnapshot(vpWidth, vpHeight, a.dashboard.scrollOffset, rect)
 						} else {
 							text = ag.ExtractText(rect)
@@ -1610,8 +1689,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if termY < 0 {
 					termY = 0
 				}
-				if termY >= a.dashboard.height-1 {
-					termY = a.dashboard.height - 2
+				if termY >= a.focusLaunchTermHeight() {
+					termY = a.focusLaunchTermHeight() - 1
 				}
 				ag.SendMouse(xvt.MouseWheel{
 					X:      termX,
@@ -1986,6 +2065,32 @@ func (a *App) screenToTermCell(screenX, screenY int) (termX, termY int, inViewpo
 	return termX, termY, inViewport
 }
 
+// focusLaunchTermHeight returns the terminal height for the focusLaunch view,
+// accounting for the header row and the tab bar row.
+func (a *App) focusLaunchTermHeight() int {
+	return a.dashboard.height - 2
+}
+
+// focusLaunchTabIndexAt returns the agent index in focusLaunchSession for a
+// tab bar click at column x, or -1 if x doesn't land on any tab. Uses the same
+// label formula as renderFocusLaunchTabBar so click targets stay in sync.
+func (a *App) focusLaunchTabIndexAt(x int) int {
+	if a.focusLaunchSession == nil {
+		return -1
+	}
+	agents := a.focusLaunchSession.Agents()
+	col := 0
+	for i, ag := range agents {
+		label := focusLaunchTabText(ag)
+		w := ansi.StringWidth(label)
+		if x >= col && x < col+w {
+			return i
+		}
+		col += w + 2 // 2-space separator between tabs
+	}
+	return -1
+}
+
 // screenToTermCellFocusLaunch converts a screen-space mouse coordinate to a VT
 // cell coordinate for the fullscreen focusLaunch agent terminal.
 func (a *App) screenToTermCellFocusLaunch(screenX, screenY int) (termX, termY int, inViewport bool) {
@@ -1997,9 +2102,9 @@ func (a *App) screenToTermCellFocusLaunch(screenX, screenY int) (termX, termY in
 		dashboardTopY++
 	}
 	termX = screenX
-	termY = screenY - dashboardTopY - 1
+	termY = screenY - dashboardTopY - 2
 	w := a.dashboard.width
-	h := a.dashboard.height - 1
+	h := a.dashboard.height - 2
 	inViewport = termX >= 0 && termX < w && termY >= 0 && termY < h
 	return
 }
@@ -2045,6 +2150,7 @@ func (a *App) refreshAgentList() {
 	a.dashboard.activeRepoName = a.activeRepoDisplayName()
 	a.dashboard.activeRepoPath = a.activeRepo
 	a.dashboard.focusLaunchAgent = a.focusLaunchAgent
+	a.dashboard.focusLaunchSession = a.focusLaunchSession
 	if a.cfg == nil {
 		// Fallback used in tests that set up managers directly without cfg.
 		if mgr := a.managers[a.activeRepo]; mgr != nil {
@@ -2274,39 +2380,53 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 			idx = len(attAgents) - 1
 		}
 		a.focusLaunchAgent = attAgents[idx]
+		a.focusLaunchSession = a.dashboard.sessionForAgent(a.focusLaunchAgent)
 		a.dashboard.panelFocus = focusLaunch
 		a.dashboard.scrollOffset = 0
-		a.focusLaunchAgent.Resize(a.dashboard.height-1, a.dashboard.width)
+		a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 		return nil, true
 	}
 	return nil, false
 }
 
-// openSessionInFocusLaunch picks the first non-shell agent in sess and opens
-// it fullscreen in focusLaunch. Falls back to the first agent of any kind so
-// shell-only sessions remain reachable. Returns true if an agent was opened.
+// openSessionInFocusLaunch picks the most-active agent in sess and opens it
+// fullscreen in focusLaunch. Priority: Active > Waiting > Idle > Starting >
+// Done/Error. Falls back to agents[0] when all have equal priority.
 func (a *App) openSessionInFocusLaunch(sess *agent.Session) bool {
 	if sess == nil {
 		return false
 	}
 	agents := sess.Agents()
-	var target *agent.Agent
-	for _, ag := range agents {
-		if !ag.IsShell {
-			target = ag
-			break
-		}
-	}
-	if target == nil && len(agents) > 0 {
-		target = agents[0]
-	}
-	if target == nil {
+	if len(agents) == 0 {
 		return false
 	}
+	statusPriority := func(ag *agent.Agent) int {
+		switch ag.Status() {
+		case agent.StatusActive:
+			return 5
+		case agent.StatusWaiting:
+			return 4
+		case agent.StatusIdle:
+			return 3
+		case agent.StatusStarting:
+			return 2
+		default:
+			return 1
+		}
+	}
+	target := agents[0]
+	bestPri := statusPriority(agents[0])
+	for _, ag := range agents[1:] {
+		if pri := statusPriority(ag); pri > bestPri {
+			bestPri = pri
+			target = ag
+		}
+	}
 	a.focusLaunchAgent = target
+	a.focusLaunchSession = sess
 	a.dashboard.panelFocus = focusLaunch
 	a.dashboard.scrollOffset = 0
-	a.focusLaunchAgent.Resize(a.dashboard.height-1, a.dashboard.width)
+	a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 	return true
 }
 
@@ -2466,7 +2586,7 @@ func (a App) View() tea.View {
 					dashboardTopY++
 				}
 				screenX := cursorX
-				screenY := cursorY + dashboardTopY + 1
+				screenY := cursorY + dashboardTopY + 2 // header row + tab bar row
 				v.Cursor = tea.NewCursor(screenX, screenY)
 			}
 		}
@@ -2539,6 +2659,9 @@ func (a *App) updateDashboardPRCache() {
 
 // repoPathForSession returns the repo path containing the given session, or "" if not found.
 func (a *App) repoPathForSession(sessionID string) string {
+	if a.cfg == nil {
+		return ""
+	}
 	for _, repo := range a.cfg.Repos {
 		mgr := a.managers[repo.Path]
 		if mgr == nil {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -118,12 +118,12 @@ type dashboardModel struct {
 	sessionElapsed      time.Duration
 	lastReviewAt        time.Time
 	focusSessionMinutes int
-	focusActiveIdx      int          // index of highlighted in-progress session row
-	focusQueueIndex     int          // index into ReadyForReview sessions in fullscreen focus mode
-	focusAttentionIdx   int          // index of highlighted waiting/error agent row
-	focusCursorSection  focusSection // which fullscreen-focus section the cursor is on
-	activeRepoName      string       // display name of the active repo
-	activeRepoPath      string       // canonical path of the active repo (for pipeline filtering)
+	focusActiveIdx      int            // index of highlighted in-progress session row
+	focusQueueIndex     int            // index into ReadyForReview sessions in fullscreen focus mode
+	focusAttentionIdx   int            // index of highlighted waiting/error agent row
+	focusCursorSection  focusSection   // which fullscreen-focus section the cursor is on
+	activeRepoName      string         // display name of the active repo
+	activeRepoPath      string         // canonical path of the active repo (for pipeline filtering)
 	focusLaunchAgent    *agent.Agent   // agent open in focusLaunch terminal; nil otherwise
 	focusLaunchSession  *agent.Session // session owning focusLaunchAgent; nil otherwise
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -124,7 +124,8 @@ type dashboardModel struct {
 	focusCursorSection  focusSection // which fullscreen-focus section the cursor is on
 	activeRepoName      string       // display name of the active repo
 	activeRepoPath      string       // canonical path of the active repo (for pipeline filtering)
-	focusLaunchAgent    *agent.Agent // agent open in focusLaunch terminal; nil otherwise
+	focusLaunchAgent    *agent.Agent   // agent open in focusLaunch terminal; nil otherwise
+	focusLaunchSession  *agent.Session // session owning focusLaunchAgent; nil otherwise
 
 	// prSectionY is the content-relative row index (0-indexed, after the AGENTS
 	// title and separator) where the PR checks summary begins, or -1 when absent.
@@ -793,6 +794,19 @@ func (d dashboardModel) attentionAgents() []*agent.Agent {
 	return result
 }
 
+// sessionForAgent returns the session that owns ag, or nil if not found.
+func (d dashboardModel) sessionForAgent(ag *agent.Agent) *agent.Session {
+	if ag == nil {
+		return nil
+	}
+	for _, item := range d.items {
+		if item.kind == listItemAgent && item.agent != nil && item.agent.ID == ag.ID {
+			return item.session
+		}
+	}
+	return nil
+}
+
 // renderAttentionRows renders Waiting/Error agents with selection marker and waiting reason.
 func (d dashboardModel) renderAttentionRows() []string {
 	lines := make([]string, 0, len(d.items))
@@ -897,6 +911,54 @@ func (d dashboardModel) renderPipelineWidget(width int) string {
 	)
 }
 
+// focusLaunchTabDot returns the status indicator character for a tab.
+func focusLaunchTabDot(ag *agent.Agent) string {
+	switch ag.Status() {
+	case agent.StatusActive, agent.StatusWaiting:
+		return "●"
+	case agent.StatusError, agent.StatusDone:
+		return "×"
+	default:
+		return "○"
+	}
+}
+
+// focusLaunchTabText returns the plain (unstyled) text for a tab label,
+// used by both rendering and click-hit detection so they stay in sync.
+func focusLaunchTabText(ag *agent.Agent) string {
+	name := truncateVisible(ag.GetDisplayName(), 18)
+	return "[" + focusLaunchTabDot(ag) + " " + name + "]"
+}
+
+// renderFocusLaunchTabBar renders the tab strip row for focusLaunch. Returns
+// the styled tab bar string and, as side-data for click handling, the starting
+// column of each tab (returned to avoid duplicating layout math in App).
+func (d dashboardModel) renderFocusLaunchTabBar(width int) string {
+	if d.focusLaunchSession == nil || d.focusLaunchAgent == nil {
+		return ""
+	}
+	agents := d.focusLaunchSession.Agents()
+	if len(agents) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, ag := range agents {
+		text := focusLaunchTabText(ag)
+		if ag.ID == d.focusLaunchAgent.ID {
+			parts = append(parts, StyleTitle.Render(text))
+		} else {
+			parts = append(parts, StyleSubtle.Render(text))
+		}
+	}
+	bar := strings.Join(parts, "  ")
+	// Truncate if it exceeds width (no wrapping).
+	if ansi.StringWidth(bar) > width {
+		bar = ansi.Truncate(bar, width, "")
+	}
+	return bar
+}
+
 // renderFocusLaunchView renders the "focus mode paused" view with a single agent terminal.
 func (d dashboardModel) renderFocusLaunchView(width, height int) string {
 	ag := d.focusLaunchAgent
@@ -905,21 +967,18 @@ func (d dashboardModel) renderFocusLaunchView(width, height int) string {
 	}
 
 	agentName := ag.GetDisplayName()
-	var sessionBranch string
-	for _, item := range d.items {
-		if item.kind == listItemAgent && item.agent == ag && item.session != nil {
-			sessionBranch = item.session.Branch()
-			break
-		}
-	}
 	headerParts := []string{fmt.Sprintf("agent: %s", agentName)}
-	if sessionBranch != "" {
-		headerParts = append(headerParts, fmt.Sprintf("branch: %s", sessionBranch))
+	if d.focusLaunchSession != nil {
+		if branch := d.focusLaunchSession.Branch(); branch != "" {
+			headerParts = append(headerParts, fmt.Sprintf("branch: %s", branch))
+		}
 	}
 	header := StyleSubtle.Render(strings.Join(headerParts, "  "))
 
+	tabBar := d.renderFocusLaunchTabBar(width)
+
 	vpWidth := width
-	vpHeight := height - 1
+	vpHeight := height - 2
 	var render string
 	if d.scrollOffset > 0 {
 		sbLines, viewport := ag.Snapshot(vpWidth, vpHeight)
@@ -952,7 +1011,10 @@ func (d dashboardModel) renderFocusLaunchView(width, height int) string {
 		render = ag.RenderPadded(vpWidth, vpHeight)
 	}
 
-	return header + "\n" + render
+	if tabBar == "" {
+		return header + "\n" + render
+	}
+	return header + "\n" + tabBar + "\n" + render
 }
 
 // renderFullscreenFocus renders the fullscreen pipeline view shown when focusModeActive is true.

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -87,6 +87,9 @@ var (
 		{"enter", "send"},
 		{"pgup/pgdn", "scroll"},
 		{"home", "live"},
+		{"⌘[/]", "switch tab"},
+		{"⌘j", "shell"},
+		{"⌘a", "new agent"},
 		{"esc", "back"},
 		{"⇧esc", "interrupt"},
 	}


### PR DESCRIPTION
## Summary

- Adds a tab strip row above the agent terminal in `focusLaunchView`, showing all agents in the session with a status dot (`●` active/waiting, `○` idle, `×` error/done) and the agent name
- Active tab is highlighted with bold/accent style (`StyleTitle`); inactive tabs use `StyleSubtle`
- `⌘[`/`⌘]` (`super+[`/`super+]`) cycle between agent tabs with wraparound
- `⌘j` opens a new shell tab in the session's worktree; `⌘a` opens a new Claude agent tab
- Mouse click on the tab bar row switches the active agent
- Entry into focusLaunch auto-selects the most-active agent (Active > Waiting > Idle > Starting > Done/Error) rather than first non-shell
- New `focusLaunchSession *agent.Session` field on `App` and `dashboardModel` tracks the session owning the active agent; paired with `focusLaunchAgent` at all set/clear sites
- `focusLaunchTermHeight()` helper centralises the `height-2` constant (header + tab bar rows)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI:
  1. Start baton with at least one active multi-agent session
  2. Press `f` to enter focus mode, navigate to a session and press Enter → tab bar visible above terminal
  3. Press `⌘]` → cycles to next tab; `⌘[` → cycles to previous tab (wraps)
  4. Press `⌘j` → new Shell tab opens and is selected; shell prompt shows
  5. Press `⌘a` → new Claude agent tab opens
  6. Click a tab with mouse → terminal switches to that agent
  7. Press `esc` → returns to focus pipeline view
  8. Status bar shows `⌘[/]: switch tab  ⌘j: shell  ⌘a: new agent  esc: back`

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — added `changelog.d/focus-launch-tab-bar.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md` — TUI changes are manual-test-only per project convention
- [x] No new public API surface without a note in the PR description