### PR TITLE
Show 4th-agent soft-limit warning as a centered modal

### DIFF
--- a/changelog.d/change-agent-limit-modal.md
+++ b/changelog.d/change-agent-limit-modal.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Focus mode 4th-agent soft-limit warning is now a centered modal instead of a one-line banner. Press `n` again to spawn anyway; any other key cancels.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -125,7 +125,7 @@ type App struct {
 	appStart               time.Time // set once at init; never reset; used for total session duration in wellness log
 	sessionStart           time.Time // per-block work timer; reset on each break completion
 	lastReviewAt           time.Time
-	newAgentPending        bool
+	agentLimitModalActive  bool
 	focusSessionMinutes    int          // cached from resolved global settings
 	focusBreakMinutes      int          // cached from resolved global settings
 	focusActiveIdx         int          // index into allInProgressSessions()
@@ -1030,10 +1030,12 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			break
 		}
 
-		// Clear the agent-limit pending flag on any key that isn't n.
-		// Done here (before focus-mode early returns) so navigation keys clear it too.
-		if a.newAgentPending && msg.String() != "n" {
-			a.newAgentPending = false
+		// Agent-limit modal: any key other than 'n' dismisses without navigating.
+		// 'n' falls through to the normal handler, which sees the flag still set
+		// and proceeds with spawn (the existing two-press guard logic below).
+		if a.agentLimitModalActive && msg.String() != "n" {
+			a.agentLimitModalActive = false
+			return a, nil
 		}
 
 		// Clear the backlog warning flag on any key that isn't n.
@@ -1174,12 +1176,11 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// path before opening the picker.
 					resolved := a.resolvedCache[a.activeRepo]
 					if resolved.MaxConcurrentAgents > 0 && a.activeAgentCount() >= resolved.MaxConcurrentAgents {
-						if !a.newAgentPending {
-							a.newAgentPending = true
-							a.setError(fmt.Sprintf("n again to override — %d+ agents shown to reduce productivity", resolved.MaxConcurrentAgents))
+						if !a.agentLimitModalActive {
+							a.agentLimitModalActive = true
 							return a, nil
 						}
-						a.newAgentPending = false
+						a.agentLimitModalActive = false
 					}
 					counts := make(map[string]int, len(a.cfg.Repos))
 					for _, repo := range a.cfg.Repos {
@@ -1316,13 +1317,12 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.focusModeActive {
 				resolved := a.resolvedCache[repoPath]
 				if resolved.MaxConcurrentAgents > 0 && a.activeAgentCount() >= resolved.MaxConcurrentAgents {
-					if !a.newAgentPending {
-						a.newAgentPending = true
-						a.setError(fmt.Sprintf("n again to override — %d+ agents shown to reduce productivity", resolved.MaxConcurrentAgents))
+					if !a.agentLimitModalActive {
+						a.agentLimitModalActive = true
 						return a, nil
 					}
-					// Second press: proceed, clear pending flag.
-					a.newAgentPending = false
+					// Second press: proceed, clear modal flag.
+					a.agentLimitModalActive = false
 				}
 
 				// Soft review-backlog limit.
@@ -2689,6 +2689,36 @@ func (a App) View() tea.View {
 			} else if a.focusSessionMinutes > 0 {
 				hints = append(hints, keyHint{key: "b", desc: "take a break"})
 			}
+		}
+		// Agent-limit modal overlay: replace body with centered modal when active.
+		if a.agentLimitModalActive {
+			modalW := a.width / 2
+			if modalW > 60 {
+				modalW = 60
+			}
+			if modalW < 40 {
+				modalW = 40
+			}
+			activeCount := a.activeAgentCount()
+			limitLine := StyleWarning.Render(fmt.Sprintf(
+				"You're already running %d agents — beyond ~3, oversight cost exceeds output value.",
+				activeCount,
+			))
+			overlayContent := lipgloss.JoinVertical(
+				lipgloss.Left,
+				StyleTitle.Render("Focus limit reached"),
+				"",
+				limitLine,
+				"",
+				"Press [n] again to spawn anyway",
+				"Any other key to cancel",
+			)
+			overlay := lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				Padding(0, 1).
+				Width(modalW).
+				Render(overlayContent)
+			body = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, overlay)
 		}
 		statusbar := renderStatusBar(hints, a.width)
 		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1666,7 +1667,7 @@ func TestFocusMode_RKey_OpensReviewWithItems(t *testing.T) {
 }
 
 // TestSoftAgentLimitGuard verifies the two-press 'n' guard in focus mode:
-// first press shows a warning and sets newAgentPending; second press proceeds.
+// first press shows the modal and sets agentLimitModalActive; second press proceeds.
 func TestSoftAgentLimitGuard(t *testing.T) {
 	requireClaude(t)
 	dir, err := os.MkdirTemp("", "baton-softlimit-*")
@@ -1725,7 +1726,7 @@ func TestSoftAgentLimitGuard(t *testing.T) {
 	// Enable focus mode.
 	app.focusModeActive = true
 
-	// First 'n' press: should set newAgentPending and show error, not create agent.
+	// First 'n' press: should set agentLimitModalActive and not create agent.
 	model, cmd := app.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
 	app = model.(App)
 	if cmd != nil {
@@ -1736,30 +1737,51 @@ func TestSoftAgentLimitGuard(t *testing.T) {
 			t.Fatal("Expected no agent creation on first 'n' press at limit")
 		}
 	}
-	if !app.newAgentPending {
-		t.Fatal("Expected newAgentPending=true after first 'n' at limit")
+	if !app.agentLimitModalActive {
+		t.Fatal("Expected agentLimitModalActive=true after first 'n' at limit")
 	}
-	if app.err == "" {
-		t.Fatal("Expected warning message after first 'n' at limit")
+	if v := app.View(); !strings.Contains(v.Content, "Focus limit reached") {
+		t.Fatalf("Expected rendered View to contain 'Focus limit reached' modal title; got:\n%s", v.Content)
 	}
 
-	// Second 'n' press: should clear pending and proceed with creation.
+	// Second 'n' press: should clear modal and proceed with creation.
 	model, cmd = app.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
 	app = model.(App)
-	if app.newAgentPending {
-		t.Fatal("Expected newAgentPending=false after second 'n'")
+	if app.agentLimitModalActive {
+		t.Fatal("Expected agentLimitModalActive=false after second 'n'")
+	}
+	if v := app.View(); strings.Contains(v.Content, "Focus limit reached") {
+		t.Fatal("Expected rendered View to NOT contain 'Focus limit reached' after override")
 	}
 	// cmd should be non-nil (agent creation is dispatched).
 	if cmd == nil {
 		t.Fatal("Expected non-nil cmd from second 'n' press (agent creation)")
 	}
 
-	// Any other key press should clear newAgentPending.
-	app.newAgentPending = true
-	model, _ = app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	// Any other key press should dismiss the modal without spawning and without
+	// performing its normal action (e.g. 'j' must not move the focus cursor).
+	app.agentLimitModalActive = true
+	beforeIdx := app.focusActiveIdx
+	beforeQueue := app.focusQueueIndex
+	beforeSection := app.focusCursorSection
+	model, dismissCmd := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	app = model.(App)
-	if app.newAgentPending {
-		t.Fatal("Expected newAgentPending cleared by non-n key press")
+	if app.agentLimitModalActive {
+		t.Fatal("Expected agentLimitModalActive cleared by non-n key press")
+	}
+	if dismissCmd != nil {
+		if msg := dismissCmd(); msg != nil {
+			if _, ok := msg.(createResultMsg); ok {
+				t.Fatal("Expected no agent creation when dismissing modal with 'j'")
+			}
+		}
+	}
+	if v := app.View(); strings.Contains(v.Content, "Focus limit reached") {
+		t.Fatal("Expected rendered View to NOT contain 'Focus limit reached' after cancel")
+	}
+	if app.focusActiveIdx != beforeIdx || app.focusQueueIndex != beforeQueue || app.focusCursorSection != beforeSection {
+		t.Fatalf("Expected focus cursor unchanged after dismiss key; before=(idx=%d,q=%d,sec=%v) after=(idx=%d,q=%d,sec=%v)",
+			beforeIdx, beforeQueue, beforeSection, app.focusActiveIdx, app.focusQueueIndex, app.focusCursorSection)
 	}
 }
 
@@ -1825,7 +1847,7 @@ func TestSoftAgentLimitGuardMultiRepo(t *testing.T) {
 	// Enable focus mode.
 	app.focusModeActive = true
 
-	// First 'n' press: should warn and set newAgentPending; picker must NOT open.
+	// First 'n' press: should show modal and set agentLimitModalActive; picker must NOT open.
 	model, cmd := app.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
 	app = model.(App)
 	if cmd != nil {
@@ -1834,21 +1856,21 @@ func TestSoftAgentLimitGuardMultiRepo(t *testing.T) {
 			t.Fatal("Expected no agent creation on first 'n' press at limit")
 		}
 	}
-	if !app.newAgentPending {
-		t.Fatal("Expected newAgentPending=true after first 'n' at limit")
+	if !app.agentLimitModalActive {
+		t.Fatal("Expected agentLimitModalActive=true after first 'n' at limit")
 	}
-	if app.err == "" {
-		t.Fatal("Expected warning message after first 'n' at limit")
+	if v := app.View(); !strings.Contains(v.Content, "Focus limit reached") {
+		t.Fatalf("Expected rendered View to contain 'Focus limit reached' modal title; got:\n%s", v.Content)
 	}
 	if app.view == ViewRepoPicker {
 		t.Fatal("Expected view != ViewRepoPicker on first 'n' at limit")
 	}
 
-	// Second 'n' press: should clear pending and open the picker.
+	// Second 'n' press: should clear modal and open the picker.
 	model, _ = app.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
 	app = model.(App)
-	if app.newAgentPending {
-		t.Fatal("Expected newAgentPending=false after second 'n'")
+	if app.agentLimitModalActive {
+		t.Fatal("Expected agentLimitModalActive=false after second 'n'")
 	}
 	if app.view != ViewRepoPicker {
 		t.Fatal("Expected view == ViewRepoPicker after second 'n' override")


### PR DESCRIPTION
## Summary

- The previous one-line `setError(...)` banner shared the auto-clearing error strip with messages like "no PR yet" or "no IDE configured", making the focus-mode 3-agent cap easy to miss.
- Replace it with a centered, bordered modal overlay (mirroring the existing `repoPickerActive` overlay pattern) so the cap is front and center. The modal shows the current agent count and the BCG-research framing ("beyond ~3, oversight cost exceeds output value").
- The two-press `n` interaction is preserved: first `n` at the limit shows the modal; second `n` overrides and spawns; any other key dismisses the modal without performing its normal action (e.g. `j` does NOT move the focus cursor).
- Renames the in-memory flag `newAgentPending` → `agentLimitModalActive` to match its new visual semantics.
- Scope: agent-count warning only. The parallel `focusBacklogWarning` keeps its one-line banner — deferred to a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./internal/tui/...` (passes; 2 unrelated pre-existing failures in `internal/hook` and `internal/config` reproduce on `origin/main`)
- [ ] Manual TUI: spawn 3 agents in focus mode, press `n` a 4th time, expect centered modal "Focus limit reached"; press `n` again to override and spawn; press `n` again to re-trigger and any other key (e.g. `j`) to cancel without moving the cursor; repeat with multi-repo config to confirm the repo picker still opens after override.

## Checklist

- [x] Added `changelog.d/change-agent-limit-modal.md` (per `CLAUDE.md`'s changelog-fragment convention)
- [x] New behavior has tests (`TestSoftAgentLimitGuard` and `TestSoftAgentLimitGuardMultiRepo` updated; new sub-case asserts non-`n` cancel does not move focus cursor; `View().Content` assertions verify the modal renders/dismisses)
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)