### PR TITLE
Focus mode: fullscreen repo picker with filter and inline add-repo

### DIFF
--- a/changelog.d/expand-focus-mode-repo-picker.md
+++ b/changelog.d/expand-focus-mode-repo-picker.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Focus mode `n` (new session) now opens a fullscreen repo picker with type-to-filter, agent-count per row, and an inline `+ add new repo…` entry. Selecting the add entry (or pressing `a`) opens the file browser and returns to the picker with the just-added repo selected. Replaces the prior centered overlay that hid peer repos and offered no path to register a missing one without exiting focus mode.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -94,6 +94,12 @@ type App struct {
 	cfg          *config.Config
 	repoBrowser  fileBrowserModel
 	branchPicker branchPickerModel
+	repoPicker   repoPickerModel
+
+	// repoPickerPending is set when the file browser was opened from the repo
+	// picker. After the browser emits a select or cancel, control returns to
+	// ViewRepoPicker rather than the dashboard.
+	repoPickerPending bool
 
 	// Settings
 	globalSettings *config.GlobalSettings
@@ -134,8 +140,6 @@ type App struct {
 	focusBreakShortWarning bool
 	focusBreakTimerUp      bool // break duration elapsed; waiting on user to resume
 	focusBreakAnimFrame    int
-	repoPickerActive       bool
-	repoPickerForm         *configForm
 	reviewDiffCache        map[string]*reviewDiffEntry // keyed by session ID
 	reviewSession          *agent.Session              // session currently open in review panel
 
@@ -229,6 +233,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.repoBrowser.height = msg.Height - 1
 		a.branchPicker.width = msg.Width
 		a.branchPicker.height = msg.Height - 1
+		a.repoPicker.width = msg.Width
+		a.repoPicker.height = msg.Height - 1
 		a.recomputePRSectionY()
 		// A resize remaps the VT viewport — any in-flight selection is now
 		// pointing at stale cells. Drop it.
@@ -742,6 +748,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.updateGlobalConfig(msg)
 	case ViewBranchPicker:
 		return a.updateBranchPicker(msg)
+	case ViewRepoPicker:
+		return a.updateRepoPicker(msg)
 	}
 
 	return a, nil
@@ -1079,55 +1087,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
-		// Repo picker overlay: intercept all keys when active.
-		if a.repoPickerActive && a.repoPickerForm != nil {
-			switch msg.String() {
-			case "enter":
-				selectedIdx := a.repoPickerForm.selectIndex("Repo")
-				a.repoPickerActive = false
-				a.repoPickerForm = nil
-				if a.cfg != nil && selectedIdx >= 0 && selectedIdx < len(a.cfg.Repos) {
-					a.activeRepo = a.cfg.Repos[selectedIdx].Path
-					a.refreshAgentList()
-				}
-				repoPath := a.activeRepo
-				if repoPath == "" {
-					return a, nil
-				}
-				fixedW := a.dashboard.fixedTermWidth()
-				fixedH := a.dashboard.fixedTermHeight()
-				if fixedW <= 0 || fixedH <= 0 {
-					a.setError("Terminal size not yet known; try again")
-					return a, nil
-				}
-				resolved := a.resolvedCache[repoPath]
-				mgr := a.managers[repoPath]
-				if mgr == nil {
-					return a, nil
-				}
-				pickerCfg := agent.Config{
-					Rows:              fixedH,
-					Cols:              fixedW,
-					BypassPermissions: resolved.BypassPermissions,
-					AgentProgram:      resolved.AgentProgram,
-				}
-				return a, func() tea.Msg {
-					sess, ag, err := mgr.CreateSession(pickerCfg)
-					if err != nil {
-						return createResultMsg{err: err}
-					}
-					return createResultMsg{sessionID: sess.ID, agentID: ag.ID}
-				}
-			case "esc":
-				a.repoPickerActive = false
-				a.repoPickerForm = nil
-				return a, nil
-			default:
-				cmd := a.repoPickerForm.Update(msg)
-				return a, cmd
-			}
-		}
-
 		// Focus-mode key handling (fullscreen pipeline view).
 		if a.focusModeActive && a.dashboard.panelFocus != focusReview {
 			switch msg.String() {
@@ -1203,18 +1162,17 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 						}
 						a.newAgentPending = false
 					}
-					var options []string
-					activeIdx := 0
-					for i, repo := range a.cfg.Repos {
-						options = append(options, repo.DisplayName())
-						if repo.Path == a.activeRepo {
-							activeIdx = i
+					counts := make(map[string]int, len(a.cfg.Repos))
+					for _, repo := range a.cfg.Repos {
+						if mgr := a.managers[repo.Path]; mgr != nil {
+							counts[repo.Path] = mgr.AgentCount()
 						}
 					}
-					fields := addSelect(nil, "Repo", options, activeIdx)
-					form := newConfigForm(fields, 40)
-					a.repoPickerActive = true
-					a.repoPickerForm = &form
+					a.repoPicker = newRepoPickerModel()
+					a.repoPicker.width = a.width
+					a.repoPicker.height = a.height - 1
+					a.repoPicker.setRepos(a.cfg.Repos, counts, a.activeRepo)
+					a.view = ViewRepoPicker
 					return a, nil
 				}
 				// Single repo: exits this case without returning, so control
@@ -1938,10 +1896,40 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (a App) updateFileBrowser(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case fileBrowserSelectMsg:
-		a.view = ViewDashboard
+		// Snapshot count before addRepo so we can tell whether registration
+		// actually appended a new entry (vs. failing or dedup'ing). Without this
+		// the picker would highlight whatever was already last on failure.
+		priorRepoCount := 0
+		if a.cfg != nil {
+			priorRepoCount = len(a.cfg.Repos)
+		}
 		cmd := a.addRepo(msg.path)
+		if a.repoPickerPending {
+			a.repoPickerPending = false
+			newPath := a.activeRepo
+			if a.cfg != nil && len(a.cfg.Repos) > priorRepoCount {
+				newPath = a.cfg.Repos[len(a.cfg.Repos)-1].Path
+			}
+			counts := make(map[string]int, len(a.cfg.Repos))
+			for _, repo := range a.cfg.Repos {
+				if mgr := a.managers[repo.Path]; mgr != nil {
+					counts[repo.Path] = mgr.AgentCount()
+				}
+			}
+			a.repoPicker.width = a.width
+			a.repoPicker.height = a.height - 1
+			a.repoPicker.setRepos(a.cfg.Repos, counts, newPath)
+			a.view = ViewRepoPicker
+			return a, cmd
+		}
+		a.view = ViewDashboard
 		return a, cmd
 	case fileBrowserCancelMsg:
+		if a.repoPickerPending {
+			a.repoPickerPending = false
+			a.view = ViewRepoPicker
+			return a, nil
+		}
 		a.view = ViewDashboard
 		return a, nil
 	}
@@ -1995,6 +1983,59 @@ func (a App) updateBranchPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	var cmd tea.Cmd
 	a.branchPicker, cmd = a.branchPicker.Update(msg)
+	return a, cmd
+}
+
+func (a App) updateRepoPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case repoPickerSelectMsg:
+		a.view = ViewDashboard
+		repoPath := msg.path
+		if repoPath == "" {
+			return a, nil
+		}
+		a.activeRepo = repoPath
+		a.refreshAgentList()
+		fixedW := a.dashboard.fixedTermWidth()
+		fixedH := a.dashboard.fixedTermHeight()
+		if fixedW <= 0 || fixedH <= 0 {
+			a.setError("Terminal size not yet known; try again")
+			return a, nil
+		}
+		resolved := a.resolvedCache[repoPath]
+		mgr := a.managers[repoPath]
+		if mgr == nil {
+			return a, nil
+		}
+		pickerCfg := agent.Config{
+			Rows:              fixedH,
+			Cols:              fixedW,
+			BypassPermissions: resolved.BypassPermissions,
+			AgentProgram:      resolved.AgentProgram,
+		}
+		return a, func() tea.Msg {
+			sess, ag, err := mgr.CreateSession(pickerCfg)
+			if err != nil {
+				return createResultMsg{err: err}
+			}
+			return createResultMsg{sessionID: sess.ID, agentID: ag.ID}
+		}
+
+	case repoPickerAddRepoMsg:
+		a.repoPickerPending = true
+		a.repoBrowser = newFileBrowserModel()
+		a.repoBrowser.width = a.width
+		a.repoBrowser.height = a.height - 1
+		a.view = ViewFileBrowser
+		return a, nil
+
+	case repoPickerCancelMsg:
+		a.view = ViewDashboard
+		return a, nil
+	}
+
+	var cmd tea.Cmd
+	a.repoPicker, cmd = a.repoPicker.Update(msg)
 	return a, cmd
 }
 
@@ -2639,29 +2680,6 @@ func (a App) View() tea.View {
 				}
 			}
 		}
-		// Repo picker overlay: replace body with centered picker when active.
-		if a.repoPickerActive && a.repoPickerForm != nil {
-			hints = repoPickerHints
-			pickerW := a.width / 2
-			if pickerW > 50 {
-				pickerW = 50
-			}
-			if pickerW < 30 {
-				pickerW = 30
-			}
-			overlayContent := lipgloss.JoinVertical(
-				lipgloss.Left,
-				StyleTitle.Render("New session in..."),
-				"",
-				a.repoPickerForm.View(),
-			)
-			overlay := lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				Padding(0, 1).
-				Width(pickerW).
-				Render(overlayContent)
-			body = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, overlay)
-		}
 		statusbar := renderStatusBar(hints, a.width)
 		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)
 	case ViewDiff:
@@ -2677,6 +2695,10 @@ func (a App) View() tea.View {
 	case ViewBranchPicker:
 		body := a.branchPicker.View()
 		statusbar := renderStatusBar(branchPickerHints, a.width)
+		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)
+	case ViewRepoPicker:
+		body := a.repoPicker.View()
+		statusbar := renderStatusBar(repoPickerHints, a.width)
 		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)
 	}
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1840,8 +1840,8 @@ func TestSoftAgentLimitGuardMultiRepo(t *testing.T) {
 	if app.err == "" {
 		t.Fatal("Expected warning message after first 'n' at limit")
 	}
-	if app.repoPickerActive {
-		t.Fatal("Expected repoPickerActive=false on first 'n' at limit")
+	if app.view == ViewRepoPicker {
+		t.Fatal("Expected view != ViewRepoPicker on first 'n' at limit")
 	}
 
 	// Second 'n' press: should clear pending and open the picker.
@@ -1850,8 +1850,8 @@ func TestSoftAgentLimitGuardMultiRepo(t *testing.T) {
 	if app.newAgentPending {
 		t.Fatal("Expected newAgentPending=false after second 'n'")
 	}
-	if !app.repoPickerActive {
-		t.Fatal("Expected repoPickerActive=true after second 'n' override")
+	if app.view != ViewRepoPicker {
+		t.Fatal("Expected view == ViewRepoPicker after second 'n' override")
 	}
 }
 

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -9,6 +9,7 @@ const (
 	ViewFileBrowser  // overlay: browse filesystem to add a repo
 	ViewGlobalConfig // overlay: edit global settings
 	ViewBranchPicker // overlay: pick branch/PR to open session on
+	ViewRepoPicker   // overlay: pick a registered repo to start a session in
 )
 
 // panelFocus tracks which dashboard panel has keyboard focus.

--- a/internal/tui/repopicker.go
+++ b/internal/tui/repopicker.go
@@ -1,0 +1,361 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/devenjarvis/baton/internal/config"
+)
+
+// repoPickerAddRepoIdx is the sentinel value stored in repoPickerModel.filtered
+// to mark the synthetic "+ add new repo…" row, distinct from any real index
+// into repoPickerModel.repos.
+const repoPickerAddRepoIdx = -1
+
+// repoPickerSelectMsg is emitted when the user picks a registered repo.
+type repoPickerSelectMsg struct{ path string }
+
+// repoPickerAddRepoMsg is emitted when the user picks the add-repo entry or
+// presses the `a` shortcut.
+type repoPickerAddRepoMsg struct{}
+
+// repoPickerCancelMsg is emitted when the user presses esc.
+type repoPickerCancelMsg struct{}
+
+// repoPickerModel is a sub-component for picking a registered repo to start a
+// session in, with type-to-filter and an inline add-repo entry.
+type repoPickerModel struct {
+	repos        []config.Repo
+	counts       map[string]int // keyed by repo path; missing → 0
+	filtered     []int          // indices into repos; repoPickerAddRepoIdx marks the add-repo entry
+	selected     int            // index into filtered
+	scrollOffset int
+	filter       string
+
+	width  int
+	height int
+}
+
+// newRepoPickerModel returns an empty picker. Call setRepos before use.
+func newRepoPickerModel() repoPickerModel {
+	return repoPickerModel{}
+}
+
+// setRepos populates the picker's data and selects initialPath if present.
+// Safe to call repeatedly to refresh after an add-repo round-trip.
+func (m *repoPickerModel) setRepos(repos []config.Repo, counts map[string]int, initialPath string) {
+	m.repos = repos
+	m.counts = counts
+	if m.counts == nil {
+		m.counts = map[string]int{}
+	}
+	m.filter = ""
+	m.scrollOffset = 0
+	m.selected = 0
+	m.applyFilter()
+	if initialPath != "" {
+		for i, idx := range m.filtered {
+			if idx >= 0 && idx < len(m.repos) && m.repos[idx].Path == initialPath {
+				m.selected = i
+				break
+			}
+		}
+	}
+	m.ensureVisible()
+}
+
+// Update handles key events for the picker.
+func (m repoPickerModel) Update(msg tea.Msg) (repoPickerModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		key := msg.String()
+		switch key {
+		case "esc":
+			return m, func() tea.Msg { return repoPickerCancelMsg{} }
+		case "up", "k":
+			if m.selected > 0 {
+				m.selected--
+			}
+		case "down", "j":
+			if m.selected < len(m.filtered)-1 {
+				m.selected++
+			}
+		case "enter":
+			if len(m.filtered) == 0 || m.selected >= len(m.filtered) {
+				break
+			}
+			idx := m.filtered[m.selected]
+			if idx == repoPickerAddRepoIdx {
+				return m, func() tea.Msg { return repoPickerAddRepoMsg{} }
+			}
+			path := m.repos[idx].Path
+			return m, func() tea.Msg { return repoPickerSelectMsg{path: path} }
+		case "a":
+			// Mirror filebrowser's `.` pattern: when the filter is active,
+			// treat `a` as a normal filter character so repo names like "alpha"
+			// stay reachable. Only triggers add-repo when the filter is empty.
+			if m.filter == "" {
+				return m, func() tea.Msg { return repoPickerAddRepoMsg{} }
+			}
+			m.filter += key
+			m.applyFilter()
+		case "backspace":
+			if len(m.filter) > 0 {
+				m.filter = m.filter[:len(m.filter)-1]
+				m.applyFilter()
+			}
+		default:
+			if len(key) == 1 && key[0] >= ' ' && key[0] <= '~' {
+				m.filter += key
+				m.applyFilter()
+			}
+		}
+	}
+	m.ensureVisible()
+	return m, nil
+}
+
+// applyFilter rebuilds the filtered slice and always appends the add-repo
+// sentinel as the final entry.
+func (m *repoPickerModel) applyFilter() {
+	m.filtered = m.filtered[:0]
+	lower := strings.ToLower(m.filter)
+	for i, r := range m.repos {
+		if lower == "" {
+			m.filtered = append(m.filtered, i)
+			continue
+		}
+		if strings.Contains(strings.ToLower(r.DisplayName()), lower) ||
+			strings.Contains(strings.ToLower(r.Path), lower) {
+			m.filtered = append(m.filtered, i)
+		}
+	}
+	m.filtered = append(m.filtered, repoPickerAddRepoIdx)
+	if m.selected >= len(m.filtered) {
+		m.selected = max(0, len(m.filtered)-1)
+	}
+}
+
+// View renders the two-panel picker. The App wraps this with a statusbar.
+func (m repoPickerModel) View() string {
+	leftWidth := m.width / 2
+	if leftWidth < 30 {
+		leftWidth = 30
+	}
+	if leftWidth > m.width-20 && m.width > 20 {
+		leftWidth = m.width - 20
+	}
+	rightWidth := m.width - leftWidth - 1
+	if rightWidth < 0 {
+		rightWidth = 0
+	}
+
+	left := m.renderList(leftWidth)
+	right := m.renderDetails(rightWidth)
+
+	leftStyle := lipgloss.NewStyle().
+		Width(leftWidth).
+		Height(m.height).
+		Border(lipgloss.NormalBorder(), false, true, false, false).
+		BorderForeground(ColorMuted)
+
+	rightStyle := lipgloss.NewStyle().
+		Width(rightWidth).
+		Height(m.height)
+
+	return lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		leftStyle.Render(left),
+		rightStyle.Render(right),
+	)
+}
+
+// renderList renders the left panel with the filtered repo list.
+func (m repoPickerModel) renderList(width int) string {
+	title := StyleTitle.Render("NEW SESSION IN…")
+	sepWidth := width - 2
+	if sepWidth < 0 {
+		sepWidth = 0
+	}
+	separator := StyleSubtle.Render(strings.Repeat("─", sepWidth))
+
+	lines := make([]string, 0, len(m.filtered)+6)
+	lines = append(lines, title, separator)
+
+	if m.filter != "" {
+		lines = append(lines, StyleSubtle.Render("filter: ")+m.filter)
+	}
+	lines = append(lines, "")
+
+	if len(m.filtered) == 0 {
+		// applyFilter always appends the add-repo entry, so this is a defensive guard.
+		lines = append(lines, StyleSubtle.Render("  (no repos)"))
+		return strings.Join(lines, "\n")
+	}
+
+	visibleLines := m.visibleEntryLines()
+	total := len(m.filtered)
+	above := m.scrollOffset
+	end := m.scrollOffset + visibleLines
+	if end > total {
+		end = total
+	}
+	below := total - end
+
+	if above > 0 {
+		lines = append(lines, StyleSubtle.Render(fmt.Sprintf("  ↑ %d more", above)))
+	}
+
+	for fi := m.scrollOffset; fi < end; fi++ {
+		idx := m.filtered[fi]
+		prefix := "  "
+		if fi == m.selected {
+			prefix = StyleActive.Render("▸ ")
+		}
+
+		if idx == repoPickerAddRepoIdx {
+			label := "+ add new repo…"
+			lines = append(lines, prefix+StyleActive.Render(truncateVisible(label, width-4)))
+			continue
+		}
+
+		repo := m.repos[idx]
+		count := m.counts[repo.Path]
+		countLabel := "—"
+		if count > 0 {
+			countLabel = fmt.Sprintf("%d active", count)
+		}
+
+		// Reserve room: prefix (2) + countLabel + 1 space gap.
+		countWidth := lipgloss.Width(countLabel)
+		// Inner width available for name + path; allow a couple cells of padding.
+		nameRoom := width - 2 - countWidth - 2
+		if nameRoom < 4 {
+			nameRoom = 4
+		}
+
+		name := repo.DisplayName()
+		shortPath := compactHomePath(repo.Path)
+
+		// Layout: "name  shortPath ……  countLabel"
+		// Compute how much space the name+path block can use, then truncate.
+		nameW := lipgloss.Width(name)
+		gap := 2
+		pathRoom := nameRoom - nameW - gap
+		var leftBlock string
+		if pathRoom > 1 {
+			truncatedPath := StyleSubtle.Render(truncateVisible(shortPath, pathRoom))
+			leftBlock = name + strings.Repeat(" ", gap) + truncatedPath
+		} else {
+			leftBlock = truncateVisible(name, nameRoom)
+		}
+
+		// Pad leftBlock so countLabel sits at the right edge.
+		leftBlockW := lipgloss.Width(leftBlock)
+		padding := nameRoom - leftBlockW
+		if padding < 1 {
+			padding = 1
+		}
+		row := prefix + leftBlock + strings.Repeat(" ", padding) + StyleSubtle.Render(countLabel)
+		lines = append(lines, row)
+	}
+
+	if below > 0 {
+		lines = append(lines, StyleSubtle.Render(fmt.Sprintf("  ↓ %d more", below)))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderDetails renders the right panel with details about the selected entry.
+func (m repoPickerModel) renderDetails(width int) string {
+	title := StyleTitle.Render("DETAILS")
+	sepWidth := width - 1
+	if sepWidth < 0 {
+		sepWidth = 0
+	}
+	separator := StyleSubtle.Render(strings.Repeat("─", sepWidth))
+
+	var lines []string
+	lines = append(lines, title, separator, "")
+
+	if len(m.filtered) == 0 || m.selected >= len(m.filtered) {
+		lines = append(lines, StyleSubtle.Render("No item selected"))
+		return strings.Join(lines, "\n")
+	}
+
+	idx := m.filtered[m.selected]
+	if idx == repoPickerAddRepoIdx {
+		lines = append(lines, StyleTitle.Render("Add new repo"))
+		lines = append(lines, "")
+		lines = append(lines, StyleSubtle.Render("Opens the file browser to register a new repo."))
+		lines = append(lines, "")
+		lines = append(lines, StyleSubtle.Render("Press enter to continue"))
+		return strings.Join(lines, "\n")
+	}
+
+	repo := m.repos[idx]
+	count := m.counts[repo.Path]
+	countLabel := "no agents running"
+	if count == 1 {
+		countLabel = "1 agent running"
+	} else if count > 1 {
+		countLabel = fmt.Sprintf("%d agents running", count)
+	}
+
+	lines = append(lines, StyleTitle.Render(repo.DisplayName()))
+	lines = append(lines, StyleSubtle.Render(repo.Path))
+	lines = append(lines, "")
+	lines = append(lines, StyleSubtle.Render(countLabel))
+	lines = append(lines, "")
+	lines = append(lines, StyleSubtle.Render("Press enter to start a session in this repo"))
+	return strings.Join(lines, "\n")
+}
+
+// ensureVisible adjusts scrollOffset so that selected is within the visible window.
+func (m *repoPickerModel) ensureVisible() {
+	visibleLines := m.visibleEntryLines()
+	if m.selected < m.scrollOffset {
+		m.scrollOffset = m.selected
+	}
+	if m.selected >= m.scrollOffset+visibleLines {
+		m.scrollOffset = m.selected - visibleLines + 1
+	}
+	if m.scrollOffset < 0 {
+		m.scrollOffset = 0
+	}
+}
+
+// visibleEntryLines returns the number of entry rows that fit in the left panel,
+// reserving space for header lines and (conservatively) both scroll indicators.
+func (m repoPickerModel) visibleEntryLines() int {
+	headerLines := 3 // title + separator + blank
+	if m.filter != "" {
+		headerLines++
+	}
+	visible := m.height - headerLines - 2
+	if visible < 1 {
+		visible = 1
+	}
+	return visible
+}
+
+// compactHomePath returns p with the user's home directory replaced by "~".
+// Used to keep repo paths short in the picker rows.
+func compactHomePath(p string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return p
+	}
+	if p == home {
+		return "~"
+	}
+	if strings.HasPrefix(p, home+string(filepath.Separator)) {
+		return "~" + p[len(home):]
+	}
+	return p
+}

--- a/internal/tui/repopicker_test.go
+++ b/internal/tui/repopicker_test.go
@@ -1,0 +1,210 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/devenjarvis/baton/internal/config"
+)
+
+// fixtureRepoPicker builds a populated repoPickerModel without touching disk.
+func fixtureRepoPicker() repoPickerModel {
+	repos := []config.Repo{
+		{Path: "/Code/alpha", Name: "alpha"},
+		{Path: "/Code/beta", Name: "beta"},
+		{Path: "/Code/gamma", Name: "gamma"},
+	}
+	counts := map[string]int{
+		"/Code/alpha": 2,
+		"/Code/gamma": 1,
+	}
+	m := newRepoPickerModel()
+	m.width = 100
+	m.height = 24
+	m.setRepos(repos, counts, "/Code/beta")
+	return m
+}
+
+func TestRepoPicker_SetReposSelectsInitialPath(t *testing.T) {
+	m := fixtureRepoPicker()
+	// initialPath was "/Code/beta", which is index 1 in the repos slice and
+	// also at index 1 of filtered (no filter applied).
+	if m.selected != 1 {
+		t.Errorf("selected = %d, want 1 (the entry for /Code/beta)", m.selected)
+	}
+	// filtered should hold all 3 repos plus the add-repo sentinel.
+	if len(m.filtered) != 4 {
+		t.Fatalf("filtered length = %d, want 4 (3 repos + add-repo)", len(m.filtered))
+	}
+	if m.filtered[3] != repoPickerAddRepoIdx {
+		t.Errorf("last filtered entry = %d, want repoPickerAddRepoIdx", m.filtered[3])
+	}
+}
+
+func TestRepoPicker_FilterNarrowsAndClampsCursor(t *testing.T) {
+	m := fixtureRepoPicker()
+	// Move cursor to position 2 (gamma).
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	if m.selected != 2 {
+		t.Fatalf("expected selected=2 after one down, got %d", m.selected)
+	}
+	// Filter "be" matches only beta. The filtered slice should hold beta + add-repo entry.
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'e', Text: "e"})
+	if len(m.filtered) != 2 {
+		t.Errorf("after filter 'be', expected 2 entries (beta + add-repo), got %d", len(m.filtered))
+	}
+	if m.selected >= len(m.filtered) {
+		t.Errorf("cursor=%d not clamped within filtered=%d", m.selected, len(m.filtered))
+	}
+}
+
+func TestRepoPicker_FilterAlsoMatchesPath(t *testing.T) {
+	m := fixtureRepoPicker()
+	// Path-only match: "Code" appears in every repo path. After filter "Code"
+	// every real repo + add-repo entry should be retained.
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'C', Text: "C"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'o', Text: "o"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'e', Text: "e"})
+	if len(m.filtered) != 4 {
+		t.Errorf("after filter 'Code' (path match), expected 4 entries, got %d", len(m.filtered))
+	}
+}
+
+func TestRepoPicker_EnterOnRealRepoEmitsSelectMsg(t *testing.T) {
+	m := fixtureRepoPicker()
+	// Cursor starts at /Code/beta (initialPath).
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from enter on real repo row")
+	}
+	out := cmd()
+	sel, ok := out.(repoPickerSelectMsg)
+	if !ok {
+		t.Fatalf("expected repoPickerSelectMsg, got %T", out)
+	}
+	if sel.path != "/Code/beta" {
+		t.Errorf("select path = %q, want %q", sel.path, "/Code/beta")
+	}
+}
+
+func TestRepoPicker_EnterOnAddRepoEntryEmitsAddMsg(t *testing.T) {
+	m := fixtureRepoPicker()
+	// Move cursor to the add-repo sentinel (last filtered entry, index 3).
+	for range 3 {
+		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	if m.selected != len(m.filtered)-1 {
+		t.Fatalf("expected cursor on last entry, got selected=%d / filtered=%d", m.selected, len(m.filtered))
+	}
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from enter on add-repo entry")
+	}
+	if _, ok := cmd().(repoPickerAddRepoMsg); !ok {
+		t.Errorf("expected repoPickerAddRepoMsg, got %T", cmd())
+	}
+}
+
+func TestRepoPicker_AHotkeyEmitsAddMsgWhenFilterEmpty(t *testing.T) {
+	m := fixtureRepoPicker()
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from 'a' hotkey with empty filter")
+	}
+	if _, ok := cmd().(repoPickerAddRepoMsg); !ok {
+		t.Errorf("expected repoPickerAddRepoMsg, got %T", cmd())
+	}
+}
+
+func TestRepoPicker_AKeyAppendsToFilterWhenFilterActive(t *testing.T) {
+	m := fixtureRepoPicker()
+	// Start a filter with a non-'a' character.
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'l', Text: "l"})
+	if m.filter != "l" {
+		t.Fatalf("filter = %q, want %q", m.filter, "l")
+	}
+	// Now typing 'a' should append to filter, not emit add-repo.
+	m, cmd := m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if cmd != nil {
+		if _, ok := cmd().(repoPickerAddRepoMsg); ok {
+			t.Error("'a' with active filter should NOT emit repoPickerAddRepoMsg")
+		}
+	}
+	if m.filter != "la" {
+		t.Errorf("filter = %q, want %q", m.filter, "la")
+	}
+}
+
+func TestRepoPicker_EscEmitsCancelMsg(t *testing.T) {
+	m := fixtureRepoPicker()
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from esc")
+	}
+	if _, ok := cmd().(repoPickerCancelMsg); !ok {
+		t.Errorf("expected repoPickerCancelMsg, got %T", cmd())
+	}
+}
+
+func TestRepoPicker_BackspaceDeletesFilterChar(t *testing.T) {
+	m := fixtureRepoPicker()
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'e', Text: "e"})
+	if m.filter != "be" {
+		t.Fatalf("filter = %q, want %q", m.filter, "be")
+	}
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	if m.filter != "b" {
+		t.Errorf("after backspace, filter = %q, want %q", m.filter, "b")
+	}
+}
+
+func TestRepoPicker_AgentCountsRenderInRows(t *testing.T) {
+	m := fixtureRepoPicker()
+	out := m.View()
+	// alpha has 2 active agents; gamma has 1; beta has 0 (em dash).
+	if !strings.Contains(out, "2 active") {
+		t.Errorf("expected '2 active' in view output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 active") {
+		t.Errorf("expected '1 active' in view output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "—") {
+		t.Errorf("expected em-dash for zero-count repo, got:\n%s", out)
+	}
+}
+
+func TestRepoPicker_AddRepoRowAlwaysPresent(t *testing.T) {
+	m := fixtureRepoPicker()
+	// Filter to a string that matches no repo.
+	for _, ch := range "zzznomatch" {
+		m, _ = m.Update(tea.KeyPressMsg{Code: rune(ch), Text: string(ch)})
+	}
+	if len(m.filtered) != 1 {
+		t.Errorf("expected only add-repo entry, got %d filtered entries", len(m.filtered))
+	}
+	if m.filtered[0] != repoPickerAddRepoIdx {
+		t.Errorf("expected sole entry to be add-repo sentinel, got %d", m.filtered[0])
+	}
+}
+
+func TestRepoPicker_NavigationClampsAtBounds(t *testing.T) {
+	m := fixtureRepoPicker()
+	// Push past the top.
+	m.selected = 0
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if m.selected != 0 {
+		t.Errorf("up at top should clamp at 0, got %d", m.selected)
+	}
+	// Push past the bottom.
+	for range 100 {
+		m, _ = m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	}
+	last := len(m.filtered) - 1
+	if m.selected != last {
+		t.Errorf("down past bottom should clamp at %d, got %d", last, m.selected)
+	}
+}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -96,8 +96,10 @@ var (
 	}
 
 	repoPickerHints = []keyHint{
-		{"←/→", "cycle repo"},
-		{"enter", "confirm"},
+		{"j/k", "navigate"},
+		{"type", "filter"},
+		{"enter", "select"},
+		{"a", "add repo"},
 		{"esc", "cancel"},
 	}
 )


### PR DESCRIPTION
## Summary

Replace the focus-mode `n` overlay (a tiny centered configForm-based picker) with a fullscreen two-panel picker:

- **Filtered list** with agent counts per row (`2 active` / `—`) and a `+ add new repo…` entry that's always at the bottom of the filtered results.
- **Details panel** showing display name, full path, and agent count for the selected entry.
- **Type-to-filter** matches both display name and path. `j/k` to navigate, `enter` to select, `esc` to cancel.
- **`a` shortcut** opens the add-repo flow directly when the filter is empty (mirrors filebrowser's `.` pattern when filter is active).
- **Round-trip add-repo**: selecting `+ add new repo…` (or pressing `a`) opens the existing file browser; on selection the new repo registers and returns to the picker with that repo highlighted; on cancel returns to the picker.

The previous overlay hid peer repos, made find-as-you-type impossible, and offered no path to register a missing repo without exiting focus mode. The soft `MaxConcurrentAgents` two-press override is preserved before the picker opens.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./internal/tui/...` (pre-existing failures in `internal/config` and `internal/hook` are unrelated to this branch)
- [ ] Manual TUI:
  - [ ] Register 2+ repos via dashboard `a`, switch to focus mode
  - [ ] Press `n` → fullscreen picker shows all repos with paths and counts; active repo highlighted
  - [ ] Type to filter; cursor clamps; add-repo entry stays at end
  - [ ] `j` to `+ add new repo…`, `enter` → file browser → pick new repo → returns to picker with new repo selected
  - [ ] Repeat using `a` hotkey
  - [ ] `enter` on a repo → session created, focus mode resumes
  - [ ] `esc` → returns to focus mode without creating a session
  - [ ] With one repo registered, `n` falls through to single-repo creation path (no picker)

## Checklist

- [x] Added `changelog.d/expand-focus-mode-repo-picker.md`
- [x] New behavior has unit tests (`internal/tui/repopicker_test.go`, 12 tests)
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)