### PR TITLE
Focus mode: surface 'may need input' badge for idle agents with trailing ?

### DIFF
--- a/changelog.d/focus-mode-asking-question-badge.md
+++ b/changelog.d/focus-mode-asking-question-badge.md
@@ -1,0 +1,3 @@
+### Added
+
+Focus mode session badge now shows "? N idle — may need input" (amber) when an idle agent's last terminal output ended with a "?", distinguishing an informal question from a completed task.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -5,14 +5,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
+	xvt "github.com/charmbracelet/x/vt"
 	"github.com/devenjarvis/baton/internal/hook"
 	bpty "github.com/devenjarvis/baton/internal/pty"
 	"github.com/devenjarvis/baton/internal/vt"
-
-	xvt "github.com/charmbracelet/x/vt"
 )
 
 // Agent ties together a PTY and VT terminal into a managed unit.
@@ -34,6 +35,7 @@ type Agent struct {
 	hasClaudeName    bool
 	status           Status
 	waitingReason    string
+	askingQuestion   bool
 	lastOutput       time.Time
 	lastInput        time.Time
 	composing        bool
@@ -417,6 +419,23 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 		// Claude finished its turn; the user is now in control. Clear the
 		// composing flag so input-display logic returns to its idle baseline.
 		a.composing = false
+		// Scan the visible viewport to find the last non-empty line and detect
+		// a trailing "?". RenderRegion holds only the terminal's own emulator
+		// lock; there is no a.mu path that would invert the order, so holding
+		// a.mu here is safe.
+		h := a.terminal.Height()
+		a.askingQuestion = false
+		if h > 0 {
+			raw := ansi.Strip(a.terminal.RenderRegion(0, h-1))
+			lines := strings.Split(raw, "\n")
+			for i := len(lines) - 1; i >= 0; i-- {
+				line := strings.TrimSpace(lines[i])
+				if line != "" {
+					a.askingQuestion = strings.HasSuffix(line, "?")
+					break
+				}
+			}
+		}
 		if a.status != StatusIdle {
 			a.status = StatusIdle
 			return true
@@ -454,6 +473,7 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 			return false
 		}
 		a.waitingReason = ""
+		a.askingQuestion = false
 		a.chimedForTurn = false
 		if a.status != StatusActive {
 			a.status = StatusActive
@@ -623,6 +643,15 @@ func (a *Agent) WaitingReason() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.waitingReason
+}
+
+// AskingQuestion reports whether the agent's last terminal output (at the time
+// of the most recent KindStop event) ended with a "?", suggesting Claude asked
+// an informal question rather than finishing a task. Cleared on KindUserPromptSubmit.
+func (a *Agent) AskingQuestion() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.askingQuestion
 }
 
 // SetDisplayName sets the human-readable display name for this agent.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -556,3 +556,75 @@ func TestShutdownCleansAll(t *testing.T) {
 		t.Errorf("expected 0 agents after shutdown, got %d", mgr.AgentCount())
 	}
 }
+
+func TestStopHookSetsAskingQuestionOnTrailingQuestion(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-asking-q", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "printf 'Is this working?'; cat")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the output to render into the terminal.
+	time.Sleep(500 * time.Millisecond)
+
+	a.OnHookEvent(hookEvent("stop"))
+
+	if !a.AskingQuestion() {
+		t.Error("expected AskingQuestion true after Stop hook with trailing '?'")
+	}
+}
+
+func TestStopHookNoAskingQuestionWithoutTrailingQuestion(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-no-asking-q", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "printf 'Task complete.'; cat")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	a.OnHookEvent(hookEvent("stop"))
+
+	if a.AskingQuestion() {
+		t.Error("expected AskingQuestion false after Stop hook with non-question output")
+	}
+}
+
+func TestUserPromptSubmitClearsAskingQuestion(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-clear-asking-q", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "echo ready; cat")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	// Set askingQuestion directly to simulate a prior Stop with trailing "?".
+	a.mu.Lock()
+	a.askingQuestion = true
+	a.mu.Unlock()
+
+	a.OnHookEvent(hookEvent("user-prompt-submit"))
+
+	if a.AskingQuestion() {
+		t.Error("expected AskingQuestion cleared after KindUserPromptSubmit")
+	}
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -794,10 +794,10 @@ func (d dashboardModel) allInProgressSessions() []listItem {
 }
 
 // sessionFocusStatus returns a styled inline status badge for a session row in
-// the unified SESSIONS list. Priority: Error > Waiting > finished (DoneAt set)
+// the unified SESSIONS list. Priority: Error > Waiting > May Need Input > finished (DoneAt set)
 // > normal (N active, M idle).
 func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
-	var waitingCount, activeCount, idleCount int
+	var waitingCount, activeCount, idleCount, idleAskingCount int
 	var firstWaitingReason string
 	var hasError bool
 	for _, item := range d.items {
@@ -816,6 +816,9 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 			activeCount++
 		case agent.StatusIdle:
 			idleCount++
+			if item.agent.AskingQuestion() {
+				idleAskingCount++
+			}
 		}
 	}
 	if hasError {
@@ -827,6 +830,9 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 			badge += " — " + truncateVisible(firstWaitingReason, 40)
 		}
 		return lipgloss.NewStyle().Foreground(ColorWaiting).Render(badge)
+	}
+	if idleAskingCount > 0 {
+		return lipgloss.NewStyle().Foreground(ColorWarning).Render(fmt.Sprintf("? %d idle — may need input", idleAskingCount))
 	}
 	if !sess.DoneAt().IsZero() {
 		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ finished — awaiting prompt")


### PR DESCRIPTION
## Summary

- Adds an \`askingQuestion bool\` field to the \`Agent\` struct, set on \`KindStop\` when the last non-empty visible terminal line ends with \`"?"\`
- Clears \`askingQuestion\` on \`KindUserPromptSubmit\`, same as \`waitingReason\`
- Exposes \`AskingQuestion() bool\` accessor (same RLock pattern as \`WaitingReason()\`)
- Focus mode \`sessionFocusStatus()\` now renders \`"? N idle — may need input"\` in amber (\`ColorWarning\`) when any idle agent is asking a question; priority is Error > Waiting > May Need Input > Finished > Normal
- When Claude asks an informal question (no permission prompt), the agent fires \`KindStop\` and drops to \`StatusIdle\`. Previously the focus-mode badge showed no hint that input was expected — this surfaces that signal without adding a new status enum value

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -race ./...\`
- [x] New unit tests: \`TestStopHookSetsAskingQuestionOnTrailingQuestion\`, \`TestStopHookNoAskingQuestionWithoutTrailingQuestion\`, \`TestUserPromptSubmitClearsAskingQuestion\`
- [ ] Manual TUI: in focus mode, have a Claude agent send a message ending in "?" without a formal permission prompt — session badge should switch from "N active, N idle" to "? 1 idle — may need input" in amber; after replying, badge should return to normal

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — changelog fragment added under `changelog.d/`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description — `AskingQuestion() bool` added, noted above