### PR TITLE
Focus mode: redesign SESSIONS cards with status stripe

### DIFF
--- a/changelog.d/focus-sessions-stripe.md
+++ b/changelog.d/focus-sessions-stripe.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Redesigned the focus-mode SESSIONS list. Each session card now leads with a colored vertical stripe whose color encodes status (red=error, magenta=waiting, amber=needs input, green=done, muted=running) and brightens to cyan for the selected card. The session name renders bold/white as a typographic anchor, the description always occupies two muted lines (so card height is constant regardless of summary length), and the bottom row consolidates branch, idle/waiting detail, and elapsed time into a single line.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/charmbracelet/x/vt v0.0.0-20260413165052-6921c759c913
 	github.com/creack/pty v1.1.24
 	github.com/google/go-github/v69 v69.2.0
+	github.com/muesli/termenv v0.16.0
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.2
 )
@@ -37,7 +38,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -882,108 +882,207 @@ func (d dashboardModel) sessionFocusPriority(sess *agent.Session) int {
 	return 3
 }
 
-// renderFocusSessionCard returns exactly 3 lines for a session card in focus mode.
-// Line 1: [prefix][name]  right-aligned [status badge]
-// Line 2: [task display]  right-aligned [branch]
-// Line 3: [waiting reason or idle indicator]  right-aligned [elapsed]
-func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected bool, width int) []string {
-	lineStyle := StyleSubtle
-	if selected {
-		lineStyle = lipgloss.NewStyle().Foreground(ColorText)
-	}
-
-	// --- Line 1 ---
-	prefix := "  "
-	name := sess.GetDisplayName()
-	var nameStyled string
-	if selected {
-		prefix = StyleActive.Render("> ")
-		nameStyled = lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
-	} else {
-		nameStyled = lineStyle.Render(name)
-	}
-	badge := d.sessionFocusStatus(sess)
-	left1 := prefix + nameStyled
-	line1 := rightAlign(left1, badge, width)
-
-	// --- Line 2 ---
-	var taskDisplay string
-	origPrompt := sess.OriginalPrompt()
-	switch {
-	case sess.HasTaskSummary() && sess.TaskSummary() != "":
-		taskDisplay = lineStyle.Render(truncateVisible(sess.TaskSummary(), width-30))
-	case sess.HasTaskSummary() && sess.TaskSummary() == "":
-		// Haiku failed — show raw prompt with same style
-		taskDisplay = lineStyle.Render(truncateVisible(origPrompt, width-30))
-	case !sess.HasTaskSummary() && origPrompt != "":
-		// Still generating — italic/muted to communicate pending state
-		taskDisplay = lipgloss.NewStyle().Foreground(ColorMuted).Italic(true).Render(truncateVisible(origPrompt, width-30))
-	default:
-		// No prompt yet
-		taskDisplay = lineStyle.Render("…")
-	}
-	left2 := "  " + taskDisplay
-	branch := ""
-	if sess.Worktree != nil {
-		branch = sess.Branch()
-	}
-	branchStr := lineStyle.Render(truncateVisible(branch, 24))
-	line2 := rightAlign(left2, branchStr, width)
-
-	// --- Line 3 ---
-	var waitingReason string
+// sessionFocusStripeColor returns the accent color for a session's left stripe
+// in the focus mode SESSIONS list. Mirrors the priority order in
+// sessionFocusStatus so the stripe and the badge agree on the dominant
+// condition. Selection highlight is applied by the caller.
+func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Color {
+	var hasError, hasWaiting, hasIdleAsking bool
 	for _, item := range d.items {
 		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
 			continue
 		}
-		if item.agent.Status() == agent.StatusWaiting {
-			if waitingReason == "" {
-				waitingReason = item.agent.WaitingReason()
+		switch item.agent.Status() {
+		case agent.StatusError:
+			hasError = true
+		case agent.StatusWaiting:
+			hasWaiting = true
+		case agent.StatusIdle:
+			if item.agent.AskingQuestion() {
+				hasIdleAsking = true
 			}
 		}
 	}
+	switch {
+	case hasError:
+		return ColorError
+	case hasWaiting:
+		return ColorWaiting
+	case hasIdleAsking:
+		return ColorWarning
+	case !sess.DoneAt().IsZero():
+		return ColorSuccess
+	default:
+		return ColorMuted
+	}
+}
 
-	var statusLeft string
+// renderFocusSessionCard returns exactly 4 lines for a session card in focus
+// mode. Each line begins with a colored vertical stripe (▎) whose color encodes
+// the dominant session state via sessionFocusStripeColor; the selected card
+// brightens the stripe to ColorSecondary. The card has fixed height so the
+// list layout is predictable regardless of summary length.
+//
+// Line 1: <stripe> <name (bold, ColorText)>     ... right-aligned <status badge>
+// Line 2: <stripe>   <description line 1 (muted; italic if pending)>
+// Line 3: <stripe>   <description line 2 or empty>  (always reserved)
+// Line 4: <stripe>   <branch [· detail]>        ... right-aligned <elapsed>
+func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected bool, width int) []string {
+	stripeColor := d.sessionFocusStripeColor(sess)
+	if selected {
+		stripeColor = ColorSecondary
+	}
+	stripe := lipgloss.NewStyle().Foreground(stripeColor).Render("▎")
+	const indent = "   "
+	const stripeIndentWidth = 4 // stripe (1) + 3 spaces
+
+	// --- Line 1: stripe + name, right-aligned status badge ---
+	name := sess.GetDisplayName()
+	nameStyled := lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
+	badge := d.sessionFocusStatus(sess)
+	line1 := rightAlign(stripe+" "+nameStyled, badge, width)
+
+	// --- Lines 2 and 3: description (always two lines) ---
+	descBudget := width - stripeIndentWidth
+	if descBudget < 1 {
+		descBudget = 1
+	}
+	descText, descPending := focusTaskDescription(sess)
+	descLine1, descLine2 := wrapTwoLines(descText, descBudget)
+	descStyle := StyleSubtle
+	if descPending {
+		descStyle = lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
+	}
+	line2 := stripe + indent + descStyle.Render(descLine1)
+	line3 := stripe + indent
+	if descLine2 != "" {
+		line3 = stripe + indent + descStyle.Render(descLine2)
+	}
+
+	// --- Line 4: branch [· detail], right-aligned elapsed ---
+	branch := ""
+	if sess.Worktree != nil {
+		branch = sess.Branch()
+	}
+	var waitingReason string
+	allIdle := true
+	anyAgent := false
+	for _, item := range d.items {
+		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
+			continue
+		}
+		anyAgent = true
+		st := item.agent.Status()
+		if st == agent.StatusActive || st == agent.StatusWaiting {
+			allIdle = false
+		}
+		if st == agent.StatusWaiting && waitingReason == "" {
+			waitingReason = item.agent.WaitingReason()
+		}
+	}
+	bottomLeftText := branch
 	switch {
 	case waitingReason != "":
-		statusLeft = lineStyle.Render("  " + truncateVisible(waitingReason, width/2))
-	case sess.LastOutputTime().IsZero():
-		statusLeft = ""
-	default:
-		// Check if all agents are idle
-		anyActive := false
-		for _, item := range d.items {
-			if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
-				continue
-			}
-			st := item.agent.Status()
-			if st == agent.StatusActive || st == agent.StatusWaiting {
-				anyActive = true
-				break
-			}
-		}
-		if !anyActive {
-			idleMins := int(time.Since(sess.LastOutputTime()).Minutes())
-			statusLeft = lineStyle.Render(fmt.Sprintf("  idle %dm", idleMins))
+		if branch != "" {
+			bottomLeftText = branch + " · " + waitingReason
 		} else {
-			statusLeft = ""
+			bottomLeftText = waitingReason
+		}
+	case anyAgent && allIdle && !sess.LastOutputTime().IsZero():
+		idleStr := fmt.Sprintf("idle %dm", int(time.Since(sess.LastOutputTime()).Minutes()))
+		if branch != "" {
+			bottomLeftText = branch + " · " + idleStr
+		} else {
+			bottomLeftText = idleStr
 		}
 	}
+	bottomBudget := width - 12
+	if bottomBudget < 1 {
+		bottomBudget = 1
+	}
+	bottomLeftText = truncateVisible(bottomLeftText, bottomBudget)
+	bottomLeft := stripe + indent + StyleSubtle.Render(bottomLeftText)
 
-	elapsed := sess.Elapsed()
+	totalMins := int(sess.Elapsed().Minutes())
 	var elapsedStr string
-	totalMins := int(elapsed.Minutes())
 	if totalMins >= 60 {
-		h := totalMins / 60
-		m := totalMins % 60
-		elapsedStr = fmt.Sprintf("%dh %dm", h, m)
+		elapsedStr = fmt.Sprintf("%dh %dm", totalMins/60, totalMins%60)
 	} else {
 		elapsedStr = fmt.Sprintf("%dm", totalMins)
 	}
-	elapsedStyled := lineStyle.Render(elapsedStr)
-	line3 := rightAlign(statusLeft, elapsedStyled, width)
+	line4 := rightAlign(bottomLeft, StyleSubtle.Render(elapsedStr), width)
 
-	return []string{line1, line2, line3}
+	return []string{line1, line2, line3, line4}
+}
+
+// focusTaskDescription chooses the description string for a session card in
+// focus mode and reports whether it should render in pending (italic) style.
+// Mirrors the legacy renderFocusSessionCard switch so callers stay consistent
+// with sessionFocusStatus regarding which signal wins.
+func focusTaskDescription(sess *agent.Session) (text string, pending bool) {
+	origPrompt := sess.OriginalPrompt()
+	switch {
+	case sess.HasTaskSummary() && sess.TaskSummary() != "":
+		return sess.TaskSummary(), false
+	case sess.HasTaskSummary() && sess.TaskSummary() == "":
+		return origPrompt, false
+	case !sess.HasTaskSummary() && origPrompt != "":
+		return origPrompt, true
+	default:
+		return "…", false
+	}
+}
+
+// wrapTwoLines greedily word-wraps s into at most two lines of `budget`
+// display cells. If only one line is needed, line2 is empty. If a third line
+// would have been required, the second line is truncated with an ellipsis.
+func wrapTwoLines(s string, budget int) (string, string) {
+	if budget <= 0 {
+		return "", ""
+	}
+	if s == "" {
+		return "", ""
+	}
+	if ansi.StringWidth(s) <= budget {
+		return s, ""
+	}
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return truncateVisible(s, budget), ""
+	}
+	var line1Words []string
+	used := 0
+	i := 0
+	for i < len(words) {
+		w := words[i]
+		ww := ansi.StringWidth(w)
+		extra := ww
+		if used > 0 {
+			extra++ // separator space
+		}
+		if used > 0 && used+extra > budget {
+			break
+		}
+		line1Words = append(line1Words, w)
+		used += extra
+		i++
+		if used >= budget {
+			// First word filled or overflowed the line; stop here.
+			break
+		}
+	}
+	line1 := strings.Join(line1Words, " ")
+	if ansi.StringWidth(line1) > budget {
+		line1 = truncateVisible(line1, budget)
+	}
+	if i >= len(words) {
+		return line1, ""
+	}
+	rest := strings.Join(words[i:], " ")
+	if ansi.StringWidth(rest) <= budget {
+		return line1, rest
+	}
+	return line1, truncateVisible(rest, budget)
 }
 
 // rightAlign places left and right on the same line with padding so the total

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -4,12 +4,24 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/baton/internal/agent"
+	"github.com/muesli/termenv"
 )
 
-// TestRenderFocusActiveCursor verifies that when the focus cursor is on an
-// active session, that row is rendered with the "> " selection prefix.
+// TestRenderFocusActiveCursor verifies that the selected session card in focus
+// mode is visually distinct: the leading stripe glyph is rendered in
+// ColorSecondary (cyan) for the selected session and a different color for
+// unselected sessions. Selection is no longer signalled by a "> " chevron.
 func TestRenderFocusActiveCursor(t *testing.T) {
+	// Force TrueColor so the rendered ANSI escapes carry the foreground color
+	// we want to assert against. Without this, lipgloss strips colors when
+	// stdout is not a TTY and selection becomes indistinguishable in the
+	// rendered string.
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
 	sessA := &agent.Session{Name: "active-a"}
 	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
 	sessB := &agent.Session{Name: "active-b"}
@@ -28,17 +40,38 @@ func TestRenderFocusActiveCursor(t *testing.T) {
 	}
 
 	out := d.renderFullscreenFocus(120, 39)
-	lines := strings.Split(out, "\n")
-	var sawSelected bool
-	for _, line := range lines {
-		if strings.Contains(line, "active-b") && strings.Contains(line, "> ") {
-			sawSelected = true
-		}
-		if strings.Contains(line, "active-a") && strings.Contains(line, "> ") {
-			t.Fatalf("active-a should not be selected (focusActiveIdx=1):\n%s", line)
+
+	selectedStripe := lipgloss.NewStyle().Foreground(ColorSecondary).Render("▎")
+	if !strings.Contains(selectedStripe, "▎") {
+		t.Fatalf("expected styled stripe to contain glyph; got %q", selectedStripe)
+	}
+
+	var selectedLine, unselectedLine string
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.Contains(line, "active-b") && selectedLine == "":
+			selectedLine = line
+		case strings.Contains(line, "active-a") && unselectedLine == "":
+			unselectedLine = line
 		}
 	}
-	if !sawSelected {
-		t.Fatalf("expected selection marker on active-b, got:\n%s", out)
+	if selectedLine == "" || unselectedLine == "" {
+		t.Fatalf("could not find both session header lines in output:\n%s", out)
+	}
+
+	if !strings.Contains(selectedLine, selectedStripe) {
+		t.Fatalf("selected card missing cyan stripe %q\nselected line: %q\nfull:\n%s",
+			selectedStripe, selectedLine, out)
+	}
+	// Unselected cards must still carry the stripe glyph (just in a different
+	// color), so confirm the glyph is present before asserting the cyan color
+	// is *not*.
+	if !strings.Contains(unselectedLine, "▎") {
+		t.Fatalf("unselected card missing stripe glyph entirely\nunselected line: %q\nfull:\n%s",
+			unselectedLine, out)
+	}
+	if strings.Contains(unselectedLine, selectedStripe) {
+		t.Fatalf("unselected card unexpectedly carries selection stripe color\nunselected line: %q\nfull:\n%s",
+			unselectedLine, out)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace the flat 3-line focus-mode session card (every line in `StyleSubtle` gray, no typographic hierarchy) with a 4-line stripe layout that gives each card a clear visual anchor and state encoding.
- Color the leading `▎` stripe by dominant agent state — red (error), magenta (waiting), amber (idle asking), green (done), muted (running) — and brighten to cyan when the card is selected. Drops the `> ` chevron in favor of the colored stripe + bold/white name.
- Always reserve two muted description lines so card height is constant regardless of Haiku summary length, and consolidate branch, waiting/idle detail, and elapsed time into a single bottom row.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `go test -race ./...` (pre-existing failures in `internal/config` XDG migration and `internal/hook` socket-path tests reproduce on `main` and are unrelated)
- [x] `go test -tags e2e -timeout 300s ./internal/e2e/`
- [ ] Manual TUI: spawn ≥2 sessions in the same repo with focus mode on; confirm stripe color reflects state, selection brightens stripe to cyan and bolds the name, description always renders as two lines, narrow widths (~80 cols) wrap cleanly.

## Checklist

- [x] Added `changelog.d/focus-sessions-stripe.md` under `### Changed`
- [x] Updated `internal/tui/focus_render_test.go` to assert the new selection cue (cyan-styled stripe glyph)
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)