### PR TITLE
Forward paste events to fullscreen focus-launch agent

### DIFF
--- a/changelog.d/fix-fullscreen-paste.md
+++ b/changelog.d/fix-fullscreen-paste.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Pasting into the fullscreen agent terminal launched from focus mode (space/enter on a session block) now works. The focus-launch panel was only forwarding `tea.KeyPressMsg` and silently dropping `tea.PasteMsg`, so clipboard content never reached the agent. Paste events are now forwarded via `Agent.Paste` just like the regular dashboard terminal preview.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -807,6 +807,14 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.dashboard.repoConfigForm = nil
 		return a, nil
 
+	case tea.PasteMsg:
+		// focusLaunch: forward paste to the launch agent. Other panels fall through
+		// to dashboard.Update, which handles paste for focusTerminal.
+		if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
+			a.focusLaunchAgent.Paste(msg.Content)
+			return a, nil
+		}
+
 	case tea.KeyPressMsg:
 		// focusLaunch: forward all keys to the launch agent; esc/ctrl+e returns to focus pipeline.
 		if a.dashboard.panelFocus == focusLaunch {


### PR DESCRIPTION
The focus-mode fullscreen terminal was silently dropping clipboard
content because updateDashboard only forwarded tea.KeyPressMsg to the
focusLaunch agent and returned early, never delegating to
dashboard.Update where the existing tea.PasteMsg handler lives.