### PR TITLE
Fix focus mode key input: panelFocus reset and d-key leak

### DIFF
--- a/changelog.d/fix-focus-mode-input-leak.md
+++ b/changelog.d/fix-focus-mode-input-leak.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Focus mode shortcuts (j/k, m, r) now work correctly after entering focus mode from a non-list panel state (e.g. review panel); `panelFocus` is reset to `focusList` on entry
+- Pressing `d` in focus mode no longer falls through to the repo-delete handler

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1009,6 +1009,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return a, a.fetchReviewDiffCmd(sess)
 				}
 				return a, nil
+			case "d":
+				return a, nil
 			case "n":
 				if a.cfg != nil && len(a.cfg.Repos) > 1 {
 					var options []string
@@ -1086,6 +1088,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.focusModeActive = !a.focusModeActive
 			a.focusModeSwitches++
 			if a.focusModeActive {
+				a.dashboard.panelFocus = focusList
 				a.dashboard.clampToRepo()
 				// Park the cursor on the first non-empty section so the
 				// selection marker is visible the moment focus mode opens,

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1989,3 +1989,73 @@ func TestClampFocusCursorHopsToNonEmptySection(t *testing.T) {
 		t.Fatalf("expected review index 0, got %d", app.focusQueueIndex)
 	}
 }
+
+// TestFocusModeResetsPanelFocus verifies that entering focus mode resets
+// panelFocus to focusList so that focus mode key handlers are reachable.
+// Reproduces the bug where panelFocus==focusReview with no reviewSession left
+// focus mode's j/k/m/r guard (`panelFocus != focusReview`) permanently false.
+func TestFocusModeResetsPanelFocus(t *testing.T) {
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+
+	// Simulate panelFocus==focusReview with a nil reviewSession (e.g. after the
+	// review was handled but panelFocus was not cleaned up). From this state the
+	// focusReview guard at the top of the key handler does NOT fire (it requires
+	// a non-nil reviewSession), so "f" falls through to the toggle handler.
+	app.dashboard.panelFocus = focusReview
+	app.reviewSession = nil
+
+	// Press "f" to enter focus mode.
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	app = model.(App)
+
+	if !app.focusModeActive {
+		t.Fatal("expected focusModeActive=true after pressing f")
+	}
+	// Without the fix panelFocus would stay focusReview, making the focus-mode
+	// handler guard (`panelFocus != focusReview`) permanently false and blocking j/k/m/r.
+	if app.dashboard.panelFocus != focusList {
+		t.Errorf("expected panelFocus=focusList after entering focus mode, got %v", app.dashboard.panelFocus)
+	}
+}
+
+// TestFocusModeBlocksDKey verifies that pressing "d" in focus mode is a no-op
+// and does not delete repos or trigger the diff view.
+func TestFocusModeBlocksDKey(t *testing.T) {
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+
+	app.cfg = &config.Config{
+		Repos: []config.Repo{
+			{Path: "/repo1", Name: "repo1"},
+		},
+	}
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/repo1", repoName: "repo1"},
+	}
+	app.dashboard.selected = 0
+
+	// Enter focus mode.
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
+	app = model.(App)
+	if !app.focusModeActive {
+		t.Fatal("expected focusModeActive=true after pressing f")
+	}
+
+	// Press "d" in focus mode — should be a no-op.
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	app = model.(App)
+
+	if len(app.cfg.Repos) != 1 {
+		t.Errorf("expected repo count=1 after d in focus mode, got %d", len(app.cfg.Repos))
+	}
+	if app.view != ViewDashboard {
+		t.Errorf("expected view=ViewDashboard after d in focus mode, got %v", app.view)
+	}
+}


### PR DESCRIPTION
## Summary

- Reset `panelFocus` to `focusList` when entering focus mode via `f`, so the focus-mode handler guard (`panelFocus != focusReview`) is never permanently false — restoring j/k/m/r bindings after toggling from the review panel
- Add `case "d": return a, nil` in the focus-mode switch to prevent the `d` key from falling through to the general repo-delete / diff-view handler while in focus mode

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `go test -race ./...`
- [x] Manual TUI: enter focus mode from review panel state; verify j/k/m/r bindings work
- [x] Manual TUI: press `d` in focus mode with a repo header selected; verify no deletion occurs
- [x] `TestFocusModeResetsPanelFocus` — new regression test covering Bug 1
- [x] `TestFocusModeBlocksDKey` — new regression test covering Bug 2

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description