### PR TITLE
Default to focus mode on startup via focus_mode_enabled setting

### DIFF
--- a/changelog.d/focus-mode-on-startup.md
+++ b/changelog.d/focus-mode-on-startup.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The global `focus_mode_enabled` setting is now exclusively the startup default — when `true`, baton enters focus mode the moment the dashboard mounts. Saving the global settings form no longer overrides the live focus state; the runtime `f` toggle is the only thing that switches focus mode mid-session, so opening settings can't drag a working session out from under you. The form field is now labeled "Focus Mode on Startup" to match.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2151,10 +2151,11 @@ func (a App) updateGlobalConfig(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.dashboard.sidebarWidth = newResolved.SidebarWidth
 			a.resizeAllForDashboard()
 		}
-		// Refresh wellness settings from updated global config.
+		// Refresh wellness settings from updated global config. FocusModeEnabled
+		// is the startup default; saving the form must not override the live
+		// runtime toggle state — only `f` controls that.
 		a.focusSessionMinutes = newResolved.FocusSessionMinutes
 		a.focusBreakMinutes = newResolved.FocusBreakMinutes
-		a.focusModeActive = newResolved.FocusModeEnabled
 		a.view = ViewDashboard
 		return a, nil
 	case globalConfigCancelMsg:

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -1436,6 +1438,61 @@ func TestFocusModeToggle(t *testing.T) {
 	}
 	if app.lastReviewAt.IsZero() {
 		t.Error("Expected lastReviewAt set when exiting focus mode (entering review)")
+	}
+}
+
+// TestFocusModeStartupDefault verifies that when global settings have
+// focus_mode_enabled=true, an initAppMsg starts the app with focus mode active.
+// The setting is the startup default; the runtime `f` toggle is independent.
+func TestFocusModeStartupDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	enabled := true
+	gs := config.GlobalSettings{FocusModeEnabled: &enabled}
+	dir := filepath.Join(home, ".baton")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.Marshal(&gs)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	app := NewApp()
+	if app.focusModeActive {
+		t.Fatal("focusModeActive should default to false before init")
+	}
+
+	model, _ := app.Update(initAppMsg{cfg: &config.Config{}})
+	app = model.(App)
+
+	if !app.focusModeActive {
+		t.Fatal("focusModeActive should be true after init when focus_mode_enabled=true")
+	}
+}
+
+// TestGlobalConfigSaveDoesNotOverrideRuntimeFocus verifies that saving global
+// settings does not toggle the live focus mode state. The setting is the
+// startup default; the runtime `f` key is the only thing that switches it
+// mid-session.
+func TestGlobalConfigSaveDoesNotOverrideRuntimeFocus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	app := NewApp()
+	app.focusModeActive = true // user pressed `f`
+
+	enabled := false
+	settings := &config.GlobalSettings{FocusModeEnabled: &enabled}
+	model, _ := app.Update(globalConfigSaveMsg{settings: settings})
+	app = model.(App)
+
+	if !app.focusModeActive {
+		t.Fatal("focusModeActive should remain true after save; the saved setting is the startup default, not a runtime override")
 	}
 }
 

--- a/internal/tui/globalconfig.go
+++ b/internal/tui/globalconfig.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	fieldFocusMode    = "Focus Mode"
+	fieldFocusMode    = "Focus Mode on Startup"
 	fieldFocusSession = "Focus Session (min)"
 	fieldFocusBreak   = "Break (min)"
 	fieldMaxAgents    = "Max Concurrent Agents"


### PR DESCRIPTION
The global focus_mode_enabled setting now exclusively controls the
startup default — when true, baton enters focus mode the moment the
dashboard mounts. Saving the global settings form no longer overrides
the live focus state, so opening settings can't drag a working session
out from under the user. The runtime `f` toggle stays the only mid-session
switch. Form field renamed to "Focus Mode on Startup" to match.

https://claude.ai/code/session_017HwgiQFaQ1zaVDL4KJRLXi