### PR TITLE
Slow breathing animation to science-backed 5.5 BPM (10s cycle)

### DIFF
--- a/changelog.d/slow-breathing-animation.md
+++ b/changelog.d/slow-breathing-animation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+Slow break-page breathing animation to science-backed 5.5 BPM (10s cycle, equal 5s inhale / 5s exhale). The previous 3.6s cycle was faster than resting breathing rate and counterproductive for relaxation; coherent/resonance breathing at 5.5 BPM maximally increases HRV and activates the parasympathetic nervous system (PMID 24380741, PMC5575449). Also fixes the compact fallback which previously ran at a 1.2s cycle.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -987,11 +987,12 @@ func (d dashboardModel) renderFocusLaunchView(width, height int) string {
 	return header + "\n" + tabBar + "\n" + render
 }
 
-// Breath animation tuning. 36 frames at the existing 100ms tick = a 3.6s
-// breath cycle (~17 BPM), which lands close to a guided-breathwork pace
-// rather than the old hyperventilating 1.2s loop.
+// Breath animation tuning. 100 frames at the 100ms tick = a 10s cycle
+// (5.5 BPM), matching coherent/resonance breathing — the rate that
+// maximally increases HRV and activates the parasympathetic nervous system
+// (PMID 24380741, PMC5575449). Equal 5s inhale / 5s exhale.
 const (
-	breathFrameCount = 36
+	breathFrameCount = 100
 	breathWidth      = 27
 	breathHeight     = 9
 )
@@ -1093,8 +1094,9 @@ func generateBreatheFrames() [breathFrameCount][breathHeight]string {
 // canvas.
 func (d dashboardModel) renderBreatheBlock(width, height int) string {
 	if width < breathWidth+4 || height < breathHeight+8 {
-		frame := d.focusBreakAnimFrame % 12
-		animColor := breatheColors[frame%len(breatheColors)]
+		cycle := d.focusBreakAnimFrame % breathFrameCount
+		frame := cycle * len(breatheFramesCompact) / breathFrameCount
+		animColor := breatheColors[(d.focusBreakAnimFrame/breathFrameCount)%len(breatheColors)]
 		animStyle := lipgloss.NewStyle().Foreground(animColor)
 		rows := breatheFramesCompact[frame]
 		return animStyle.Render(rows[0]) + "\n" +
@@ -1116,19 +1118,16 @@ func (d dashboardModel) renderBreatheBlock(width, height int) string {
 	return strings.Join(out, "\n")
 }
 
-// breathPhaseLabel returns a one-word cue ("inhale" / "hold" / "exhale")
-// matching the current breath phase so the user has a focal point.
+// breathPhaseLabel returns a one-word cue ("inhale" / "exhale") matching
+// the current breath phase. No hold phase — the sparkle ring in
+// generateBreatheFrames provides the held feeling visually at the peak.
 func (d dashboardModel) breathPhaseLabel() string {
 	frame := d.focusBreakAnimFrame % breathFrameCount
 	half := breathFrameCount / 2
-	switch {
-	case frame >= half-2 && frame <= half+1:
-		return "hold"
-	case frame < half:
+	if frame < half {
 		return "inhale"
-	default:
-		return "exhale"
 	}
+	return "exhale"
 }
 
 // renderBreakOverlay returns a fullscreen centered break screen. Behaviour


### PR DESCRIPTION
## Summary

- Change `breathFrameCount` from 36 to 100 — at 100ms/tick this gives a 10s cycle (5.5 BPM), matching coherent/resonance breathing research (PMID 24380741, PMC5575449) that identifies this rate as maximally increasing HRV and activating the parasympathetic nervous system
- The previous 3.6s cycle (~17 BPM) was faster than resting breathing rate; following the animation would cause hyperventilation rather than relaxation
- Remove the "hold" label phase from `breathPhaseLabel()` — with an equal 5s/5s pattern there is no hold; the sparkle ring in `generateBreatheFrames` already provides the held feeling visually at the peak
- Fix compact fallback in `renderBreatheBlock()`: the old `% 12` produced a 1.2s cycle; now uses proportional mapping `cycle * 12 / 100` so compact mode plays at the same 10s pace

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: open a focus session → trigger a break → verify the breathing circle expands over ~5s and contracts over ~5s, "inhale"/"exhale" label flips at the midpoint, feels calm not frantic
- [ ] Manual TUI: resize terminal below 31×17 to trigger compact fallback — verify compact animation also plays slowly (~10s cycle)

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — added `changelog.d/slow-breathing-animation.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md` — animation rate is verified manually
- [x] No new public API surface without a note in the PR description