### PR TITLE
Fix focus-mode review panel orphaning sessions with no PR

### DIFF
--- a/changelog.d/fix-focus-review-orphan.md
+++ b/changelog.d/fix-focus-review-orphan.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Focus-mode review panel no longer orphans sessions. A session whose phase has progressed to `LifecycleInReview` now stays visible in REVIEW QUEUE (with a subtle `(reviewing)` tag), so pressing `ESC` after `p` with no PR cached can no longer leave the session unreachable.
+
+### Added
+
+- Two new keys in the focus-mode review panel:
+  - `t` — open the session's most-active agent in the fullscreen terminal (useful for sessions with no PR yet, e.g. running `gh pr create` manually, or for inspecting individual agents in a multi-agent session via the tab bar).
+  - `c` — mark the session complete without opening a PR, for design-doc / exploratory branches.
+- Footer hint in the review panel now advertises all available actions (`p / t / c / e / d / ESC`).

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1065,6 +1065,9 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			case "p":
 				// Ship: open PR URL if one exists, transition to Shipping.
+				// TODO(stacked-PR): when entry.stack is non-empty, offer a way
+				// to cycle through stack entries instead of always opening the
+				// head PR.
 				sess := a.reviewSession
 				if entry := a.prCache[sess.ID]; entry != nil && entry.pr != nil && entry.pr.URL != "" {
 					if err := openURL(entry.pr.URL); err != nil {
@@ -1075,8 +1078,27 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.dashboard.panelFocus = focusList
 					a.reviewSession = nil
 				} else {
-					a.setError("no open PR yet — create one in GitHub first")
+					a.setError("no open PR yet — press t to open the agent terminal or c to mark complete")
 				}
+				return a, nil
+			case "t":
+				// Open the session's most-active agent in the fullscreen
+				// focusLaunch terminal. Useful for sessions with no PR yet
+				// (run gh pr create manually) or for inspecting individual
+				// agents within a multi-agent session via the tab bar.
+				sess := a.reviewSession
+				a.reviewSession = nil
+				if !a.openSessionInFocusLaunch(sess) {
+					a.setError("session has no agents to open")
+				}
+				return a, nil
+			case "c":
+				// Mark complete without a PR (e.g. design docs, exploratory
+				// branches). Closes the panel.
+				sess := a.reviewSession
+				sess.SetLifecyclePhase(agent.LifecycleComplete)
+				a.dashboard.panelFocus = focusList
+				a.reviewSession = nil
 				return a, nil
 			case "e":
 				// Open in editor — same pattern as the existing "i" key handler.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2541,3 +2541,101 @@ func TestFocusMode_RKey_NonEmptyQueue_OpensReviewPanel(t *testing.T) {
 		t.Errorf("expected sessR phase=InReview, got %v", sessR.LifecyclePhase())
 	}
 }
+
+// TestReviewPanel_CKey_MarksComplete verifies that pressing "c" in the review
+// panel transitions the session to LifecycleComplete and closes the panel.
+// This unblocks workflows where a session has no PR (design docs, exploration)
+// and the user wants to take it off the review queue.
+func TestReviewPanel_CKey_MarksComplete(t *testing.T) {
+	app, _, sessR := makeFocusModeMRApp(t)
+	sessR.SetLifecyclePhase(agent.LifecycleInReview)
+	app.reviewSession = sessR
+	app.dashboard.panelFocus = focusReview
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	app = model.(App)
+
+	if sessR.LifecyclePhase() != agent.LifecycleComplete {
+		t.Errorf("expected sessR phase=Complete, got %v", sessR.LifecyclePhase())
+	}
+	if app.dashboard.panelFocus != focusList {
+		t.Errorf("expected panelFocus=focusList after c, got %v", app.dashboard.panelFocus)
+	}
+	if app.reviewSession != nil {
+		t.Errorf("expected reviewSession cleared, got %v", app.reviewSession)
+	}
+}
+
+// TestReviewPanel_TKey_NoAgents_ShowsError verifies that pressing "t" in the
+// review panel when the session has no agents (synthetic test scenario)
+// surfaces an error and clears reviewSession. Spawning a real-PTY-backed
+// agent for the success path is covered by TestFocusModeEnterOnActiveOpensFocusLaunch
+// since the underlying helper (openSessionInFocusLaunch) is shared.
+func TestReviewPanel_TKey_NoAgents_ShowsError(t *testing.T) {
+	app, _, sessR := makeFocusModeMRApp(t)
+	sessR.SetLifecyclePhase(agent.LifecycleInReview)
+	app.reviewSession = sessR
+	app.dashboard.panelFocus = focusReview
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	app = model.(App)
+
+	if app.err == "" {
+		t.Fatal("expected error when session has no agents")
+	}
+	if !strings.Contains(app.err, "no agents") {
+		t.Errorf("expected error to mention no agents, got %q", app.err)
+	}
+	if app.reviewSession != nil {
+		t.Errorf("expected reviewSession cleared after t, got %v", app.reviewSession)
+	}
+	// Phase preserved so the session is still in REVIEW QUEUE.
+	if sessR.LifecyclePhase() != agent.LifecycleInReview {
+		t.Errorf("expected sessR phase preserved=InReview, got %v", sessR.LifecyclePhase())
+	}
+}
+
+// TestReviewPanel_PKey_NoPR_DoesNotOrphan verifies the regression: pressing
+// "p" with no PR cached must NOT make the session unreachable. Even though
+// the session is already in LifecycleInReview, reviewQueueSessions() must
+// still surface it so the user can re-enter the panel after pressing ESC.
+func TestReviewPanel_PKey_NoPR_DoesNotOrphan(t *testing.T) {
+	app, _, sessR := makeFocusModeMRApp(t)
+	sessR.SetLifecyclePhase(agent.LifecycleInReview)
+	app.reviewSession = sessR
+	app.dashboard.panelFocus = focusReview
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+	app = model.(App)
+
+	if app.err == "" {
+		t.Fatal("expected error message when pressing p with no cached PR")
+	}
+	if !strings.Contains(app.err, "terminal") || !strings.Contains(app.err, "complete") {
+		t.Errorf("expected error to suggest t/c alternatives, got %q", app.err)
+	}
+
+	// Press ESC to close the panel — session stays InReview.
+	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	app = model.(App)
+
+	if app.dashboard.panelFocus != focusList {
+		t.Errorf("expected panelFocus=focusList after esc, got %v", app.dashboard.panelFocus)
+	}
+	if sessR.LifecyclePhase() != agent.LifecycleInReview {
+		t.Errorf("expected sessR phase=InReview after esc, got %v", sessR.LifecyclePhase())
+	}
+
+	// Regression: the InReview session must still appear in the review queue.
+	queue := app.dashboard.reviewQueueSessions()
+	found := false
+	for _, item := range queue {
+		if item.session == sessR {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("InReview session orphaned: not present in reviewQueueSessions() after p+esc with no PR")
+	}
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -766,12 +766,20 @@ func (d dashboardModel) renderList(width int) string {
 	return strings.Join(lines, "\n")
 }
 
-// reviewQueueSessions returns listItems for sessions in ReadyForReview phase.
+// reviewQueueSessions returns listItems for sessions in ReadyForReview or
+// InReview phase. InReview sessions are kept in the queue so that an ESC out
+// of the review panel never orphans them — without this, a session whose user
+// peeked at the review panel and backed out (or hit "open PR" with no PR
+// cached) would disappear from both SESSIONS (InProgress only) and the queue,
+// even though the pipeline IN REVIEW count showed it was still there.
 func (d dashboardModel) reviewQueueSessions() []listItem {
 	var result []listItem
 	for _, item := range d.items {
-		if item.kind == listItemSession && item.session != nil &&
-			item.session.LifecyclePhase() == agent.LifecycleReadyForReview {
+		if item.kind != listItemSession || item.session == nil {
+			continue
+		}
+		phase := item.session.LifecyclePhase()
+		if phase == agent.LifecycleReadyForReview || phase == agent.LifecycleInReview {
 			result = append(result, item)
 		}
 	}
@@ -1658,11 +1666,16 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 				prefix = cardStyle.Render("> ")
 			}
 
-			// Line 1: prefix + name (left) + prIndicator (right-aligned)
-			line1 := prefix + cardStyle.Render(name)
+			// Line 1: prefix + name (+ optional reviewing tag) (left) + prIndicator (right-aligned)
+			nameRendered := cardStyle.Render(name)
+			if sess.LifecyclePhase() == agent.LifecycleInReview {
+				tag := lipgloss.NewStyle().Foreground(lipgloss.Color("#9b7fdb")).Render(" (reviewing)")
+				nameRendered += tag
+			}
+			line1 := prefix + nameRendered
 			if prEntry := d.prCache[sess.ID]; prEntry != nil {
 				if prInd := prIndicator(prEntry); prInd != "" {
-					line1 = rightAlign(prefix+cardStyle.Render(name), prInd, width)
+					line1 = rightAlign(prefix+nameRendered, prInd, width)
 				}
 			}
 

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -455,3 +455,42 @@ func TestAllInProgressSessions_StableWithinPriority(t *testing.T) {
 		}
 	}
 }
+
+// TestReviewQueueSessions_IncludesInReview verifies that sessions whose phase
+// has progressed to LifecycleInReview still appear in the queue. Without this,
+// pressing ESC out of the review panel (which intentionally leaves the phase
+// at InReview) would orphan the session — invisible in both SESSIONS and
+// REVIEW QUEUE, even though the pipeline IN REVIEW count includes it.
+func TestReviewQueueSessions_IncludesInReview(t *testing.T) {
+	sessReady := &agent.Session{ID: "sr", Name: "ready"}
+	sessReady.SetLifecyclePhase(agent.LifecycleReadyForReview)
+
+	sessInReview := &agent.Session{ID: "si", Name: "in-review"}
+	sessInReview.SetLifecyclePhase(agent.LifecycleInReview)
+
+	sessProgress := &agent.Session{ID: "sp", Name: "in-progress"}
+	sessProgress.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	d := newDashboardModel()
+	d.prCache = make(map[string]*prCacheEntry)
+	d.items = []listItem{
+		{kind: listItemSession, session: sessReady},
+		{kind: listItemSession, session: sessInReview},
+		{kind: listItemSession, session: sessProgress},
+	}
+
+	queue := d.reviewQueueSessions()
+	if len(queue) != 2 {
+		t.Fatalf("expected 2 sessions in queue (Ready+InReview), got %d", len(queue))
+	}
+	got := map[string]bool{}
+	for _, item := range queue {
+		got[item.session.Name] = true
+	}
+	if !got["ready"] || !got["in-review"] {
+		t.Errorf("expected queue to contain ready and in-review sessions, got %v", got)
+	}
+	if got["in-progress"] {
+		t.Error("InProgress session must not appear in review queue")
+	}
+}

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -90,7 +90,9 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
 	hints := "  " +
 		lipgloss.NewStyle().Foreground(lipgloss.Color("#5ab58a")).Render("p") + StyleSubtle.Render(" — open PR in GitHub") +
-		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#7ec8e3")).Render("e") + StyleSubtle.Render(" — open in editor") +
+		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#7ec8e3")).Render("t") + StyleSubtle.Render(" — open agent terminal") +
+		"   " + StyleSubtle.Render("c — mark complete") +
+		"   " + StyleSubtle.Render("e — open in editor") +
 		"   " + StyleSubtle.Render("d — defer") +
 		"   " + StyleSubtle.Render("ESC — back to focus")
 	lines = append(lines, hints)

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -72,3 +72,28 @@ func TestWrapText(t *testing.T) {
 		t.Error("expected wrapping to produce multiple lines")
 	}
 }
+
+// TestRenderReviewPanel_FooterAdvertisesAllActions verifies that the action
+// footer surfaces the new t/c keys alongside p/e/d/ESC. Without these hints,
+// users who can't open a PR (no PR yet, design doc, etc.) have no visible
+// path forward and may end up orphaning the session.
+func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-1", "fix-auth")
+	sess.SetOriginalPrompt("Fix the auth bug")
+	sess.MarkDone()
+
+	output := renderReviewPanel(sess, nil, 120, 40)
+
+	for _, want := range []string{
+		"open PR",
+		"open agent terminal",
+		"mark complete",
+		"open in editor",
+		"defer",
+		"back to focus",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("footer must advertise %q; got:\n%s", want, output)
+		}
+	}
+}


### PR DESCRIPTION
In focus mode, activating a session for review flips its lifecycle to
InReview. The panel only offered `p` (open existing PR), and pressing it
on a session with no cached PR showed an error without reverting state.
Pressing ESC then closed the panel — but InReview sessions appeared in
neither SESSIONS (InProgress) nor REVIEW QUEUE (ReadyForReview), so the
session was orphaned: the pipeline IN REVIEW count showed it but no UI
reached it.

Broaden the REVIEW QUEUE filter to include InReview sessions (rendered
with a subtle "(reviewing)" tag), and add two new actions in the panel:
`t` opens the session's most-active agent in the fullscreen terminal
(useful for `gh pr create` or inspecting individual agents in a
multi-agent session), and `c` marks the session complete without a PR
(for design docs / exploratory branches). The footer advertises the
expanded action set, and the no-PR error message points to the new
alternatives.