### PR TITLE
Rename Pomodoro to Block in focus mode timer

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -117,7 +117,7 @@ type App struct {
 	// Wellness / focus mode state.
 	focusModeActive        bool
 	appStart               time.Time // set once at init; never reset; used for total session duration in wellness log
-	sessionStart           time.Time // per-pomodoro work timer; reset on each break completion
+	sessionStart           time.Time // per-block work timer; reset on each break completion
 	lastReviewAt           time.Time
 	newAgentPending        bool
 	focusSessionMinutes    int          // cached from resolved global settings
@@ -130,7 +130,7 @@ type App struct {
 	focusBacklogWarning    bool // first n at backlog limit shows warning; second proceeds
 	focusBreakMode         bool
 	focusBreakStart        time.Time // wall-clock; monotonic stripped so suspend counts toward elapsed
-	focusPomodoroCount     int
+	focusBlockCount        int
 	focusBreakShortWarning bool
 	focusBreakTimerUp      bool // break duration elapsed; waiting on user to resume
 	focusBreakAnimFrame    int
@@ -1297,7 +1297,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Break is fully elapsed; user is opting back in. Exit
 				// without any "are you sure" friction.
 				a.sessionStart = time.Now()
-				a.focusPomodoroCount++
+				a.focusBlockCount++
 				a.focusBreakMode = false
 				a.focusBreakShortWarning = false
 				a.focusBreakTimerUp = false
@@ -1308,7 +1308,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Third b press while still inside the break window:
 				// override the short-break guard and end early.
 				a.sessionStart = time.Now()
-				a.focusPomodoroCount++
+				a.focusBlockCount++
 				a.focusBreakMode = false
 				a.focusBreakShortWarning = false
 				a.focusBreakTimerUp = false
@@ -2305,7 +2305,7 @@ func (a *App) refreshAgentList() {
 	} else {
 		a.dashboard.focusBreakElapsed = 0
 	}
-	a.dashboard.focusPomodoroCount = a.focusPomodoroCount
+	a.dashboard.focusBlockCount = a.focusBlockCount
 	a.dashboard.focusBreakMinutes = a.focusBreakMinutes
 	a.dashboard.focusBreakAnimFrame = a.focusBreakAnimFrame
 	a.dashboard.focusBreakShortWarning = a.focusBreakShortWarning
@@ -3092,7 +3092,7 @@ type wellnessLogEntry struct {
 	AgentsCreated      int    `json:"agents_created"`
 	SessionsCreated    int    `json:"sessions_created"`
 	FocusSwitches      int    `json:"focus_switches"`
-	PomodorosCompleted int    `json:"pomodoros_completed"`
+	BlocksCompleted    int    `json:"blocks_completed"`
 }
 
 // writeWellnessLog appends a single JSON line to <repoPath>/.baton/logs/wellness.log.
@@ -3118,7 +3118,7 @@ func (a *App) writeWellnessLog() {
 		AgentsCreated:      a.agentsCreatedCount,
 		SessionsCreated:    a.sessionsCreatedCount,
 		FocusSwitches:      a.focusModeSwitches,
-		PomodorosCompleted: a.focusPomodoroCount,
+		BlocksCompleted: a.focusBlockCount,
 	}
 	data, err := json.Marshal(entry)
 	if err != nil {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3087,12 +3087,12 @@ func (a *App) activeAgentCount() int {
 
 // wellnessLogEntry is the JSON structure written on session end.
 type wellnessLogEntry struct {
-	Date               string `json:"date"`
-	DurationMin        int    `json:"duration_min"`
-	AgentsCreated      int    `json:"agents_created"`
-	SessionsCreated    int    `json:"sessions_created"`
-	FocusSwitches      int    `json:"focus_switches"`
-	BlocksCompleted    int    `json:"blocks_completed"`
+	Date            string `json:"date"`
+	DurationMin     int    `json:"duration_min"`
+	AgentsCreated   int    `json:"agents_created"`
+	SessionsCreated int    `json:"sessions_created"`
+	FocusSwitches   int    `json:"focus_switches"`
+	BlocksCompleted int    `json:"blocks_completed"`
 }
 
 // writeWellnessLog appends a single JSON line to <repoPath>/.baton/logs/wellness.log.
@@ -3113,11 +3113,11 @@ func (a *App) writeWellnessLog() {
 
 	elapsed := time.Since(a.appStart)
 	entry := wellnessLogEntry{
-		Date:               time.Now().UTC().Format(time.RFC3339),
-		DurationMin:        int(elapsed.Minutes()),
-		AgentsCreated:      a.agentsCreatedCount,
-		SessionsCreated:    a.sessionsCreatedCount,
-		FocusSwitches:      a.focusModeSwitches,
+		Date:            time.Now().UTC().Format(time.RFC3339),
+		DurationMin:     int(elapsed.Minutes()),
+		AgentsCreated:   a.agentsCreatedCount,
+		SessionsCreated: a.sessionsCreatedCount,
+		FocusSwitches:   a.focusModeSwitches,
 		BlocksCompleted: a.focusBlockCount,
 	}
 	data, err := json.Marshal(entry)

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -123,7 +123,7 @@ type dashboardModel struct {
 	focusSessionMinutes    int
 	focusBreakMode         bool
 	focusBreakElapsed      time.Duration
-	focusPomodoroCount     int
+	focusBlockCount        int
 	focusBreakMinutes      int
 	focusBreakAnimFrame    int
 	focusBreakShortWarning bool
@@ -1146,9 +1146,9 @@ func (d dashboardModel) renderBreakOverlay(width, height int) string {
 	titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#38BDF8")).Bold(true)
 	title := titleStyle.Render("BREAK")
 
-	var pomodoroLine string
-	if d.focusPomodoroCount > 0 {
-		pomodoroLine = StyleSubtle.Render(fmt.Sprintf("🍅 Pomodoro %d", d.focusPomodoroCount))
+	var blockLine string
+	if d.focusBlockCount > 0 {
+		blockLine = StyleSubtle.Render(fmt.Sprintf("Block %d", d.focusBlockCount))
 	}
 
 	phaseLine := StyleSubtle.Render(d.breathPhaseLabel())
@@ -1174,8 +1174,8 @@ func (d dashboardModel) renderBreakOverlay(width, height int) string {
 
 	var parts []string
 	parts = append(parts, title)
-	if pomodoroLine != "" {
-		parts = append(parts, pomodoroLine)
+	if blockLine != "" {
+		parts = append(parts, blockLine)
 	}
 	parts = append(parts, "")
 	parts = append(parts, animBlock)
@@ -1224,9 +1224,9 @@ func (d dashboardModel) renderBreakCompleteOverlay(width, height int) string {
 		}
 	}
 
-	var pomodoroLine string
-	if d.focusPomodoroCount > 0 {
-		pomodoroLine = StyleSubtle.Render(fmt.Sprintf("🍅 Pomodoro %d so far", d.focusPomodoroCount))
+	var blockLine string
+	if d.focusBlockCount > 0 {
+		blockLine = StyleSubtle.Render(fmt.Sprintf("Block %d so far", d.focusBlockCount))
 	}
 
 	prompt := lipgloss.NewStyle().
@@ -1239,8 +1239,8 @@ func (d dashboardModel) renderBreakCompleteOverlay(width, height int) string {
 	if stats != "" {
 		parts = append(parts, "", stats)
 	}
-	if pomodoroLine != "" {
-		parts = append(parts, pomodoroLine)
+	if blockLine != "" {
+		parts = append(parts, blockLine)
 	}
 	parts = append(parts, "", prompt, hint)
 
@@ -1258,8 +1258,8 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 
 	// Header: title + timer
 	title := StyleTitle.Render("FOCUS")
-	if d.focusPomodoroCount > 0 {
-		title += "  " + StyleSubtle.Render(fmt.Sprintf("🍅 Pomodoro %d", d.focusPomodoroCount))
+	if d.focusBlockCount > 0 {
+		title += "  " + StyleSubtle.Render(fmt.Sprintf("Block %d", d.focusBlockCount))
 	}
 	timerStr := ""
 	if d.focusSessionMinutes > 0 {


### PR DESCRIPTION
## Summary

- Renames the focus mode work-period counter from "Pomodoro" to "Block" throughout the codebase — the concept is ours, not the Pomodoro Technique's
- Removes the 🍅 tomato emoji from break and focus overlay UI strings
- Renames internal fields (`focusPomodoroCount` → `focusBlockCount`, `PomodorosCompleted` → `BlocksCompleted`) and the wellness log JSON key (`pomodoros_completed` → `blocks_completed`)

## Test plan

- [x] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI: enter focus mode, complete a break, verify header shows "Block 1" (not "🍅 Pomodoro 1")

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description