### PR TITLE
Focus mode: auto-enter break when work timer expires

### DIFF
--- a/changelog.d/auto-enter-break-mode.md
+++ b/changelog.d/auto-enter-break-mode.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Focus mode now auto-enters break when the session timer expires, instead of waiting for the user to press `b`. Auto-entry is deferred while inside the fullscreen agent terminal and fires the moment the user returns to the focus pipeline.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -375,6 +375,25 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.audioPlayer.Play()
 				}
 			}
+		} else if a.focusModeActive && a.focusSessionMinutes > 0 &&
+			a.dashboard.panelFocus != focusLaunch &&
+			time.Since(a.sessionStart) >= time.Duration(a.focusSessionMinutes)*time.Minute {
+			// Auto-enter break when the work block elapses. The asymmetry
+			// with break-end (which waits for explicit `b`) is intentional:
+			// end-of-block SHOULD interrupt the user — that's the whole
+			// point of the timer — whereas end-of-break should not drag
+			// them back from the keyboard. Deferred while in focusLaunch
+			// (fullscreen agent terminal); fires the moment they pop back.
+			a.focusBreakMode = true
+			a.focusBreakStart = time.Now().Round(0)
+			a.focusBreakShortWarning = false
+			a.focusBreakTimerUp = false
+			a.focusBreakAnimFrame = 0
+			// Bypass focus-mode chime suppression — same rationale as
+			// the break-end branch above.
+			if a.audioPlayer != nil {
+				a.audioPlayer.Play()
+			}
 		}
 		a.refreshAgentList()
 		// Detect Active->Idle transitions for diff-stats refresh. Chime
@@ -2627,16 +2646,7 @@ func (a App) View() tea.View {
 					hints = []keyHint{{key: "b", desc: "exit early"}}
 				}
 			} else if a.focusSessionMinutes > 0 {
-				elapsed := time.Since(a.sessionStart)
-				if elapsed >= time.Duration(a.focusSessionMinutes)*time.Minute {
-					breakHint := keyHint{
-						key:  "⌛",
-						desc: fmt.Sprintf("%dm — [b] take a break", a.focusSessionMinutes),
-					}
-					hints = append([]keyHint{breakHint}, hints...)
-				} else {
-					hints = append(hints, keyHint{key: "b", desc: "take a break"})
-				}
+				hints = append(hints, keyHint{key: "b", desc: "take a break"})
 			}
 		}
 		// Repo picker overlay: replace body with centered picker when active.


### PR DESCRIPTION
## Summary

- Symmetric to the existing break-end auto-detection — when the focus-mode session timer elapses, baton now flips into break mode automatically and plays the chime, instead of waiting for the user to notice the hint and press `b`. Per the focus-mode philosophy ("interrupt-driven review is the goal; polling is the anti-pattern"), end-of-block should interrupt the user — that's the whole point of the timer.
- Deferred while the fullscreen agent terminal (`focusLaunch`) is open so the break overlay doesn't preempt an active terminal view; auto-entry fires on the next tick after returning to the focus pipeline.
- Asymmetry with break-end (which still requires explicit `b` to resume) is intentional and consistent with the comment on the existing break-end branch — end-of-break should not drag the user back from the keyboard.
- Removed the redundant `⌛ Xm — [b] take a break` hint branch that was reachable for ~1 tick before auto-entry fires; the always-on `b — take a break` hint stays for the rest of the block.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` — relevant TUI suite passes; pre-existing failures in `internal/config` (XDG migration) and `internal/hook` (unix-socket bind on macOS temp paths) reproduce on the unmodified baseline branch and are unrelated.
- [ ] Manual TUI: with `FocusSessionMinutes = 1`, toggle focus mode (`f`), wait ~60s — chime plays and the break overlay appears without pressing `b`. Wait another ~60s — existing break-end behavior fires, `b` resumes focus.
- [ ] Manual TUI (focusLaunch carve-out): in the fullscreen agent terminal past the threshold, no auto-entry; on returning to the pipeline (`esc`/`ctrl+e`), break overlay appears within one tick.
- [ ] Manual TUI (timer disabled): `FocusSessionMinutes = 0` — no auto-entry, no `⌛` hint anywhere.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (added `changelog.d/auto-enter-break-mode.md` per repo convention)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md` (TUI tests are manual-only per project convention)
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)