### PR TITLE
Make break mode more immersive, sleep-resilient, and opt-in to resume

### DIFF
--- a/changelog.d/improve-break-mode.md
+++ b/changelog.d/improve-break-mode.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **Break mode is more immersive.** The breathing animation is now larger
+  (27×9 vs the old 9×3), longer (a 36-frame, ~3.6 s cycle that lands near a
+  guided-breathwork pace), smoother (cosine-eased radius, sparkle ring at
+  peak), and shifts colour per breath cycle so the eye has something to
+  settle on. Smaller terminals fall back to the original compact frames.
+- **Break mode no longer drops you back into focus on its own.** When the
+  break duration elapses, the screen flips to a warm bordered "BREAK
+  COMPLETE" panel with a pulsing colour, an over-time counter, and a chime.
+  Pressing `b` is the only way back to work — walk away as long as you want.
+- **Break timer counts wall-clock time, not just monotonic ticks.** The
+  start instant has its monotonic reading stripped, so suspending the
+  laptop during a break still drains the timer. Coming back from lunch no
+  longer leaves you with ten phantom minutes.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -129,9 +129,10 @@ type App struct {
 	focusLaunchSession     *agent.Session
 	focusBacklogWarning    bool // first n at backlog limit shows warning; second proceeds
 	focusBreakMode         bool
-	focusBreakStart        time.Time
+	focusBreakStart        time.Time // wall-clock; monotonic stripped so suspend counts toward elapsed
 	focusPomodoroCount     int
 	focusBreakShortWarning bool
+	focusBreakTimerUp      bool // break duration elapsed; waiting on user to resume
 	focusBreakAnimFrame    int
 	repoPickerActive       bool
 	repoPickerForm         *configForm
@@ -355,15 +356,24 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, tea.Batch(cmds...)
 
 	case tickMsg:
-		// Break mode: advance animation and check for auto-exit.
+		// Break mode: advance animation and detect timer expiry. We DO NOT
+		// auto-exit — once the configured break elapses we flip into a
+		// "ready" state and wait for the user to explicitly resume. This
+		// avoids dropping the user back into focus mode while they're still
+		// away from the keyboard.
 		if a.focusBreakMode {
 			a.focusBreakAnimFrame++
-			if a.focusBreakMinutes > 0 && time.Since(a.focusBreakStart) >= time.Duration(a.focusBreakMinutes)*time.Minute {
-				a.sessionStart = time.Now()
-				a.focusPomodoroCount++
-				a.focusBreakMode = false
+			if a.focusBreakMinutes > 0 && !a.focusBreakTimerUp &&
+				time.Since(a.focusBreakStart) >= time.Duration(a.focusBreakMinutes)*time.Minute {
+				a.focusBreakTimerUp = true
 				a.focusBreakShortWarning = false
 				a.focusBreakAnimFrame = 0
+				// One unmistakable cue when the break ends. Played even in
+				// focus mode (the normal suppression path), since the whole
+				// point is to grab attention.
+				if a.audioPlayer != nil {
+					a.audioPlayer.Play()
+				}
 			}
 		}
 		a.refreshAgentList()
@@ -1273,19 +1283,35 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if !a.focusModeActive {
 				return a, nil
 			}
-			if !a.focusBreakMode {
+			switch {
+			case !a.focusBreakMode:
+				// Enter break. Round(0) strips the monotonic reading so
+				// time.Since uses wall-clock arithmetic, which keeps the
+				// timer honest across suspend/resume.
 				a.focusBreakMode = true
-				a.focusBreakStart = time.Now()
+				a.focusBreakStart = time.Now().Round(0)
 				a.focusBreakShortWarning = false
+				a.focusBreakTimerUp = false
 				a.focusBreakAnimFrame = 0
-			} else if !a.focusBreakShortWarning {
-				a.focusBreakShortWarning = true
-			} else {
-				// Third b press: override — end break early.
+			case a.focusBreakTimerUp:
+				// Break is fully elapsed; user is opting back in. Exit
+				// without any "are you sure" friction.
 				a.sessionStart = time.Now()
 				a.focusPomodoroCount++
 				a.focusBreakMode = false
 				a.focusBreakShortWarning = false
+				a.focusBreakTimerUp = false
+				a.focusBreakAnimFrame = 0
+			case !a.focusBreakShortWarning:
+				a.focusBreakShortWarning = true
+			default:
+				// Third b press while still inside the break window:
+				// override the short-break guard and end early.
+				a.sessionStart = time.Now()
+				a.focusPomodoroCount++
+				a.focusBreakMode = false
+				a.focusBreakShortWarning = false
+				a.focusBreakTimerUp = false
 				a.focusBreakAnimFrame = 0
 			}
 			return a, nil
@@ -2283,6 +2309,7 @@ func (a *App) refreshAgentList() {
 	a.dashboard.focusBreakMinutes = a.focusBreakMinutes
 	a.dashboard.focusBreakAnimFrame = a.focusBreakAnimFrame
 	a.dashboard.focusBreakShortWarning = a.focusBreakShortWarning
+	a.dashboard.focusBreakTimerUp = a.focusBreakTimerUp
 	a.dashboard.focusActiveIdx = a.focusActiveIdx
 	a.dashboard.focusQueueIndex = a.focusQueueIndex
 	a.dashboard.focusCursorSection = a.focusCursorSection
@@ -2583,7 +2610,11 @@ func (a App) View() tea.View {
 		// Skip when in focusLaunch: b routes to the agent terminal there, not to break control.
 		if a.focusModeActive && a.dashboard.panelFocus != focusLaunch {
 			if a.focusBreakMode {
-				hints = []keyHint{{key: "b", desc: "exit early"}}
+				if a.focusBreakTimerUp {
+					hints = []keyHint{{key: "b", desc: "resume focus"}}
+				} else {
+					hints = []keyHint{{key: "b", desc: "exit early"}}
+				}
 			} else if a.focusSessionMinutes > 0 {
 				elapsed := time.Since(a.sessionStart)
 				if elapsed >= time.Duration(a.focusSessionMinutes)*time.Minute {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"image/color"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -126,6 +127,7 @@ type dashboardModel struct {
 	focusBreakMinutes      int
 	focusBreakAnimFrame    int
 	focusBreakShortWarning bool
+	focusBreakTimerUp      bool
 	focusActiveIdx         int            // index of highlighted in-progress session row
 	focusQueueIndex        int            // index into ReadyForReview sessions in fullscreen focus mode
 	focusCursorSection     focusSection   // which fullscreen-focus section the cursor is on
@@ -985,9 +987,22 @@ func (d dashboardModel) renderFocusLaunchView(width, height int) string {
 	return header + "\n" + tabBar + "\n" + render
 }
 
-// breatheFrames is the 12-frame expand/contract animation for the break overlay.
-// Each frame is 3 rows of equal width, rendered at the center of the screen.
-var breatheFrames = [12][3]string{
+// Breath animation tuning. 36 frames at the existing 100ms tick = a 3.6s
+// breath cycle (~17 BPM), which lands close to a guided-breathwork pace
+// rather than the old hyperventilating 1.2s loop.
+const (
+	breathFrameCount = 36
+	breathWidth      = 27
+	breathHeight     = 9
+)
+
+// breatheFrames is built at package init via generateBreatheFrames so the
+// animation stays smooth across many frames without hand-tuning each one.
+var breatheFrames = generateBreatheFrames()
+
+// breatheFramesCompact is a smaller fallback for terminals that can't fit
+// the full-size breath. Mirrors the original three-row design.
+var breatheFramesCompact = [12][3]string{
 	{"         ", "    ·    ", "         "},
 	{"   · · · ", "  · · ·  ", " · · ·   "},
 	{"  ○○○○○  ", "  ○   ○  ", "  ○○○○○  "},
@@ -1002,23 +1017,131 @@ var breatheFrames = [12][3]string{
 	{"   · · · ", "  · · ·  ", " · · ·   "},
 }
 
-// breatheColors cycles through calm hues over the 12-frame animation.
-var breatheColors = [3]lipgloss.Color{
+// breatheColors cycles through calm hues. The longer cycle gives the user
+// something to gently track without becoming repetitive.
+var breatheColors = [4]lipgloss.Color{
 	"#38BDF8", // sky blue
 	"#818CF8", // indigo
 	"#34D399", // emerald
+	"#F472B6", // rose — adds variety on every other breath
 }
 
-// renderBreakOverlay returns a fullscreen centered break screen.
-func (d dashboardModel) renderBreakOverlay(width, height int) string {
-	frame := d.focusBreakAnimFrame % 12
-	animColor := breatheColors[frame%3]
+// completeColors pulse warm tones once the timer is up so the screen reads
+// unmistakably as "done" without auto-advancing the user back to work.
+var completeColors = [3]lipgloss.Color{
+	"#F59E0B", // amber
+	"#FBBF24", // gold
+	"#FACC15", // yellow
+}
+
+// generateBreatheFrames builds a smooth concentric breath cycle. The first
+// half of the cycle inhales (radius grows), the second half exhales. A
+// cosine easing keeps motion organic; an aspect-ratio correction keeps the
+// shape feeling round despite character cells being roughly twice as tall
+// as they are wide.
+func generateBreatheFrames() [breathFrameCount][breathHeight]string {
+	var out [breathFrameCount][breathHeight]string
+	cx := float64(breathWidth-1) / 2.0
+	cy := float64(breathHeight-1) / 2.0
+	const aspect = 2.3
+	maxR := cy + 0.6
+
+	for f := 0; f < breathFrameCount; f++ {
+		half := breathFrameCount / 2
+		var phase float64
+		if f < half {
+			phase = float64(f) / float64(half-1)
+		} else {
+			phase = float64(breathFrameCount-1-f) / float64(half-1)
+		}
+		eased := 0.5 - 0.5*math.Cos(phase*math.Pi)
+		radius := eased * maxR
+
+		for r := 0; r < breathHeight; r++ {
+			row := make([]rune, breathWidth)
+			for c := 0; c < breathWidth; c++ {
+				dx := (float64(c) - cx) / aspect
+				dy := float64(r) - cy
+				dist := math.Sqrt(dx*dx + dy*dy)
+				ch := ' '
+				switch {
+				case radius < 0.35:
+					if dist < 0.6 {
+						ch = '·'
+					}
+				case dist < radius-1.0:
+					ch = '●'
+				case dist < radius-0.45:
+					ch = '◉'
+				case dist < radius+0.15:
+					ch = '○'
+				case dist < radius+0.55 && phase > 0.85:
+					// Sparkle ring at the top of the inhale gives the
+					// peak a held, alive feeling.
+					ch = '·'
+				}
+				row[c] = ch
+			}
+			out[f][r] = string(row)
+		}
+	}
+	return out
+}
+
+// renderBreatheBlock returns the current breath frame as a colored block.
+// Falls back to the compact frames when the terminal can't fit the bigger
+// canvas.
+func (d dashboardModel) renderBreatheBlock(width, height int) string {
+	if width < breathWidth+4 || height < breathHeight+8 {
+		frame := d.focusBreakAnimFrame % 12
+		animColor := breatheColors[frame%len(breatheColors)]
+		animStyle := lipgloss.NewStyle().Foreground(animColor)
+		rows := breatheFramesCompact[frame]
+		return animStyle.Render(rows[0]) + "\n" +
+			animStyle.Render(rows[1]) + "\n" +
+			animStyle.Render(rows[2])
+	}
+	frame := d.focusBreakAnimFrame % breathFrameCount
+	// Color rotates per breath cycle, not per frame, so the eye gets a
+	// stable hue to settle on for the duration of one breath.
+	cycle := d.focusBreakAnimFrame / breathFrameCount
+	animColor := breatheColors[cycle%len(breatheColors)]
 	animStyle := lipgloss.NewStyle().Foreground(animColor)
 
-	frameRows := breatheFrames[frame]
-	animBlock := animStyle.Render(frameRows[0]) + "\n" +
-		animStyle.Render(frameRows[1]) + "\n" +
-		animStyle.Render(frameRows[2])
+	rows := breatheFrames[frame]
+	out := make([]string, breathHeight)
+	for i, row := range rows {
+		out[i] = animStyle.Render(row)
+	}
+	return strings.Join(out, "\n")
+}
+
+// breathPhaseLabel returns a one-word cue ("inhale" / "hold" / "exhale")
+// matching the current breath phase so the user has a focal point.
+func (d dashboardModel) breathPhaseLabel() string {
+	frame := d.focusBreakAnimFrame % breathFrameCount
+	half := breathFrameCount / 2
+	switch {
+	case frame >= half-2 && frame <= half+1:
+		return "hold"
+	case frame < half:
+		return "inhale"
+	default:
+		return "exhale"
+	}
+}
+
+// renderBreakOverlay returns a fullscreen centered break screen. Behaviour
+// depends on whether the configured break duration has elapsed:
+//   - Active break: large breath animation, countdown, exit-early hint.
+//   - Timer up: warm "BREAK COMPLETE" panel that waits for the user to
+//     explicitly opt back in (no auto-resume).
+func (d dashboardModel) renderBreakOverlay(width, height int) string {
+	if d.focusBreakTimerUp {
+		return d.renderBreakCompleteOverlay(width, height)
+	}
+
+	animBlock := d.renderBreatheBlock(width, height)
 
 	titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#38BDF8")).Bold(true)
 	title := titleStyle.Render("BREAK")
@@ -1027,6 +1150,8 @@ func (d dashboardModel) renderBreakOverlay(width, height int) string {
 	if d.focusPomodoroCount > 0 {
 		pomodoroLine = StyleSubtle.Render(fmt.Sprintf("🍅 Pomodoro %d", d.focusPomodoroCount))
 	}
+
+	phaseLine := StyleSubtle.Render(d.breathPhaseLabel())
 
 	var countdownLine string
 	if d.focusBreakMinutes > 0 {
@@ -1037,13 +1162,7 @@ func (d dashboardModel) renderBreakOverlay(width, height int) string {
 		}
 		mins := remainSecs / 60
 		secs := remainSecs % 60
-		if remainSecs > 0 {
-			countdownLine = StyleSubtle.Render(fmt.Sprintf("%dm %02ds remaining", mins, secs))
-		} else {
-			elapsedMins := int(d.focusBreakElapsed.Minutes())
-			elapsedSecs := int(d.focusBreakElapsed.Seconds()) % 60
-			countdownLine = StyleSubtle.Render(fmt.Sprintf("%dm %02ds — great work", elapsedMins, elapsedSecs))
-		}
+		countdownLine = StyleSubtle.Render(fmt.Sprintf("%dm %02ds remaining", mins, secs))
 	}
 
 	var actionLine string
@@ -1061,12 +1180,71 @@ func (d dashboardModel) renderBreakOverlay(width, height int) string {
 	parts = append(parts, "")
 	parts = append(parts, animBlock)
 	parts = append(parts, "")
+	parts = append(parts, phaseLine)
 	if countdownLine != "" {
 		parts = append(parts, countdownLine)
 	}
+	parts = append(parts, "")
 	parts = append(parts, actionLine)
 
 	inner := strings.Join(parts, "\n")
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, inner)
+}
+
+// renderBreakCompleteOverlay is shown once the break timer has elapsed.
+// The visual is intentionally loud: warm bordered banner, pulsing colour,
+// over-time counter. The user must press b to leave — we never advance on
+// their behalf.
+func (d dashboardModel) renderBreakCompleteOverlay(width, height int) string {
+	pulse := completeColors[(d.focusBreakAnimFrame/3)%len(completeColors)]
+	bannerStyle := lipgloss.NewStyle().
+		Foreground(pulse).
+		Bold(true).
+		Border(lipgloss.DoubleBorder()).
+		BorderForeground(pulse).
+		Padding(1, 4)
+	banner := bannerStyle.Render("⏰  B R E A K   C O M P L E T E  ⏰")
+
+	subStyle := lipgloss.NewStyle().Foreground(pulse).Bold(true)
+	subhead := subStyle.Render("ready when you are")
+
+	var stats string
+	if d.focusBreakMinutes > 0 {
+		breakSecs := int(d.focusBreakElapsed.Seconds())
+		bm, bs := breakSecs/60, breakSecs%60
+		over := breakSecs - d.focusBreakMinutes*60
+		if over < 0 {
+			over = 0
+		}
+		om, os := over/60, over%60
+		if over > 0 {
+			stats = StyleSubtle.Render(fmt.Sprintf("on break %dm %02ds · %dm %02ds past timer", bm, bs, om, os))
+		} else {
+			stats = StyleSubtle.Render(fmt.Sprintf("on break %dm %02ds", bm, bs))
+		}
+	}
+
+	var pomodoroLine string
+	if d.focusPomodoroCount > 0 {
+		pomodoroLine = StyleSubtle.Render(fmt.Sprintf("🍅 Pomodoro %d so far", d.focusPomodoroCount))
+	}
+
+	prompt := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#34D399")).
+		Bold(true).
+		Render("[b] resume focus session")
+	hint := StyleSubtle.Render("(no rush — the timer won't drag you back in)")
+
+	parts := []string{banner, "", subhead}
+	if stats != "" {
+		parts = append(parts, "", stats)
+	}
+	if pomodoroLine != "" {
+		parts = append(parts, pomodoroLine)
+	}
+	parts = append(parts, "", prompt, hint)
+
+	inner := lipgloss.JoinVertical(lipgloss.Center, parts...)
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, inner)
 }
 


### PR DESCRIPTION
- Bigger, longer breathing animation (27x9, 36 frames, ~3.6s cycle with
  cosine easing and per-cycle colour drift). Compact 9x3 fallback retained
  for narrow terminals.
- Break timer no longer auto-exits. When the configured duration elapses,
  the screen flips to a "BREAK COMPLETE" banner with an over-time counter
  and a chime; only pressing 'b' returns to focus mode.
- focusBreakStart strips its monotonic reading via Round(0) so suspend time
  counts toward elapsed. Walking away for lunch no longer leaves a phantom
  ten minutes on the timer.

https://claude.ai/code/session_015tqtJms3oigxCTRuQt5e2b