### PR TITLE
Fix Haiku branch namer's broken --mcp-config payload

### DIFF
--- a/changelog.d/fix-haiku-mcp-config.md
+++ b/changelog.d/fix-haiku-mcp-config.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Branch rename and task summary subprocesses no longer crash on Claude's strict MCP schema validator. The `--mcp-config` payload is now `{"mcpServers":{}}` instead of `{}`, which Claude rejects with `mcpServers: Invalid input: expected record, received undefined`.

--- a/internal/agent/haikuname.go
+++ b/internal/agent/haikuname.go
@@ -110,6 +110,13 @@ func DefaultTaskSummarizer() TaskSummarizer {
 // which disables hooks, LSP, plugin sync, attribution, auto-memory,
 // background prefetches, keychain reads, and CLAUDE.md auto-discovery.
 // --bare requires API-key auth; OAuth-only users silently miss the win.
+//
+// The --mcp-config payload MUST be a JSON object containing an "mcpServers"
+// key (with an empty record as the value to declare zero servers). Claude's
+// strict schema validator rejects a bare "{}" with
+// `mcpServers: Invalid input: expected record, received undefined`, which
+// makes every Haiku subprocess exit 1 in ~225ms and silently breaks the
+// branch rename and task summary flows. Do not simplify this back to "{}".
 func buildClaudeHaikuArgs() []string {
 	args := []string{"-p", "--model", claudeHaikuModel}
 	if os.Getenv("ANTHROPIC_API_KEY") != "" {
@@ -117,7 +124,7 @@ func buildClaudeHaikuArgs() []string {
 	}
 	args = append(
 		args,
-		"--strict-mcp-config", "--mcp-config", "{}",
+		"--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`,
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--tools", "",

--- a/internal/agent/haikuname_test.go
+++ b/internal/agent/haikuname_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -555,7 +556,6 @@ func TestBuildClaudeHaikuArgs_AlwaysOnFlags(t *testing.T) {
 	}
 	for _, want := range []string{
 		"--strict-mcp-config",
-		"--mcp-config {}",
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--tools ",
@@ -565,6 +565,34 @@ func TestBuildClaudeHaikuArgs_AlwaysOnFlags(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("argv missing %q; got %q", want, joined)
 		}
+	}
+
+	// --mcp-config must be a JSON object with an "mcpServers" record. A bare
+	// "{}" is rejected by claude's strict schema validator (regression guard
+	// for the silent branch-rename / task-summary failure).
+	mcpIdx := -1
+	for i, a := range args {
+		if a == "--mcp-config" {
+			mcpIdx = i
+			break
+		}
+	}
+	if mcpIdx < 0 {
+		t.Fatalf("argv missing --mcp-config; got %v", args)
+	}
+	if mcpIdx+1 >= len(args) {
+		t.Fatalf("--mcp-config has no value; got %v", args)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(args[mcpIdx+1]), &cfg); err != nil {
+		t.Fatalf("--mcp-config value %q not valid JSON: %v", args[mcpIdx+1], err)
+	}
+	servers, ok := cfg["mcpServers"]
+	if !ok {
+		t.Errorf("--mcp-config value %q missing required \"mcpServers\" key", args[mcpIdx+1])
+	}
+	if _, ok := servers.(map[string]any); !ok {
+		t.Errorf("--mcp-config \"mcpServers\" must be an object; got %T (%v)", servers, servers)
 	}
 }
 


### PR DESCRIPTION
## Summary

- The always-on `--strict-mcp-config --mcp-config "{}"` flag added in #139 is rejected by Claude 2.1.137's strict schema validator with `mcpServers: Invalid input: expected record, received undefined`. Every Haiku subprocess exits 1 in ~225ms, so all three retry attempts fail identically — the random branch (e.g. `baton/oxford-comma`) never gets renamed and task summaries silently come back empty (`DefaultTaskSummarizer` swallows subprocess errors as `("", nil)` per the contract from #139).
- Pass `{"mcpServers":{}}` — the canonical "no MCP servers" value that the strict validator accepts. Other always-on flags (`--disable-slash-commands`, `--no-session-persistence`, `--tools ""`, `--setting-sources user`, `--exclude-dynamic-system-prompt-sections`, the `--bare`-when-API-key-present logic) are untouched. Doc comment now explains *why* the JSON must contain an `mcpServers` key so a future contributor doesn't simplify it back.
- Replace the literal-match `"--mcp-config {}"` assertion in `TestBuildClaudeHaikuArgs_AlwaysOnFlags` with a `json.Unmarshal` shape check that locates `--mcp-config` in argv and asserts the value parses as an object with an `mcpServers` record. This is what should have caught the regression in #139 — confirmed locally that the new test fails on `"{}"` and passes on `{"mcpServers":{}}`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `go test -race ./internal/agent/...`
- [x] Regression-guard verified: stashed the `haikuname.go` fix and reran the test → fails with `--mcp-config value "{}" missing required "mcpServers" key`
- [ ] Manual TUI smoke: `./baton`, start a session, send a real first prompt, confirm random branch gets replaced by Haiku-derived suffix within ~10s and `.baton/logs/haiku.log` shows `kind=branch status=ok` and `kind=summary status=ok`

## Checklist

- [x] Added `changelog.d/fix-haiku-mcp-config.md` (project uses changelog.d/ fragments per CLAUDE.md, not `CHANGELOG.md` directly)
- [x] New behavior has tests — `TestBuildClaudeHaikuArgs_AlwaysOnFlags` now guards the JSON shape
- [x] No new public API surface