### PR TITLE
Focus-launch: replace super+ bindings with alt+/ctrl+, add ctrl+w close-tab

### DIFF
--- a/changelog.d/focus-launch-tui-safe-keybindings.md
+++ b/changelog.d/focus-launch-tui-safe-keybindings.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Focus-launch key bindings now use terminal-safe `alt+`/`ctrl+` modifiers instead of `super+` (cmd) keys that macOS intercepts: `alt+[`/`alt+]` switch tabs, `ctrl+t` opens a shell, `ctrl+n` spawns a new agent.
+
+### Added
+
+- `ctrl+w` closes the current focus-launch tab: switches to an adjacent tab and kills the agent asynchronously; on the last tab, returns to the dashboard.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -819,7 +819,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case "home":
 				a.dashboard.scrollOffset = 0
-			case "super+]", "super+[":
+			case "alt+]", "alt+[":
 				if a.focusLaunchSession != nil {
 					agents := a.focusLaunchSession.Agents()
 					idx := 0
@@ -829,7 +829,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 							break
 						}
 					}
-					if msg.String() == "super+]" {
+					if msg.String() == "alt+]" {
 						idx = (idx + 1) % len(agents)
 					} else {
 						idx = (idx - 1 + len(agents)) % len(agents)
@@ -838,7 +838,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.dashboard.scrollOffset = 0
 					a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 				}
-			case "super+j":
+			case "ctrl+t":
 				if a.focusLaunchSession != nil {
 					repoPath := a.repoPathForSession(a.focusLaunchSession.ID)
 					mgr := a.managers[repoPath]
@@ -857,7 +857,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 						}
 					}
 				}
-			case "super+a":
+			case "ctrl+n":
 				if a.focusLaunchSession != nil {
 					repoPath := a.repoPathForSession(a.focusLaunchSession.ID)
 					mgr := a.managers[repoPath]
@@ -875,6 +875,78 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 						} else {
 							a.setError(err.Error())
 						}
+					}
+				}
+			case "ctrl+w":
+				if a.focusLaunchSession == nil || a.focusLaunchAgent == nil {
+					return a, nil
+				}
+				agents := a.focusLaunchSession.Agents()
+				if len(agents) == 0 {
+					a.focusLaunchAgent = nil
+					a.focusLaunchSession = nil
+					a.dashboard.panelFocus = focusList
+					a.dashboard.scrollOffset = 0
+					return a, nil
+				}
+				oldID := a.focusLaunchAgent.ID
+				sessionID := a.focusLaunchSession.ID
+				currentIdx := 0
+				for i, ag := range agents {
+					if ag.ID == oldID {
+						currentIdx = i
+						break
+					}
+				}
+				if len(agents) == 1 {
+					a.focusLaunchAgent = nil
+					a.focusLaunchSession = nil
+					a.dashboard.panelFocus = focusList
+					a.dashboard.scrollOffset = 0
+					if a.closingAgents[oldID] {
+						return a, nil
+					}
+					repoPath := a.repoPathForSession(sessionID)
+					mgr := a.managers[repoPath]
+					if mgr == nil {
+						return a, nil
+					}
+					a.closingAgents[oldID] = true
+					return a, func() tea.Msg {
+						err := mgr.KillAgent(sessionID, oldID)
+						return killResultMsg{
+							scope:     killScopeAgent,
+							sessionID: sessionID,
+							agentID:   oldID,
+							err:       err,
+						}
+					}
+				}
+				var nextIdx int
+				if currentIdx == len(agents)-1 {
+					nextIdx = currentIdx - 1
+				} else {
+					nextIdx = currentIdx + 1
+				}
+				a.focusLaunchAgent = agents[nextIdx]
+				a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+				a.dashboard.scrollOffset = 0
+				if a.closingAgents[oldID] {
+					return a, nil
+				}
+				repoPath := a.repoPathForSession(sessionID)
+				mgr := a.managers[repoPath]
+				if mgr == nil {
+					return a, nil
+				}
+				a.closingAgents[oldID] = true
+				return a, func() tea.Msg {
+					err := mgr.KillAgent(sessionID, oldID)
+					return killResultMsg{
+						scope:     killScopeAgent,
+						sessionID: sessionID,
+						agentID:   oldID,
+						err:       err,
 					}
 				}
 			default:

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -87,9 +87,10 @@ var (
 		{"enter", "send"},
 		{"pgup/pgdn", "scroll"},
 		{"home", "live"},
-		{"⌘[/]", "switch tab"},
-		{"⌘j", "shell"},
-		{"⌘a", "new agent"},
+		{"alt+[/]", "switch tab"},
+		{"ctrl+t", "shell"},
+		{"ctrl+n", "new agent"},
+		{"ctrl+w", "close tab"},
 		{"esc", "back"},
 		{"⇧esc", "interrupt"},
 	}


### PR DESCRIPTION
## Summary

- macOS terminal emulators intercept `cmd+a`, `cmd+n`, `cmd+[`, and `cmd+]` before the TUI sees them, making the previous focus-launch bindings unreliable on most setups
- Replace all four `super+` bindings with terminal-safe alternatives: `alt+[`/`alt+]` for tab switching, `ctrl+t` for new shell, `ctrl+n` for new agent
- Add `ctrl+w` close-tab action: switches to an adjacent tab and kills the old agent asynchronously; on the last tab, exits focus-launch and returns to the dashboard (also kills the agent)
- Status bar hints updated to reflect the new bindings — no ⌘ symbols remain

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: open a session in focus mode, verify `alt+]`/`alt+[` switch tabs, `ctrl+t` spawns shell, `ctrl+n` spawns agent, `ctrl+w` closes tab (multi and last-tab cases), status bar shows correct hints, `esc`/`ctrl+e` still exits

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description