### PR TITLE
Focus mode: surface ready-for-input idle state in SESSIONS cards

### DIFF
--- a/changelog.d/focus-mode-ready-for-input.md
+++ b/changelog.d/focus-mode-ready-for-input.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Focus mode SESSIONS cards now distinguish idle-but-ready agents from actively-working ones: an all-idle session renders a mint `▎` stripe and a `✓ N ready for input` badge, while a mixed session shows `N active · M ready` with the ready count called out in mint
+- This is separate from the existing purple `waiting` state (Claude blocked on a permission prompt) and the yellow `may need input` heuristic, preserving the urgency hierarchy

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -635,6 +635,17 @@ func (a *Agent) Status() Status {
 	return a.status
 }
 
+// ForceStatusForTest sets the agent's status directly, bypassing the hook
+// pipeline. Test-only: production code drives status through OnHookEvent
+// (which depends on a real terminal for KindStop's askingQuestion scan).
+// Cross-package tests in internal/tui need this to construct agents in
+// StatusIdle without spinning up real PTYs.
+func (a *Agent) ForceStatusForTest(s Status) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.status = s
+}
+
 // WaitingReason returns the message from the most recent KindNotification event
 // that drove the agent to StatusWaiting, or "" if the agent is not waiting.
 // The reason is cleared when the agent transitions away from StatusWaiting via

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -64,6 +64,13 @@ type sessionTicker struct {
 // needs it today — add to theme.go if another view ever surfaces waiting.
 var ColorWaiting = lipgloss.Color("#D946EF")
 
+// ColorReady is the accent used in focus mode SESSIONS to flag sessions whose
+// agents are idle, finished a turn, ready for the next prompt — distinct from
+// ColorWaiting which is Claude-blocked on a permission/notification prompt.
+// Scoped to the dashboard because no other view surfaces this state today —
+// add to theme.go if another view ever needs it.
+var ColorReady = lipgloss.Color("#5EEAD4")
+
 // listItemKind distinguishes repo headers, session rows, and agent rows in the dashboard list.
 type listItemKind int
 
@@ -806,8 +813,9 @@ func (d dashboardModel) allInProgressSessions() []listItem {
 }
 
 // sessionFocusStatus returns a styled inline status badge for a session row in
-// the unified SESSIONS list. Priority: Error > Waiting > May Need Input > finished (DoneAt set)
-// > normal (N active, M idle).
+// the unified SESSIONS list. Priority: Error > Waiting > May Need Input >
+// finished (DoneAt set) > ready (all-idle, "✓ N ready for input") >
+// mixed (active+idle, "N active · M ready") > muted ("N active").
 func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 	var waitingCount, activeCount, idleCount, idleAskingCount int
 	var firstWaitingReason string
@@ -849,7 +857,16 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 	if !sess.DoneAt().IsZero() {
 		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ finished — awaiting prompt")
 	}
-	return StyleSubtle.Render(fmt.Sprintf("%d active, %d idle", activeCount, idleCount))
+	switch {
+	case activeCount == 0 && idleCount > 0:
+		return lipgloss.NewStyle().Foreground(ColorReady).Render(fmt.Sprintf("✓ %d ready for input", idleCount))
+	case activeCount > 0 && idleCount > 0:
+		left := StyleSubtle.Render(fmt.Sprintf("%d active", activeCount))
+		right := lipgloss.NewStyle().Foreground(ColorReady).Render(fmt.Sprintf("%d ready", idleCount))
+		return left + " · " + right
+	default:
+		return StyleSubtle.Render(fmt.Sprintf("%d active", activeCount))
+	}
 }
 
 // sessionFocusPriority returns an integer priority for sorting sessions in the
@@ -887,7 +904,7 @@ func (d dashboardModel) sessionFocusPriority(sess *agent.Session) int {
 // sessionFocusStatus so the stripe and the badge agree on the dominant
 // condition. Selection highlight is applied by the caller.
 func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Color {
-	var hasError, hasWaiting, hasIdleAsking bool
+	var hasError, hasWaiting, hasIdleAsking, hasIdle, hasActive bool
 	for _, item := range d.items {
 		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
 			continue
@@ -897,7 +914,10 @@ func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Co
 			hasError = true
 		case agent.StatusWaiting:
 			hasWaiting = true
+		case agent.StatusActive:
+			hasActive = true
 		case agent.StatusIdle:
+			hasIdle = true
 			if item.agent.AskingQuestion() {
 				hasIdleAsking = true
 			}
@@ -912,6 +932,8 @@ func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Co
 		return ColorWarning
 	case !sess.DoneAt().IsZero():
 		return ColorSuccess
+	case hasIdle && !hasActive:
+		return ColorReady
 	default:
 		return ColorMuted
 	}

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/baton/internal/agent"
 	"github.com/devenjarvis/baton/internal/github"
 	"github.com/devenjarvis/baton/internal/hook"
+	"github.com/muesli/termenv"
 )
 
 func TestSelectionRect_Inactive(t *testing.T) {
@@ -454,4 +456,126 @@ func TestAllInProgressSessions_StableWithinPriority(t *testing.T) {
 				i, sessions[0].session.Name, sessions[1].session.Name)
 		}
 	}
+}
+
+// TestSessionFocusStatusAllIdleReadyForInput verifies that a session whose
+// non-shell agents have all transitioned to StatusIdle (no AskingQuestion, no
+// DoneAt) renders the mint "ready for input" badge. This is the call-to-action
+// surface for "agents finished a turn, waiting on the user".
+func TestSessionFocusStatusAllIdleReadyForInput(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	sess := &agent.Session{ID: "s", Name: "ready"}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	a1 := &agent.Agent{Name: "a1"}
+	a1.ForceStatusForTest(agent.StatusIdle)
+	a2 := &agent.Agent{Name: "a2"}
+	a2.ForceStatusForTest(agent.StatusIdle)
+
+	d := newDashboardModel()
+	d.prCache = make(map[string]*prCacheEntry)
+	d.items = []listItem{
+		{kind: listItemSession, session: sess},
+		{kind: listItemAgent, session: sess, agent: a1},
+		{kind: listItemAgent, session: sess, agent: a2},
+	}
+
+	got := d.sessionFocusStatus(sess)
+	if !strings.Contains(got, "ready for input") {
+		t.Errorf("badge missing %q text\ngot: %q", "ready for input", got)
+	}
+	want := lipgloss.NewStyle().Foreground(ColorReady).Render("✓ 2 ready for input")
+	if !strings.Contains(got, want) {
+		t.Errorf("badge missing ColorReady-styled segment\nwant contains: %q\ngot: %q", want, got)
+	}
+}
+
+// TestSessionFocusStatusMixedActiveIdle verifies that a session with one active
+// and one idle agent renders the mixed "N active · M ready" badge — the
+// trailing ready segment in ColorReady, the leading active segment in
+// StyleSubtle, joined by a middle dot. Stripe stays muted (covered by
+// TestSessionFocusStripeColorAllIdle); only the badge calls out the count.
+func TestSessionFocusStatusMixedActiveIdle(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	sess := &agent.Session{ID: "s", Name: "mixed"}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	agActive := &agent.Agent{Name: "ag-active"}
+	agActive.OnHookEvent(hook.Event{Kind: hook.KindSessionStart})
+	agIdle := &agent.Agent{Name: "ag-idle"}
+	agIdle.ForceStatusForTest(agent.StatusIdle)
+
+	d := newDashboardModel()
+	d.prCache = make(map[string]*prCacheEntry)
+	d.items = []listItem{
+		{kind: listItemSession, session: sess},
+		{kind: listItemAgent, session: sess, agent: agActive},
+		{kind: listItemAgent, session: sess, agent: agIdle},
+	}
+
+	got := d.sessionFocusStatus(sess)
+	if !strings.Contains(got, "1 active") {
+		t.Errorf("badge missing %q segment\ngot: %q", "1 active", got)
+	}
+	if !strings.Contains(got, "1 ready") {
+		t.Errorf("badge missing %q segment\ngot: %q", "1 ready", got)
+	}
+	if !strings.Contains(got, "·") {
+		t.Errorf("badge missing %q separator\ngot: %q", "·", got)
+	}
+	wantReady := lipgloss.NewStyle().Foreground(ColorReady).Render("1 ready")
+	if !strings.Contains(got, wantReady) {
+		t.Errorf("badge ready segment not in ColorReady\nwant contains: %q\ngot: %q", wantReady, got)
+	}
+}
+
+// TestSessionFocusStripeColorAllIdle pins the stripe-color rules for the new
+// ready-for-input state: all-idle returns ColorReady, mixed (any active)
+// stays muted to preserve the noise budget, and all-active stays muted.
+// Higher-priority cases (error/waiting/asking/done) are covered by their own
+// tests; this one focuses on the new branch.
+func TestSessionFocusStripeColorAllIdle(t *testing.T) {
+	build := func(statuses ...agent.Status) (dashboardModel, *agent.Session) {
+		sess := &agent.Session{ID: "s", Name: "n"}
+		sess.SetLifecyclePhase(agent.LifecycleInProgress)
+		d := newDashboardModel()
+		d.prCache = make(map[string]*prCacheEntry)
+		items := []listItem{{kind: listItemSession, session: sess}}
+		for i, st := range statuses {
+			a := &agent.Agent{Name: "a"}
+			switch st {
+			case agent.StatusActive:
+				a.OnHookEvent(hook.Event{Kind: hook.KindSessionStart})
+			default:
+				a.ForceStatusForTest(st)
+			}
+			items = append(items, listItem{kind: listItemAgent, session: sess, agent: a})
+			_ = i
+		}
+		d.items = items
+		return d, sess
+	}
+
+	t.Run("all idle → ColorReady", func(t *testing.T) {
+		d, sess := build(agent.StatusIdle, agent.StatusIdle)
+		if got := d.sessionFocusStripeColor(sess); got != ColorReady {
+			t.Errorf("all-idle stripe: got %v, want ColorReady (%v)", got, ColorReady)
+		}
+	})
+	t.Run("mixed active+idle → ColorMuted", func(t *testing.T) {
+		d, sess := build(agent.StatusActive, agent.StatusIdle)
+		if got := d.sessionFocusStripeColor(sess); got != ColorMuted {
+			t.Errorf("mixed stripe: got %v, want ColorMuted (%v)", got, ColorMuted)
+		}
+	})
+	t.Run("all active → ColorMuted", func(t *testing.T) {
+		d, sess := build(agent.StatusActive, agent.StatusActive)
+		if got := d.sessionFocusStripeColor(sess); got != ColorMuted {
+			t.Errorf("all-active stripe: got %v, want ColorMuted (%v)", got, ColorMuted)
+		}
+	})
 }

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/baton/internal/agent"
+	"github.com/devenjarvis/baton/internal/hook"
 	"github.com/muesli/termenv"
 )
 
@@ -73,5 +74,77 @@ func TestRenderFocusActiveCursor(t *testing.T) {
 	if strings.Contains(unselectedLine, selectedStripe) {
 		t.Fatalf("unselected card unexpectedly carries selection stripe color\nunselected line: %q\nfull:\n%s",
 			unselectedLine, out)
+	}
+}
+
+// TestRenderFocusStripeMintForAllIdleSession verifies the render path
+// surfaces ColorReady for an all-idle session (every non-shell agent is
+// StatusIdle, no asking-question, no DoneAt). A second session in the same
+// render pass with at least one StatusActive agent must continue to render
+// the muted stripe — the new accent must not bleed across sessions.
+func TestRenderFocusStripeMintForAllIdleSession(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	sessIdle := &agent.Session{Name: "all-idle"}
+	sessIdle.SetLifecyclePhase(agent.LifecycleInProgress)
+	idleA := &agent.Agent{Name: "idle-a"}
+	idleA.ForceStatusForTest(agent.StatusIdle)
+	idleB := &agent.Agent{Name: "idle-b"}
+	idleB.ForceStatusForTest(agent.StatusIdle)
+
+	sessActive := &agent.Session{Name: "has-active"}
+	sessActive.SetLifecyclePhase(agent.LifecycleInProgress)
+	activeAg := &agent.Agent{Name: "active"}
+	activeAg.OnHookEvent(hook.Event{Kind: hook.KindSessionStart})
+
+	d := newDashboardModel()
+	d.width = 120
+	d.height = 39
+	d.focusModeActive = true
+	d.focusCursorSection = focusSectionActive
+	// Keep the cursor away from either of these sessions so neither gets the
+	// selection-highlight cyan stripe — that would mask the underlying
+	// stripe color we want to assert against.
+	d.focusActiveIdx = 99
+	d.items = []listItem{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+		{kind: listItemSession, repoPath: "/r", session: sessIdle},
+		{kind: listItemAgent, repoPath: "/r", session: sessIdle, agent: idleA},
+		{kind: listItemAgent, repoPath: "/r", session: sessIdle, agent: idleB},
+		{kind: listItemSession, repoPath: "/r", session: sessActive},
+		{kind: listItemAgent, repoPath: "/r", session: sessActive, agent: activeAg},
+	}
+
+	out := d.renderFullscreenFocus(120, 39)
+
+	mintStripe := lipgloss.NewStyle().Foreground(ColorReady).Render("▎")
+	mutedStripe := lipgloss.NewStyle().Foreground(ColorMuted).Render("▎")
+
+	var idleLine, activeLine string
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.Contains(line, "all-idle") && idleLine == "":
+			idleLine = line
+		case strings.Contains(line, "has-active") && activeLine == "":
+			activeLine = line
+		}
+	}
+	if idleLine == "" || activeLine == "" {
+		t.Fatalf("could not find both session header lines in output:\n%s", out)
+	}
+
+	if !strings.Contains(idleLine, mintStripe) {
+		t.Fatalf("all-idle card missing mint stripe %q\nline: %q\nfull:\n%s",
+			mintStripe, idleLine, out)
+	}
+	if !strings.Contains(activeLine, mutedStripe) {
+		t.Fatalf("active card missing muted stripe %q\nline: %q\nfull:\n%s",
+			mutedStripe, activeLine, out)
+	}
+	if strings.Contains(activeLine, mintStripe) {
+		t.Fatalf("active card unexpectedly carries mint stripe (mint must not bleed across sessions)\nline: %q\nfull:\n%s",
+			activeLine, out)
 	}
 }


### PR DESCRIPTION
## Summary

- Focus-mode SESSIONS cards now flip to a mint stripe and a `✓ N ready for input` badge when every non-shell agent in the session is `StatusIdle` with no asking-question — the call-to-action surface for "agents finished a turn, waiting on the user"
- Mixed sessions render `N active · M ready` with the ready count in mint and the active count muted; stripe stays muted because work is still happening
- New accent (`ColorReady = #5EEAD4`) is distinct from purple `ColorWaiting` (Claude blocked on a permission prompt) and yellow `ColorWarning` (idle-with-`?` heuristic), preserving the urgency hierarchy
- Added `Agent.ForceStatusForTest` (matches existing `NewSessionForTest` precedent) so cross-package tests can drive an agent to `StatusIdle` without spinning up a real PTY — `OnHookEvent(KindStop)` reads the terminal viewport, which would NIL panic on literal-constructed test agents

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` — 4 pre-existing failures on `main` (`TestLoad_MigratesFromLegacyXDGPath`, three `TestServer*` in `internal/hook`) reproduce unchanged on this branch and stem from `/var/folders` sandboxing, unrelated to this change
- [ ] Manual TUI:
  - Launch focus mode with one session, two agents
  - While both are running: badge reads `2 active` muted, stripe muted
  - One agent finishes a turn: badge flips to `1 active · 1 ready` (ready in mint), stripe stays muted
  - Both agents finish: badge flips to `✓ 2 ready for input` in mint, stripe becomes mint
  - Send a follow-up to one: badge returns to mixed
  - Trigger a permission prompt: purple `⏸ 1 waiting` still wins
  - Mark session done with `m`: green `✓ finished — awaiting prompt` replaces the mint badge
  - Confirm focusLaunch tab dots, pipeline widget, and review-queue are visually unchanged

## Checklist

- [x] Updated `changelog.d/focus-mode-ready-for-input.md`
- [x] New behavior has tests (3 unit tests in `dashboard_test.go`, 1 render test in `focus_render_test.go`)
- [x] One new public surface (`Agent.ForceStatusForTest`) noted above; matches existing `NewSessionForTest` convention