### PR TITLE
Focus mode: rich 3-line session cards with Haiku task summaries

### DIFF
--- a/changelog.d/focus-mode-rich-session-cards.md
+++ b/changelog.d/focus-mode-rich-session-cards.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Focus mode session list now shows 3-line cards: name + status badge on line 1, task summary (Haiku-generated) on line 2, waiting reason / idle time + elapsed on line 3
+- Sessions with errors or waiting agents sort to the top of the SESSIONS list; active sessions sort above idle
+- Review queue entries now show 2-line cards: name + PR indicator on line 1, task summary + age on line 2
+- Task summaries are generated asynchronously by Haiku on the first actionable prompt and update in place without blocking

--- a/internal/agent/haikuname.go
+++ b/internal/agent/haikuname.go
@@ -81,11 +81,11 @@ func DefaultTaskSummarizer() TaskSummarizer {
 		}
 		claudePath, err := exec.LookPath("claude")
 		if err != nil {
-			return "", nil
+			return "", nil //nolint:nilerr // advisory display feature; absence of claude is not an error for callers
 		}
 		text, err := runClaudeHaikuText(ctx, claudePath, taskSummaryPrompt+prompt)
 		if err != nil {
-			return "", nil
+			return "", nil //nolint:nilerr // swallow subprocess errors; callers treat "" as "no summary available"
 		}
 		return text, nil
 	}

--- a/internal/agent/haikuname.go
+++ b/internal/agent/haikuname.go
@@ -19,6 +19,17 @@ import (
 // slugify() so callers can use it without additional sanitization.
 type BranchNamer func(ctx context.Context, instruction string) (string, error)
 
+// TaskSummarizer asynchronously summarizes a user prompt into a short
+// plain-English description (10-15 words) suitable for display in the TUI.
+// Unlike BranchNamer the result is NOT slugified — it is display text.
+// Returns ("", nil) on empty prompt; returns ("", err) on failure so callers
+// can fall back gracefully without panicking.
+type TaskSummarizer func(ctx context.Context, prompt string) (string, error)
+
+// taskSummaryPrompt is prepended to the user prompt when asking Haiku for a
+// short plain-English task description.
+const taskSummaryPrompt = "Describe this task in 10-15 words of plain English, no punctuation at the end:\n\n"
+
 const claudeHaikuModel = "claude-haiku-4-5"
 
 // ErrClaudeNotFound is returned when the `claude` binary is not on PATH.
@@ -58,7 +69,32 @@ func DefaultBranchNamer() BranchNamer {
 	}
 }
 
-func runClaudeHaiku(ctx context.Context, claudePath, instruction string) (string, error) {
+// DefaultTaskSummarizer returns a TaskSummarizer that shells out to
+// `claude -p --model claude-haiku-4-5` to produce a short plain-English
+// description of the user's task. The result is NOT slugified — it is display
+// text for the TUI. Returns "" on empty prompt, and "" (not an error) on any
+// subprocess failure so callers can fall back gracefully.
+func DefaultTaskSummarizer() TaskSummarizer {
+	return func(ctx context.Context, prompt string) (string, error) {
+		if strings.TrimSpace(prompt) == "" {
+			return "", nil
+		}
+		claudePath, err := exec.LookPath("claude")
+		if err != nil {
+			return "", nil
+		}
+		text, err := runClaudeHaikuText(ctx, claudePath, taskSummaryPrompt+prompt)
+		if err != nil {
+			return "", nil
+		}
+		return text, nil
+	}
+}
+
+// runClaudeHaikuText runs `claude -p --model claude-haiku-4-5` with instruction
+// on stdin and returns the trimmed raw stdout. No slugification is applied.
+// This is the shared subprocess path; runClaudeHaiku adds slugification on top.
+func runClaudeHaikuText(ctx context.Context, claudePath, instruction string) (string, error) {
 	cmd := exec.CommandContext(ctx, claudePath, "-p", "--model", claudeHaikuModel)
 	cmd.Stdin = strings.NewReader(instruction)
 	// Strip baton's hook-wiring env vars so the Haiku subprocess does not
@@ -80,7 +116,16 @@ func runClaudeHaiku(ctx context.Context, claudePath, instruction string) (string
 		return "", fmt.Errorf("claude haiku: %w (stderr=%q)", err, strings.TrimSpace(stderr.String()))
 	}
 
-	slug := slugify(strings.TrimSpace(stdout.String()))
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func runClaudeHaiku(ctx context.Context, claudePath, instruction string) (string, error) {
+	raw, err := runClaudeHaikuText(ctx, claudePath, instruction)
+	if err != nil {
+		return "", err
+	}
+
+	slug := slugify(raw)
 	if slug == "" {
 		return "", ErrEmptySlug
 	}

--- a/internal/agent/haikuname.go
+++ b/internal/agent/haikuname.go
@@ -22,8 +22,8 @@ type BranchNamer func(ctx context.Context, instruction string) (string, error)
 // TaskSummarizer asynchronously summarizes a user prompt into a short
 // plain-English description (10-15 words) suitable for display in the TUI.
 // Unlike BranchNamer the result is NOT slugified — it is display text.
-// Returns ("", nil) on empty prompt; returns ("", err) on failure so callers
-// can fall back gracefully without panicking.
+// Returns ("", nil) on empty prompt and on any subprocess failure — callers
+// should treat "" as "no summary available" and fall back gracefully.
 type TaskSummarizer func(ctx context.Context, prompt string) (string, error)
 
 // taskSummaryPrompt is prepended to the user prompt when asking Haiku for a

--- a/internal/agent/haikuname_test.go
+++ b/internal/agent/haikuname_test.go
@@ -447,3 +447,116 @@ func TestCallNamerWithRetry_LogsEachAttempt(t *testing.T) {
 		t.Errorf("second log entry: %+v, want attempt=2 suffix=ok-slug err=nil", seen[1])
 	}
 }
+
+// TestDefaultTaskSummarizer_NotNil verifies that DefaultTaskSummarizer returns
+// a non-nil callable.
+func TestDefaultTaskSummarizer_NotNil(t *testing.T) {
+	s := DefaultTaskSummarizer()
+	if s == nil {
+		t.Fatal("DefaultTaskSummarizer() returned nil")
+	}
+}
+
+// TestDefaultTaskSummarizer_EmptyPrompt verifies that an empty (or whitespace)
+// prompt returns "" without panic and without error.
+func TestDefaultTaskSummarizer_EmptyPrompt(t *testing.T) {
+	s := DefaultTaskSummarizer()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for _, prompt := range []string{"", "   ", "\t\n"} {
+		got, err := s(ctx, prompt)
+		if err != nil {
+			t.Errorf("prompt=%q: unexpected error: %v", prompt, err)
+		}
+		if got != "" {
+			t.Errorf("prompt=%q: got %q, want \"\"", prompt, got)
+		}
+	}
+}
+
+// TestDefaultTaskSummarizer_ClaudeMissing verifies that when claude is not on
+// PATH the summarizer returns ("", nil) — no panic, no error.
+func TestDefaultTaskSummarizer_ClaudeMissing(t *testing.T) {
+	empty := t.TempDir()
+	t.Setenv("PATH", empty)
+
+	s := DefaultTaskSummarizer()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	got, err := s(ctx, "implement dark mode for the settings panel")
+	if err != nil {
+		t.Errorf("expected nil error when claude is absent, got: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string when claude is absent, got: %q", got)
+	}
+}
+
+// TestDefaultTaskSummarizer_Success verifies that when a fake claude echoes a
+// plain-English phrase the summarizer returns that phrase verbatim (no slugify).
+func TestDefaultTaskSummarizer_Success(t *testing.T) {
+	dir := t.TempDir()
+	const response = "add dark mode to the settings panel"
+	writeFakeClaude(t, dir, response, 0)
+	withPATH(t, dir)
+
+	s := DefaultTaskSummarizer()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	got, err := s(ctx, "implement dark mode for the settings panel")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != response {
+		t.Errorf("got %q, want %q", got, response)
+	}
+}
+
+// TestDefaultTaskSummarizer_NonZeroExitReturnsEmpty verifies that a non-zero
+// claude exit results in ("", nil) — the summarizer swallows the error.
+func TestDefaultTaskSummarizer_NonZeroExitReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeClaude(t, dir, "some text", 1)
+	withPATH(t, dir)
+
+	s := DefaultTaskSummarizer()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	got, err := s(ctx, "implement dark mode")
+	if err != nil {
+		t.Errorf("expected nil error on subprocess failure, got: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string on subprocess failure, got: %q", got)
+	}
+}
+
+// TestDefaultTaskSummarizer_OutputNotSlugified verifies that the summarizer
+// returns plain text with spaces — NOT a hyphen-separated slug.
+func TestDefaultTaskSummarizer_OutputNotSlugified(t *testing.T) {
+	dir := t.TempDir()
+	// Response with spaces — would become "implement dark mode" if not slugified,
+	// or "implement-dark-mode" if slugified.
+	const response = "implement dark mode for settings"
+	writeFakeClaude(t, dir, response, 0)
+	withPATH(t, dir)
+
+	s := DefaultTaskSummarizer()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	got, err := s(ctx, "add dark mode")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "-") {
+		t.Errorf("output appears slugified (contains hyphen): %q", got)
+	}
+	if got != response {
+		t.Errorf("got %q, want %q", got, response)
+	}
+}

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -1701,3 +1701,287 @@ func TestSmartBranchRename_TemplateWithoutPlaceholderAppendsPrompt(t *testing.T)
 		t.Errorf("rendered instruction = %q, want %q", got, wantInstruction)
 	}
 }
+
+// stubTaskSummarizer is a TaskSummarizer that returns a fixed result and counts calls.
+type stubTaskSummarizer struct {
+	result string
+	calls  atomic.Int32
+	block  chan struct{} // if non-nil, blocks on receive before returning
+}
+
+func (s *stubTaskSummarizer) fn() TaskSummarizer {
+	return func(ctx context.Context, prompt string) (string, error) {
+		s.calls.Add(1)
+		if s.block != nil {
+			select {
+			case <-s.block:
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		}
+		return s.result, nil
+	}
+}
+
+// waitForTaskSummary polls sess.HasTaskSummary() until it returns true or the deadline elapses.
+func waitForTaskSummary(t *testing.T, sess *Session, d time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if sess.HasTaskSummary() {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// TestTaskSummarizerTriggeredOnFirstActionablePrompt verifies that the first
+// actionable UserPromptSubmit causes the TaskSummarizer goroutine to run and
+// sets sess.HasTaskSummary() to true with the expected summary text.
+func TestTaskSummarizerTriggeredOnFirstActionablePrompt(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	stub := &stubTaskSummarizer{result: "fix the broken login flow"}
+	mgr.SetTaskSummarizer(stub.fn())
+	// Disable branch namer to keep the test focused on task summary.
+	mgr.SetBranchNamer(func(_ context.Context, _ string) (string, error) {
+		return "stub-branch", nil
+	})
+
+	cfg := Config{Name: "task-summary-test", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "fix the broken login flow",
+	}); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+
+	if !waitForTaskSummary(t, sess, 3*time.Second) {
+		t.Fatal("HasTaskSummary() did not become true within 3s")
+	}
+	if got := sess.TaskSummary(); got != "fix the broken login flow" {
+		t.Errorf("TaskSummary() = %q, want %q", got, "fix the broken login flow")
+	}
+	if stub.calls.Load() != 1 {
+		t.Errorf("summarizer call count = %d, want 1", stub.calls.Load())
+	}
+}
+
+// TestTaskSummarizerSkipsNonActionablePrompt verifies that slash-only and
+// empty prompts do not trigger the task summarizer.
+func TestTaskSummarizerSkipsNonActionablePrompt(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	stub := &stubTaskSummarizer{result: "should not be called"}
+	mgr.SetTaskSummarizer(stub.fn())
+	mgr.SetBranchNamer(nil)
+
+	cfg := Config{Name: "task-summary-skip", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	// Non-actionable: slash-only prompt.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "/clear",
+	}); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	if sess.HasTaskSummary() {
+		t.Error("slash-only prompt should not set HasTaskSummary")
+	}
+	if stub.calls.Load() != 0 {
+		t.Errorf("summarizer should not be called for slash-only prompt, got %d", stub.calls.Load())
+	}
+}
+
+// TestTaskSummarizerNilDisablesFeature verifies that SetTaskSummarizer(nil)
+// disables the feature gracefully — no panic, no goroutine spawned.
+func TestTaskSummarizerNilDisablesFeature(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	mgr.SetTaskSummarizer(nil)
+	mgr.SetBranchNamer(nil)
+
+	cfg := Config{Name: "task-summary-nil", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "do some real work",
+	}); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	if sess.HasTaskSummary() {
+		t.Error("nil summarizer should not set HasTaskSummary")
+	}
+}
+
+// TestTaskSummarizerDoubleDispatchGated verifies that a second UserPromptSubmit
+// arriving while the first summarizer call is still running does not dispatch
+// a second goroutine.
+func TestTaskSummarizerDoubleDispatchGated(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	release := make(chan struct{})
+	stub := &stubTaskSummarizer{result: "slow-summary", block: release}
+	mgr.SetTaskSummarizer(stub.fn())
+	mgr.SetBranchNamer(func(_ context.Context, _ string) (string, error) {
+		return "stub", nil
+	})
+
+	cfg := Config{Name: "task-summary-gate", Task: "test", Rows: 24, Cols: 80}
+	sess, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "first prompt",
+	}); err != nil {
+		t.Fatalf("SendEvent 1: %v", err)
+	}
+
+	// Wait for the first call to actually enter the stub.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && stub.calls.Load() < 1 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if stub.calls.Load() != 1 {
+		t.Fatal("first summarizer call did not start")
+	}
+
+	// Send a second prompt — it must NOT trigger a second summarizer call.
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "second prompt (should be gated)",
+	}); err != nil {
+		t.Fatalf("SendEvent 2: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if got := stub.calls.Load(); got != 1 {
+		t.Errorf("summarizer call count = %d, want 1 (second prompt should be gated)", got)
+	}
+
+	// Release the first call and check HasTaskSummary becomes true.
+	close(release)
+	if !waitForTaskSummary(t, sess, 2*time.Second) {
+		t.Fatal("HasTaskSummary() did not become true after release")
+	}
+	if n := stub.calls.Load(); n != 1 {
+		t.Errorf("final summarizer call count = %d, want 1", n)
+	}
+}
+
+// TestTaskSummarizerShutdownCancelsInflight verifies that Manager.Shutdown
+// cancels the in-flight summarizer goroutine so it doesn't outlive the manager.
+func TestTaskSummarizerShutdownCancelsInflight(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+
+	// Block the summarizer forever — only ctx cancellation should release it.
+	stub := &stubTaskSummarizer{result: "never-returns", block: make(chan struct{})}
+	mgr.SetTaskSummarizer(stub.fn())
+	mgr.SetBranchNamer(func(_ context.Context, _ string) (string, error) {
+		return "stub", nil
+	})
+
+	cfg := Config{Name: "task-summary-shutdown", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindUserPromptSubmit,
+		AgentID: ag.ID,
+		Prompt:  "trigger a summary that will block",
+	}); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+
+	// Wait for the goroutine to actually enter the summarizer.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && stub.calls.Load() < 1 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if stub.calls.Load() < 1 {
+		t.Fatal("summarizer did not run before shutdown")
+	}
+
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		defer once.Do(func() { close(done) })
+		mgr.Shutdown()
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown did not return — summarizer goroutine likely leaked")
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -71,7 +71,8 @@ type Manager struct {
 	hookSocketPath string
 	hookDispatcher sync.WaitGroup
 
-	branchNamer BranchNamer
+	branchNamer    BranchNamer
+	taskSummarizer TaskSummarizer
 }
 
 // haikuNamePerAttemptTimeout bounds how long a single Haiku summarization
@@ -107,13 +108,14 @@ var haikuNameBackoff = []time.Duration{1 * time.Second, 3 * time.Second}
 // out of Active.
 func NewManager(repoPath string, settings config.ResolvedSettings) *Manager {
 	m := &Manager{
-		repoPath:     repoPath,
-		settings:     settings,
-		sessions:     make(map[string]*Session),
-		pendingNames: make(map[string]struct{}),
-		events:       make(chan Event, 64),
-		done:         make(chan struct{}),
-		branchNamer:  DefaultBranchNamer(),
+		repoPath:       repoPath,
+		settings:       settings,
+		sessions:       make(map[string]*Session),
+		pendingNames:   make(map[string]struct{}),
+		events:         make(chan Event, 64),
+		done:           make(chan struct{}),
+		branchNamer:    DefaultBranchNamer(),
+		taskSummarizer: DefaultTaskSummarizer(),
 	}
 
 	batonDir := filepath.Join(repoPath, ".baton")
@@ -149,6 +151,22 @@ func (m *Manager) SetBranchNamer(n BranchNamer) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.branchNamer = n
+}
+
+// SetTaskSummarizer overrides the TaskSummarizer used for generating plain-English
+// task descriptions. Passing nil disables the feature gracefully. Safe to call
+// while the manager is running — the summarizer is swapped atomically.
+func (m *Manager) SetTaskSummarizer(ts TaskSummarizer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.taskSummarizer = ts
+}
+
+// getTaskSummarizer returns the current TaskSummarizer under a read lock.
+func (m *Manager) getTaskSummarizer() TaskSummarizer {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.taskSummarizer
 }
 
 // hookSocketPath returns the unix socket path for a given repoPath.
@@ -198,6 +216,7 @@ func (m *Manager) dispatchHookEvents() {
 			if IsActionablePrompt(e.Prompt) {
 				sess.SetOriginalPrompt(e.Prompt)
 			}
+			m.maybeStartTaskSummary(sess)
 		}
 	}
 }
@@ -310,6 +329,55 @@ func (m *Manager) maybeRenameFromPrompt(sess *Session, a *Agent, prompt string) 
 		// fires so subscribers (PR scheduler, TUI) see a coherent snapshot.
 		sess.SetDisplayName(suffix)
 		m.emitBranchRenamed(sess, a, newBranch)
+	}()
+}
+
+// maybeStartTaskSummary generates a short plain-English task description from
+// the session's original prompt and stores it via Session.SetTaskSummary.
+// It reads sess.OriginalPrompt() (set idempotently by the dispatcher) so
+// slash-only and empty prompts that never stored an original prompt are
+// silently skipped. Session.TryStartTaskSummary gates double-dispatch so a
+// second prompt arriving while the summarizer is running is a no-op.
+func (m *Manager) maybeStartTaskSummary(sess *Session) {
+	if sess == nil {
+		return
+	}
+
+	prompt := sess.OriginalPrompt()
+	if prompt == "" {
+		return
+	}
+
+	ts := m.getTaskSummarizer()
+	if ts == nil {
+		return
+	}
+
+	if !sess.TryStartTaskSummary() {
+		return
+	}
+
+	m.watchers.Add(1)
+	go func() {
+		defer m.watchers.Done()
+		defer sess.finishTaskSummary()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		// Cancel the summarizer subprocess if the manager shuts down mid-call.
+		doneCh := make(chan struct{})
+		defer close(doneCh)
+		go func() {
+			select {
+			case <-m.done:
+				cancel()
+			case <-doneCh:
+			}
+		}()
+
+		summary, _ := ts(ctx, prompt)
+		sess.SetTaskSummary(summary)
 	}()
 }
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -29,6 +29,9 @@ type Session struct {
 	doneAt         time.Time
 	ownsBranch     bool   // true if this session created the branch (cleanup should delete it)
 	hookSocketPath string // absolute path to the manager's hook socket ("" disables hooks)
+	taskSummary    string // short summary of the session's task, set once by the summarizer goroutine
+	hasTaskSummary bool   // true once SetTaskSummary has been called
+	summarizing    bool   // true while an async task-summary goroutine is in flight; gates double-dispatch
 }
 
 // newSession creates a session with the given worktree.
@@ -522,4 +525,69 @@ func (s *Session) RestoreDoneAt(t time.Time) {
 // NewSessionForTest creates a Session for use in tests outside the agent package.
 func NewSessionForTest(id, name string) *Session {
 	return newSession(id, name, &git.WorktreeInfo{})
+}
+
+// TaskSummary returns the session's task summary. Empty until SetTaskSummary is called.
+func (s *Session) TaskSummary() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.taskSummary
+}
+
+// HasTaskSummary reports whether a task summary has been set.
+func (s *Session) HasTaskSummary() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.hasTaskSummary
+}
+
+// SetTaskSummary stores the task summary and marks hasTaskSummary=true.
+// It is safe to call with an empty string (haiku failed but we don't retry).
+func (s *Session) SetTaskSummary(summary string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.taskSummary = summary
+	s.hasTaskSummary = true
+}
+
+// TryStartTaskSummary atomically returns true if a task-summary goroutine should
+// start now, or false if one is already in flight or the session already has a
+// summary. Callers that receive true must call finishTaskSummary when done.
+func (s *Session) TryStartTaskSummary() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.hasTaskSummary || s.summarizing {
+		return false
+	}
+	s.summarizing = true
+	return true
+}
+
+// finishTaskSummary clears the in-flight summarizing flag. Called from the
+// deferred cleanup of the goroutine spawned after TryStartTaskSummary returns true.
+func (s *Session) finishTaskSummary() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.summarizing = false
+}
+
+// LastOutputTime returns the most recent lastOutput time across all non-shell
+// agents in this session. Returns the zero time if there are no such agents or
+// none have produced any output yet.
+func (s *Session) LastOutputTime() time.Time {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var max time.Time
+	for _, a := range s.agents {
+		if a.IsShell {
+			continue
+		}
+		a.mu.RLock()
+		t := a.lastOutput
+		a.mu.RUnlock()
+		if t.After(max) {
+			max = t
+		}
+	}
+	return max
 }

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -577,7 +577,7 @@ func (s *Session) finishTaskSummary() {
 func (s *Session) LastOutputTime() time.Time {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	var max time.Time
+	var latest time.Time
 	for _, a := range s.agents {
 		if a.IsShell {
 			continue
@@ -585,9 +585,9 @@ func (s *Session) LastOutputTime() time.Time {
 		a.mu.RLock()
 		t := a.lastOutput
 		a.mu.RUnlock()
-		if t.After(max) {
-			max = t
+		if t.After(latest) {
+			latest = t
 		}
 	}
-	return max
+	return latest
 }

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -692,3 +692,133 @@ func TestSession_RestoreDoneAt(t *testing.T) {
 		t.Errorf("second RestoreDoneAt: DoneAt = %v, want %v", got, ts2)
 	}
 }
+
+// --- Task summary tests ---
+
+func TestSession_TryStartTaskSummary_FirstCallReturnsTrue(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	if !s.TryStartTaskSummary() {
+		t.Error("TryStartTaskSummary() should return true on first call")
+	}
+}
+
+func TestSession_TryStartTaskSummary_ReturnsFalseIfSummarizing(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	if !s.TryStartTaskSummary() {
+		t.Fatal("expected true on first call")
+	}
+	// In-flight summarize: second call should return false.
+	if s.TryStartTaskSummary() {
+		t.Error("TryStartTaskSummary() should return false while summarizing is in flight")
+	}
+}
+
+func TestSession_TryStartTaskSummary_ReturnsFalseAfterHasSummary(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	s.SetTaskSummary("done")
+	// hasTaskSummary is now true; should never start again.
+	if s.TryStartTaskSummary() {
+		t.Error("TryStartTaskSummary() should return false once hasTaskSummary is true")
+	}
+}
+
+func TestSession_FinishTaskSummary_AllowsRetry(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	if !s.TryStartTaskSummary() {
+		t.Fatal("expected true on first call")
+	}
+	s.finishTaskSummary()
+	// After finish (no hasTaskSummary set), should be allowed to try again.
+	if !s.TryStartTaskSummary() {
+		t.Error("TryStartTaskSummary() should return true after finishTaskSummary clears the flag")
+	}
+}
+
+func TestSession_SetTaskSummary_SetsFieldsAndHasTaskSummary(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	if s.HasTaskSummary() {
+		t.Fatal("HasTaskSummary() should be false initially")
+	}
+	s.SetTaskSummary("implement auth")
+	if !s.HasTaskSummary() {
+		t.Error("HasTaskSummary() should be true after SetTaskSummary")
+	}
+	if got := s.TaskSummary(); got != "implement auth" {
+		t.Errorf("TaskSummary() = %q, want %q", got, "implement auth")
+	}
+}
+
+func TestSession_SetTaskSummary_EmptyStringStillSetsHasSummary(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	s.SetTaskSummary("")
+	if !s.HasTaskSummary() {
+		t.Error("HasTaskSummary() should be true even when summary is empty string")
+	}
+}
+
+// --- LastOutputTime tests ---
+
+func TestSession_LastOutputTime_ZeroWithNoAgents(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	if got := s.LastOutputTime(); !got.IsZero() {
+		t.Errorf("LastOutputTime() = %v, want zero", got)
+	}
+}
+
+func TestSession_LastOutputTime_ReturnsMaxAcrossAgents(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+
+	earlier := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	later := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	a1 := &Agent{ID: "a1", IsShell: false, CreatedAt: time.Now()}
+	a1.lastOutput = earlier
+	a2 := &Agent{ID: "a2", IsShell: false, CreatedAt: time.Now()}
+	a2.lastOutput = later
+
+	s.mu.Lock()
+	s.agents["a1"] = a1
+	s.agents["a2"] = a2
+	s.mu.Unlock()
+
+	if got := s.LastOutputTime(); !got.Equal(later) {
+		t.Errorf("LastOutputTime() = %v, want %v", got, later)
+	}
+}
+
+func TestSession_LastOutputTime_SkipsShellAgents(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+
+	shellTime := time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)
+	claudeTime := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	shell := &Agent{ID: "shell", IsShell: true, CreatedAt: time.Now()}
+	shell.lastOutput = shellTime
+	claude := &Agent{ID: "claude", IsShell: false, CreatedAt: time.Now()}
+	claude.lastOutput = claudeTime
+
+	s.mu.Lock()
+	s.agents["shell"] = shell
+	s.agents["claude"] = claude
+	s.mu.Unlock()
+
+	// Should return claudeTime, not shellTime (shell is excluded).
+	if got := s.LastOutputTime(); !got.Equal(claudeTime) {
+		t.Errorf("LastOutputTime() = %v, want %v (shell excluded)", got, claudeTime)
+	}
+}
+
+func TestSession_LastOutputTime_ZeroWhenOnlyShellAgents(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+
+	shell := &Agent{ID: "shell", IsShell: true, CreatedAt: time.Now()}
+	shell.lastOutput = time.Now()
+
+	s.mu.Lock()
+	s.agents["shell"] = shell
+	s.mu.Unlock()
+
+	if got := s.LastOutputTime(); !got.IsZero() {
+		t.Errorf("LastOutputTime() = %v, want zero (only shell agents)", got)
+	}
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -893,7 +893,7 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected boo
 		prefix = StyleActive.Render("> ")
 		nameStyled = lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
 	} else {
-		nameStyled = name
+		nameStyled = lineStyle.Render(name)
 	}
 	badge := d.sessionFocusStatus(sess)
 	left1 := prefix + nameStyled

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -875,6 +875,121 @@ func (d dashboardModel) sessionFocusPriority(sess *agent.Session) int {
 	return 3
 }
 
+// renderFocusSessionCard returns exactly 3 lines for a session card in focus mode.
+// Line 1: [prefix][name]  right-aligned [status badge]
+// Line 2: [task display]  right-aligned [branch]
+// Line 3: [waiting reason or idle indicator]  right-aligned [elapsed]
+func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected bool, width int) []string {
+	lineStyle := StyleSubtle
+	if selected {
+		lineStyle = lipgloss.NewStyle().Foreground(ColorText)
+	}
+
+	// --- Line 1 ---
+	prefix := "  "
+	name := sess.GetDisplayName()
+	var nameStyled string
+	if selected {
+		prefix = StyleActive.Render("> ")
+		nameStyled = lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
+	} else {
+		nameStyled = name
+	}
+	badge := d.sessionFocusStatus(sess)
+	left1 := prefix + nameStyled
+	line1 := rightAlign(left1, badge, width)
+
+	// --- Line 2 ---
+	var taskDisplay string
+	origPrompt := sess.OriginalPrompt()
+	switch {
+	case sess.HasTaskSummary() && sess.TaskSummary() != "":
+		taskDisplay = lineStyle.Render(truncateVisible(sess.TaskSummary(), width-30))
+	case sess.HasTaskSummary() && sess.TaskSummary() == "":
+		// Haiku failed — show raw prompt with same style
+		taskDisplay = lineStyle.Render(truncateVisible(origPrompt, width-30))
+	case !sess.HasTaskSummary() && origPrompt != "":
+		// Still generating — italic/muted to communicate pending state
+		taskDisplay = lipgloss.NewStyle().Foreground(ColorMuted).Italic(true).Render(truncateVisible(origPrompt, width-30))
+	default:
+		// No prompt yet
+		taskDisplay = lineStyle.Render("…")
+	}
+	left2 := "  " + taskDisplay
+	branch := ""
+	if sess.Worktree != nil {
+		branch = sess.Branch()
+	}
+	branchStr := lineStyle.Render(truncateVisible(branch, 24))
+	line2 := rightAlign(left2, branchStr, width)
+
+	// --- Line 3 ---
+	var waitingReason string
+	for _, item := range d.items {
+		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
+			continue
+		}
+		if item.agent.Status() == agent.StatusWaiting {
+			if waitingReason == "" {
+				waitingReason = item.agent.WaitingReason()
+			}
+		}
+	}
+
+	var statusLeft string
+	switch {
+	case waitingReason != "":
+		statusLeft = lineStyle.Render("  " + truncateVisible(waitingReason, width/2))
+	case sess.LastOutputTime().IsZero():
+		statusLeft = ""
+	default:
+		// Check if all agents are idle
+		anyActive := false
+		for _, item := range d.items {
+			if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
+				continue
+			}
+			st := item.agent.Status()
+			if st == agent.StatusActive || st == agent.StatusWaiting {
+				anyActive = true
+				break
+			}
+		}
+		if !anyActive {
+			idleMins := int(time.Since(sess.LastOutputTime()).Minutes())
+			statusLeft = lineStyle.Render(fmt.Sprintf("  idle %dm", idleMins))
+		} else {
+			statusLeft = ""
+		}
+	}
+
+	elapsed := sess.Elapsed()
+	var elapsedStr string
+	totalMins := int(elapsed.Minutes())
+	if totalMins >= 60 {
+		h := totalMins / 60
+		m := totalMins % 60
+		elapsedStr = fmt.Sprintf("%dh %dm", h, m)
+	} else {
+		elapsedStr = fmt.Sprintf("%dm", totalMins)
+	}
+	elapsedStyled := lineStyle.Render(elapsedStr)
+	line3 := rightAlign(statusLeft, elapsedStyled, width)
+
+	return []string{line1, line2, line3}
+}
+
+// rightAlign places left and right on the same line with padding so the total
+// visible width equals width. ANSI-escape-aware via lipgloss.Width.
+func rightAlign(left, right string, width int) string {
+	total := lipgloss.Width(left) + lipgloss.Width(right)
+	pad := width - total
+	if pad < 1 {
+		pad = 1
+	}
+	return left + strings.Repeat(" ", pad) + right
+}
+
 // renderPipelineWidget renders the 4-cell pipeline row.
 func (d dashboardModel) renderPipelineWidget(width int) string {
 	var inProgress, readyForReview, inReview, shipping int
@@ -1399,16 +1514,12 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, StyleSubtle.Render("SESSIONS"))
 		for i, item := range allSessions {
 			sess := item.session
-			name := sess.GetDisplayName()
 			selected := d.focusCursorSection == focusSectionActive && i == d.focusActiveIdx
-			prefix := "  "
-			nameStyled := name
-			if selected {
-				prefix = StyleActive.Render("> ")
-				nameStyled = lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
+			card := d.renderFocusSessionCard(sess, selected, width)
+			lines = append(lines, card...)
+			if i < len(allSessions)-1 {
+				lines = append(lines, "")
 			}
-			badge := d.sessionFocusStatus(sess)
-			lines = append(lines, fmt.Sprintf("%s%s  %s", prefix, nameStyled, badge))
 		}
 		lines = append(lines, "")
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1537,15 +1537,15 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 				mins := int(time.Since(sess.DoneAt()).Minutes())
 				age = fmt.Sprintf("done %dm ago", mins)
 			}
-			prefix := "  "
-			if selected {
-				prefix = "> "
-			}
 			var cardStyle lipgloss.Style
 			if selected {
 				cardStyle = lipgloss.NewStyle().Foreground(ColorWarning)
 			} else {
 				cardStyle = StyleSubtle
+			}
+			prefix := "  "
+			if selected {
+				prefix = cardStyle.Render("> ")
 			}
 
 			// Line 1: prefix + name (left) + prIndicator (right-aligned)

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -790,6 +790,17 @@ func (d dashboardModel) allInProgressSessions() []listItem {
 			result = append(result, item)
 		}
 	}
+	sort.SliceStable(result, func(i, j int) bool {
+		pi := d.sessionFocusPriority(result[i].session)
+		pj := d.sessionFocusPriority(result[j].session)
+		if pi != pj {
+			return pi < pj
+		}
+		// Same priority: sort by last output time DESC (more recent = earlier)
+		ti := result[i].session.LastOutputTime()
+		tj := result[j].session.LastOutputTime()
+		return ti.After(tj)
+	})
 	return result
 }
 
@@ -832,6 +843,36 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ finished — awaiting prompt")
 	}
 	return StyleSubtle.Render(fmt.Sprintf("%d active, %d idle", activeCount, idleCount))
+}
+
+// sessionFocusPriority returns an integer priority for sorting sessions in the
+// focus mode SESSIONS list. Lower values surface first (needs attention first).
+// 0=error, 1=waiting, 2=active, 3=idle/other.
+func (d dashboardModel) sessionFocusPriority(sess *agent.Session) int {
+	var hasError, hasWaiting, hasActive bool
+	for _, item := range d.items {
+		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
+			continue
+		}
+		switch item.agent.Status() {
+		case agent.StatusError:
+			hasError = true
+		case agent.StatusWaiting:
+			hasWaiting = true
+		case agent.StatusActive:
+			hasActive = true
+		}
+	}
+	if hasError {
+		return 0
+	}
+	if hasWaiting {
+		return 1
+	}
+	if hasActive {
+		return 2
+	}
+	return 3
 }
 
 // renderPipelineWidget renders the 4-cell pipeline row.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1547,16 +1547,36 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 			} else {
 				cardStyle = StyleSubtle
 			}
-			line := cardStyle.Render(fmt.Sprintf("%s%s", prefix, name))
+
+			// Line 1: prefix + name (left) + prIndicator (right-aligned)
+			line1 := prefix + cardStyle.Render(name)
 			if prEntry := d.prCache[sess.ID]; prEntry != nil {
-				if ind := prIndicator(prEntry); ind != "" {
-					line += "  " + ind
+				if prInd := prIndicator(prEntry); prInd != "" {
+					line1 = rightAlign(prefix+cardStyle.Render(name), prInd, width)
 				}
 			}
-			if age != "" {
-				line += StyleSubtle.Render("  " + age)
+
+			// Line 2: task display (left) + age (right-aligned)
+			var taskDisplay string
+			origPrompt := sess.OriginalPrompt()
+			switch {
+			case sess.HasTaskSummary() && sess.TaskSummary() != "":
+				taskDisplay = cardStyle.Render(truncateVisible(sess.TaskSummary(), width-30))
+			case origPrompt != "":
+				taskDisplay = cardStyle.Render(truncateVisible(origPrompt, width-30))
+			default:
+				taskDisplay = cardStyle.Render("…")
 			}
-			lines = append(lines, line)
+			left2 := "  " + taskDisplay
+			line2 := left2
+			if age != "" {
+				line2 = rightAlign(left2, StyleSubtle.Render(age), width)
+			}
+
+			lines = append(lines, line1, line2)
+			if i < len(reviewSessions)-1 {
+				lines = append(lines, "")
+			}
 		}
 		lines = append(lines, "")
 	}

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/devenjarvis/baton/internal/agent"
 	"github.com/devenjarvis/baton/internal/github"
+	"github.com/devenjarvis/baton/internal/hook"
 )
 
 func TestSelectionRect_Inactive(t *testing.T) {
@@ -327,5 +328,95 @@ func TestAdvanceTickers_EndReached_SnapsBack(t *testing.T) {
 	}
 	if !tk.pauseUntil.After(beforeSnap) {
 		t.Error("snap should set a fresh start pause")
+	}
+}
+
+// TestSessionFocusPriority_DefaultIsIdle verifies that a session whose agents
+// have not received any status-changing events (StatusStarting, the zero value)
+// reports priority 3 (idle/other).
+func TestSessionFocusPriority_DefaultIsIdle(t *testing.T) {
+	sess := &agent.Session{ID: "s1", Name: "s1"}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := &agent.Agent{Name: "a1"}
+
+	d := newDashboardModel()
+	d.prCache = make(map[string]*prCacheEntry)
+	d.items = []listItem{
+		{kind: listItemSession, session: sess},
+		{kind: listItemAgent, session: sess, agent: ag},
+	}
+
+	if got := d.sessionFocusPriority(sess); got != 3 {
+		t.Errorf("sessionFocusPriority with StatusStarting agent: got %d, want 3", got)
+	}
+}
+
+// TestSessionFocusPriority_ActiveBeforeIdle verifies that a session with an
+// active agent (priority 2) sorts ahead of one with only idle/default agents
+// (priority 3). We drive StatusActive via OnHookEvent(KindSessionStart).
+func TestSessionFocusPriority_ActiveBeforeIdle(t *testing.T) {
+	sessActive := &agent.Session{ID: "sa", Name: "active"}
+	sessActive.SetLifecyclePhase(agent.LifecycleInProgress)
+	agActive := &agent.Agent{Name: "ag-active"}
+	// Drive to StatusActive.
+	agActive.OnHookEvent(hook.Event{Kind: hook.KindSessionStart})
+
+	sessIdle := &agent.Session{ID: "si", Name: "idle"}
+	sessIdle.SetLifecyclePhase(agent.LifecycleInProgress)
+	agIdle := &agent.Agent{Name: "ag-idle"}
+
+	d := newDashboardModel()
+	d.prCache = make(map[string]*prCacheEntry)
+	d.items = []listItem{
+		{kind: listItemSession, session: sessActive},
+		{kind: listItemAgent, session: sessActive, agent: agActive},
+		{kind: listItemSession, session: sessIdle},
+		{kind: listItemAgent, session: sessIdle, agent: agIdle},
+	}
+
+	pa := d.sessionFocusPriority(sessActive)
+	pi := d.sessionFocusPriority(sessIdle)
+	if pa != 2 {
+		t.Errorf("active session priority: got %d, want 2", pa)
+	}
+	if pi != 3 {
+		t.Errorf("idle session priority: got %d, want 3", pi)
+	}
+}
+
+// TestAllInProgressSessions_SortOrder verifies that after building the result
+// slice, sessions with lower priority (more urgent) appear first.
+// Session order in d.items: idle first, then active — after sort active should
+// be first.
+func TestAllInProgressSessions_SortOrder(t *testing.T) {
+	sessIdle := &agent.Session{ID: "si", Name: "idle"}
+	sessIdle.SetLifecyclePhase(agent.LifecycleInProgress)
+	agIdle := &agent.Agent{Name: "ag-idle"}
+
+	sessActive := &agent.Session{ID: "sa", Name: "active"}
+	sessActive.SetLifecyclePhase(agent.LifecycleInProgress)
+	agActive := &agent.Agent{Name: "ag-active"}
+	// Drive to StatusActive.
+	agActive.OnHookEvent(hook.Event{Kind: hook.KindSessionStart})
+
+	d := newDashboardModel()
+	d.prCache = make(map[string]*prCacheEntry)
+	// Idle session is listed first in items; active second — sort should invert.
+	d.items = []listItem{
+		{kind: listItemSession, session: sessIdle},
+		{kind: listItemAgent, session: sessIdle, agent: agIdle},
+		{kind: listItemSession, session: sessActive},
+		{kind: listItemAgent, session: sessActive, agent: agActive},
+	}
+
+	sessions := d.allInProgressSessions()
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(sessions))
+	}
+	if sessions[0].session != sessActive {
+		t.Errorf("first session after sort should be active (priority 2), got %q", sessions[0].session.Name)
+	}
+	if sessions[1].session != sessIdle {
+		t.Errorf("second session after sort should be idle (priority 3), got %q", sessions[1].session.Name)
 	}
 }


### PR DESCRIPTION
## Summary

- **3-line session cards in focus mode** — each session now shows name + status badge on line 1, a Haiku-generated plain-English task summary on line 2 (falling back to the original prompt while generating), and idle/waiting context + elapsed time on line 3
- **Async task summarization** — on the first actionable prompt, `Manager` spawns a goroutine (mirroring the branch-rename flow) that calls `DefaultTaskSummarizer()` → `claude -p --model claude-haiku-4-5` with a 20s timeout; the result lands on `Session.taskSummary` and surfaces in the card within ~3–5s without blocking anything
- **Needs-attention-first sort** — `allInProgressSessions()` now uses `sort.SliceStable` ordered by priority (error=0, waiting=1, active=2, idle=3) then `LastOutputTime DESC`; sessions requiring attention float to the top automatically
- **2-line review queue cards** — REVIEW QUEUE entries gain a second line with task summary and right-aligned "done Xm ago" age; PR indicator stays right-aligned on line 1
- **Visual consistency** — `rightAlign()` helper uses `lipgloss.Width()` (ANSI-aware) for all right-aligned fields; unselected session names use `StyleSubtle` to match the rest of the muted card

**Why:** The 3-agent ceiling means a developer has 2–3 sessions to track. A single-line name+badge gives almost no context when returning to focus mode — "which session was the auth refactor?" requires clicking into each one. 3-line cards surface that context without any extra keystrokes, reducing the overhead of switching between sessions.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (39s agent, 4.7s tui)
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] Manual TUI: open focus mode (`f`), create 3 sessions via `n`, send a prompt to each; verify 3-line cards appear, task summary updates after ~5s, waiting session sorts above active

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (fragment added to `changelog.d/`)
- [x] New behavior has tests — 10 session tests, 6 TaskSummarizer tests, 5 manager integration tests, 3 TUI tests
- [x] No new public API surface without a note (TaskSummarizer type + SetTaskSummarizer are internal test hooks)