### PR TITLE
Fix focus-mode session list flickering during agent output

### DIFF
--- a/changelog.d/fix-focus-mode-session-list-flicker.md
+++ b/changelog.d/fix-focus-mode-session-list-flicker.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Focus mode SESSIONS list no longer flickers/reorders while agents stream output. Same-priority sessions now sort by `Session.CreatedAt` instead of `Session.LastOutputTime()`, so the order only shifts when a session crosses a priority boundary (e.g. `active → waiting`, `idle → error`) — i.e. on a real state change.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -796,10 +796,11 @@ func (d dashboardModel) allInProgressSessions() []listItem {
 		if pi != pj {
 			return pi < pj
 		}
-		// Same priority: sort by last output time DESC (more recent = earlier)
-		ti := result[i].session.LastOutputTime()
-		tj := result[j].session.LastOutputTime()
-		return ti.After(tj)
+		// Same priority: stable order by CreatedAt ASC. Using a time-of-output
+		// key here would re-sort the list on every burst of agent output,
+		// causing visible flicker. The order should only change when a session
+		// crosses a priority boundary (i.e., a real state change).
+		return result[i].session.CreatedAt.Before(result[j].session.CreatedAt)
 	})
 	return result
 }

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -420,3 +420,38 @@ func TestAllInProgressSessions_SortOrder(t *testing.T) {
 		t.Errorf("second session after sort should be idle (priority 3), got %q", sessions[1].session.Name)
 	}
 }
+
+// TestAllInProgressSessions_StableWithinPriority pins the ordering of
+// same-priority sessions to CreatedAt rather than a continuously-changing
+// signal like LastOutputTime. This is what prevents focus-mode list flicker
+// while agents stream output: rebuilds during a render must produce the same
+// order until a session's status crosses a priority boundary.
+func TestAllInProgressSessions_StableWithinPriority(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	sessOlder := &agent.Session{ID: "so", Name: "older", CreatedAt: t0}
+	sessOlder.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	sessNewer := &agent.Session{ID: "sn", Name: "newer", CreatedAt: t0.Add(time.Minute)}
+	sessNewer.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	d := newDashboardModel()
+	d.prCache = make(map[string]*prCacheEntry)
+	// Insert newer first so we can confirm the sort actually runs and the
+	// result is keyed on CreatedAt, not insertion order.
+	d.items = []listItem{
+		{kind: listItemSession, session: sessNewer},
+		{kind: listItemSession, session: sessOlder},
+	}
+
+	for i := 0; i < 5; i++ {
+		sessions := d.allInProgressSessions()
+		if len(sessions) != 2 {
+			t.Fatalf("iter %d: expected 2 sessions, got %d", i, len(sessions))
+		}
+		if sessions[0].session != sessOlder || sessions[1].session != sessNewer {
+			t.Fatalf("iter %d: same-priority order should be CreatedAt ASC; got [%q, %q]",
+				i, sessions[0].session.Name, sessions[1].session.Name)
+		}
+	}
+}


### PR DESCRIPTION
The unified SESSIONS list in focus mode resorted on every render using
LastOutputTime() as the secondary key, so the order shifted continuously
while agents streamed output. Use Session.CreatedAt as the stable secondary
sort key instead — same-priority sessions keep their slot until one of
them actually crosses a priority boundary.