### PR TITLE
Pin focus-mode keymap hints to the screen footer

### DIFF
--- a/changelog.d/fix-focus-footer-position.md
+++ b/changelog.d/fix-focus-footer-position.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Focus mode: the keymap hint bar now sits as a static footer at the bottom of the screen instead of floating up against the sessions list. The fullscreen pipeline view pads its content to fill the available height, matching the behaviour of the break overlays.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1686,7 +1686,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, "")
 	}
 
-	return strings.Join(lines, "\n")
+	return lipgloss.Place(width, height, lipgloss.Left, lipgloss.Top, strings.Join(lines, "\n"))
 }
 
 func (d dashboardModel) renderPreview(width int) string {


### PR DESCRIPTION
## Summary

- The fullscreen focus pipeline returned its joined lines without filling the dashboard's allocated height, so the statusbar (joined below in `App.View`) sat right under the SESSIONS list instead of at the bottom of the screen.
- Wrap the body in `lipgloss.Place(width, height, Left, Top, …)` so the keymap hint bar pins to the bottom as a static footer, matching the break overlays.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./internal/tui/...`
- [ ] Manual TUI: enter focus mode with a small/medium sessions list and confirm the keymap row sits at the bottom of the terminal regardless of how many sessions are listed.

## Checklist

- [x] Changelog fragment added under `changelog.d/`
- [x] No new public API surface