### PR TITLE
Remove dead code left over from focus-mode refactor

### DIFF
--- a/changelog.d/cleanup-post-focus-mode-refactor.md
+++ b/changelog.d/cleanup-post-focus-mode-refactor.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Removed the dead `focusTerminal` panel-focus state (preview-panel terminal focus is gone now that the pipeline view is the only dashboard). Drops ~150 lines of unreachable paste/key/wheel/cursor handling, the unused `screenToTermCell` and `forwardWheelToAgent` helpers, the `focusTerminalHints` status bar, and the now-orphaned `previewTermWidth/Height` and `previewMetadataRows` accessors.
+- Removed `agent.Status.Symbol()` — no callers since the focus-mode redesign.
+- Selection drag-copy now goes through a single focusLaunch path; the stale `selectedAgent()`-via-`d.selected` path was unreachable (selections only seed in focusLaunch) and could have copied with the wrong viewport size.
+- Trimmed always-same-value parameters from a few helpers: `addEditorFields(inputWidth)`, `renderReviewPanel(height)`, `writeUnifiedLine(width)`, and the test helpers `waitForStatus(d)`, `waitForBranch(d)`, `tickerDashboard(sidebarW)`, `sandboxGitConfig` return value, and `makeFocusModeApp` unused returns.

--- a/internal/agent/haikulog_test.go
+++ b/internal/agent/haikulog_test.go
@@ -69,12 +69,12 @@ func TestHaikuLog_ConcurrentWritesNoInterleaving(t *testing.T) {
 	var wg sync.WaitGroup
 	for g := 0; g < goroutines; g++ {
 		wg.Add(1)
-		go func(g int) {
+		go func() {
 			defer wg.Done()
 			for i := 0; i < perGoroutine; i++ {
 				haikuLog(repo, "tag-XYZ-marker")
 			}
-		}(g)
+		}()
 	}
 	wg.Wait()
 

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -55,7 +55,7 @@ func TestManagerDispatchesHookEventsToAgent(t *testing.T) {
 	}
 
 	// Manager emits EventStatusChanged on each hook-driven status mutation.
-	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusActive) {
 		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
 	}
 	if got := ag.ClaudeSessionID(); got != "claude-uuid-42" {
@@ -70,7 +70,7 @@ func TestManagerDispatchesHookEventsToAgent(t *testing.T) {
 		t.Fatalf("SendEvent Stop: %v", err)
 	}
 
-	if !waitForStatus(t, ag, StatusIdle, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusIdle) {
 		t.Fatalf("expected Idle after Stop, got %s", ag.Status())
 	}
 }
@@ -140,7 +140,7 @@ func TestManagerDispatchesNotificationAndStop(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent SessionStart: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusActive) {
 		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
 	}
 
@@ -152,7 +152,7 @@ func TestManagerDispatchesNotificationAndStop(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent Notification: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusWaiting, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusWaiting) {
 		t.Fatalf("expected Waiting after Notification, got %s", ag.Status())
 	}
 
@@ -163,7 +163,7 @@ func TestManagerDispatchesNotificationAndStop(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent Stop: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusIdle, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusIdle) {
 		t.Fatalf("expected Idle after Stop, got %s", ag.Status())
 	}
 }
@@ -201,7 +201,7 @@ func TestManagerUserPromptSubmitRearmsChime(t *testing.T) {
 		t.Fatalf("SendEvent UserPromptSubmit: %v", err)
 	}
 
-	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusActive) {
 		t.Fatalf("expected Active after UserPromptSubmit, got %s", ag.Status())
 	}
 	if ag.ChimedForTurn() {
@@ -354,7 +354,7 @@ func TestNotificationIgnoredWhenIdle(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent SessionStart: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusActive) {
 		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
 	}
 	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
@@ -363,7 +363,7 @@ func TestNotificationIgnoredWhenIdle(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent Stop: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusIdle, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusIdle) {
 		t.Fatalf("expected Idle after Stop, got %s", ag.Status())
 	}
 
@@ -498,7 +498,7 @@ func TestManagerPreToolUseClearsWaiting(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent SessionStart: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusActive) {
 		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
 	}
 
@@ -510,7 +510,7 @@ func TestManagerPreToolUseClearsWaiting(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent Notification: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusWaiting, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusWaiting) {
 		t.Fatalf("expected Waiting after Notification, got %s", ag.Status())
 	}
 
@@ -527,7 +527,7 @@ func TestManagerPreToolUseClearsWaiting(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent PreToolUse: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusActive) {
 		t.Fatalf("expected Active after PreToolUse, got %s", ag.Status())
 	}
 	if !ag.ChimedForTurn() {
@@ -633,7 +633,7 @@ func TestUserPromptSubmitRenamesBranch(t *testing.T) {
 		t.Fatalf("SendEvent prompt: %v", err)
 	}
 
-	got := waitForBranch(t, sess, "baton/add-dark-mode-to-dashboard", 2*time.Second)
+	got := waitForBranch(t, sess, "baton/add-dark-mode-to-dashboard")
 	if got != "baton/add-dark-mode-to-dashboard" {
 		t.Errorf("expected branch baton/add-dark-mode-to-dashboard, got %q", got)
 	}
@@ -695,7 +695,7 @@ func TestUserPromptSubmitSlashWithArgRenamesBranch(t *testing.T) {
 		t.Fatalf("SendEvent slash+arg: %v", err)
 	}
 
-	got := waitForBranch(t, sess, "baton/add-dark-mode", 2*time.Second)
+	got := waitForBranch(t, sess, "baton/add-dark-mode")
 	if got != "baton/add-dark-mode" {
 		t.Errorf("expected branch baton/add-dark-mode, got %q", got)
 	}
@@ -734,7 +734,7 @@ func TestWaitingReasonStoredAndCleared(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent SessionStart: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusActive) {
 		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
 	}
 
@@ -747,7 +747,7 @@ func TestWaitingReasonStoredAndCleared(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent Notification: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusWaiting, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusWaiting) {
 		t.Fatalf("expected Waiting after Notification, got %s", ag.Status())
 	}
 	if got := ag.WaitingReason(); got != wantReason {
@@ -761,7 +761,7 @@ func TestWaitingReasonStoredAndCleared(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent PreToolUse: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusActive) {
 		t.Fatalf("expected Active after PreToolUse, got %s", ag.Status())
 	}
 	if got := ag.WaitingReason(); got != "" {
@@ -769,10 +769,10 @@ func TestWaitingReasonStoredAndCleared(t *testing.T) {
 	}
 }
 
-// waitForStatus polls the agent status up to d for the desired value.
-func waitForStatus(t *testing.T, a *Agent, want Status, d time.Duration) bool {
+// waitForStatus polls the agent status up to 2s for the desired value.
+func waitForStatus(t *testing.T, a *Agent, want Status) bool {
 	t.Helper()
-	deadline := time.Now().Add(d)
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if a.Status() == want {
 			return true
@@ -915,7 +915,7 @@ func TestManagerSecondUserPromptSubmitDoesNotRename(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SendEvent: %v", err)
 	}
-	if !waitForStatus(t, ag, StatusActive, 2*time.Second) {
+	if !waitForStatus(t, ag, StatusActive) {
 		t.Fatalf("expected Active after second UserPromptSubmit")
 	}
 
@@ -988,7 +988,7 @@ func TestManagerEmptyPromptDoesNotConsumeGate(t *testing.T) {
 
 	// Follow-up actionable prompt: gate is still open, rename succeeds.
 	sendUserPromptSubmit(t, mgr, ag, "the real prompt")
-	if got := waitForBranch(t, sess, "baton/real-prompt-result", 2*time.Second); got != "baton/real-prompt-result" {
+	if got := waitForBranch(t, sess, "baton/real-prompt-result"); got != "baton/real-prompt-result" {
 		t.Errorf("retry rename: branch = %q, want baton/real-prompt-result", got)
 	}
 }
@@ -1098,11 +1098,11 @@ func TestManagerNamerErrorLeavesNamesUnchanged(t *testing.T) {
 	}
 }
 
-// waitForBranch polls Session.Branch() until it matches want or the deadline
-// elapses. Returns the last-observed branch on timeout for useful error output.
-func waitForBranch(t *testing.T, sess *Session, want string, d time.Duration) string {
+// waitForBranch polls Session.Branch() until it matches want or 2s elapses.
+// Returns the last-observed branch on timeout for useful error output.
+func waitForBranch(t *testing.T, sess *Session, want string) string {
 	t.Helper()
-	deadline := time.Now().Add(d)
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if got := sess.Branch(); got == want {
 			return got
@@ -1282,7 +1282,7 @@ func TestSmartBranchRename_NamerErrorRetriesNextPrompt(t *testing.T) {
 		t.Fatalf("SendEvent retry: %v", err)
 	}
 
-	got := waitForBranch(t, sess, "baton/second-attempt", 2*time.Second)
+	got := waitForBranch(t, sess, "baton/second-attempt")
 	if got != "baton/second-attempt" {
 		t.Errorf("retry branch = %q, want baton/second-attempt", got)
 	}
@@ -1345,7 +1345,7 @@ func TestSmartBranchRename_SlashOnlyDoesNotInvokeNamer(t *testing.T) {
 		t.Fatalf("SendEvent retry: %v", err)
 	}
 
-	got := waitForBranch(t, sess, "baton/real-result", 2*time.Second)
+	got := waitForBranch(t, sess, "baton/real-result")
 	if got != "baton/real-result" {
 		t.Errorf("retry branch = %q, want baton/real-result", got)
 	}
@@ -1414,7 +1414,7 @@ func TestSmartBranchRename_DoubleDispatchGated(t *testing.T) {
 	// Release the first call and ensure the rename completes.
 	close(release)
 
-	got := waitForBranch(t, sess, "baton/slow-result", 2*time.Second)
+	got := waitForBranch(t, sess, "baton/slow-result")
 	if got != "baton/slow-result" {
 		t.Errorf("branch = %q, want baton/slow-result", got)
 	}
@@ -1576,7 +1576,7 @@ func TestSmartBranchRename_CustomTemplateRendered(t *testing.T) {
 		t.Fatalf("SendEvent: %v", err)
 	}
 
-	got := waitForBranch(t, sess, "baton/fix-login", 2*time.Second)
+	got := waitForBranch(t, sess, "baton/fix-login")
 	if got != "baton/fix-login" {
 		t.Fatalf("branch = %q, want baton/fix-login", got)
 	}
@@ -1694,7 +1694,7 @@ func TestSmartBranchRename_TemplateWithoutPlaceholderAppendsPrompt(t *testing.T)
 		t.Fatalf("SendEvent: %v", err)
 	}
 
-	if got := waitForBranch(t, sess, "baton/ok", 2*time.Second); got != "baton/ok" {
+	if got := waitForBranch(t, sess, "baton/ok"); got != "baton/ok" {
 		t.Fatalf("branch = %q, want baton/ok", got)
 	}
 
@@ -2055,7 +2055,7 @@ func TestSmartBranchRename_RetryUsesOriginalPrompt(t *testing.T) {
 		t.Fatalf("SendEvent retry: %v", err)
 	}
 
-	got := waitForBranch(t, sess, "baton/focus-mode-pomodoro", 2*time.Second)
+	got := waitForBranch(t, sess, "baton/focus-mode-pomodoro")
 	if got != "baton/focus-mode-pomodoro" {
 		t.Errorf("retry branch = %q, want baton/focus-mode-pomodoro", got)
 	}

--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -30,23 +30,3 @@ func (s Status) String() string {
 		return "Unknown"
 	}
 }
-
-// Symbol returns a single-character symbol for the status.
-func (s Status) Symbol() string {
-	switch s {
-	case StatusStarting:
-		return "▷"
-	case StatusActive:
-		return "▶"
-	case StatusWaiting:
-		return "⏺"
-	case StatusIdle:
-		return "⏸"
-	case StatusDone:
-		return "⏭"
-	case StatusError:
-		return "⏹"
-	default:
-		return "?"
-	}
-}

--- a/internal/config/template_test.go
+++ b/internal/config/template_test.go
@@ -36,13 +36,12 @@ func TestExpandBranchPrefix_Date(t *testing.T) {
 // or mutate the developer's real ~/.gitconfig. HOME + XDG_CONFIG_HOME handle
 // most setups; GIT_CONFIG_GLOBAL=/dev/null is a belt-and-braces override in
 // case the caller's env already set it to a non-default path.
-func sandboxGitConfig(t *testing.T) string {
+func sandboxGitConfig(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
-	return dir
 }
 
 func TestExpandBranchPrefix_User(t *testing.T) {

--- a/internal/e2e/views_test.go
+++ b/internal/e2e/views_test.go
@@ -8,8 +8,7 @@ import "testing"
 //
 //   - dashboardAnchor: only appears in the dashboard status bar (not in any
 //     overlay's hint set, all of which use "navigate" too).
-//   - listFocusAnchor: dashboard text shown only when focus is on the list
-//     panel (terminal focus uses focusTerminalHints, which omits this).
+//   - listFocusAnchor: dashboard text shown only when focus is on the list.
 const (
 	dashboardAnchor = "new session"
 	listFocusAnchor = "new session"

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -857,8 +857,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case tea.PasteMsg:
-		// focusLaunch: forward paste to the launch agent. Other panels fall through
-		// to dashboard.Update, which handles paste for focusTerminal.
 		if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
 			a.focusLaunchAgent.Paste(msg.Content)
 			return a, nil
@@ -1036,8 +1034,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
-		// When the terminal or config panel has focus, skip all app-level bindings.
-		if a.dashboard.panelFocus == focusTerminal || a.dashboard.panelFocus == focusConfig {
+		// When the config panel has focus, skip all app-level bindings.
+		if a.dashboard.panelFocus == focusConfig {
 			a.confirmQuit = false
 			break
 		}
@@ -1758,39 +1756,16 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if msg, ok := msg.(tea.MouseMotionMsg); ok {
-		// Drag updates the cursor end of an in-flight selection. A motion
-		// event with the left button still held is the only signal we have
-		// that the user is dragging — bubbletea's MouseModeCellMotion gives
-		// us these while a button is down.
-		if a.dashboard.selection.active && msg.Button == tea.MouseLeft {
-			if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
-				tx, ty, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
-				if inVP {
-					a.dashboard.selection.cursorX = tx
-					a.dashboard.selection.cursorY = ty
-					a.dashboard.selection.dragSeen = true
-				}
-			} else {
-				termX, termY, _ := a.screenToTermCell(msg.X, msg.Y)
-				if w := a.dashboard.fixedTermWidth(); w > 0 {
-					if termX < 0 {
-						termX = 0
-					} else if termX >= w {
-						termX = w - 1
-					}
-				}
-				if h := a.dashboard.fixedTermHeight(); h > 0 {
-					if termY < 0 {
-						termY = 0
-					} else if termY >= h {
-						termY = h - 1
-					}
-				}
-				a.dashboard.selection.cursorX = termX
-				a.dashboard.selection.cursorY = termY
-				if termX != a.dashboard.selection.anchorX || termY != a.dashboard.selection.anchorY {
-					a.dashboard.selection.dragSeen = true
-				}
+		// Drag updates the cursor end of an in-flight selection. Selections
+		// only seed in focusLaunch (see MouseClickMsg), so any motion outside
+		// focusLaunch can be ignored here.
+		if a.dashboard.selection.active && msg.Button == tea.MouseLeft &&
+			a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
+			tx, ty, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
+			if inVP {
+				a.dashboard.selection.cursorX = tx
+				a.dashboard.selection.cursorY = ty
+				a.dashboard.selection.dragSeen = true
 			}
 		}
 		return a, nil
@@ -1799,26 +1774,9 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if _, ok := msg.(tea.MouseReleaseMsg); ok {
 		if a.dashboard.selection.active {
 			if a.dashboard.selection.dragSeen {
-				// Real drag — copy the highlighted region. The highlight
-				// stays on screen until the next click clears or replaces it.
-				if ag := a.dashboard.selectedAgent(); ag != nil && ag.ID == a.dashboard.selection.agentID {
-					if sx, sy, ex, ey, ok := a.dashboard.selectionRect(); ok {
-						rect := vt.SelectionRect{
-							StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
-						}
-						var text string
-						if a.dashboard.scrollOffset > 0 {
-							vpWidth := a.dashboard.previewTermWidth()
-							vpHeight := a.dashboard.previewTermHeight()
-							text = ag.ExtractTextFromSnapshot(vpWidth, vpHeight, a.dashboard.scrollOffset, rect)
-						} else {
-							text = ag.ExtractText(rect)
-						}
-						if text != "" {
-							return a, tea.SetClipboard(text)
-						}
-					}
-				} else if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == a.dashboard.selection.agentID {
+				// Real drag — copy the highlighted region. Selections only seed
+				// in focusLaunch (see MouseClickMsg), so this is the only path.
+				if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == a.dashboard.selection.agentID {
 					if sx, sy, ex, ey, ok := a.dashboard.selectionRect(); ok {
 						rect := vt.SelectionRect{
 							StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
@@ -1885,33 +1843,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
-		if a.dashboard.panelFocus == focusTerminal {
-			ag := a.dashboard.selectedAgent()
-			if ag != nil {
-				// Alt-screen apps (Claude's /tui fullscreen, vim, less) redraw
-				// the viewport instead of scrolling — baton's scrollback is
-				// inert for them. Forward the wheel event so the app can drive
-				// its own scrollback. SendMouse is a no-op unless the app has
-				// enabled mouse reporting.
-				if ag.IsAltScreen() {
-					a.forwardWheelToAgent(ag, msg)
-					return a, nil
-				}
-				switch msg.Button {
-				case tea.MouseWheelUp:
-					a.dashboard.scrollOffset += 3
-					maxOffset := len(ag.ScrollbackLines())
-					if a.dashboard.scrollOffset > maxOffset {
-						a.dashboard.scrollOffset = maxOffset
-					}
-				case tea.MouseWheelDown:
-					a.dashboard.scrollOffset -= 3
-					if a.dashboard.scrollOffset < 0 {
-						a.dashboard.scrollOffset = 0
-					}
-				}
-			}
-		}
 		return a, nil
 	}
 
@@ -1930,12 +1861,10 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 	// Maintain the invariant: a text selection only persists while the user
-	// remains focused on the same agent's terminal. Any focus or agent change
-	// (sidebar nav, esc, click on the list, etc.) drops it.
+	// remains in focusLaunch viewing the same agent. Any focus or agent
+	// change (esc back to pipeline, tab switch, etc.) drops it.
 	if a.dashboard.selection.active {
-		ag := a.dashboard.selectedAgent()
-		if (a.dashboard.panelFocus != focusTerminal || ag == nil || ag.ID != a.dashboard.selection.agentID) &&
-			(a.dashboard.panelFocus != focusLaunch || a.focusLaunchAgent == nil || a.focusLaunchAgent.ID != a.dashboard.selection.agentID) {
+		if a.dashboard.panelFocus != focusLaunch || a.focusLaunchAgent == nil || a.focusLaunchAgent.ID != a.dashboard.selection.agentID {
 			a.dashboard.clearSelection()
 		}
 	}
@@ -2146,10 +2075,10 @@ func (a *App) initRepoConfigForm(repoPath string) {
 	fields = addTextInput(fields, "Default Branch", defaultBranch, "auto-detect", inputWidth)
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
-	fields = addEditorFields(fields, ideCommand, inputWidth)
+	fields = addEditorFields(fields, ideCommand)
 	fields = addTextInput(fields, "Worktree Directory", worktreeDir, config.DefaultWorktreeDir, inputWidth)
 
-	form := newConfigForm(fields, a.dashboard.previewTermWidth())
+	form := newConfigForm(fields, a.dashboard.fixedTermWidth())
 	a.dashboard.repoConfigForm = &form
 	a.dashboard.configRepoPath = repoPath
 	a.dashboard.panelFocus = focusConfig
@@ -2270,40 +2199,6 @@ func (a App) activeRepoDisplayName() string {
 	return filepath.Base(a.activeRepo)
 }
 
-// screenToTermCell converts a screen-space mouse coordinate to a VT cell
-// coordinate inside the agent preview viewport. inViewport is false when the
-// point lies outside the viewport rectangle — callers that want clamping
-// should clamp to [0, fixedTermWidth) × [0, fixedTermHeight) themselves.
-//
-// The translation mirrors the dashboard layout: an optional error/confirm-quit
-// banner pushes content down, the list panel and its border occupy columns
-// 0..30 (the preview's left border lives at column 31), and the preview's
-// lipgloss frame plus the metadata rows above the VT viewport offset the
-// top-left cell.
-func (a *App) screenToTermCell(screenX, screenY int) (termX, termY int, inViewport bool) {
-	dashboardTopY := 0
-	if a.err != "" {
-		dashboardTopY++
-	}
-	if a.confirmQuit {
-		dashboardTopY++
-	}
-	const (
-		// previewColOffset is the screen column of the preview's left border
-		// (= listWidth + list-panel right border = 30 + 1). The preview's left
-		// border occupies that column; VT cell 0 sits at previewColOffset + 1.
-		previewColOffset  = 31
-		previewLeftBorder = 1
-		previewTopBorder  = 1
-	)
-	w := a.dashboard.fixedTermWidth()
-	h := a.dashboard.fixedTermHeight()
-	termX = screenX - previewColOffset - previewLeftBorder
-	termY = screenY - dashboardTopY - previewTopBorder - a.dashboard.previewMetadataRows()
-	inViewport = w > 0 && h > 0 && termX >= 0 && termX < w && termY >= 0 && termY < h
-	return termX, termY, inViewport
-}
-
 // focusLaunchTermHeight returns the terminal height for the focusLaunch view,
 // accounting for the header row and the tab bar row.
 func (a *App) focusLaunchTermHeight() int {
@@ -2345,34 +2240,7 @@ func (a *App) screenToTermCellFocusLaunch(screenX, screenY int) (termX, termY in
 	w := a.dashboard.width
 	h := a.dashboard.height - 2
 	inViewport = termX >= 0 && termX < w && termY >= 0 && termY < h
-	return
-}
-
-// forwardWheelToAgent encodes a mouse wheel event and feeds it to the agent's
-// terminal. Coordinates are translated from dashboard-screen space to cells
-// relative to the agent's PTY viewport and clamped to [0,W)×[0,H). The
-// emulator only emits bytes when the running program has enabled mouse
-// reporting (DECSET 1000/1002/1003 + SGR 1006).
-func (a *App) forwardWheelToAgent(ag *agent.Agent, msg tea.MouseWheelMsg) {
-	termX, termY, _ := a.screenToTermCell(msg.X, msg.Y)
-	if termX < 0 {
-		termX = 0
-	}
-	if w := a.dashboard.fixedTermWidth(); w > 0 && termX >= w {
-		termX = w - 1
-	}
-	if termY < 0 {
-		termY = 0
-	}
-	if h := a.dashboard.fixedTermHeight(); h > 0 && termY >= h {
-		termY = h - 1
-	}
-	ag.SendMouse(xvt.MouseWheel{
-		X:      termX,
-		Y:      termY,
-		Button: xvt.MouseButton(msg.Button),
-		Mod:    xvt.KeyMod(msg.Mod),
-	})
+	return termX, termY, inViewport
 }
 
 func (a *App) refreshAgentList() {
@@ -2771,15 +2639,13 @@ func (a App) View() tea.View {
 	case ViewDashboard:
 		if a.dashboard.panelFocus == focusReview && a.reviewSession != nil {
 			entry := a.reviewDiffCache[a.reviewSession.ID]
-			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width, a.height))
+			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width))
 			v.AltScreen = true
 			return v
 		}
 		body := a.dashboard.View()
 		hints := dashboardHints
 		switch a.dashboard.panelFocus {
-		case focusTerminal:
-			hints = focusTerminalHints
 		case focusConfig:
 			hints = repoConfigHints
 		case focusLaunch:
@@ -2866,25 +2732,7 @@ func (a App) View() tea.View {
 	v.AltScreen = true
 	if a.view == ViewDashboard {
 		v.MouseMode = tea.MouseModeCellMotion
-		if a.dashboard.panelFocus == focusTerminal && a.dashboard.scrollOffset == 0 {
-			if item := a.dashboard.selectedItem(); item != nil && item.kind == listItemAgent && item.agent != nil && item.agent.CursorVisible() {
-				cursorX, cursorY := item.agent.CursorPosition()
-				dashboardTopY := 0
-				if a.err != "" {
-					dashboardTopY++
-				}
-				if a.confirmQuit {
-					dashboardTopY++
-				}
-				// previewColOffset is the column of the preview's left border;
-				// VT cell 0 lives one column to its right. Mirrors the constant
-				// in screenToTermCell — the two formulas must move in lockstep.
-				const previewColOffset = 31
-				screenX := cursorX + previewColOffset + 1
-				screenY := cursorY + dashboardTopY + 1 + a.dashboard.previewMetadataRows()
-				v.Cursor = tea.NewCursor(screenX, screenY)
-			}
-		} else if a.dashboard.panelFocus == focusLaunch && a.dashboard.scrollOffset == 0 && a.focusLaunchAgent != nil {
+		if a.dashboard.panelFocus == focusLaunch && a.dashboard.scrollOffset == 0 && a.focusLaunchAgent != nil {
 			ag := a.focusLaunchAgent
 			if !ag.IsAltScreen() && ag.CursorVisible() {
 				cursorX, cursorY := ag.CursorPosition()

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -23,23 +23,19 @@ func requireClaude(t *testing.T) {
 	}
 }
 
-// createAgent presses 'n' and executes the async create cmd, returning the updated app.
-// returnToList exits any panel where keys are forwarded to the agent
-// (focusTerminal or focusLaunch) so app-level key handlers can fire.
+// returnToList exits the focusLaunch overlay (where keys forward to the agent
+// terminal) so app-level key handlers can fire.
 func returnToList(app App) App {
-	switch app.dashboard.panelFocus {
-	case focusTerminal:
-		model, _ := app.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
-		return model.(App)
-	case focusLaunch:
+	if app.dashboard.panelFocus == focusLaunch {
 		model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 		return model.(App)
 	}
 	return app
 }
 
-// If the terminal panel is already focused it presses Ctrl+E first so the 'n' key isn't
-// forwarded to the agent.
+// createAgent presses 'n' and executes the async create cmd, returning the
+// updated app. If the focusLaunch overlay is active it escapes back first so
+// the 'n' key isn't forwarded to the agent.
 func createAgent(t *testing.T, app App) App {
 	t.Helper()
 
@@ -185,7 +181,7 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 		t.Fatalf("Expected 1 agent, got %d", mgr.AgentCount())
 	}
 
-	// Create second session+agent (createAgent presses Ctrl+E first to exit focusTerminal)
+	// Create second session+agent (createAgent escapes any focusLaunch overlay first)
 	t.Log("=== Creating session 2 ===")
 	app = createAgent(t, app)
 	t.Logf("After session2: view=%v, err=%q, agents=%d, dashboard=%d",
@@ -1136,7 +1132,7 @@ func TestRKey_NoopWithEmptyQueue(t *testing.T) {
 // frame and the user sees nothing change — which is the "r doesn't do anything"
 // bug this guards against.
 func TestFocusMode_RKey_OpensReviewWithItems(t *testing.T) {
-	app, _, _, sessR := makeFocusModeApp(t)
+	app, sessR := makeFocusModeApp(t)
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	app = model.(App)
@@ -1419,7 +1415,7 @@ func TestClampToRepo(t *testing.T) {
 // makeFocusModeApp wires up an App in focus mode with two in-progress sessions
 // and one ready-for-review session. Used by the tests below to exercise unified
 // cursor navigation across the Active and Review sections.
-func makeFocusModeApp(t *testing.T) (App, *agent.Session, *agent.Session, *agent.Session) {
+func makeFocusModeApp(t *testing.T) (App, *agent.Session) {
 	t.Helper()
 	sessA := &agent.Session{Name: "active-a"}
 	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
@@ -1439,14 +1435,14 @@ func makeFocusModeApp(t *testing.T) (App, *agent.Session, *agent.Session, *agent
 		{kind: listItemSession, repoPath: "/r", session: sessB},
 		{kind: listItemSession, repoPath: "/r", session: sessR},
 	}
-	return app, sessA, sessB, sessR
+	return app, sessR
 }
 
 // TestFocusModeNavigationCrossesSections verifies that j/k in focus mode
 // traverses Active → Review in render order, transitioning between sections at
 // the boundaries instead of bouncing two indices in lockstep.
 func TestFocusModeNavigationCrossesSections(t *testing.T) {
-	app, _, _, _ := makeFocusModeApp(t)
+	app, _ := makeFocusModeApp(t)
 	if app.focusCursorSection != focusSectionActive {
 		// clampFocusCursor only runs from refreshAgentList; here we drive the
 		// state directly. Make the starting condition explicit.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -13,7 +13,6 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
-	xvt "github.com/charmbracelet/x/vt"
 	"github.com/devenjarvis/baton/internal/agent"
 	"github.com/devenjarvis/baton/internal/config"
 	"github.com/devenjarvis/baton/internal/vt"
@@ -229,79 +228,14 @@ func (d *dashboardModel) advanceTickers(now time.Time) {
 }
 
 func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.PasteMsg:
-		if d.panelFocus == focusTerminal {
-			if ag := d.selectedAgent(); ag != nil {
-				ag.Paste(msg.Content)
-			}
-		}
-		return d, nil
-	case tea.KeyPressMsg:
-		// Config panel focus: delegate to form.
+	if msg, ok := msg.(tea.KeyPressMsg); ok {
+		// Config overlay: delegate to the form. Pipeline navigation (j/k/enter)
+		// is handled at the app level via moveFocusCursorUp/Down and
+		// activateFocusCursor; nothing else needs to reach the dashboard here.
 		if d.panelFocus == focusConfig && d.repoConfigForm != nil {
 			cmd := d.repoConfigForm.Update(msg)
 			return d, cmd
 		}
-
-		if d.panelFocus == focusTerminal {
-			ag := d.selectedAgent()
-			switch msg.String() {
-			case "ctrl+e", "esc":
-				d.panelFocus = focusList
-				d.scrollOffset = 0
-			case "shift+esc":
-				if ag != nil {
-					ag.SendKey(xvt.KeyPressEvent{Code: tea.KeyEscape})
-				}
-			case "enter":
-				if ag != nil {
-					ag.SendKey(xvt.KeyPressEvent(msg))
-				}
-			case "pgup":
-				if ag != nil {
-					sbLen := len(ag.ScrollbackLines())
-					vpHeight := d.previewTermHeight()
-					step := vpHeight / 2
-					if step < 1 {
-						step = 1
-					}
-					d.scrollOffset += step
-					maxOffset := sbLen + vpHeight - vpHeight
-					if maxOffset < 0 {
-						maxOffset = 0
-					}
-					if d.scrollOffset > maxOffset {
-						d.scrollOffset = maxOffset
-					}
-				}
-			case "pgdown":
-				step := d.previewTermHeight() / 2
-				if step < 1 {
-					step = 1
-				}
-				d.scrollOffset -= step
-				if d.scrollOffset < 0 {
-					d.scrollOffset = 0
-				}
-			case "home":
-				d.scrollOffset = 0
-			default:
-				if ag != nil {
-					if msg.Text != "" {
-						ag.SendText(msg.Text)
-					} else {
-						ag.SendKey(xvt.KeyPressEvent(msg))
-					}
-				}
-			}
-			return d, nil
-		}
-
-		// focusList: pipeline navigation (j/k/enter) is handled at the app
-		// level via moveFocusCursorUp/Down and activateFocusCursor. The only
-		// thing reaching here is the residual right-arrow path used by repo
-		// header config entry, which the app layer translates first.
 	}
 	return d, nil
 }
@@ -340,50 +274,18 @@ func (d dashboardModel) contentHeight() int {
 }
 
 // fixedTermWidth returns the terminal column count that all agents should use.
-// This is always the focusTerminal width (deducting the border) regardless of
-// the current panelFocus, so that focus switches never trigger a resize.
+// Held constant across panel focus changes so transitions never trigger a
+// resize.
 func (d dashboardModel) fixedTermWidth() int {
-	return d.width - d.listWidth() - 1 - 2 // list border + focusTerminal border
+	return d.width - d.listWidth() - 1 - 2 // list border + preview border
 }
 
 // fixedTermHeight returns the terminal row count that all agents should use.
-// This is always the focusTerminal height (deducting the border) regardless of
-// the current panelFocus. It intentionally does NOT deduct the PR line —
-// accepting 1 row of clipping when PR is visible is better than per-session
-// resize churn.
+// Held constant across panel focus changes. It intentionally does NOT deduct
+// the PR line — accepting 1 row of clipping when PR is visible is better than
+// per-session resize churn.
 func (d dashboardModel) fixedTermHeight() int {
 	return d.contentHeight() - 2 - 2 // 2 metadata rows (sessionInfo + blank) + 2 border rows
-}
-
-// previewMetadataRows returns the number of non-VT rows rendered above the
-// terminal viewport in the preview panel: sessionInfo and the blank separator
-// — plus one row for the PR info line when the selected session has an open
-// PR. Mouse coordinate translation in app.go consumes this via screenToTermCell
-// so wheel/click/drag stay aligned with the viewport when the PR row appears
-// or disappears.
-func (d dashboardModel) previewMetadataRows() int {
-	rows := 2 // sessionInfo + blank; assumes agents always have a non-nil session
-	if sess := d.selectedSession(); sess != nil {
-		if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
-			rows++ // head PR line
-			for _, base := range entry.stack {
-				if base != nil && base.pr != nil {
-					rows++ // one row per valid base PR
-				}
-			}
-		}
-	}
-	return rows
-}
-
-// previewTermWidth returns the terminal column count for the preview panel.
-func (d dashboardModel) previewTermWidth() int {
-	return d.fixedTermWidth()
-}
-
-// previewTermHeight returns the terminal row count for the preview panel.
-func (d dashboardModel) previewTermHeight() int {
-	return d.fixedTermHeight()
 }
 
 // renderRepoConfigOverlay renders the per-repo settings form full-screen. It's

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/devenjarvis/baton/internal/agent"
-	"github.com/devenjarvis/baton/internal/github"
 	"github.com/devenjarvis/baton/internal/hook"
 )
 
@@ -111,10 +110,11 @@ func TestClearSelection(t *testing.T) {
 	}
 }
 
-// tickerDashboard builds a minimal dashboardModel for ticker tests.
-func tickerDashboard(sidebarW int, sessions ...*agent.Session) dashboardModel {
+// tickerDashboard builds a minimal dashboardModel for ticker tests with
+// sidebarWidth=30 (yielding maxNameLen=20 in the ticker tests below).
+func tickerDashboard(sessions ...*agent.Session) dashboardModel {
 	d := newDashboardModel()
-	d.sidebarWidth = sidebarW
+	d.sidebarWidth = 30
 	d.prCache = make(map[string]*prCacheEntry)
 	d.closingSessions = make(map[string]bool)
 	for _, s := range sessions {
@@ -158,7 +158,7 @@ func TestTickerSlice_MultibyteRunes(t *testing.T) {
 func TestAdvanceTickers_NameFits_NoTickerCreated(t *testing.T) {
 	// sidebarW=30 → maxNameLen=20; "short" (5 chars) fits easily.
 	sess := &agent.Session{ID: "s1", Name: "short"}
-	d := tickerDashboard(30, sess)
+	d := tickerDashboard(sess)
 	d.advanceTickers(time.Now())
 	if _, exists := d.tickers["s1"]; exists {
 		t.Error("ticker should not be created for a name that fits")
@@ -168,7 +168,7 @@ func TestAdvanceTickers_NameFits_NoTickerCreated(t *testing.T) {
 func TestAdvanceTickers_NameFits_ClearsStale(t *testing.T) {
 	// Stale ticker entry from a previous long name should be removed.
 	sess := &agent.Session{ID: "s1", Name: "short"}
-	d := tickerDashboard(30, sess)
+	d := tickerDashboard(sess)
 	d.tickers["s1"] = &sessionTicker{offset: 5}
 	d.advanceTickers(time.Now())
 	if _, exists := d.tickers["s1"]; exists {
@@ -180,7 +180,7 @@ func TestAdvanceTickers_OverflowCreatesTickerWithPause(t *testing.T) {
 	// sidebarW=30 → maxNameLen=20; long name (26 chars) overflows.
 	longName := "abcdefghijklmnopqrstuvwxyz"
 	sess := &agent.Session{ID: "s1", Name: longName}
-	d := tickerDashboard(30, sess)
+	d := tickerDashboard(sess)
 	now := time.Now()
 	d.advanceTickers(now)
 	tk := d.tickers["s1"]
@@ -198,7 +198,7 @@ func TestAdvanceTickers_OverflowCreatesTickerWithPause(t *testing.T) {
 func TestAdvanceTickers_AdvancePastPause_IncrementsOffset(t *testing.T) {
 	longName := "abcdefghijklmnopqrstuvwxyz"
 	sess := &agent.Session{ID: "s1", Name: longName}
-	d := tickerDashboard(30, sess)
+	d := tickerDashboard(sess)
 	// Pre-seed expired ticker so initial pause is already over.
 	d.tickers["s1"] = &sessionTicker{pauseUntil: past(), nextAdvance: past()}
 	d.advanceTickers(time.Now())
@@ -214,7 +214,7 @@ func TestAdvanceTickers_WideCharName_ScrollsNotStuck(t *testing.T) {
 	// offset=0 (0+20=20 >= 14), preventing the name from ever scrolling.
 	wideName := strings.Repeat("日", 12)
 	sess := &agent.Session{ID: "s1", Name: wideName}
-	d := tickerDashboard(30, sess)
+	d := tickerDashboard(sess)
 	d.tickers["s1"] = &sessionTicker{pauseUntil: past(), nextAdvance: past()}
 	d.advanceTickers(time.Now())
 	tk := d.tickers["s1"]
@@ -226,83 +226,13 @@ func TestAdvanceTickers_WideCharName_ScrollsNotStuck(t *testing.T) {
 	}
 }
 
-// TestPreviewMetadataRows verifies the row count used for mouse coordinate
-// mapping: 2 baseline (sessionInfo + blank), +1 for a single PR, +N for stack.
-func TestPreviewMetadataRows(t *testing.T) {
-	makeSession := func(id string) *agent.Session {
-		return &agent.Session{ID: id, Name: id}
-	}
-
-	tests := []struct {
-		name       string
-		cacheEntry *prCacheEntry
-		want       int
-	}{
-		{
-			name:       "no PR",
-			cacheEntry: nil,
-			want:       2,
-		},
-		{
-			name:       "single PR, no stack",
-			cacheEntry: &prCacheEntry{pr: &github.PRState{Number: 1}},
-			want:       3,
-		},
-		{
-			name: "stacked 2-deep",
-			cacheEntry: &prCacheEntry{
-				pr: &github.PRState{Number: 2},
-				stack: []*prCacheEntry{
-					{pr: &github.PRState{Number: 1}},
-				},
-			},
-			want: 4,
-		},
-		{
-			name: "stacked 3-deep",
-			cacheEntry: &prCacheEntry{
-				pr: &github.PRState{Number: 3},
-				stack: []*prCacheEntry{
-					{pr: &github.PRState{Number: 2}},
-					{pr: &github.PRState{Number: 1}},
-				},
-			},
-			want: 5,
-		},
-		{
-			name: "stack with nil entry is skipped",
-			cacheEntry: &prCacheEntry{
-				pr:    &github.PRState{Number: 2},
-				stack: []*prCacheEntry{nil},
-			},
-			want: 3, // nil stack entry not counted
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			sess := makeSession("s1")
-			d := newDashboardModel()
-			d.prCache = make(map[string]*prCacheEntry)
-			d.items = []listItem{{kind: listItemSession, session: sess}}
-			d.selected = 0
-			if tc.cacheEntry != nil {
-				d.prCache["s1"] = tc.cacheEntry
-			}
-			if got := d.previewMetadataRows(); got != tc.want {
-				t.Errorf("previewMetadataRows() = %d, want %d", got, tc.want)
-			}
-		})
-	}
-}
-
 func TestAdvanceTickers_EndReached_SnapsBack(t *testing.T) {
 	// sidebarW=30 → maxNameLen=20
 	// longName=26 chars → fullName "…" + " ·" = 28 runes
 	// end condition: offset+20 >= 28 → offset >= 8
 	longName := "12345678901234567890123456"
 	sess := &agent.Session{ID: "s1", Name: longName}
-	d := tickerDashboard(30, sess)
+	d := tickerDashboard(sess)
 
 	// Set offset to 7 (one step before end); advance once → hits 8 → atEnd=true.
 	d.tickers["s1"] = &sessionTicker{offset: 7, pauseUntil: past(), nextAdvance: past()}

--- a/internal/tui/diff/render.go
+++ b/internal/tui/diff/render.go
@@ -156,13 +156,13 @@ func (r *Renderer) renderUnified(width int) string {
 		b.WriteString(styleHunkBan.Render(truncateVisible(h.Header, width)))
 		b.WriteByte('\n')
 		for _, l := range h.Lines {
-			r.writeUnifiedLine(&b, l, width, gutter, content)
+			r.writeUnifiedLine(&b, l, gutter, content)
 		}
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
 
-func (r *Renderer) writeUnifiedLine(b *strings.Builder, l diffmodel.Line, width, gutter, content int) {
+func (r *Renderer) writeUnifiedLine(b *strings.Builder, l diffmodel.Line, gutter, content int) {
 	var num int
 	var mark string
 	var rowStyle, markStyle lipgloss.Style

--- a/internal/tui/globalconfig.go
+++ b/internal/tui/globalconfig.go
@@ -90,7 +90,7 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	fields = addTextInput(fields, "Default Branch", defaultBranch, "auto-detect", inputWidth)
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
-	fields = addEditorFields(fields, ideCommand, inputWidth)
+	fields = addEditorFields(fields, ideCommand)
 	fields = addTextInput(fields, "Sidebar Width", sidebarWidth, strconv.Itoa(config.DefaultSidebarWidth), inputWidth)
 	fields = addTextInput(fields, fieldFocusSession, focusSessionMinutes, strconv.Itoa(config.DefaultFocusSessionMinutes), inputWidth)
 	fields = addTextInput(fields, fieldFocusBreak, focusBreakMinutes, strconv.Itoa(config.DefaultFocusBreakMinutes), inputWidth)

--- a/internal/tui/idecommand.go
+++ b/internal/tui/idecommand.go
@@ -19,7 +19,8 @@ const (
 // a form. stored is the raw IDE command currently saved (may be empty). The
 // select is pre-selected to match stored if it corresponds to a detected
 // editor, otherwise "Custom" with stored placed in the text field.
-func addEditorFields(fields []formField, stored string, inputWidth int) []formField {
+func addEditorFields(fields []formField, stored string) []formField {
+	const inputWidth = 30
 	detected := editor.Detect()
 	options := make([]string, 0, len(detected)+1)
 	for _, e := range detected {

--- a/internal/tui/idecommand_test.go
+++ b/internal/tui/idecommand_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAddEditorFields_EmptyStoredShape(t *testing.T) {
 	var fields []formField
-	fields = addEditorFields(fields, "", 30)
+	fields = addEditorFields(fields, "")
 	form := newConfigForm(fields, 30)
 
 	got := form.selectValue(editorFieldLabel)
@@ -28,7 +28,7 @@ func TestAddEditorFields_EmptyStoredShape(t *testing.T) {
 
 func TestAddEditorFields_LegacyCustomLoad(t *testing.T) {
 	var fields []formField
-	fields = addEditorFields(fields, "code -n --foo", 30)
+	fields = addEditorFields(fields, "code -n --foo")
 	form := newConfigForm(fields, 30)
 	if got := form.selectValue(editorFieldLabel); got != editorCustomOption {
 		t.Fatalf("expected Custom, got %q", got)

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -12,15 +12,14 @@ const (
 	ViewRepoPicker   // overlay: pick a registered repo to start a session in
 )
 
-// panelFocus tracks which dashboard panel has keyboard focus.
+// panelFocus tracks which dashboard surface has keyboard focus.
 type panelFocus int
 
 const (
-	focusList     panelFocus = iota // sidebar: j/k navigate agents
-	focusTerminal                   // preview: keys forwarded to agent
-	focusConfig                     // preview: repo config form
-	focusReview                     // preview: review panel (fullscreen focus mode)
-	focusLaunch                     // focus mode paused — viewing an agent terminal
+	focusList   panelFocus = iota // pipeline: j/k navigate sessions
+	focusConfig                   // overlay: per-repo config form
+	focusReview                   // overlay: review panel
+	focusLaunch                   // overlay: fullscreen agent terminal
 )
 
 // focusSection identifies which row group the fullscreen focus-mode cursor is

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -16,7 +16,7 @@ import (
 
 // renderReviewPanel renders the fullscreen review panel for a session.
 // entry may be nil while diff stats are being fetched (shows loading placeholder).
-func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height int) string {
+func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width int) string {
 	var lines []string
 
 	// Header

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -21,7 +21,7 @@ func TestRenderReviewPanel_ShowsOriginalPrompt(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 213, Deletions: 34},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40)
+	output := renderReviewPanel(sess, entry, 120)
 
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("review panel must show the original prompt")
@@ -36,7 +36,7 @@ func TestRenderReviewPanel_NilDiffEntry(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 
 	// nil entry — should not panic
-	output := renderReviewPanel(sess, nil, 120, 40)
+	output := renderReviewPanel(sess, nil, 120)
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("must still show prompt even with nil diff entry")
 	}
@@ -82,7 +82,7 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40)
+	output := renderReviewPanel(sess, nil, 120)
 
 	for _, want := range []string{
 		"open PR",

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -30,14 +30,6 @@ var (
 		{"q", "quit"},
 	}
 
-	focusTerminalHints = []keyHint{
-		{"enter", "send"},
-		{"pgup/pgdn", "scroll"},
-		{"home", "live"},
-		{"esc", "back"},
-		{"⇧esc", "interrupt"},
-	}
-
 	diffHints = []keyHint{
 		{"j/k", "tree"},
 		{"h/l", "fold/open"},


### PR DESCRIPTION
The "Make Focus Mode the only dashboard" refactor (#142) collapsed the
split-panel dashboard into a single pipeline view, but left behind
several unreachable code paths and unused helpers.

- Drop the focusTerminal panelFocus value: no code ever assigns it, so
  every `panelFocus == focusTerminal` branch was dead. Removes the paste
  / key / wheel / cursor / hint paths that targeted the old preview
  terminal, plus the now-orphaned screenToTermCell, forwardWheelToAgent,
  previewTermWidth/Height, and previewMetadataRows helpers.

- Simplify selection drag-copy: selections only seed in focusLaunch
  (MouseClickMsg), so the dual-branch handling on MouseReleaseMsg /
  MouseMotionMsg was redundant and the `selectedAgent()`-via-`d.selected`
  branch could have copied with the wrong viewport size.

- Remove agent.Status.Symbol() — zero callers since the redesign.

- Trim always-same-value parameters from a few helpers, both production
  (renderReviewPanel height, writeUnifiedLine width, addEditorFields
  inputWidth) and test (waitForStatus/waitForBranch timeout,
  tickerDashboard sidebar, makeFocusModeApp returns, sandboxGitConfig
  return).

Net: 354 lines removed across 17 files. go build, go vet, and the full
golangci-lint config remain clean.

https://claude.ai/code/session_016sQg9nt4VteABmeRw3Y41f