### PR TITLE
Fix focus-mode m/r keys to work between Claude turns

### DIFF
--- a/changelog.d/fix-focus-mode-mark-and-review-keys.md
+++ b/changelog.d/fix-focus-mode-mark-and-review-keys.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Focus-mode `m` (mark for review) and `r` (open review) keys now work end-to-end during a normal Claude workflow. Previously `m` only fired after the user manually `/exit`'d Claude (the only path that set `DoneAt`), which meant the review queue was unreachable in typical use and `r` always saw an empty queue. `m` is now available the moment Claude finishes a turn (any non-shell agent in `Idle`/`Done`/`Error`), and both keys surface inline error messages explaining no-ops instead of failing silently. `m` also respects which section the cursor is on, and finished session cards now show a `✓ idle — press m to review` cue so the affordance is discoverable.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -257,6 +257,32 @@ func (s *Session) Status() Status {
 	return StatusIdle
 }
 
+// IsReviewable reports whether the session is at a natural review point: it
+// has at least one non-shell agent, and every non-shell agent is in
+// {StatusIdle, StatusDone, StatusError}. Equivalently, no non-shell agent is
+// Active, Waiting, or Starting. Shell agents are ignored — they're long-lived
+// helpers, not work that produces a reviewable result. This is additive to
+// MarkDone()/DoneAt(), which still mean "process exited"; IsReviewable also
+// returns true between Claude turns when the agent is Idle but hasn't /exit'd.
+func (s *Session) IsReviewable() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	nonShell := 0
+	for _, a := range s.agents {
+		if a.IsShell {
+			continue
+		}
+		nonShell++
+		switch a.Status() {
+		case StatusIdle, StatusDone, StatusError:
+			// reviewable
+		default:
+			return false
+		}
+	}
+	return nonShell > 0
+}
+
 // AgentCount returns the number of agents in this session.
 func (s *Session) AgentCount() int {
 	s.mu.RLock()
@@ -525,6 +551,19 @@ func (s *Session) RestoreDoneAt(t time.Time) {
 // NewSessionForTest creates a Session for use in tests outside the agent package.
 func NewSessionForTest(id, name string) *Session {
 	return newSession(id, name, &git.WorktreeInfo{})
+}
+
+// AddTestAgent injects a synthetic agent with the given id/shell flag/status
+// into the session for use in tests outside the agent package. It bypasses the
+// normal PTY-spawning path so callers don't need a real subprocess to exercise
+// status-dependent session logic (e.g. IsReviewable).
+func (s *Session) AddTestAgent(id string, isShell bool, status Status) *Agent {
+	a := &Agent{ID: id, IsShell: isShell, CreatedAt: time.Now()}
+	a.status = status
+	s.mu.Lock()
+	s.agents[id] = a
+	s.mu.Unlock()
+	return a
 }
 
 // TaskSummary returns the session's task summary. Empty until SetTaskSummary is called.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -556,10 +556,13 @@ func NewSessionForTest(id, name string) *Session {
 // AddTestAgent injects a synthetic agent with the given id/shell flag/status
 // into the session for use in tests outside the agent package. It bypasses the
 // normal PTY-spawning path so callers don't need a real subprocess to exercise
-// status-dependent session logic (e.g. IsReviewable).
+// status-dependent session logic (e.g. IsReviewable). The status write is
+// guarded by a.mu to match the pattern of every production writer of status.
 func (s *Session) AddTestAgent(id string, isShell bool, status Status) *Agent {
 	a := &Agent{ID: id, IsShell: isShell, CreatedAt: time.Now()}
+	a.mu.Lock()
 	a.status = status
+	a.mu.Unlock()
 	s.mu.Lock()
 	s.agents[id] = a
 	s.mu.Unlock()

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -820,5 +821,90 @@ func TestSession_LastOutputTime_ZeroWhenOnlyShellAgents(t *testing.T) {
 
 	if got := s.LastOutputTime(); !got.IsZero() {
 		t.Errorf("LastOutputTime() = %v, want zero (only shell agents)", got)
+	}
+}
+
+// --- IsReviewable tests ---
+
+func makeReviewableSession(t *testing.T, statuses []Status, includeShell bool) *Session {
+	t.Helper()
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	s.mu.Lock()
+	for i, st := range statuses {
+		id := fmt.Sprintf("a%d", i)
+		ag := &Agent{ID: id, IsShell: false, CreatedAt: time.Now()}
+		ag.status = st
+		s.agents[id] = ag
+	}
+	if includeShell {
+		shell := &Agent{ID: "shell", IsShell: true, CreatedAt: time.Now()}
+		shell.status = StatusActive
+		s.agents["shell"] = shell
+	}
+	s.mu.Unlock()
+	return s
+}
+
+func TestSession_IsReviewable_AllIdle(t *testing.T) {
+	s := makeReviewableSession(t, []Status{StatusIdle, StatusIdle}, false)
+	if !s.IsReviewable() {
+		t.Error("IsReviewable() = false, want true for all-idle session")
+	}
+}
+
+func TestSession_IsReviewable_MixedIdleAndActive(t *testing.T) {
+	s := makeReviewableSession(t, []Status{StatusIdle, StatusActive}, false)
+	if s.IsReviewable() {
+		t.Error("IsReviewable() = true, want false when an agent is Active")
+	}
+}
+
+func TestSession_IsReviewable_AllDone(t *testing.T) {
+	s := makeReviewableSession(t, []Status{StatusDone, StatusDone}, false)
+	if !s.IsReviewable() {
+		t.Error("IsReviewable() = false, want true for all-done session")
+	}
+}
+
+func TestSession_IsReviewable_Waiting(t *testing.T) {
+	s := makeReviewableSession(t, []Status{StatusWaiting}, false)
+	if s.IsReviewable() {
+		t.Error("IsReviewable() = true, want false for waiting session")
+	}
+}
+
+func TestSession_IsReviewable_Starting(t *testing.T) {
+	s := makeReviewableSession(t, []Status{StatusStarting}, false)
+	if s.IsReviewable() {
+		t.Error("IsReviewable() = true, want false for starting session")
+	}
+}
+
+func TestSession_IsReviewable_ShellOnly(t *testing.T) {
+	s := makeReviewableSession(t, nil, true)
+	if s.IsReviewable() {
+		t.Error("IsReviewable() = true, want false for shell-only session")
+	}
+}
+
+func TestSession_IsReviewable_NoAgents(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	if s.IsReviewable() {
+		t.Error("IsReviewable() = true, want false for no-agents session")
+	}
+}
+
+func TestSession_IsReviewable_SingleError(t *testing.T) {
+	s := makeReviewableSession(t, []Status{StatusError}, false)
+	if !s.IsReviewable() {
+		t.Error("IsReviewable() = false, want true for single-error session")
+	}
+}
+
+func TestSession_IsReviewable_IgnoresShellWhenOtherAgentsReviewable(t *testing.T) {
+	// Shell agent in StatusActive shouldn't block reviewability.
+	s := makeReviewableSession(t, []Status{StatusIdle}, true)
+	if !s.IsReviewable() {
+		t.Error("IsReviewable() = false, want true (shell agent should be ignored)")
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1140,19 +1140,42 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			case "m":
 				// Mark the session under the focus cursor as ReadyForReview.
-				inProgress := a.dashboard.allInProgressSessions()
-				if a.focusActiveIdx < len(inProgress) {
-					sess := inProgress[a.focusActiveIdx].session
-					if sess != nil && !sess.DoneAt().IsZero() {
-						sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
-						a.focusQueueIndex = 0
-						return a, a.fetchReviewDiffCmd(sess)
-					}
+				if a.focusCursorSection != focusSectionActive {
+					a.setError("nothing to mark — cursor is on the review queue")
+					return a, nil
 				}
-				return a, nil
+				inProgress := a.dashboard.allInProgressSessions()
+				if len(inProgress) == 0 {
+					a.setError("no in-progress sessions")
+					return a, nil
+				}
+				if a.focusActiveIdx >= len(inProgress) {
+					a.setError("no in-progress sessions")
+					return a, nil
+				}
+				sess := inProgress[a.focusActiveIdx].session
+				if sess == nil {
+					a.setError("no in-progress sessions")
+					return a, nil
+				}
+				if !sess.IsReviewable() {
+					switch sess.Status() {
+					case agent.StatusActive:
+						a.setError("session is still running — wait for Claude to finish its turn")
+					case agent.StatusWaiting:
+						a.setError("session is waiting for input — resolve the prompt first")
+					default:
+						a.setError("session is still running — wait for Claude to finish its turn")
+					}
+					return a, nil
+				}
+				sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
+				a.focusQueueIndex = 0
+				return a, a.fetchReviewDiffCmd(sess)
 			case "r":
 				reviewItems := a.dashboard.reviewQueueSessions()
 				if len(reviewItems) == 0 {
+					a.setError("review queue is empty — press m on a finished session first")
 					return a, nil
 				}
 				idx := a.focusQueueIndex

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2348,12 +2348,12 @@ func TestFocusLaunch_FocusModeKeysForwardToAgent(t *testing.T) {
 // view marks the session under the cursor (focusActiveIdx), not the first matching
 // session in the list.
 func TestFocusMode_MKey_IsCursorAware(t *testing.T) {
-	sessA := &agent.Session{Name: "active-a"}
+	sessA := agent.NewSessionForTest("a", "active-a")
 	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
-	sessA.MarkDone()
-	sessB := &agent.Session{Name: "active-b"}
+	sessA.AddTestAgent("a-1", false, agent.StatusIdle)
+	sessB := agent.NewSessionForTest("b", "active-b")
 	sessB.SetLifecyclePhase(agent.LifecycleInProgress)
-	sessB.MarkDone()
+	sessB.AddTestAgent("b-1", false, agent.StatusIdle)
 
 	app := NewApp()
 	app.width = 120
@@ -2378,5 +2378,166 @@ func TestFocusMode_MKey_IsCursorAware(t *testing.T) {
 	}
 	if sessA.LifecyclePhase() != agent.LifecycleInProgress {
 		t.Errorf("expected sessA (non-cursor session) phase unchanged=InProgress, got %v", sessA.LifecyclePhase())
+	}
+}
+
+// makeFocusModeMRApp wires up an App in focus mode with one in-progress session
+// (sessA) and one ready-for-review session (sessR). Used by the m/r handler tests
+// below. The caller is responsible for adding agents to sessA via AddTestAgent.
+func makeFocusModeMRApp(t *testing.T) (App, *agent.Session, *agent.Session) {
+	t.Helper()
+	sessA := agent.NewSessionForTest("a", "active-a")
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessR := agent.NewSessionForTest("r", "review-r")
+	sessR.SetLifecyclePhase(agent.LifecycleReadyForReview)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sessA},
+		{kind: listItemSession, repoPath: "/r", session: sessR},
+	}
+	return app, sessA, sessR
+}
+
+// TestFocusMode_MKey_CursorOnReviewSection_ShowsError verifies that pressing "m"
+// while the cursor is on the REVIEW QUEUE section is a no-op that surfaces an
+// error explaining why nothing happened.
+func TestFocusMode_MKey_CursorOnReviewSection_ShowsError(t *testing.T) {
+	app, sessA, _ := makeFocusModeMRApp(t)
+	sessA.AddTestAgent("a-1", false, agent.StatusIdle)
+	app.focusCursorSection = focusSectionReview
+	app.focusQueueIndex = 0
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	app = model.(App)
+
+	if app.err == "" {
+		t.Fatal("expected error message when pressing m with cursor on review section")
+	}
+	if !strings.Contains(app.err, "review queue") {
+		t.Errorf("expected error to mention review queue, got %q", app.err)
+	}
+	// sessA must NOT have transitioned phase.
+	if sessA.LifecyclePhase() != agent.LifecycleInProgress {
+		t.Errorf("expected sessA phase unchanged=InProgress, got %v", sessA.LifecyclePhase())
+	}
+}
+
+// TestFocusMode_MKey_ActiveSession_ShowsRunningError verifies that pressing "m"
+// on an active (non-reviewable) session surfaces a "still running" error and
+// does not transition the session phase.
+func TestFocusMode_MKey_ActiveSession_ShowsRunningError(t *testing.T) {
+	app, sessA, _ := makeFocusModeMRApp(t)
+	sessA.AddTestAgent("a-1", false, agent.StatusActive)
+	app.focusCursorSection = focusSectionActive
+	app.focusActiveIdx = 0
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	app = model.(App)
+
+	if app.err == "" {
+		t.Fatal("expected error message when pressing m on active session")
+	}
+	if !strings.Contains(app.err, "still running") {
+		t.Errorf("expected error to mention still running, got %q", app.err)
+	}
+	if sessA.LifecyclePhase() != agent.LifecycleInProgress {
+		t.Errorf("expected sessA phase unchanged=InProgress, got %v", sessA.LifecyclePhase())
+	}
+}
+
+// TestFocusMode_MKey_IdleSession_TransitionsToReady verifies that pressing "m"
+// on a session whose agents are all idle (Claude finished a turn but did not
+// /exit) transitions the session to ReadyForReview and fires the diff fetch.
+func TestFocusMode_MKey_IdleSession_TransitionsToReady(t *testing.T) {
+	app, sessA, _ := makeFocusModeMRApp(t)
+	sessA.AddTestAgent("a-1", false, agent.StatusIdle)
+	app.focusCursorSection = focusSectionActive
+	app.focusActiveIdx = 0
+
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	app = model.(App)
+
+	if sessA.LifecyclePhase() != agent.LifecycleReadyForReview {
+		t.Errorf("expected sessA phase=ReadyForReview, got %v", sessA.LifecyclePhase())
+	}
+	if app.focusQueueIndex != 0 {
+		t.Errorf("expected focusQueueIndex reset to 0, got %d", app.focusQueueIndex)
+	}
+	if cmd == nil {
+		t.Error("expected a diff-fetch Cmd, got nil")
+	}
+	if app.err != "" {
+		t.Errorf("expected no error on success, got %q", app.err)
+	}
+}
+
+// TestFocusMode_RKey_EmptyQueue_ShowsError verifies that pressing "r" with no
+// review-phase sessions surfaces an error and does not change panelFocus.
+func TestFocusMode_RKey_EmptyQueue_ShowsError(t *testing.T) {
+	sessA := agent.NewSessionForTest("a", "active-a")
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessA.AddTestAgent("a-1", false, agent.StatusActive)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.focusModeActive = true
+	app.dashboard.focusModeActive = true
+	app.dashboard.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sessA},
+	}
+	app.focusCursorSection = focusSectionActive
+	app.focusActiveIdx = 0
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	app = model.(App)
+
+	if app.err == "" {
+		t.Fatal("expected error message when pressing r with empty queue")
+	}
+	if !strings.Contains(app.err, "review queue is empty") {
+		t.Errorf("expected error to mention empty review queue, got %q", app.err)
+	}
+	if app.dashboard.panelFocus == focusReview {
+		t.Error("expected panelFocus to stay focusList, got focusReview")
+	}
+	if app.reviewSession != nil {
+		t.Errorf("expected reviewSession to stay nil, got %v", app.reviewSession)
+	}
+}
+
+// TestFocusMode_RKey_NonEmptyQueue_OpensReviewPanel verifies that pressing "r"
+// with at least one review-phase session opens the review panel and selects the
+// session at focusQueueIndex.
+func TestFocusMode_RKey_NonEmptyQueue_OpensReviewPanel(t *testing.T) {
+	app, _, sessR := makeFocusModeMRApp(t)
+	app.focusCursorSection = focusSectionReview
+	app.focusQueueIndex = 0
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	app = model.(App)
+
+	if app.err != "" {
+		t.Errorf("expected no error, got %q", app.err)
+	}
+	if app.dashboard.panelFocus != focusReview {
+		t.Errorf("expected panelFocus=focusReview, got %v", app.dashboard.panelFocus)
+	}
+	if app.reviewSession != sessR {
+		t.Errorf("expected reviewSession=sessR, got %v", app.reviewSession)
+	}
+	if sessR.LifecyclePhase() != agent.LifecycleInReview {
+		t.Errorf("expected sessR phase=InReview, got %v", sessR.LifecyclePhase())
 	}
 }

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -806,8 +806,8 @@ func (d dashboardModel) allInProgressSessions() []listItem {
 }
 
 // sessionFocusStatus returns a styled inline status badge for a session row in
-// the unified SESSIONS list. Priority: Error > Waiting > May Need Input > finished (DoneAt set)
-// > normal (N active, M idle).
+// the unified SESSIONS list. Priority: Error > Waiting > May Need Input >
+// idle-but-reviewable > finished (DoneAt set) > normal (N active, M idle).
 func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 	var waitingCount, activeCount, idleCount, idleAskingCount int
 	var firstWaitingReason string
@@ -845,6 +845,9 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 	}
 	if idleAskingCount > 0 {
 		return lipgloss.NewStyle().Foreground(ColorWarning).Render(fmt.Sprintf("? %d idle — may need input", idleAskingCount))
+	}
+	if sess.IsReviewable() && sess.DoneAt().IsZero() {
+		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ idle — press m to review")
 	}
 	if !sess.DoneAt().IsZero() {
 		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ finished — awaiting prompt")
@@ -910,6 +913,8 @@ func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Co
 		return ColorWaiting
 	case hasIdleAsking:
 		return ColorWarning
+	case sess.IsReviewable() && sess.DoneAt().IsZero():
+		return ColorSuccess
 	case !sess.DoneAt().IsZero():
 		return ColorSuccess
 	default:

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -75,3 +75,89 @@ func TestRenderFocusActiveCursor(t *testing.T) {
 			unselectedLine, out)
 	}
 }
+
+// TestSessionFocusStatus_IdleReviewableShowsCue verifies that a session whose
+// non-shell agents are all Idle (and DoneAt is zero — i.e. Claude finished a
+// turn but did not /exit) renders the "press m to review" cue. This makes the
+// review affordance discoverable on every natural review point, not only after
+// the user manually exits Claude.
+func TestSessionFocusStatus_IdleReviewableShowsCue(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "active-a")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := d.sessionFocusStatus(sess)
+	if !strings.Contains(badge, "press m to review") {
+		t.Errorf("expected reviewable cue, got %q", badge)
+	}
+}
+
+// TestSessionFocusStatus_ActiveDoesNotShowCue verifies that the "press m to
+// review" cue does not fire when at least one non-shell agent is Active —
+// i.e. Claude is mid-turn and there is nothing to review yet.
+func TestSessionFocusStatus_ActiveDoesNotShowCue(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "active-a")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := d.sessionFocusStatus(sess)
+	if strings.Contains(badge, "press m to review") {
+		t.Errorf("did not expect reviewable cue with active agent, got %q", badge)
+	}
+}
+
+// TestSessionFocusStripeColor_IdleReviewableMatchesBadge verifies that the
+// session stripe color and the badge color agree for the new idle-reviewable
+// state — the function comment on sessionFocusStripeColor makes this an
+// explicit invariant.
+func TestSessionFocusStripeColor_IdleReviewableMatchesBadge(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "active-a")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	if got := d.sessionFocusStripeColor(sess); got != ColorSuccess {
+		t.Errorf("expected stripe ColorSuccess for idle-reviewable session, got %v", got)
+	}
+}
+
+// TestSessionFocusStatus_FinishedTakesPrecedence verifies that once DoneAt is
+// set (Claude /exit'd), the existing "✓ finished — awaiting prompt" badge wins
+// over the new idle cue, preserving the original badge ordering.
+func TestSessionFocusStatus_FinishedTakesPrecedence(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "active-a")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("a-1", false, agent.StatusDone)
+	sess.MarkDone()
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := d.sessionFocusStatus(sess)
+	if !strings.Contains(badge, "finished") {
+		t.Errorf("expected finished badge to win, got %q", badge)
+	}
+	if strings.Contains(badge, "press m to review") {
+		t.Errorf("expected idle cue not to fire when DoneAt set, got %q", badge)
+	}
+}


### PR DESCRIPTION
## Summary

- Focus-mode \`m\` (mark for review) and \`r\` (open review) were unreachable in typical use. \`m\` required \`!sess.DoneAt().IsZero()\`, which is only set when **all** non-shell agents reach Done/Error — i.e. when the user manually \`/exit\`s Claude. Between turns Claude sits at \`StatusIdle\`, so \`m\` silently no-op'd, no session reached \`LifecycleReadyForReview\`, and \`r\` always saw an empty queue.
- New \`Session.IsReviewable()\` is true iff the session has ≥1 non-shell agent and every non-shell agent is in \`{Idle, Done, Error}\`. The \`m\` handler uses it instead of \`DoneAt\`, so review becomes available the moment Claude finishes a turn.
- Both handlers now surface \`setError\` messages on every no-op path (cursor on review queue / no in-progress sessions / still running / waiting for input / empty review queue) instead of failing silently. \`m\` also respects \`focusCursorSection\`.
- Session cards show a \`✓ idle — press m to review\` cue when \`IsReviewable() && DoneAt.IsZero()\`, making the affordance discoverable. Stripe color tracks the new badge case to preserve the documented stripe/badge agreement invariant.
- \`MarkDone()\`/\`DoneAt()\` semantics and the existing \`✓ finished — awaiting prompt\` badge are unchanged. \`focusLaunch\` key forwarding is untouched.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`gofumpt -l .\` (clean)
- [ ] \`golangci-lint run ./...\`
- [x] \`go test -race ./...\` (passes for \`internal/agent\` and \`internal/tui\`; pre-existing env-specific failures in \`internal/config\` and \`internal/hook\` confirmed unrelated by stash-and-rerun on \`main\`)
- [ ] Manual TUI:
  - [ ] Enter focus mode (\`f\`), spawn a session (\`n\`), give Claude a prompt
  - [ ] While Claude is mid-turn, press \`m\` → "session is still running" error
  - [ ] Wait for Claude to finish; card shows the new \`✓ idle — press m to review\` cue
  - [ ] Press \`m\` → session moves to REVIEW QUEUE; \`r\` opens the review panel
  - [ ] With empty queue, press \`r\` → "review queue is empty" error
  - [ ] Move cursor into the review queue, press \`m\` → "cursor is on the review queue" error

## Checklist

- [x] Added \`changelog.d/fix-focus-mode-mark-and-review-keys.md\` fragment
- [x] New behavior has tests (\`Session.IsReviewable\` unit tests, focus-mode \`m\`/\`r\` handler tests, \`sessionFocusStatus\` and \`sessionFocusStripeColor\` render tests)
- [x] No new public API beyond \`Session.IsReviewable()\` and the \`Session.AddTestAgent\` cross-package test helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)