### PR TITLE
Fix concurrency/lifecycle bugs and close test-coverage gaps

### DIFF
--- a/changelog.d/fix-state-and-resume-races.md
+++ b/changelog.d/fix-state-and-resume-races.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Serialize `state.Save`/`Load`/`Remove` with a package-level mutex so concurrent writers can't race on the final `os.Rename` and silently roll back session-recovery data.
+- `ResumeSession` no longer drops failures on the floor: when an agent fails to spawn, the manager now emits `EventError` so the TUI can surface the failure (the on-disk worktree is still preserved in case it holds uncommitted user work).
+- Closed a TOCTOU race in session creation: `createSessionWorktree` and `createSessionOnBranchWorktree` now reserve the chosen name in a `pendingNames` set under `Manager.mu`, so two concurrent `CreateSession` calls can't pick the same slug and collide on the same worktree path.
+- `applyHookEnv` now returns an error (instead of silently writing a useless env) when an agent ID is missing while hooks are otherwise wired up — preventing zombie agents that the hook server can't route events back to. Adds direct unit tests for `applyHookEnv`, `buildHookArgs`, `agentProgram`, and `supportsHooks` (previously only exercised via integration tests).
+- Config forms now respond to the spacebar: Bubble Tea v2's `KeyPressMsg.String()` returns `"space"`, so the form handler now matches `"space"` alongside `" "` and `"enter"` for toggling and select cycling.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -90,7 +90,9 @@ func newAgent(id string, cfg Config, worktreePath, socketPath string) (*Agent, e
 	cmd := exec.Command(prog, args...)
 	cmd.Dir = worktreePath
 	cmd.Env = append(cmd.Environ(), "TERM=xterm-256color")
-	applyHookEnv(cmd, cfg, id, socketPath)
+	if err := applyHookEnv(cmd, cfg, id, socketPath); err != nil {
+		return nil, err
+	}
 
 	p := &bpty.PTY{}
 	if err := p.Start(cmd, uint16(cfg.Rows), uint16(cfg.Cols)); err != nil {
@@ -142,7 +144,9 @@ func newResumedAgent(
 	cmd := exec.Command(agentProgram(cfg), args...)
 	cmd.Dir = worktreePath
 	cmd.Env = append(cmd.Environ(), "TERM=xterm-256color")
-	applyHookEnv(cmd, cfg, id, socketPath)
+	if err := applyHookEnv(cmd, cfg, id, socketPath); err != nil {
+		return nil, err
+	}
 
 	p := &bpty.PTY{}
 	if err := p.Start(cmd, uint16(cfg.Rows), uint16(cfg.Cols)); err != nil {
@@ -226,16 +230,25 @@ func buildHookArgs(cfg Config, worktreePath, socketPath string) ([]string, error
 
 // applyHookEnv sets BATON_HOOK_SOCKET and BATON_AGENT_ID on cmd so the
 // baton-hook CLI (invoked by claude) knows where to forward events.
-// No-op when hooks are disabled for this program.
-func applyHookEnv(cmd *exec.Cmd, cfg Config, agentID, socketPath string) {
+// No-op when hooks are disabled for this program (socketPath empty or
+// program is not claude).
+//
+// Returns an error if agentID is empty while hooks are otherwise enabled —
+// without an agent ID, the hook server can't route events back to a
+// specific agent and we'd produce a zombie.
+func applyHookEnv(cmd *exec.Cmd, cfg Config, agentID, socketPath string) error {
 	if socketPath == "" || !supportsHooks(cfg) {
-		return
+		return nil
+	}
+	if agentID == "" {
+		return fmt.Errorf("applyHookEnv: agentID is empty for claude agent on %s", socketPath)
 	}
 	cmd.Env = append(
 		cmd.Env,
 		"BATON_HOOK_SOCKET="+socketPath,
 		"BATON_AGENT_ID="+agentID,
 	)
+	return nil
 }
 
 // newAgentWithCommand creates an agent using a custom command instead of claude.

--- a/internal/agent/detach_resume_test.go
+++ b/internal/agent/detach_resume_test.go
@@ -4,9 +4,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/devenjarvis/baton/internal/config"
 	"github.com/devenjarvis/baton/internal/state"
 )
 
@@ -502,6 +504,126 @@ func TestDetachResumePreservesHasClaudeName(t *testing.T) {
 			resumed.Worktree.Branch, prevBranch)
 	}
 	_ = ag
+}
+
+// TestResumeSessionPreservesWorktreeOnAgentFailure verifies that when
+// AddAgentResumed fails, ResumeSession:
+//   - removes the session from the manager,
+//   - emits an EventError so the TUI can surface the failure, and
+//   - does NOT delete the on-disk worktree (which may contain user work).
+func TestResumeSessionPreservesWorktreeOnAgentFailure(t *testing.T) {
+	repo := setupTestRepo(t)
+
+	// First manager: create a real worktree to resume against.
+	mgr1 := NewManager(repo, defaultTestSettings())
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr1.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wtPath := sess.Worktree.Path
+	bs := mgr1.Detach()
+	if bs == nil {
+		t.Fatal("expected non-nil BatonState")
+	}
+
+	// Second manager: settings point AgentProgram at a missing binary so
+	// PTY.Start in newResumedAgent fails deterministically.
+	settings := config.Resolve(nil, nil)
+	settings.AgentProgram = "/definitely/not/a/real/binary/baton-test-missing"
+	mgr2 := NewManager(repo, settings)
+	defer mgr2.Shutdown()
+
+	// Drain events in the background so emit() doesn't block on the buffered
+	// channel, and capture EventError.
+	var errEvents []Event
+	var evMu sync.Mutex
+	doneCh := make(chan struct{})
+	go func() {
+		for ev := range mgr2.Events() {
+			if ev.Type == EventError {
+				evMu.Lock()
+				errEvents = append(errEvents, ev)
+				evMu.Unlock()
+			}
+		}
+		close(doneCh)
+	}()
+
+	err = mgr2.ResumeSession(bs.Sessions[0], Config{Rows: 24, Cols: 80})
+	if err == nil {
+		t.Fatal("expected ResumeSession to fail when AgentProgram is missing")
+	}
+
+	// Session must be gone from the manager.
+	if got := mgr2.GetSession(bs.Sessions[0].ID); got != nil {
+		t.Errorf("expected session to be removed after resume failure, found %+v", got)
+	}
+
+	// Worktree on disk must be preserved (user data may be there).
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Errorf("worktree should still exist after resume failure: %v", err)
+	}
+
+	// EventError should have been emitted. Give the drain goroutine a tick.
+	time.Sleep(50 * time.Millisecond)
+	evMu.Lock()
+	gotErr := len(errEvents) > 0
+	evMu.Unlock()
+	if !gotErr {
+		t.Errorf("expected EventError emit on resume failure, got none")
+	}
+}
+
+// TestCreateSessionConcurrentNameUniqueness verifies that concurrent
+// CreateSession calls never produce two sessions with the same slug. Without
+// the pendingNames reservation, two goroutines that both pass the existing-
+// name check before either has inserted into m.sessions can collide on the
+// same slug. Some attempts may fail with git contention errors (the on-disk
+// index is a single locked resource); we assert only that *successful*
+// creations have unique names.
+func TestCreateSessionConcurrentNameUniqueness(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	const N = 4
+	var wg sync.WaitGroup
+	wg.Add(N)
+	results := make(chan string, N)
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	for range N {
+		go func() {
+			defer wg.Done()
+			sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+				return exec.Command("bash", "-c", "sleep 30")
+			})
+			if err != nil {
+				// Git contention is environmental — log but don't fail.
+				t.Logf("CreateSession returned error (likely git contention): %v", err)
+				return
+			}
+			results <- sess.Name
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	seen := make(map[string]int)
+	for name := range results {
+		seen[name]++
+	}
+	if len(seen) < 2 {
+		t.Skipf("got fewer than 2 successful creates; cannot exercise uniqueness invariant (counts: %+v)", seen)
+	}
+	for name, count := range seen {
+		if count > 1 {
+			t.Errorf("name %q reused %d times — pendingNames reservation is broken", name, count)
+		}
+	}
 }
 
 func TestParseSessionNum(t *testing.T) {

--- a/internal/agent/hookwiring_test.go
+++ b/internal/agent/hookwiring_test.go
@@ -1,0 +1,136 @@
+package agent
+
+import (
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestAgentProgramDefault(t *testing.T) {
+	if got := agentProgram(Config{}); got != "claude" {
+		t.Errorf("agentProgram(empty) = %q, want %q", got, "claude")
+	}
+}
+
+func TestAgentProgramOverride(t *testing.T) {
+	if got := agentProgram(Config{AgentProgram: "/usr/local/bin/claude-shim"}); got != "/usr/local/bin/claude-shim" {
+		t.Errorf("agentProgram override = %q", got)
+	}
+}
+
+func TestSupportsHooks(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"default claude", Config{}, true},
+		{"explicit claude", Config{AgentProgram: "claude"}, true},
+		{"claude with absolute path", Config{AgentProgram: "/usr/local/bin/claude"}, true},
+		{"bash shim", Config{AgentProgram: "bash"}, false},
+		{"custom tool", Config{AgentProgram: "my-agent-tool"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := supportsHooks(tt.cfg); got != tt.want {
+				t.Errorf("supportsHooks(%+v) = %v, want %v", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyHookEnv_NoOpWhenSocketEmpty(t *testing.T) {
+	cmd := exec.Command("echo")
+	if err := applyHookEnv(cmd, Config{}, "agent-1", ""); err != nil {
+		t.Fatalf("expected no error with empty socket, got: %v", err)
+	}
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "BATON_HOOK_SOCKET=") || strings.HasPrefix(e, "BATON_AGENT_ID=") {
+			t.Errorf("expected no BATON_* env when socket empty, got %q", e)
+		}
+	}
+}
+
+func TestApplyHookEnv_NoOpWhenProgramNotClaude(t *testing.T) {
+	cmd := exec.Command("echo")
+	cfg := Config{AgentProgram: "bash"}
+	if err := applyHookEnv(cmd, cfg, "agent-1", "/tmp/hook.sock"); err != nil {
+		t.Fatalf("expected no error for non-claude program, got: %v", err)
+	}
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "BATON_HOOK_SOCKET=") {
+			t.Errorf("expected no BATON_HOOK_SOCKET for non-claude program, got %q", e)
+		}
+	}
+}
+
+func TestApplyHookEnv_SetsEnvWhenWired(t *testing.T) {
+	cmd := exec.Command("echo")
+	cfg := Config{AgentProgram: "claude"}
+	if err := applyHookEnv(cmd, cfg, "agent-42", "/tmp/baton-hook.sock"); err != nil {
+		t.Fatalf("applyHookEnv: %v", err)
+	}
+
+	if !slices.Contains(cmd.Env, "BATON_HOOK_SOCKET=/tmp/baton-hook.sock") {
+		t.Errorf("expected BATON_HOOK_SOCKET in env, got %v", cmd.Env)
+	}
+	if !slices.Contains(cmd.Env, "BATON_AGENT_ID=agent-42") {
+		t.Errorf("expected BATON_AGENT_ID=agent-42 in env, got %v", cmd.Env)
+	}
+}
+
+func TestApplyHookEnv_ErrorsWhenAgentIDMissing(t *testing.T) {
+	cmd := exec.Command("echo")
+	cfg := Config{AgentProgram: "claude"}
+	err := applyHookEnv(cmd, cfg, "", "/tmp/hook.sock")
+	if err == nil {
+		t.Fatal("expected error when agentID empty for claude agent")
+	}
+	if !strings.Contains(err.Error(), "agentID") {
+		t.Errorf("expected error to mention agentID, got: %v", err)
+	}
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "BATON_HOOK_SOCKET=") {
+			t.Errorf("env should not contain BATON_HOOK_SOCKET on error, got %q", e)
+		}
+	}
+}
+
+func TestBuildHookArgs_DisabledForBashShim(t *testing.T) {
+	dir := t.TempDir()
+	args, err := buildHookArgs(Config{AgentProgram: "bash"}, dir, "/tmp/socket")
+	if err != nil {
+		t.Fatalf("buildHookArgs: %v", err)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args for non-claude, got %v", args)
+	}
+}
+
+func TestBuildHookArgs_DisabledWhenSocketEmpty(t *testing.T) {
+	dir := t.TempDir()
+	args, err := buildHookArgs(Config{AgentProgram: "claude"}, dir, "")
+	if err != nil {
+		t.Fatalf("buildHookArgs: %v", err)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args when socket empty, got %v", args)
+	}
+}
+
+func TestBuildHookArgs_WritesSettingsAndReturnsFlags(t *testing.T) {
+	dir := t.TempDir()
+	args, err := buildHookArgs(Config{AgentProgram: "claude"}, dir, "/tmp/socket")
+	if err != nil {
+		t.Fatalf("buildHookArgs: %v", err)
+	}
+	if len(args) != 2 || args[0] != "--settings" {
+		t.Fatalf("expected [--settings <path>], got %v", args)
+	}
+	wantPath := filepath.Join(dir, ".baton", "hooks.json")
+	if args[1] != wantPath {
+		t.Errorf("settings path = %q, want %q", args[1], wantPath)
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -55,7 +55,13 @@ type Manager struct {
 
 	mu       sync.RWMutex
 	sessions map[string]*Session
-	nextID   int
+	// pendingNames holds session names reserved by an in-flight
+	// createSessionWorktree / createSessionOnBranchWorktree call. The git
+	// worktree creation runs without holding mu so reads of m.sessions don't
+	// block on git I/O; this set lets concurrent callers see the reservation
+	// and pick a different name.
+	pendingNames map[string]struct{}
+	nextID       int
 
 	events   chan Event
 	done     chan struct{}
@@ -101,12 +107,13 @@ var haikuNameBackoff = []time.Duration{1 * time.Second, 3 * time.Second}
 // out of Active.
 func NewManager(repoPath string, settings config.ResolvedSettings) *Manager {
 	m := &Manager{
-		repoPath:    repoPath,
-		settings:    settings,
-		sessions:    make(map[string]*Session),
-		events:      make(chan Event, 64),
-		done:        make(chan struct{}),
-		branchNamer: DefaultBranchNamer(),
+		repoPath:     repoPath,
+		settings:     settings,
+		sessions:     make(map[string]*Session),
+		pendingNames: make(map[string]struct{}),
+		events:       make(chan Event, 64),
+		done:         make(chan struct{}),
+		branchNamer:  DefaultBranchNamer(),
 	}
 
 	batonDir := filepath.Join(repoPath, ".baton")
@@ -534,15 +541,21 @@ func (m *Manager) CreateSessionOnBranchWithCommand(branch, baseBranch string, cf
 // If baseBranch is non-empty, it overrides the default base on the returned WorktreeInfo.
 func (m *Manager) createSessionOnBranchWorktree(branch, baseBranch string, cfg Config) (*Session, error) {
 	m.mu.Lock()
-	existing := make([]string, 0, len(m.sessions))
-	for _, s := range m.sessions {
-		existing = append(existing, s.CurrentName())
-	}
+	existing := m.allReservedNamesLocked()
 	name := slugifyBranchName(branch, existing)
+	m.pendingNames[name] = struct{}{}
 	m.nextID++
 	id := fmt.Sprintf("session-%d", m.nextID)
 	settings := m.settings
 	m.mu.Unlock()
+
+	// Always release the reservation; on success we replace it with the real
+	// session entry below, on failure we just clear it.
+	defer func() {
+		m.mu.Lock()
+		delete(m.pendingNames, name)
+		m.mu.Unlock()
+	}()
 
 	cfg.RepoPath = m.repoPath
 	if cfg.AgentProgram == "" {
@@ -573,6 +586,19 @@ func (m *Manager) createSessionOnBranchWorktree(branch, baseBranch string, cfg C
 	return sess, nil
 }
 
+// allReservedNamesLocked returns every session name currently in use or
+// reserved by an in-flight create. m.mu must be held.
+func (m *Manager) allReservedNamesLocked() []string {
+	out := make([]string, 0, len(m.sessions)+len(m.pendingNames))
+	for _, s := range m.sessions {
+		out = append(out, s.CurrentName())
+	}
+	for n := range m.pendingNames {
+		out = append(out, n)
+	}
+	return out
+}
+
 // slugifyBranchName derives a session name from a branch name.
 // Takes the last path segment (e.g. "feature/add-auth" → "add-auth"), slugifies it,
 // and falls back to RandomName if the result is empty or collides.
@@ -597,18 +623,23 @@ func slugifyBranchName(branch string, existing []string) string {
 
 // createSessionWorktree creates a session with its worktree, adds it to the map.
 func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
-	// Generate session name.
+	// Generate session name. Reserve the name in pendingNames so a concurrent
+	// CreateSession can't pick the same slug while we're doing git I/O.
 	m.mu.Lock()
-	existing := make([]string, 0, len(m.sessions))
-	for _, s := range m.sessions {
-		existing = append(existing, s.CurrentName())
-	}
+	existing := m.allReservedNamesLocked()
 	track := songs.Pick(existing)
 	name := track.Slug()
+	m.pendingNames[name] = struct{}{}
 	m.nextID++
 	id := fmt.Sprintf("session-%d", m.nextID)
 	settings := m.settings
 	m.mu.Unlock()
+
+	defer func() {
+		m.mu.Lock()
+		delete(m.pendingNames, name)
+		m.mu.Unlock()
+	}()
 
 	cfg.RepoPath = m.repoPath
 	if cfg.AgentProgram == "" {
@@ -1071,6 +1102,10 @@ func (m *Manager) ResumeSession(ss state.SessionState, cfg Config) error {
 			m.mu.Lock()
 			delete(m.sessions, ss.ID)
 			m.mu.Unlock()
+			// Surface the failure so the TUI can show it; the caller in
+			// app.go currently discards the error. Don't Cleanup() the
+			// worktree — it may contain uncommitted user work.
+			m.emit(Event{Type: EventError, SessionID: ss.ID, Status: StatusError})
 			return fmt.Errorf("resuming agent %s: %w", as.Name, err)
 		}
 

--- a/internal/hook/server_test.go
+++ b/internal/hook/server_test.go
@@ -1,6 +1,8 @@
 package hook
 
 import (
+	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -162,5 +164,127 @@ func TestSendEventNoServer(t *testing.T) {
 	// Dialing a nonexistent socket must fail (caller decides to ignore).
 	if err := SendEvent(filepath.Join(t.TempDir(), "nope.sock"), Event{Kind: KindStop, AgentID: "a"}); err == nil {
 		t.Error("expected error dialing nonexistent socket")
+	}
+}
+
+// TestServerRemovesPriorRegularFile verifies that NewServer cleans up a
+// stale leftover at the socket path even if the previous baton crashed.
+func TestServerRemovesPriorRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "hook.sock")
+
+	if err := os.WriteFile(socketPath, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer should remove stale file and bind, got: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	// Round-trip a real event to confirm the listener is functional.
+	if err := SendEvent(socketPath, Event{Kind: KindStop, AgentID: "a"}); err != nil {
+		t.Fatalf("SendEvent after stale-file cleanup: %v", err)
+	}
+	select {
+	case <-srv.Events():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+// TestServerMalformedJSONSkipped verifies that a malformed line on a single
+// connection is ignored without killing the server, and a subsequent
+// well-formed message on the same connection is still delivered.
+func TestServerMalformedJSONSkipped(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	// First a malformed line, then a valid event.
+	if _, err := conn.Write([]byte("{not json\n{\"kind\":\"stop\",\"agentId\":\"a\"}\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	_ = conn.Close()
+
+	select {
+	case got := <-srv.Events():
+		if got.Kind != KindStop {
+			t.Errorf("expected Stop event after malformed line, got %q", got.Kind)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out — server may have died on malformed JSON")
+	}
+}
+
+// TestServerConnectionDropMidLine verifies the server handles a connection
+// closed before sending a newline-terminator without crashing or blocking
+// other handlers.
+func TestServerConnectionDropMidLine(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	// Open a connection, send an incomplete JSON fragment, close.
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	if _, err := conn.Write([]byte("{\"kind\":\"Sto")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	_ = conn.Close()
+
+	// Server should still accept and process subsequent valid events.
+	if err := SendEvent(socketPath, Event{Kind: KindStop, AgentID: "alive"}); err != nil {
+		t.Fatalf("SendEvent after dropped conn: %v", err)
+	}
+	select {
+	case got := <-srv.Events():
+		if got.AgentID != "alive" {
+			t.Errorf("AgentID = %q, want alive", got.AgentID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out — server may have wedged after partial-line drop")
+	}
+}
+
+// TestServerSlowConsumerDoesNotBlock verifies that a stuck consumer does
+// not block the hook senders. The events channel is buffered at 64 and
+// excess messages must be dropped, not block the writer (which would in
+// turn wedge `claude`).
+func TestServerSlowConsumerDoesNotBlock(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	const burst = 200
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < burst; i++ {
+			_ = SendEvent(socketPath, Event{Kind: KindStop, AgentID: "a"})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Senders unblocked even though the events channel was never drained.
+	case <-time.After(5 * time.Second):
+		t.Fatal("senders blocked — slow consumer wedged the hook path")
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -5,8 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
+
+// saveMu serializes Save/Load/Remove so concurrent callers can't race on the
+// final os.Rename — the rename itself is atomic, but two interleaved calls
+// could still let an older snapshot win over a newer one.
+var saveMu sync.Mutex
 
 // BatonState is the top-level persisted state for session recovery.
 type BatonState struct {
@@ -45,8 +51,13 @@ func statePath(repoPath string) string {
 	return filepath.Join(repoPath, ".baton", "state.json")
 }
 
-// Save persists the BatonState to disk using atomic temp+rename.
+// Save persists the BatonState to disk using atomic temp+rename. Calls are
+// serialized by a package-level mutex so concurrent writes can't race on the
+// final rename.
 func Save(repoPath string, s *BatonState) error {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+
 	path := statePath(repoPath)
 	dir := filepath.Dir(path)
 
@@ -92,6 +103,9 @@ func Save(repoPath string, s *BatonState) error {
 
 // Load reads the BatonState from disk. Returns (nil, nil) if the file does not exist.
 func Load(repoPath string) (*BatonState, error) {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+
 	path := statePath(repoPath)
 
 	data, err := os.ReadFile(path)
@@ -112,6 +126,9 @@ func Load(repoPath string) (*BatonState, error) {
 
 // Remove deletes the state file. It is idempotent: returns nil if the file does not exist.
 func Remove(repoPath string) error {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+
 	path := statePath(repoPath)
 
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,8 +1,11 @@
 package state
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -241,6 +244,90 @@ func TestSessionState_LifecyclePersistence(t *testing.T) {
 	}
 	if s.DoneAt == nil || !s.DoneAt.Equal(time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)) {
 		t.Errorf("DoneAt = %v, want 2026-05-03T12:00:00Z", s.DoneAt)
+	}
+}
+
+func TestSaveConcurrent(t *testing.T) {
+	dir := t.TempDir()
+
+	const writers = 32
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for i := range writers {
+		go func() {
+			defer wg.Done()
+			s := &BatonState{
+				Version: 1,
+				SavedAt: time.Now(),
+				Sessions: []SessionState{
+					{ID: fmt.Sprintf("sess-%d", i), Name: fmt.Sprintf("name-%d", i), WorktreePath: "/tmp", Branch: "main"},
+				},
+			}
+			if err := Save(dir, s); err != nil {
+				t.Errorf("Save: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load after concurrent Save: %v", err)
+	}
+	if loaded == nil || len(loaded.Sessions) != 1 {
+		t.Fatalf("expected exactly one session in the final snapshot, got %+v", loaded)
+	}
+
+	// No leftover .json.tmp files should remain.
+	batonDir := filepath.Join(dir, ".baton")
+	entries, err := os.ReadDir(batonDir)
+	if err != nil {
+		t.Fatalf("read .baton: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestLoadCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	batonDir := filepath.Join(dir, ".baton")
+	if err := os.MkdirAll(batonDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(batonDir, "state.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected error loading corrupt file, got nil")
+	}
+	if loaded != nil {
+		t.Errorf("expected nil state on corrupt load, got %+v", loaded)
+	}
+	if !strings.Contains(err.Error(), "unmarshalling state") {
+		t.Errorf("expected unmarshal error, got: %v", err)
+	}
+}
+
+func TestSaveDirCreateFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Make repoPath/.baton a regular file so MkdirAll fails.
+	blocker := filepath.Join(dir, ".baton")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &BatonState{Version: 1, SavedAt: time.Now()}
+	err := Save(dir, s)
+	if err == nil {
+		t.Fatal("expected error when .baton is a regular file, got nil")
+	}
+	if !strings.Contains(err.Error(), "creating dir") {
+		t.Errorf("expected dir-creation error, got: %v", err)
 	}
 }
 

--- a/internal/tui/branchpicker_test.go
+++ b/internal/tui/branchpicker_test.go
@@ -1,0 +1,177 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// fixtureBranchPickerLoaded returns a model populated as if loadBranchPickerData
+// had completed, so tests can drive Update without hitting git or GitHub.
+func fixtureBranchPickerLoaded() branchPickerModel {
+	m := newBranchPickerModel()
+	m.width = 80
+	m.height = 24
+	msg := branchPickerDataMsg{
+		prs: []branchPickerItem{
+			{kind: "pr", branch: "feature-a", baseBranch: "main", prNumber: 42, prTitle: "Add feature A"},
+		},
+		local: []branchPickerItem{
+			{kind: "local", branch: "bugfix-123"},
+			{kind: "local", branch: "experiment"},
+		},
+		remote: []branchPickerItem{
+			{kind: "remote", branch: "origin/foo"},
+		},
+	}
+	m, _ = m.Update(msg)
+	return m
+}
+
+func TestBranchPicker_LoadingThenLoaded(t *testing.T) {
+	m := newBranchPickerModel()
+	if !m.loading {
+		t.Error("expected initial state to be loading=true")
+	}
+	m, _ = m.Update(branchPickerDataMsg{
+		local: []branchPickerItem{{kind: "local", branch: "main"}},
+	})
+	if m.loading {
+		t.Error("expected loading=false after data msg")
+	}
+	if len(m.items) != 1 {
+		t.Errorf("expected 1 item after load, got %d", len(m.items))
+	}
+}
+
+func TestBranchPicker_LoadError(t *testing.T) {
+	m := newBranchPickerModel()
+	m, _ = m.Update(branchPickerDataMsg{err: errStub("network down")})
+	if m.loadErr != "network down" {
+		t.Errorf("loadErr = %q, want %q", m.loadErr, "network down")
+	}
+	if m.loading {
+		t.Error("loading should clear after error")
+	}
+}
+
+func TestBranchPicker_DownKeyMovesCursor(t *testing.T) {
+	m := fixtureBranchPickerLoaded()
+	if m.selected != 0 {
+		t.Fatalf("initial selected = %d, want 0", m.selected)
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	if m.selected != 1 {
+		t.Errorf("after 'j', selected = %d, want 1", m.selected)
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.selected != 2 {
+		t.Errorf("after 'down', selected = %d, want 2", m.selected)
+	}
+}
+
+func TestBranchPicker_UpKeyClampsAtZero(t *testing.T) {
+	m := fixtureBranchPickerLoaded()
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if m.selected != 0 {
+		t.Errorf("up at top should clamp at 0, got %d", m.selected)
+	}
+}
+
+func TestBranchPicker_DownKeyClampsAtEnd(t *testing.T) {
+	m := fixtureBranchPickerLoaded()
+	for range 10 {
+		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	last := len(m.filtered) - 1
+	if m.selected != last {
+		t.Errorf("over-scrolled selected = %d, want %d", m.selected, last)
+	}
+}
+
+func TestBranchPicker_FilterNarrowsList(t *testing.T) {
+	m := fixtureBranchPickerLoaded()
+	original := len(m.filtered)
+	if original < 4 {
+		t.Fatalf("expected ≥4 items in fixture, got %d", original)
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
+	if len(m.filtered) != 1 {
+		t.Errorf("after filter 'b', expected 1 match (bugfix-123), got %d", len(m.filtered))
+	}
+	if m.filter != "b" {
+		t.Errorf("filter = %q, want %q", m.filter, "b")
+	}
+}
+
+func TestBranchPicker_BackspaceClearsFilter(t *testing.T) {
+	m := fixtureBranchPickerLoaded()
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if m.filter != "" {
+		t.Errorf("filter after backspace = %q, want empty", m.filter)
+	}
+}
+
+func TestBranchPicker_FilterMatchesPRTitle(t *testing.T) {
+	m := fixtureBranchPickerLoaded()
+	// Type "feature" — matches PR title and the 'feature-a' branch.
+	for _, c := range "feature" {
+		m, _ = m.Update(tea.KeyPressMsg{Code: rune(c), Text: string(c)})
+	}
+	if len(m.filtered) == 0 {
+		t.Fatal("expected at least one match for 'feature'")
+	}
+	// PR with title "Add feature A" must be present.
+	found := false
+	for _, idx := range m.filtered {
+		if m.items[idx].prTitle == "Add feature A" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("PR title match not in filtered set")
+	}
+}
+
+func TestBranchPicker_EnterEmitsSelectMsg(t *testing.T) {
+	m := fixtureBranchPickerLoaded()
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for enter")
+	}
+	out := cmd()
+	sel, ok := out.(branchPickerSelectMsg)
+	if !ok {
+		t.Fatalf("expected branchPickerSelectMsg, got %T", out)
+	}
+	if sel.item.branch != "feature-a" {
+		t.Errorf("selected item branch = %q, want %q", sel.item.branch, "feature-a")
+	}
+}
+
+func TestBranchPicker_EscEmitsCancelMsg(t *testing.T) {
+	m := fixtureBranchPickerLoaded()
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for esc")
+	}
+	if _, ok := cmd().(branchPickerCancelMsg); !ok {
+		t.Errorf("expected branchPickerCancelMsg, got %T", cmd())
+	}
+}
+
+func TestBranchPicker_EnterWithEmptyListIsNoop(t *testing.T) {
+	m := newBranchPickerModel()
+	m, _ = m.Update(branchPickerDataMsg{}) // no items
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd != nil {
+		t.Errorf("expected nil cmd when list is empty, got %v", cmd)
+	}
+}
+
+// errStub is a tiny helper so we don't pull in errors.New everywhere.
+type errStub string
+
+func (e errStub) Error() string { return string(e) }

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -156,7 +156,7 @@ func (f *configForm) Update(msg tea.Msg) tea.Cmd {
 				field.selected = (field.selected - 1 + len(field.options)) % len(field.options)
 			}
 			return nil
-		case "enter", " ":
+		case "enter", " ", "space":
 			switch field.kind {
 			case fieldToggle:
 				field.toggleValue = !field.toggleValue

--- a/internal/tui/configform_test.go
+++ b/internal/tui/configform_test.go
@@ -1,0 +1,194 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func sampleForm() configForm {
+	fields := []formField{}
+	fields = addToggle(fields, "Enable focus mode", true)
+	fields = addTextInput(fields, "Branch prefix", "baton/", "baton/", 30)
+	fields = addSelect(fields, "Theme", []string{"light", "dark", "auto"}, 1)
+	return newConfigForm(fields, 60)
+}
+
+func TestConfigForm_InitialFocusIsFirstField(t *testing.T) {
+	f := sampleForm()
+	if f.focused != 0 {
+		t.Errorf("focused = %d, want 0", f.focused)
+	}
+}
+
+func TestConfigForm_DownArrowAdvancesFocus(t *testing.T) {
+	f := sampleForm()
+	f.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	if f.focused != 1 {
+		t.Errorf("after 'j', focused = %d, want 1", f.focused)
+	}
+	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if f.focused != 2 {
+		t.Errorf("after 'down', focused = %d, want 2", f.focused)
+	}
+}
+
+func TestConfigForm_DownClampsAtLastField(t *testing.T) {
+	f := sampleForm()
+	for range 10 {
+		f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	if f.focused != len(f.fields)-1 {
+		t.Errorf("expected focused = %d (last), got %d", len(f.fields)-1, f.focused)
+	}
+}
+
+func TestConfigForm_UpClampsAtFirstField(t *testing.T) {
+	f := sampleForm()
+	f.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if f.focused != 0 {
+		t.Errorf("up at top should clamp at 0, got %d", f.focused)
+	}
+}
+
+func TestConfigForm_SpaceTogglesBoolean(t *testing.T) {
+	f := sampleForm()
+	if !f.toggleValue("Enable focus mode") {
+		t.Fatal("fixture should start with toggle=true")
+	}
+	f.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	if f.toggleValue("Enable focus mode") {
+		t.Error("space should toggle boolean to false")
+	}
+	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !f.toggleValue("Enable focus mode") {
+		t.Error("enter on toggle should also toggle, back to true")
+	}
+}
+
+func TestConfigForm_RightCyclesSelect(t *testing.T) {
+	f := sampleForm()
+	// Move to select field (index 2).
+	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+
+	if got := f.selectValue("Theme"); got != "dark" {
+		t.Fatalf("initial Theme = %q, want dark", got)
+	}
+	f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	if got := f.selectValue("Theme"); got != "auto" {
+		t.Errorf("after right, Theme = %q, want auto", got)
+	}
+	f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	if got := f.selectValue("Theme"); got != "light" {
+		t.Errorf("after second right, Theme = %q (expected wraparound to light)", got)
+	}
+}
+
+func TestConfigForm_LeftCyclesSelectBackwards(t *testing.T) {
+	f := sampleForm()
+	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+
+	f.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	if got := f.selectValue("Theme"); got != "light" {
+		t.Errorf("after left from dark, Theme = %q, want light", got)
+	}
+	f.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	if got := f.selectValue("Theme"); got != "auto" {
+		t.Errorf("after wraparound, Theme = %q, want auto", got)
+	}
+}
+
+func TestConfigForm_EnterOnTextEntersEditMode(t *testing.T) {
+	f := sampleForm()
+	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if f.fields[1].editing {
+		t.Fatal("text field should not be editing initially")
+	}
+	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !f.fields[1].editing {
+		t.Error("enter on text field should enter edit mode")
+	}
+	// Esc exits edit mode without submitting form.
+	f.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if f.fields[1].editing {
+		t.Error("esc in edit mode should exit edit mode")
+	}
+}
+
+func TestConfigForm_EnterExitsEditModeOnText(t *testing.T) {
+	f := sampleForm()
+	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // enter edit
+	if !f.fields[1].editing {
+		t.Fatal("expected editing=true")
+	}
+	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // exit edit
+	if f.fields[1].editing {
+		t.Error("second enter should exit edit mode")
+	}
+}
+
+func TestConfigForm_CtrlSEmitsSaveMsg(t *testing.T) {
+	f := sampleForm()
+	cmd := f.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for ctrl+s")
+	}
+	if _, ok := cmd().(configFormSaveMsg); !ok {
+		t.Errorf("expected configFormSaveMsg, got %T", cmd())
+	}
+}
+
+func TestConfigForm_EscEmitsCancelMsg(t *testing.T) {
+	f := sampleForm()
+	cmd := f.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for esc")
+	}
+	if _, ok := cmd().(configFormCancelMsg); !ok {
+		t.Errorf("expected configFormCancelMsg, got %T", cmd())
+	}
+}
+
+func TestConfigForm_AccessorsByLabel(t *testing.T) {
+	f := sampleForm()
+	if !f.toggleValue("Enable focus mode") {
+		t.Error("toggleValue should read fixture value")
+	}
+	if got := f.textValue("Branch prefix"); got != "baton/" {
+		t.Errorf("textValue = %q, want %q", got, "baton/")
+	}
+	if got := f.selectValue("Theme"); got != "dark" {
+		t.Errorf("selectValue = %q, want %q", got, "dark")
+	}
+	if got := f.selectIndex("Theme"); got != 1 {
+		t.Errorf("selectIndex = %d, want 1", got)
+	}
+	// Missing label: zero values.
+	if f.toggleValue("missing") || f.textValue("missing") != "" || f.selectValue("missing") != "" {
+		t.Error("accessors on missing label should return zero values")
+	}
+}
+
+func TestConfigForm_AddSelectClampsInvalidIndex(t *testing.T) {
+	fields := addSelect(nil, "T", []string{"a", "b"}, 99)
+	if fields[0].selected != 0 {
+		t.Errorf("invalid index should clamp to 0, got %d", fields[0].selected)
+	}
+}
+
+func TestConfigForm_AddSelectEmptyOptionsGetsPlaceholder(t *testing.T) {
+	fields := addSelect(nil, "T", nil, 0)
+	if len(fields[0].options) == 0 {
+		t.Error("addSelect with nil options should provide a placeholder")
+	}
+}
+
+func TestConfigForm_EmptyFormUpdateNoCrash(t *testing.T) {
+	f := newConfigForm(nil, 60)
+	if cmd := f.Update(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd != nil {
+		t.Errorf("empty form should return nil cmd, got %v", cmd)
+	}
+}

--- a/internal/tui/filebrowser_test.go
+++ b/internal/tui/filebrowser_test.go
@@ -1,0 +1,247 @@
+package tui
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// fixtureFileBrowserAt builds a fileBrowserModel rooted at dir without
+// touching $HOME, so tests don't depend on the developer's filesystem.
+func fixtureFileBrowserAt(dir string) fileBrowserModel {
+	m := fileBrowserModel{
+		currentDir: dir,
+		width:      80,
+		height:     24,
+	}
+	m.entries = loadEntries(dir, false)
+	m.applyFilter()
+	m.refreshGitStatus()
+	return m
+}
+
+func makeGitRepo(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = path
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(path, "README.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "init"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = path
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func TestFileBrowser_LoadEntriesSkipsFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "alpha"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "beta"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "regular.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := fixtureFileBrowserAt(root)
+	if len(m.entries) != 2 {
+		t.Errorf("expected 2 dir entries (regular file skipped), got %d", len(m.entries))
+	}
+}
+
+func TestFileBrowser_HiddenDirsHiddenByDefault(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{".hidden", "visible"} {
+		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m := fixtureFileBrowserAt(root)
+	if len(m.entries) != 1 || m.entries[0].Name() != "visible" {
+		names := make([]string, 0, len(m.entries))
+		for _, e := range m.entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected only [visible], got %v", names)
+	}
+}
+
+func TestFileBrowser_DotTogglesHiddenWhenFilterEmpty(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{".hidden", "visible"} {
+		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m := fixtureFileBrowserAt(root)
+	m, _ = m.Update(tea.KeyPressMsg{Code: '.', Text: "."})
+	if !m.showHidden {
+		t.Error("expected showHidden=true after '.' with empty filter")
+	}
+	if len(m.entries) != 2 {
+		t.Errorf("expected 2 entries when hidden shown, got %d", len(m.entries))
+	}
+}
+
+func TestFileBrowser_DotIsFilterCharWhenFilterActive(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"v2.0", "v3"} {
+		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m := fixtureFileBrowserAt(root)
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'v', Text: "v"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: '2', Text: "2"})
+	// Now filter is "v2"; '.' should append, not toggle.
+	prevHidden := m.showHidden
+	m, _ = m.Update(tea.KeyPressMsg{Code: '.', Text: "."})
+	if m.showHidden != prevHidden {
+		t.Error("'.' with filter active should not toggle showHidden")
+	}
+	if m.filter != "v2." {
+		t.Errorf("filter = %q, want %q", m.filter, "v2.")
+	}
+}
+
+func TestFileBrowser_BackspaceAscendsWhenFilterEmpty(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "subdir")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := fixtureFileBrowserAt(child)
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if m.currentDir != root {
+		t.Errorf("expected ascend to %s, got %s", root, m.currentDir)
+	}
+}
+
+func TestFileBrowser_BackspaceDeletesFilterChar(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "alpha"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := fixtureFileBrowserAt(root)
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if m.filter != "" {
+		t.Errorf("filter should be cleared, got %q", m.filter)
+	}
+	if m.currentDir != root {
+		t.Error("backspace with non-empty filter should not ascend")
+	}
+}
+
+func TestFileBrowser_EnterOnNonRepoDescends(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := fixtureFileBrowserAt(root)
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd != nil {
+		t.Errorf("descending into non-repo should return nil cmd, got %v", cmd)
+	}
+	if m.currentDir != child {
+		t.Errorf("expected currentDir = %s, got %s", child, m.currentDir)
+	}
+}
+
+func TestFileBrowser_EnterOnGitRepoEmitsSelectMsg(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "myrepo")
+	makeGitRepo(t, repo)
+
+	m := fixtureFileBrowserAt(root)
+	if !m.isGitRepo {
+		t.Fatal("expected refreshGitStatus to detect git repo on selected entry")
+	}
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd when entering on a git repo")
+	}
+	out := cmd()
+	sel, ok := out.(fileBrowserSelectMsg)
+	if !ok {
+		t.Fatalf("expected fileBrowserSelectMsg, got %T", out)
+	}
+	if sel.path != repo {
+		t.Errorf("select path = %q, want %q", sel.path, repo)
+	}
+}
+
+func TestFileBrowser_EscEmitsCancel(t *testing.T) {
+	root := t.TempDir()
+	m := fixtureFileBrowserAt(root)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for esc")
+	}
+	if _, ok := cmd().(fileBrowserCancelMsg); !ok {
+		t.Errorf("expected fileBrowserCancelMsg, got %T", cmd())
+	}
+}
+
+func TestFileBrowser_EnterOnEmptyDirIsNoop(t *testing.T) {
+	root := t.TempDir()
+	m := fixtureFileBrowserAt(root) // no children
+	prev := m.currentDir
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd != nil {
+		t.Errorf("expected nil cmd when filtered list is empty, got %v", cmd)
+	}
+	if m.currentDir != prev {
+		t.Errorf("currentDir changed unexpectedly: %s -> %s", prev, m.currentDir)
+	}
+}
+
+func TestFileBrowser_FilterNarrowsAndClampsCursor(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m := fixtureFileBrowserAt(root)
+	if len(m.filtered) != 3 {
+		t.Fatalf("expected 3 entries pre-filter, got %d", len(m.filtered))
+	}
+	// Move cursor down to position 2.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.selected != 2 {
+		t.Fatalf("expected selected=2, got %d", m.selected)
+	}
+	// Filter "a" matches alpha and gamma — cursor should clamp.
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if m.selected >= len(m.filtered) {
+		t.Errorf("cursor=%d not clamped within filtered=%d", m.selected, len(m.filtered))
+	}
+}


### PR DESCRIPTION
State persistence: serialize Save/Load/Remove with a package-level mutex
so concurrent writers can't race on the final atomic rename and silently
roll back session-recovery data.

Manager: on ResumeSession agent-spawn failure, emit EventError so the
TUI can surface it (the on-disk worktree is preserved — it may hold
uncommitted user work). Close the TOCTOU between session-name collision
checks and worktree creation by reserving names in a pendingNames set
under Manager.mu, so concurrent CreateSession calls can't pick the same
slug.

Hook wiring: applyHookEnv now returns an error (instead of silently
writing useless env) when an agent ID is missing while hooks are wired
up; previously this produced a zombie agent the hook server couldn't
route events back to. Hardens previously integration-only paths
(applyHookEnv, buildHookArgs, agentProgram, supportsHooks) with direct
unit tests.

TUI: configform now matches Bubble Tea v2's "space" key string in
addition to " " for toggle/select activation — previously the spacebar
was silently ignored on toggles.

New tests: concurrent state writes, corrupt state file, dir-create
failure; resume-failure cleanup behavior; concurrent name uniqueness;
hook server protocol (stale regular-file at socket path, malformed
JSON, partial-line drop, slow-consumer non-blocking); model Update
coverage for branchpicker, filebrowser, and configform (~40 new tests
across 1,100 LOC of previously untested UI logic).

https://claude.ai/code/session_014EKjPwty7AVpaFSY67n6WS