### PR TITLE
Fix multi-repo soft agent limit bypass in focus mode

### DIFF
--- a/changelog.d/fix-multirepo-soft-agent-limit.md
+++ b/changelog.d/fix-multirepo-soft-agent-limit.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Multi-repo users now see the focus-mode `MaxConcurrentAgents` wellness warning when pressing `n` to create a new agent; previously the repo picker opened immediately, bypassing the two-press guard that single-repo users already had

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1192,6 +1192,17 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			case "n":
 				if a.cfg != nil && len(a.cfg.Repos) > 1 {
+					// Apply the same soft agent-count guard as the single-repo
+					// path before opening the picker.
+					resolved := a.resolvedCache[a.activeRepo]
+					if resolved.MaxConcurrentAgents > 0 && a.activeAgentCount() >= resolved.MaxConcurrentAgents {
+						if !a.newAgentPending {
+							a.newAgentPending = true
+							a.setError(fmt.Sprintf("n again to override — %d+ agents shown to reduce productivity", resolved.MaxConcurrentAgents))
+							return a, nil
+						}
+						a.newAgentPending = false
+					}
 					var options []string
 					activeIdx := 0
 					for i, repo := range a.cfg.Repos {
@@ -1207,11 +1218,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return a, nil
 				}
 				// Single repo: exits this case without returning, so control
-				// continues past this switch to the general "n" handler below
-				// (which includes the agent-count / backlog soft-limit checks).
-				// Multi-repo path skips those checks intentionally: picker
-				// navigation clears the pending flags anyway, and the user's
-				// explicit repo selection signals clear intent.
+				// falls through to the general "n" handler below, which contains
+				// the agent-count and backlog soft-limit checks.
 			}
 		}
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1706,6 +1706,98 @@ func TestSoftAgentLimitGuard(t *testing.T) {
 	}
 }
 
+// TestSoftAgentLimitGuardMultiRepo verifies the two-press 'n' guard in focus
+// mode applies to the multi-repo path (picker) just like the single-repo path.
+func TestSoftAgentLimitGuardMultiRepo(t *testing.T) {
+	requireClaude(t)
+	dir, err := os.MkdirTemp("", "baton-softlimit-multi-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "init")
+
+	mgr := agent.NewManager(dir, config.ResolvedSettings{
+		BypassPermissions:   true,
+		AgentProgram:        "claude",
+		MaxConcurrentAgents: 1,
+	})
+	defer mgr.Shutdown()
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.resolvedCache[dir] = config.ResolvedSettings{
+		BypassPermissions:   true,
+		AgentProgram:        "claude",
+		MaxConcurrentAgents: 1,
+	}
+	// Two repos triggers the multi-repo branch.
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}, {Path: "/fake/other"}}}
+
+	// Create the first agent to reach the limit.
+	app = createAgent(t, app)
+	if app.err != "" {
+		t.Fatalf("Error creating first agent: %s", app.err)
+	}
+	if mgr.AgentCount() != 1 {
+		t.Fatalf("Expected 1 agent, got %d", mgr.AgentCount())
+	}
+
+	// Return to list focus so 'n' reaches the app-level handler.
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
+	app = model.(App)
+	if app.dashboard.panelFocus != focusList {
+		t.Fatalf("Expected focusList after ctrl+e, got %v", app.dashboard.panelFocus)
+	}
+
+	// Enable focus mode.
+	app.focusModeActive = true
+
+	// First 'n' press: should warn and set newAgentPending; picker must NOT open.
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	app = model.(App)
+	if cmd != nil {
+		msg := cmd()
+		if _, ok := msg.(createResultMsg); ok {
+			t.Fatal("Expected no agent creation on first 'n' press at limit")
+		}
+	}
+	if !app.newAgentPending {
+		t.Fatal("Expected newAgentPending=true after first 'n' at limit")
+	}
+	if app.err == "" {
+		t.Fatal("Expected warning message after first 'n' at limit")
+	}
+	if app.repoPickerActive {
+		t.Fatal("Expected repoPickerActive=false on first 'n' at limit")
+	}
+
+	// Second 'n' press: should clear pending and open the picker.
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
+	app = model.(App)
+	if app.newAgentPending {
+		t.Fatal("Expected newAgentPending=false after second 'n'")
+	}
+	if !app.repoPickerActive {
+		t.Fatal("Expected repoPickerActive=true after second 'n' override")
+	}
+}
+
 // TestClampToRepo verifies that clampToRepo always lands on a listItemRepo row.
 func TestClampToRepo(t *testing.T) {
 	sess := &agent.Session{Name: "s"}


### PR DESCRIPTION
## Summary

- Multi-repo users were bypassing the `MaxConcurrentAgents` wellness guard in focus mode: pressing `n` immediately opened the repo picker, skipping the two-press warning that single-repo users already saw
- Added the same `newAgentPending` double-press guard inside the multi-repo branch before the picker opens — first press warns, second press proceeds
- Updated the stale comment that incorrectly claimed the bypass was intentional
- Added `TestSoftAgentLimitGuardMultiRepo` to verify both the warning and override paths for the multi-repo branch

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `go test ./internal/tui/... -run TestSoftAgentLimit` — both `TestSoftAgentLimitGuard` and `TestSoftAgentLimitGuardMultiRepo` pass
- [ ] Manual TUI: launch baton with 2+ repos configured, enable focus mode, create 3 sessions (with `MaxConcurrentAgents: 3`), press `n` — confirm warning appears; press `n` again — confirm picker opens

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — added `changelog.d/fix-multirepo-soft-agent-limit.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description