### PR TITLE
Fix claude-code-review action to actually post PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,9 +36,20 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this PR for correctness, concurrency safety (the race
+            detector matters here — see CLAUDE.md), test coverage, and
+            adherence to project conventions. Focus on bugs and design
+            issues; skip nitpicks.
+
+            Provide feedback using inline comments on specific lines.
+            Use a top-level summary comment for general observations.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/changelog.d/fix-claude-code-review-action.md
+++ b/changelog.d/fix-claude-code-review-action.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Claude Code Review GitHub Action now actually posts review comments on PRs. The previous configuration invoked the `code-review` plugin's slash command, which printed feedback to stdout instead of using the action's inline-comment MCP tool, so reviews ran successfully but never reached the PR. The workflow now uses the canonical inline-comment prompt and grants `mcp__github_inline_comment__create_inline_comment` so feedback gets buffered and flushed to the PR.


### PR DESCRIPTION
## Summary

- The Claude Code Review workflow has been running successfully on every PR but never posting comments. Last 5 runs all show `conclusion: success`, but every PR ends up with zero review comments.
- Root cause: the prompt used `/code-review:code-review` from the `code-review` plugin, which is designed for interactive terminal use and prints review feedback to stdout. The GitHub Action's PR-comment pipeline expects the agent to call the `mcp__github_inline_comment__create_inline_comment` MCP tool, which buffers comments for a post-step (`post-buffered-inline-comments.ts`) to flush to the PR. Logs from the most recent run confirm `No buffered inline comments` and `permission_denials_count: 2` — the agent generated a review but had no allowed path to surface it.
- Fix: drop the plugin-based prompt, use the canonical inline-comment prompt from `anthropics/claude-code-action/examples/pr-review-comprehensive.yml`, and grant `mcp__github_inline_comment__create_inline_comment` in `--allowedTools`. Subscription auth via `claude_code_oauth_token` was never the problem and is preserved.

## Test plan

- [ ] After merge, open a follow-up PR (or push a commit to a draft) and confirm Claude posts inline review comments on changed lines plus a top-level summary.
- [ ] Verify the workflow run logs show non-empty buffered inline comments (no longer `No buffered inline comments`).
- [ ] Confirm the run still authenticates against the Claude Code subscription and does not regress on cost/duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)