### PR TITLE
Fix focus mode 'm' and 'r' key bindings

### DIFF
--- a/changelog.d/fix-focus-mode-m-r-keys.md
+++ b/changelog.d/fix-focus-mode-m-r-keys.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Pressing `m` or `r` while viewing an agent in fullscreen (`focusLaunch`) now correctly exits fullscreen and triggers the lifecycle transition instead of silently forwarding the keystroke to the agent terminal.
+- Pressing `m` in focus pipeline view now marks the session under the cursor, not the first matching session in the list.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -987,6 +987,40 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 						err:       err,
 					}
 				}
+			case "m":
+				sess := a.focusLaunchSession
+				a.resizeAgentForDashboard(a.focusLaunchAgent)
+				a.focusLaunchAgent = nil
+				a.focusLaunchSession = nil
+				a.dashboard.panelFocus = focusList
+				a.dashboard.scrollOffset = 0
+				if sess != nil && sess.LifecyclePhase() == agent.LifecycleInProgress && !sess.DoneAt().IsZero() {
+					sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
+					return a, a.fetchReviewDiffCmd(sess)
+				}
+				return a, nil
+			case "r":
+				a.resizeAgentForDashboard(a.focusLaunchAgent)
+				a.focusLaunchAgent = nil
+				a.focusLaunchSession = nil
+				a.dashboard.scrollOffset = 0
+				reviewItems := a.dashboard.reviewQueueSessions()
+				if len(reviewItems) == 0 {
+					a.dashboard.panelFocus = focusList
+					return a, nil
+				}
+				idx := a.focusQueueIndex
+				if idx >= len(reviewItems) {
+					idx = len(reviewItems) - 1
+				}
+				sess := reviewItems[idx].session
+				sess.SetLifecyclePhase(agent.LifecycleInReview)
+				a.reviewSession = sess
+				a.dashboard.panelFocus = focusReview
+				if _, ok := a.reviewDiffCache[sess.ID]; !ok {
+					return a, a.fetchReviewDiffCmd(sess)
+				}
+				return a, nil
 			default:
 				if msg.Text != "" {
 					a.focusLaunchAgent.SendText(msg.Text)
@@ -1159,14 +1193,14 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				return a, nil
 			case "m":
-				// Mark first Done-but-InProgress session as ReadyForReview.
-				for _, item := range a.dashboard.items {
-					if item.kind == listItemSession && item.session != nil &&
-						item.session.LifecyclePhase() == agent.LifecycleInProgress &&
-						!item.session.DoneAt().IsZero() {
-						item.session.SetLifecyclePhase(agent.LifecycleReadyForReview)
+				// Mark the session under the focus cursor as ReadyForReview.
+				inProgress := a.dashboard.allInProgressSessions()
+				if a.focusActiveIdx < len(inProgress) {
+					sess := inProgress[a.focusActiveIdx].session
+					if sess != nil && !sess.DoneAt().IsZero() {
+						sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
 						a.focusQueueIndex = 0
-						return a, a.fetchReviewDiffCmd(item.session)
+						return a, a.fetchReviewDiffCmd(sess)
 					}
 				}
 				return a, nil

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -996,6 +996,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.dashboard.scrollOffset = 0
 				if sess != nil && sess.LifecyclePhase() == agent.LifecycleInProgress && !sess.DoneAt().IsZero() {
 					sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
+					a.focusQueueIndex = 0
 					return a, a.fetchReviewDiffCmd(sess)
 				}
 				return a, nil

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2128,6 +2128,37 @@ func TestFocusLaunch_MKey_ExitsAndMarksReadyForReview(t *testing.T) {
 	}
 }
 
+// TestFocusLaunch_MKey_ResetsFocusQueueIndex verifies that pressing "m" from
+// focusLaunch resets focusQueueIndex to 0 so a subsequent "r" opens the
+// newly-queued session rather than a stale position.
+func TestFocusLaunch_MKey_ResetsFocusQueueIndex(t *testing.T) {
+	sess := &agent.Session{Name: "active"}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	sess.MarkDone()
+
+	app := NewApp()
+	app.width = 120
+	app.dashboard.width = 120
+	app.dashboard.height = 0
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sess},
+	}
+	app.dashboard.panelFocus = focusLaunch
+	app.focusLaunchAgent = &agent.Agent{}
+	app.focusLaunchSession = sess
+	app.focusQueueIndex = 2 // stale nonzero index
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	app = model.(App)
+
+	if app.focusQueueIndex != 0 {
+		t.Errorf("expected focusQueueIndex=0 after m, got %d", app.focusQueueIndex)
+	}
+}
+
 // TestFocusLaunch_MKey_NoopWhenDoneAtZero verifies that pressing "m" while in
 // focusLaunch exits fullscreen but does not change the lifecycle phase when
 // the session's DoneAt is zero (agents still running).

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2087,3 +2087,150 @@ func TestFocusModeBlocksDKey(t *testing.T) {
 		t.Errorf("expected view=ViewDashboard after d in focus mode, got %v", app.view)
 	}
 }
+
+// TestFocusLaunch_MKey_ExitsAndMarksReadyForReview verifies that pressing "m"
+// while viewing an agent in fullscreen exits focusLaunch and marks the session
+// ReadyForReview when the session is InProgress and DoneAt is set.
+func TestFocusLaunch_MKey_ExitsAndMarksReadyForReview(t *testing.T) {
+	sess := &agent.Session{Name: "active"}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	sess.MarkDone()
+
+	app := NewApp()
+	app.width = 120
+	app.dashboard.width = 120
+	// height=0 makes fixedTermHeight()<=0, skipping resize on the placeholder agent.
+	app.dashboard.height = 0
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sess},
+	}
+	app.dashboard.panelFocus = focusLaunch
+	app.focusLaunchAgent = &agent.Agent{}
+	app.focusLaunchSession = sess
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	app = model.(App)
+
+	if app.dashboard.panelFocus != focusList {
+		t.Errorf("expected panelFocus=focusList after m, got %v", app.dashboard.panelFocus)
+	}
+	if app.focusLaunchAgent != nil {
+		t.Error("expected focusLaunchAgent=nil after m")
+	}
+	if app.focusLaunchSession != nil {
+		t.Error("expected focusLaunchSession=nil after m")
+	}
+	if sess.LifecyclePhase() != agent.LifecycleReadyForReview {
+		t.Errorf("expected session phase=ReadyForReview, got %v", sess.LifecyclePhase())
+	}
+}
+
+// TestFocusLaunch_MKey_NoopWhenDoneAtZero verifies that pressing "m" while in
+// focusLaunch exits fullscreen but does not change the lifecycle phase when
+// the session's DoneAt is zero (agents still running).
+func TestFocusLaunch_MKey_NoopWhenDoneAtZero(t *testing.T) {
+	sess := &agent.Session{Name: "active"}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	// DoneAt is zero: agents are still running.
+
+	app := NewApp()
+	app.width = 120
+	app.dashboard.width = 120
+	app.dashboard.height = 0
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sess},
+	}
+	app.dashboard.panelFocus = focusLaunch
+	app.focusLaunchAgent = &agent.Agent{}
+	app.focusLaunchSession = sess
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	app = model.(App)
+
+	if app.dashboard.panelFocus != focusList {
+		t.Errorf("expected panelFocus=focusList after m, got %v", app.dashboard.panelFocus)
+	}
+	if sess.LifecyclePhase() != agent.LifecycleInProgress {
+		t.Errorf("expected session phase unchanged=InProgress, got %v", sess.LifecyclePhase())
+	}
+}
+
+// TestFocusLaunch_RKey_ExitsAndOpensReview verifies that pressing "r" while in
+// focusLaunch exits fullscreen and opens the review panel for the queued session.
+func TestFocusLaunch_RKey_ExitsAndOpensReview(t *testing.T) {
+	sessA := &agent.Session{Name: "active"}
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessR := &agent.Session{Name: "ready"}
+	sessR.SetLifecyclePhase(agent.LifecycleReadyForReview)
+
+	app := NewApp()
+	app.width = 120
+	app.dashboard.width = 120
+	app.dashboard.height = 0
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sessA},
+		{kind: listItemSession, repoPath: "/r", session: sessR},
+	}
+	app.dashboard.panelFocus = focusLaunch
+	app.focusLaunchAgent = &agent.Agent{}
+	app.focusLaunchSession = sessA
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	app = model.(App)
+
+	if app.dashboard.panelFocus != focusReview {
+		t.Fatalf("expected panelFocus=focusReview after r, got %v", app.dashboard.panelFocus)
+	}
+	if app.focusLaunchAgent != nil {
+		t.Error("expected focusLaunchAgent=nil after r")
+	}
+	if sessR.LifecyclePhase() != agent.LifecycleInReview {
+		t.Errorf("expected sessR phase=InReview, got %v", sessR.LifecyclePhase())
+	}
+}
+
+// TestFocusMode_MKey_IsCursorAware verifies that pressing "m" in focus pipeline
+// view marks the session under the cursor (focusActiveIdx), not the first matching
+// session in the list.
+func TestFocusMode_MKey_IsCursorAware(t *testing.T) {
+	sessA := &agent.Session{Name: "active-a"}
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessA.MarkDone()
+	sessB := &agent.Session{Name: "active-b"}
+	sessB.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessB.MarkDone()
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sessA},
+		{kind: listItemSession, repoPath: "/r", session: sessB},
+	}
+	app.focusCursorSection = focusSectionActive
+	app.focusActiveIdx = 1 // cursor on sessB, not sessA
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	app = model.(App)
+
+	if sessB.LifecyclePhase() != agent.LifecycleReadyForReview {
+		t.Errorf("expected sessB (cursor session) phase=ReadyForReview, got %v", sessB.LifecyclePhase())
+	}
+	if sessA.LifecyclePhase() != agent.LifecycleInProgress {
+		t.Errorf("expected sessA (non-cursor session) phase unchanged=InProgress, got %v", sessA.LifecyclePhase())
+	}
+}


### PR DESCRIPTION
## Summary

- **"m" and "r" intercepted in focusLaunch**: When viewing an agent in fullscreen, all keys previously hit the `default` handler and were forwarded to the agent terminal. Pressing `m` or `r` silently went to the agent instead of triggering lifecycle transitions. Added explicit cases before `default` in the focusLaunch key switch so they exit fullscreen and mark/review the session correctly.
- **"m" is now cursor-aware**: The `m` handler in focus pipeline view was iterating all items to find the *first* matching session, ignoring the focus cursor position. Changed to index into `allInProgressSessions()` via `focusActiveIdx` so the session under the cursor is marked, not the first one in the list.
- **focusQueueIndex reset on focusLaunch "m"**: The focusLaunch `m` path now resets `focusQueueIndex = 0` to match the focusList path, so a subsequent `r` opens the freshly-queued session rather than a stale position.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (pre-existing failures in `internal/config` and `internal/hook` are unrelated to this PR — confirmed present on `main`)
- [x] 5 new unit tests:
  - `TestFocusLaunch_MKey_ExitsAndMarksReadyForReview`
  - `TestFocusLaunch_MKey_ResetsFocusQueueIndex`
  - `TestFocusLaunch_MKey_NoopWhenDoneAtZero`
  - `TestFocusLaunch_RKey_ExitsAndOpensReview`
  - `TestFocusMode_MKey_IsCursorAware`
- [ ] Manual TUI: enter focus mode (`f`), open agent in fullscreen (space/enter), press `m` → exits fullscreen and marks session ReadyForReview; press `r` → exits fullscreen and opens review panel; in pipeline view navigate cursor to a finished session and press `m` → that specific session moves to REVIEW QUEUE

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — added `changelog.d/fix-focus-mode-m-r-keys.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description