### PR TITLE
Fix focus mode 'r' key dropping out of alt-screen

### DIFF
--- a/changelog.d/fix-review-key-focus.md
+++ b/changelog.d/fix-review-key-focus.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Pressing `r` in focus mode now opens the review panel as expected. The review-panel branch of `App.View()` returned a view without `AltScreen=true`, causing Bubble Tea to drop out of the alternate screen each frame so the panel never became visible — making `r` look like it did nothing.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2556,7 +2556,9 @@ func (a App) View() tea.View {
 	case ViewDashboard:
 		if a.dashboard.panelFocus == focusReview && a.reviewSession != nil {
 			entry := a.reviewDiffCache[a.reviewSession.ID]
-			return tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width, a.height))
+			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width, a.height))
+			v.AltScreen = true
+			return v
 		}
 		body := a.dashboard.View()
 		hints := dashboardHints

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1580,6 +1580,34 @@ func TestFocusMode_RKey_NoopWithEmptyQueue(t *testing.T) {
 	}
 }
 
+// TestFocusMode_RKey_OpensReviewWithItems verifies that pressing "r" in focus
+// mode with a non-empty review queue switches to the review panel and that
+// the review-panel view stays inside alt-screen. Without AltScreen=true on the
+// review-panel branch of View(), the framework drops out of alt-screen each
+// frame and the user sees nothing change — which is the "r doesn't do anything"
+// bug this guards against.
+func TestFocusMode_RKey_OpensReviewWithItems(t *testing.T) {
+	app, _, _, sessR := makeFocusModeApp(t)
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	app = model.(App)
+
+	if app.dashboard.panelFocus != focusReview {
+		t.Fatalf("expected panelFocus=focusReview after r, got %v", app.dashboard.panelFocus)
+	}
+	if app.reviewSession != sessR {
+		t.Fatalf("expected reviewSession=sessR, got %v", app.reviewSession)
+	}
+	if sessR.LifecyclePhase() != agent.LifecycleInReview {
+		t.Errorf("expected sessR phase=InReview, got %v", sessR.LifecyclePhase())
+	}
+
+	view := app.View()
+	if !view.AltScreen {
+		t.Error("review panel View must keep AltScreen=true; otherwise focus mode flickers out of alt-screen and r looks like a no-op")
+	}
+}
+
 // TestSoftAgentLimitGuard verifies the two-press 'n' guard in focus mode:
 // first press shows a warning and sets newAgentPending; second press proceeds.
 func TestSoftAgentLimitGuard(t *testing.T) {


### PR DESCRIPTION
The review-panel branch of App.View() returned tea.NewView(...) without
setting AltScreen=true. Every other branch sets it on the wrapped view
at the bottom of View(), but the early return for focusReview skipped
that step. Each render after pressing 'r' would toggle AltScreen
true→false and the framework would exit alt-screen, so the review panel
rendered into the main screen instead of replacing the focus mode view —
making 'r' look like a no-op.

https://claude.ai/code/session_01C7NaaL2A6xvZaATDtLkWNC