### PR TITLE
Plan-first planning, PR 1: PlanDrafter + plan persistence + Drafting lifecycle

### DIFF
--- a/changelog.d/plan-first-planning-plumbing.md
+++ b/changelog.d/plan-first-planning-plumbing.md
@@ -1,0 +1,9 @@
+### Added
+
+- `PlanDrafter` interface in `internal/agent` with a default Sonnet-backed implementation (`claude -p --model claude-sonnet-4-6`) for generating and revising plan markdown
+- `Session.PlanPath`, `ReadPlan`, `WritePlan`, `HasPlan` helpers — plan markdown lives at `<worktree>/.claude/plan.md`, with atomic temp+rename writes and best-effort `.gitignore` upkeep so the plan never leaks into the PR diff
+- `LifecycleDrafting` phase plus `Manager.StartDraft(sessionID, prompt)` to drive the async draft. Drafting is gated by `Session.TryStartDraft` to prevent double dispatch, transitions back to `LifecyclePlanning` on completion (with `Session.DraftError` set on failure), is cancellable via `Session.CancelDraft`, and is drained on `Manager.Shutdown` / `Manager.KillSession`. Drafting subprocesses do not count against `MaxConcurrentAgents`.
+
+### Notes
+
+- No user-visible change yet — this is the plumbing for the plan-first planning flow. Editor, prompt modal, approve→spawn, and revise loop ship in follow-up PRs.

--- a/internal/agent/lifecycle.go
+++ b/internal/agent/lifecycle.go
@@ -5,12 +5,13 @@ package agent
 type LifecyclePhase int
 
 const (
-	LifecyclePlanning       LifecyclePhase = iota // default for new sessions; user is scoping the work, advances to Building with 'b'
+	LifecyclePlanning       LifecyclePhase = iota // plan exists, user editing/approving
 	LifecycleInProgress                           // Building: agent running or done, not yet marked ready
 	LifecycleReadyForReview                       // developer marked it ready
 	LifecycleInReview                             // developer committed to reviewing
 	LifecycleShipping                             // PR open, waiting for CI/team
 	LifecycleComplete                             // PR merged or manually marked done
+	LifecycleDrafting                             // claude -p plan subprocess is running; transitions to Planning on completion
 )
 
 func (p LifecyclePhase) String() string {
@@ -27,15 +28,22 @@ func (p LifecyclePhase) String() string {
 		return "shipping"
 	case LifecycleComplete:
 		return "complete"
+	case LifecycleDrafting:
+		return "drafting"
 	default:
 		return "in_progress"
 	}
 }
 
 // LifecyclePhaseFromString parses a string produced by String(). Unknown/empty → InProgress.
+// "drafting" is treated as Planning on restore: a draft cannot survive a
+// detach (the subprocess is gone), so the user lands in Planning where they
+// can edit the partial plan or restart the draft.
 func LifecyclePhaseFromString(s string) LifecyclePhase {
 	switch s {
 	case "planning":
+		return LifecyclePlanning
+	case "drafting":
 		return LifecyclePlanning
 	case "in_progress":
 		return LifecycleInProgress

--- a/internal/agent/lifecycle.go
+++ b/internal/agent/lifecycle.go
@@ -11,8 +11,18 @@ const (
 	LifecycleInReview                             // developer committed to reviewing
 	LifecycleShipping                             // PR open, waiting for CI/team
 	LifecycleComplete                             // PR merged or manually marked done
-	LifecycleDrafting                             // claude -p plan subprocess is running; transitions to Planning on completion
 )
+
+// LifecycleDrafting is a transient pre-Planning sub-phase: a `claude -p`
+// plan subprocess is running and will transition the session to
+// LifecyclePlanning on completion. It is declared in a separate const
+// block with an explicit negative value so any future range check
+// (e.g. phase >= LifecycleComplete) classifies it as "earlier than
+// Planning", matching its position in the visual pipeline. Keeping it
+// outside the main iota block also preserves the 0..5 numeric ordering
+// of the forward phases. Serialization is string-based (see String /
+// LifecyclePhaseFromString) so the numeric value is never persisted.
+const LifecycleDrafting LifecyclePhase = -1
 
 func (p LifecyclePhase) String() string {
 	switch p {

--- a/internal/agent/lifecycle_test.go
+++ b/internal/agent/lifecycle_test.go
@@ -22,6 +22,25 @@ func TestLifecyclePhase_String(t *testing.T) {
 	}
 }
 
+func TestLifecycleDrafting_OrdersBeforeForwardPhases(t *testing.T) {
+	// Drafting must sort numerically before every forward phase so any
+	// future range check (`phase >= LifecycleComplete`, etc.) classifies
+	// it as "earlier than Planning". Locks in the explicit -1 assignment.
+	forward := []LifecyclePhase{
+		LifecyclePlanning,
+		LifecycleInProgress,
+		LifecycleReadyForReview,
+		LifecycleInReview,
+		LifecycleShipping,
+		LifecycleComplete,
+	}
+	for _, phase := range forward {
+		if LifecycleDrafting >= phase {
+			t.Errorf("LifecycleDrafting (%d) should be < %s (%d)", LifecycleDrafting, phase, phase)
+		}
+	}
+}
+
 func TestLifecyclePhaseFromString(t *testing.T) {
 	cases := []struct {
 		s    string

--- a/internal/agent/lifecycle_test.go
+++ b/internal/agent/lifecycle_test.go
@@ -13,6 +13,7 @@ func TestLifecyclePhase_String(t *testing.T) {
 		{LifecycleInReview, "in_review"},
 		{LifecycleShipping, "shipping"},
 		{LifecycleComplete, "complete"},
+		{LifecycleDrafting, "drafting"},
 	}
 	for _, tc := range cases {
 		if got := tc.phase.String(); got != tc.want {
@@ -32,6 +33,7 @@ func TestLifecyclePhaseFromString(t *testing.T) {
 		{"in_review", LifecycleInReview},
 		{"shipping", LifecycleShipping},
 		{"complete", LifecycleComplete},
+		{"drafting", LifecyclePlanning},  // drafting cannot survive detach; restore as Planning
 		{"", LifecycleInProgress},        // empty → default
 		{"unknown", LifecycleInProgress}, // unknown → default
 	}

--- a/internal/agent/main_test.go
+++ b/internal/agent/main_test.go
@@ -47,5 +47,12 @@ func TestMain(m *testing.M) {
 	haikuSummaryOverallTimeout = 3 * time.Second
 	haikuSummaryBackoff = []time.Duration{}
 
+	// Plan drafting is one-shot (no retry), so the production 60s ceiling is
+	// just the wall-clock budget a hung subprocess would burn in tests
+	// before surfacing. Shrink to 5s — long enough that legitimate stub
+	// drafters don't race the deadline, short enough that a regression
+	// causing Draft to block forever surfaces quickly.
+	PlanDraftTimeout = 5 * time.Second
+
 	os.Exit(m.Run())
 }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -73,6 +74,7 @@ type Manager struct {
 
 	branchNamer    BranchNamer
 	taskSummarizer TaskSummarizer
+	planDrafter    PlanDrafter
 }
 
 // haikuNamePerAttemptTimeout bounds how long a single Haiku summarization
@@ -130,6 +132,7 @@ func NewManager(repoPath string, settings config.ResolvedSettings) *Manager {
 		done:           make(chan struct{}),
 		branchNamer:    DefaultBranchNamer(),
 		taskSummarizer: DefaultTaskSummarizer(),
+		planDrafter:    DefaultPlanDrafter(),
 	}
 
 	batonDir := filepath.Join(repoPath, ".baton")
@@ -174,6 +177,16 @@ func (m *Manager) SetTaskSummarizer(ts TaskSummarizer) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.taskSummarizer = ts
+}
+
+// SetPlanDrafter overrides the PlanDrafter used for generating and revising
+// plan markdown. Intended for tests so they can stub out the Sonnet
+// subprocess. Passing nil disables planning gracefully — StartDraft will
+// return an error rather than spawning a broken subprocess.
+func (m *Manager) SetPlanDrafter(p PlanDrafter) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.planDrafter = p
 }
 
 // getTaskSummarizer returns the current TaskSummarizer under a read lock.
@@ -442,6 +455,112 @@ func (m *Manager) maybeStartTaskSummary(sess *Session) {
 		}
 		sess.SetTaskSummary(summary)
 	}()
+}
+
+// ErrDraftInFlight is returned when StartDraft is called for a session that
+// already has an in-flight drafting subprocess. Surfaces double-dispatch from
+// the UI layer (e.g. user pressed `enter` twice on the modal) without
+// silently spawning a duplicate Sonnet call.
+var ErrDraftInFlight = errors.New("draft already in flight for session")
+
+// ErrPlanDrafterNotConfigured is returned when StartDraft is called but the
+// manager has no plan drafter (e.g. a test set it to nil to disable).
+var ErrPlanDrafterNotConfigured = errors.New("plan drafter not configured")
+
+// StartDraft begins async drafting of a plan for sessionID with the given
+// user prompt. Transitions the session to LifecycleDrafting, then spawns a
+// goroutine that calls PlanDrafter.Draft, writes the result via
+// Session.WritePlan, and transitions to LifecyclePlanning on success or
+// LifecyclePlanning(error) on failure. The goroutine is tracked in
+// m.watchers so Shutdown drains cleanly; cancellation occurs when m.done
+// closes (manager shutdown), KillSession is called, or CancelDraft is
+// called directly. Drafting subprocesses are NOT counted against
+// MaxConcurrentAgents — they are transient text-generation calls, not
+// long-lived agents.
+func (m *Manager) StartDraft(sessionID, prompt string) error {
+	m.mu.RLock()
+	sess := m.sessions[sessionID]
+	drafter := m.planDrafter
+	m.mu.RUnlock()
+
+	if sess == nil {
+		return fmt.Errorf("session %s not found", sessionID)
+	}
+	if drafter == nil {
+		return ErrPlanDrafterNotConfigured
+	}
+	if !IsActionablePrompt(prompt) {
+		return fmt.Errorf("prompt is empty or non-actionable")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), PlanDraftTimeout)
+	if !sess.TryStartDraft(cancel) {
+		cancel()
+		return ErrDraftInFlight
+	}
+
+	sess.SetOriginalPrompt(prompt)
+	sess.SetLifecyclePhase(LifecycleDrafting)
+	sess.SetDraftError(nil)
+	m.emit(Event{Type: EventStatusChanged, SessionID: sessionID})
+
+	m.watchers.Add(1)
+	go m.runDraft(ctx, sess, drafter, prompt)
+	return nil
+}
+
+// runDraft executes a Draft call against drafter and writes the resulting
+// plan markdown via sess.WritePlan. Any failure path (drafter error, empty
+// output, write error) lands the session in LifecyclePlanning with
+// DraftError set so the Planning card can render a useful error badge —
+// the user can then retry via the editor's revise flow or by pressing
+// `n` again. Always emits EventStatusChanged on transition so the UI
+// repaints.
+func (m *Manager) runDraft(ctx context.Context, sess *Session, drafter PlanDrafter, prompt string) {
+	defer m.watchers.Done()
+	defer sess.finishDraft()
+
+	// Cancel the drafting subprocess if the manager shuts down mid-call.
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+	go func() {
+		select {
+		case <-m.done:
+			sess.CancelDraft()
+		case <-doneCh:
+		}
+	}()
+
+	body, err := drafter.Draft(ctx, DraftRequest{UserPrompt: prompt})
+
+	// If the session has already been removed from the manager (e.g. by a
+	// completed KillSession), skip the post-draft writes — there is nothing
+	// for the resulting state to attach to. Mirrors renameSessionBranch's
+	// gating pattern. This does NOT eliminate a narrow race where KillSession
+	// is in the middle of Cleanup but has not yet deleted the map entry: in
+	// that window WritePlan can still race directory removal. The race is
+	// benign — WritePlan returns an error and we set DraftError on a session
+	// that's about to be garbage-collected — so we accept it for parity with
+	// the rest of the manager.
+	m.mu.RLock()
+	_, stillOpen := m.sessions[sess.ID]
+	m.mu.RUnlock()
+	if !stillOpen {
+		return
+	}
+
+	if err == nil && strings.TrimSpace(body) == "" {
+		err = errors.New("planner returned empty plan")
+	}
+	if err == nil {
+		if writeErr := sess.WritePlan(body); writeErr != nil {
+			err = writeErr
+		}
+	}
+
+	sess.SetDraftError(err)
+	sess.SetLifecyclePhase(LifecyclePlanning)
+	m.emit(Event{Type: EventStatusChanged, SessionID: sess.ID})
 }
 
 // IsActionablePrompt reports whether prompt carries enough text for a
@@ -998,6 +1117,11 @@ func (m *Manager) KillSession(sessionID string) error {
 	if sess == nil {
 		return fmt.Errorf("session %s not found", sessionID)
 	}
+
+	// Cancel any in-flight plan-drafting subprocess so the goroutine drains
+	// before we remove the worktree. WritePlan would otherwise race with
+	// directory removal. CancelDraft is a no-op when no draft is running.
+	sess.CancelDraft()
 
 	sess.KillAll()
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1125,13 +1125,20 @@ func (m *Manager) KillSession(sessionID string) error {
 
 	sess.KillAll()
 
-	if err := sess.Cleanup(m.repoPath); err != nil {
-		return fmt.Errorf("cleanup session %s: %w", sessionID, err)
-	}
-
+	// Delete the session from the map BEFORE removing the worktree so
+	// runDraft's stillOpen guard observes the session as gone before any
+	// post-Cleanup WritePlan attempt. The previous order (Cleanup first,
+	// delete second) left a window where stillOpen=true while the worktree
+	// directory was already removed, relying on an implicit contract that
+	// PlanDrafter.Draft must return a non-nil error on context cancellation.
+	// Mirrors closeSession's delete-then-cleanup ordering.
 	m.mu.Lock()
 	delete(m.sessions, sessionID)
 	m.mu.Unlock()
+
+	if err := sess.Cleanup(m.repoPath); err != nil {
+		return fmt.Errorf("cleanup session %s: %w", sessionID, err)
+	}
 
 	return nil
 }
@@ -1423,6 +1430,13 @@ func (m *Manager) closeSession(sessionID string, sess *Session) {
 	delete(m.sessions, sessionID)
 	m.mu.Unlock()
 
+	// Cancel any in-flight plan-drafting subprocess for symmetry with
+	// KillSession. The current pipeline never reaches closeSession with a
+	// draft running (drafting precedes building), but StartDraft does not
+	// enforce that precondition — without this call, Shutdown could block
+	// on m.watchers for up to PlanDraftTimeout if the gap is ever reached.
+	// CancelDraft is a no-op when no draft is running.
+	sess.CancelDraft()
 	sess.KillAll()
 	_ = sess.Cleanup(m.repoPath)
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1,0 +1,448 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubPlanDrafter is a configurable PlanDrafter for tests. Each call records
+// the request and either returns the configured response or invokes the
+// configured callback for finer control (e.g. blocking until a channel
+// closes, observing context cancellation).
+type stubPlanDrafter struct {
+	mu       sync.Mutex
+	drafted  []DraftRequest
+	revised  []ReviseRequest
+	draftFn  func(ctx context.Context, req DraftRequest) (string, error)
+	reviseFn func(ctx context.Context, req ReviseRequest) (string, error)
+}
+
+func (s *stubPlanDrafter) Draft(ctx context.Context, req DraftRequest) (string, error) {
+	s.mu.Lock()
+	s.drafted = append(s.drafted, req)
+	fn := s.draftFn
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, req)
+	}
+	return "", errors.New("draftFn not configured")
+}
+
+func (s *stubPlanDrafter) Revise(ctx context.Context, req ReviseRequest) (string, error) {
+	s.mu.Lock()
+	s.revised = append(s.revised, req)
+	fn := s.reviseFn
+	s.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, req)
+	}
+	return "", errors.New("reviseFn not configured")
+}
+
+func (s *stubPlanDrafter) DraftCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.drafted)
+}
+
+// waitForCondition polls cond until it returns true or timeout elapses.
+// Fails the test on timeout. Used to await drafting goroutines without
+// hard-coded sleeps.
+func waitForCondition(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not satisfied within %v", timeout)
+}
+
+func TestManager_StartDraft_Success(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	const planMD = "# Goal\nDo X\n\n## Tasks\n- [ ] step\n"
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		draftFn: func(ctx context.Context, req DraftRequest) (string, error) {
+			return planMD, nil
+		},
+	})
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.StartDraft(sess.ID, "add dark mode"); err != nil {
+		t.Fatalf("StartDraft: %v", err)
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool {
+		return !sess.IsDrafting() && sess.LifecyclePhase() == LifecyclePlanning && sess.HasPlan()
+	})
+
+	if got := sess.LifecyclePhase(); got != LifecyclePlanning {
+		t.Errorf("phase after success = %v, want LifecyclePlanning", got)
+	}
+	body, err := sess.ReadPlan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != planMD {
+		t.Errorf("plan = %q, want %q", body, planMD)
+	}
+	if sess.DraftError() != nil {
+		t.Errorf("DraftError = %v, want nil after success", sess.DraftError())
+	}
+	if sess.OriginalPrompt() != "add dark mode" {
+		t.Errorf("OriginalPrompt = %q, want %q", sess.OriginalPrompt(), "add dark mode")
+	}
+}
+
+func TestManager_StartDraft_TransitionsToDraftingImmediately(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	block := make(chan struct{})
+	defer close(block)
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		draftFn: func(ctx context.Context, req DraftRequest) (string, error) {
+			<-block
+			return "# Goal\nx", nil
+		},
+	})
+
+	sess, _, err := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.StartDraft(sess.ID, "add thing"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drafting is set synchronously by StartDraft before returning.
+	if got := sess.LifecyclePhase(); got != LifecycleDrafting {
+		t.Errorf("phase after StartDraft = %v, want LifecycleDrafting", got)
+	}
+	if !sess.IsDrafting() {
+		t.Error("IsDrafting() should be true while subprocess runs")
+	}
+}
+
+func TestManager_StartDraft_DrafterErrorLandsInPlanning(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	wantErr := errors.New("sonnet boom")
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		draftFn: func(ctx context.Context, req DraftRequest) (string, error) {
+			return "", wantErr
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+
+	if err := mgr.StartDraft(sess.ID, "add thing"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForCondition(t, 2*time.Second, func() bool { return !sess.IsDrafting() })
+
+	if got := sess.LifecyclePhase(); got != LifecyclePlanning {
+		t.Errorf("phase after error = %v, want LifecyclePlanning", got)
+	}
+	if sess.HasPlan() {
+		t.Error("plan file should not exist after drafter error")
+	}
+	if !errors.Is(sess.DraftError(), wantErr) {
+		t.Errorf("DraftError = %v, want errors.Is(err, %v)", sess.DraftError(), wantErr)
+	}
+}
+
+func TestManager_StartDraft_EmptyPlanLandsInPlanningWithError(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		draftFn: func(ctx context.Context, req DraftRequest) (string, error) {
+			return "   ", nil // whitespace-only counts as empty
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+
+	if err := mgr.StartDraft(sess.ID, "add thing"); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, 2*time.Second, func() bool { return !sess.IsDrafting() })
+
+	if got := sess.LifecyclePhase(); got != LifecyclePlanning {
+		t.Errorf("phase after empty plan = %v, want LifecyclePlanning", got)
+	}
+	if sess.HasPlan() {
+		t.Error("plan file should not exist when planner returned empty body")
+	}
+	if sess.DraftError() == nil {
+		t.Error("DraftError should be non-nil for empty plan")
+	}
+}
+
+func TestManager_StartDraft_DoubleDispatchReturnsErrDraftInFlight(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	block := make(chan struct{})
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		draftFn: func(ctx context.Context, req DraftRequest) (string, error) {
+			<-block
+			return "# Goal\nx", nil
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+
+	if err := mgr.StartDraft(sess.ID, "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.StartDraft(sess.ID, "second"); !errors.Is(err, ErrDraftInFlight) {
+		t.Errorf("second StartDraft err = %v, want ErrDraftInFlight", err)
+	}
+
+	close(block)
+	waitForCondition(t, 2*time.Second, func() bool { return !sess.IsDrafting() })
+}
+
+func TestManager_StartDraft_KillSessionCancelsSubprocess(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cancelled := make(chan struct{})
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		draftFn: func(ctx context.Context, req DraftRequest) (string, error) {
+			<-ctx.Done()
+			close(cancelled)
+			return "", ctx.Err()
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+
+	if err := mgr.StartDraft(sess.ID, "x"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until the goroutine has actually entered Draft (so the cancel
+	// signal has a subprocess to interrupt). One tick of the manager event
+	// pump is enough to ensure StartDraft fully ran.
+	waitForCondition(t, time.Second, func() bool { return sess.IsDrafting() })
+
+	if err := mgr.KillSession(sess.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("draft was not cancelled within 2s of KillSession")
+	}
+}
+
+func TestManager_StartDraft_ShutdownDrainsGoroutine(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+
+	finished := atomic.Bool{}
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		draftFn: func(ctx context.Context, req DraftRequest) (string, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+
+	if err := mgr.StartDraft(sess.ID, "x"); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, func() bool { return sess.IsDrafting() })
+
+	go func() {
+		mgr.Shutdown()
+		finished.Store(true)
+	}()
+
+	// Shutdown must complete in bounded time even with a draft in flight.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if finished.Load() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("Shutdown did not return within 3s while a draft was in flight")
+}
+
+func TestManager_StartDraft_NoDrafterConfigured(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	mgr.SetPlanDrafter(nil)
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+
+	err := mgr.StartDraft(sess.ID, "add dark mode")
+	if !errors.Is(err, ErrPlanDrafterNotConfigured) {
+		t.Errorf("err = %v, want ErrPlanDrafterNotConfigured", err)
+	}
+}
+
+func TestManager_StartDraft_UnknownSession(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	if err := mgr.StartDraft("not-a-session", "x"); err == nil {
+		t.Fatal("expected error for unknown session")
+	}
+}
+
+func TestManager_StartDraft_NonActionablePromptRejected(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+
+	for _, prompt := range []string{"", "   ", "/clear"} {
+		if err := mgr.StartDraft(sess.ID, prompt); err == nil {
+			t.Errorf("StartDraft(%q) should error", prompt)
+		}
+	}
+	if sess.IsDrafting() {
+		t.Error("IsDrafting should remain false after rejected prompts")
+	}
+}
+
+// TestManager_StartDraft_GuardSkipsWritePlanAfterKillSession exercises the
+// stillOpen guard in runDraft. The stub ignores context cancellation and
+// returns a non-empty plan only after the test releases it — by which point
+// KillSession has already removed the session from m.sessions. With the
+// guard in place, WritePlan must not run, so no plan.md should land in the
+// (now-removed) worktree path. Without the guard, WritePlan would race
+// directory removal and the test would either flake or leave a stray file.
+func TestManager_StartDraft_GuardSkipsWritePlanAfterKillSession(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	release := make(chan struct{})
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		draftFn: func(ctx context.Context, req DraftRequest) (string, error) {
+			<-release
+			return "# Goal\nshould-not-land", nil
+		},
+	})
+
+	sess, _, err := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessID := sess.ID
+	worktreePath := sess.Worktree.Path
+
+	if err := mgr.StartDraft(sessID, "x"); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, func() bool { return sess.IsDrafting() })
+
+	// KillSession is synchronous: by the time it returns, the session has
+	// been removed from m.sessions. Releasing the stub afterward makes the
+	// runDraft post-Draft re-check observe stillOpen=false deterministically.
+	if err := mgr.KillSession(sessID); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+
+	waitForCondition(t, 2*time.Second, func() bool { return !sess.IsDrafting() })
+
+	planPath := filepath.Join(worktreePath, ".claude", "plan.md")
+	if _, err := os.Stat(planPath); !os.IsNotExist(err) {
+		t.Errorf("plan file should not exist after stillOpen guard short-circuited; stat err=%v", err)
+	}
+}
+
+func TestManager_StartDraft_DoesNotCountTowardAgentCount(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		draftFn: func(ctx context.Context, req DraftRequest) (string, error) {
+			return "# Goal\nx", nil
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+
+	before := mgr.AgentCount()
+
+	if err := mgr.StartDraft(sess.ID, "x"); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, 2*time.Second, func() bool { return !sess.IsDrafting() })
+
+	if got := mgr.AgentCount(); got != before {
+		t.Errorf("AgentCount changed across StartDraft: before=%d after=%d (drafting must not count as an agent)", before, got)
+	}
+}

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -1,0 +1,169 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const claudeSonnetModel = "claude-sonnet-4-6"
+
+// PlanDraftTimeout bounds a single Draft or Revise subprocess. Plan generation
+// is one-shot (no retry), so this is also the wall-clock budget the user
+// waits before the editor opens. Declared as var so tests can shrink it.
+var PlanDraftTimeout = 60 * time.Second
+
+// ErrEmptyPrompt is returned when Draft is called with an empty user prompt.
+var ErrEmptyPrompt = errors.New("planner: empty user prompt")
+
+// ErrEmptyPlan is returned when Revise is called with an empty current plan.
+var ErrEmptyPlan = errors.New("planner: empty current plan")
+
+// ErrEmptyCritique is returned when Revise is called with an empty critique.
+var ErrEmptyCritique = errors.New("planner: empty critique")
+
+// PlanDrafter generates and revises plan markdown via a backing model.
+// Implementations may shell out to a binary, mock the call for tests, or
+// call an API directly. Both methods accept a context for cancellation.
+type PlanDrafter interface {
+	Draft(ctx context.Context, req DraftRequest) (string, error)
+	Revise(ctx context.Context, req ReviseRequest) (string, error)
+}
+
+// DraftRequest is the input to PlanDrafter.Draft.
+type DraftRequest struct {
+	UserPrompt string
+}
+
+// ReviseRequest is the input to PlanDrafter.Revise.
+type ReviseRequest struct {
+	CurrentPlan string
+	Critique    string
+}
+
+// planDraftPrompt frames each Draft call. The five fixed sections match what
+// the plan editor expects (Goal / Context / Tasks / Verification / Not in
+// scope). Kept in lockstep with the editor's render so a renamed section
+// would be a code-coupled change, not a silent drift.
+const planDraftPrompt = `You are helping a developer plan a coding task before they hand it to an AI coding agent. Produce a concise markdown plan with these sections, in order:
+
+# Goal
+One sentence: what is the developer trying to accomplish?
+
+## Context
+2-3 sentences of background. What part of the system does this touch, and what constraints matter?
+
+## Tasks
+A short checklist of the steps to ship this. Each task should be small and independently verifiable. Use markdown task syntax: - [ ] description.
+
+## Verification
+How will the developer know the change works? Tests, manual checks, or both.
+
+## Not in scope
+What this plan deliberately excludes.
+
+Keep the whole plan under 400 words. The developer will edit your output before approving — favor a short, clear plan they can refine over an exhaustive one. Output only the markdown plan; no preamble, no surrounding explanation.
+
+The developer's task description follows.
+
+`
+
+// planRevisePrompt frames each Revise call. The current plan and critique
+// are appended verbatim so the model sees the literal markdown it produced
+// earlier alongside the change request.
+const planRevisePrompt = `You are revising an existing plan for a coding task based on the developer's feedback. Output the full revised plan with the same five sections (Goal / Context / Tasks / Verification / Not in scope). Preserve sections, wording, and tasks the feedback does not touch — make small, surgical changes. Output only the markdown plan; no preamble.
+
+CURRENT PLAN:
+`
+
+// DefaultPlanDrafter returns a PlanDrafter that shells out to
+// `claude -p --model claude-sonnet-4-6` with the planning instruction piped
+// on stdin. Mirrors DefaultBranchNamer's approach: bounded per-call context,
+// env stripped of baton hook wiring so the subprocess does not register
+// against the running TUI's hook socket as the parent agent.
+//
+// Sonnet (not Haiku) is intentional: planning quality compounds downstream,
+// since a fuzzier plan turns into a fuzzier agent run and more verification
+// tax. The cost of one extra one-shot subprocess at planning time is low
+// next to the human review time it saves later.
+func DefaultPlanDrafter() PlanDrafter {
+	return &defaultPlanDrafter{}
+}
+
+type defaultPlanDrafter struct{}
+
+func (d *defaultPlanDrafter) Draft(ctx context.Context, req DraftRequest) (string, error) {
+	prompt := strings.TrimSpace(req.UserPrompt)
+	if prompt == "" {
+		return "", ErrEmptyPrompt
+	}
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrClaudeNotFound, err)
+	}
+	return runClaudePlanner(ctx, claudePath, planDraftPrompt+prompt)
+}
+
+func (d *defaultPlanDrafter) Revise(ctx context.Context, req ReviseRequest) (string, error) {
+	current := strings.TrimSpace(req.CurrentPlan)
+	critique := strings.TrimSpace(req.Critique)
+	if current == "" {
+		return "", ErrEmptyPlan
+	}
+	if critique == "" {
+		return "", ErrEmptyCritique
+	}
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrClaudeNotFound, err)
+	}
+	instruction := planRevisePrompt + current + "\n\nCRITIQUE:\n" + critique + "\n"
+	return runClaudePlanner(ctx, claudePath, instruction)
+}
+
+// buildClaudePlannerArgs returns the argv (excluding the binary path) for a
+// one-shot planning subprocess. Mirrors buildClaudeHaikuArgs but uses Sonnet.
+// Tools stay disabled — the planner generates a markdown document, it does
+// not need to touch the filesystem or call MCP servers.
+func buildClaudePlannerArgs() []string {
+	args := []string{"-p", "--model", claudeSonnetModel}
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		args = append(args, "--bare")
+	}
+	args = append(
+		args,
+		"--strict-mcp-config", "--mcp-config", "{}",
+		"--disable-slash-commands",
+		"--no-session-persistence",
+		"--tools", "",
+		"--setting-sources", "user",
+		"--exclude-dynamic-system-prompt-sections",
+	)
+	return args
+}
+
+// runClaudePlanner runs `claude -p --model claude-sonnet-4-6` with instruction
+// on stdin and returns the trimmed raw stdout (markdown). Strips baton's hook
+// env so the subprocess does not register against the running TUI's hook
+// socket as the parent agent.
+func runClaudePlanner(ctx context.Context, claudePath, instruction string) (string, error) {
+	cmd := exec.CommandContext(ctx, claudePath, buildClaudePlannerArgs()...)
+	cmd.Stdin = strings.NewReader(instruction)
+	cmd.Env = sanitizedHaikuEnv(os.Environ())
+	cmd.WaitDelay = 500 * time.Millisecond
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("claude planner: %w (stderr=%q)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -1,0 +1,268 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultPlanDrafter_DraftSuccess(t *testing.T) {
+	dir := t.TempDir()
+	const planMD = "# Goal\nAdd dark mode\n\n## Tasks\n- [ ] thing"
+	writeFakeClaude(t, dir, planMD, 0)
+	withPATH(t, dir)
+
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	got, err := d.Draft(ctx, DraftRequest{UserPrompt: "add dark mode"})
+	if err != nil {
+		t.Fatalf("Draft returned error: %v", err)
+	}
+	if got != planMD {
+		t.Errorf("Draft = %q, want %q", got, planMD)
+	}
+}
+
+func TestDefaultPlanDrafter_DraftEmptyPromptError(t *testing.T) {
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	for _, prompt := range []string{"", "   ", "\t\n"} {
+		_, err := d.Draft(ctx, DraftRequest{UserPrompt: prompt})
+		if !errors.Is(err, ErrEmptyPrompt) {
+			t.Errorf("prompt=%q: err = %v, want ErrEmptyPrompt", prompt, err)
+		}
+	}
+}
+
+func TestDefaultPlanDrafter_DraftPipesPromptVerbatim(t *testing.T) {
+	dir := t.TempDir()
+	stdinFile := filepath.Join(dir, "stdin.txt")
+	writeStdinCapturingClaude(t, dir, stdinFile, "# Goal\nstub")
+	withPATH(t, dir)
+
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const prompt = "add dark mode toggle to settings"
+	if _, err := d.Draft(ctx, DraftRequest{UserPrompt: prompt}); err != nil {
+		t.Fatalf("Draft: %v", err)
+	}
+
+	got, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatalf("read stdin: %v", err)
+	}
+	body := string(got)
+	if !strings.HasPrefix(body, planDraftPrompt) {
+		t.Errorf("stdin missing planDraftPrompt prefix\nstdin=%q", body)
+	}
+	if !strings.Contains(body, prompt) {
+		t.Errorf("stdin missing user prompt; got=%q", body)
+	}
+}
+
+func TestDefaultPlanDrafter_DraftClaudeMissing(t *testing.T) {
+	empty := t.TempDir()
+	t.Setenv("PATH", empty)
+
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := d.Draft(ctx, DraftRequest{UserPrompt: "add dark mode"})
+	if !errors.Is(err, ErrClaudeNotFound) {
+		t.Errorf("err = %v, want errors.Is(err, ErrClaudeNotFound)", err)
+	}
+}
+
+func TestDefaultPlanDrafter_DraftNonZeroExitSurfacesStderr(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeClaude(t, dir, "noise", 1)
+	withPATH(t, dir)
+
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := d.Draft(ctx, DraftRequest{UserPrompt: "add dark mode"})
+	if err == nil {
+		t.Fatal("Draft should error on non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "claude planner") {
+		t.Errorf("err message should mention claude planner; got %q", err.Error())
+	}
+}
+
+func TestDefaultPlanDrafter_DraftContextTimeout(t *testing.T) {
+	dir := t.TempDir()
+	writeSlowClaude(t, dir, 10)
+	withPATH(t, dir)
+
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := d.Draft(ctx, DraftRequest{UserPrompt: "add dark mode"})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("Draft waited %v after 200ms timeout (expected to be killed promptly)", elapsed)
+	}
+}
+
+func TestDefaultPlanDrafter_DraftStripsBatonHookEnv(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "env.txt")
+	writeEnvDumpingClaude(t, dir, envFile, "# Goal\nstub")
+	withPATH(t, dir)
+
+	t.Setenv("BATON_HOOK_SOCKET", "/should/not/leak.sock")
+	t.Setenv("BATON_AGENT_ID", "should-not-leak")
+
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := d.Draft(ctx, DraftRequest{UserPrompt: "add dark mode"}); err != nil {
+		t.Fatalf("Draft: %v", err)
+	}
+
+	envContents, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	body := string(envContents)
+	for _, banned := range []string{"BATON_HOOK_SOCKET=", "BATON_AGENT_ID="} {
+		if strings.Contains(body, banned) {
+			t.Errorf("planner env contained %q; should have been stripped\n%s", banned, body)
+		}
+	}
+}
+
+func TestDefaultPlanDrafter_ReviseSuccess(t *testing.T) {
+	dir := t.TempDir()
+	const revised = "# Goal\nRevised\n\n## Tasks\n- [ ] one\n- [ ] two"
+	writeFakeClaude(t, dir, revised, 0)
+	withPATH(t, dir)
+
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	got, err := d.Revise(ctx, ReviseRequest{
+		CurrentPlan: "# Goal\nold\n",
+		Critique:    "split task",
+	})
+	if err != nil {
+		t.Fatalf("Revise: %v", err)
+	}
+	if got != revised {
+		t.Errorf("Revise = %q, want %q", got, revised)
+	}
+}
+
+func TestDefaultPlanDrafter_ReviseEmptyInputs(t *testing.T) {
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := d.Revise(ctx, ReviseRequest{CurrentPlan: "", Critique: "x"})
+	if !errors.Is(err, ErrEmptyPlan) {
+		t.Errorf("empty plan err = %v, want ErrEmptyPlan", err)
+	}
+	_, err = d.Revise(ctx, ReviseRequest{CurrentPlan: "x", Critique: ""})
+	if !errors.Is(err, ErrEmptyCritique) {
+		t.Errorf("empty critique err = %v, want ErrEmptyCritique", err)
+	}
+}
+
+func TestDefaultPlanDrafter_RevisePipesPlanAndCritique(t *testing.T) {
+	dir := t.TempDir()
+	stdinFile := filepath.Join(dir, "stdin.txt")
+	writeStdinCapturingClaude(t, dir, stdinFile, "# Goal\nrevised")
+	withPATH(t, dir)
+
+	d := DefaultPlanDrafter()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const plan = "# Goal\nAdd thing\n## Tasks\n- [ ] do A"
+	const critique = "split task A into A1 and A2"
+	if _, err := d.Revise(ctx, ReviseRequest{CurrentPlan: plan, Critique: critique}); err != nil {
+		t.Fatalf("Revise: %v", err)
+	}
+
+	got, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatalf("read stdin: %v", err)
+	}
+	body := string(got)
+	if !strings.HasPrefix(body, planRevisePrompt) {
+		t.Errorf("stdin missing planRevisePrompt prefix\nstdin=%q", body)
+	}
+	if !strings.Contains(body, plan) {
+		t.Errorf("stdin missing current plan; got=%q", body)
+	}
+	if !strings.Contains(body, critique) {
+		t.Errorf("stdin missing critique; got=%q", body)
+	}
+}
+
+func TestBuildClaudePlannerArgs_UsesSonnet(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	args := buildClaudePlannerArgs()
+	if args[0] != "-p" {
+		t.Errorf("first arg = %q, want -p", args[0])
+	}
+	if !containsPair(args, "--model", claudeSonnetModel) {
+		t.Errorf("missing --model %s; args=%v", claudeSonnetModel, args)
+	}
+	for _, banned := range []string{"claude-haiku-4-5", "claude-haiku-3-5"} {
+		for _, a := range args {
+			if a == banned {
+				t.Errorf("planner args contain Haiku model %q; should be Sonnet", banned)
+			}
+		}
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"--strict-mcp-config",
+		"--mcp-config {}",
+		"--disable-slash-commands",
+		"--no-session-persistence",
+		"--tools ",
+		"--setting-sources user",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("argv missing %q; got %q", want, joined)
+		}
+	}
+}
+
+func TestBuildClaudePlannerArgs_BareGatedByAPIKey(t *testing.T) {
+	t.Run("with API key", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+		args := buildClaudePlannerArgs()
+		if !contains(args, "--bare") {
+			t.Errorf("expected --bare with ANTHROPIC_API_KEY set; got %v", args)
+		}
+	})
+	t.Run("without API key", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		args := buildClaudePlannerArgs()
+		if contains(args, "--bare") {
+			t.Errorf("did not expect --bare without ANTHROPIC_API_KEY; got %v", args)
+		}
+	})
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -1,8 +1,13 @@
 package agent
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -32,6 +37,9 @@ type Session struct {
 	taskSummary    string // short summary of the session's task, set once by the summarizer goroutine
 	hasTaskSummary bool   // true once SetTaskSummary has been called
 	summarizing    bool   // true while an async task-summary goroutine is in flight; gates double-dispatch
+	drafting       bool   // true while a plan-drafting subprocess is in flight; gates double-dispatch
+	draftCancel    context.CancelFunc
+	draftErr       error // last drafting error, surfaced by the Planning card; cleared on successful draft
 }
 
 // newSession creates a session with the given worktree. New sessions land in
@@ -661,6 +669,188 @@ func (s *Session) finishTaskSummary() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.summarizing = false
+}
+
+// IsDrafting reports whether a plan-drafting subprocess is currently in flight.
+func (s *Session) IsDrafting() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.drafting
+}
+
+// TryStartDraft atomically returns true if a plan-drafting subprocess should
+// start now, or false if one is already in flight. The provided cancel func
+// is stored so CancelDraft can cancel an in-flight subprocess (e.g. when
+// KillSession is called or the manager shuts down). Callers that receive
+// true must call finishDraft when done.
+func (s *Session) TryStartDraft(cancel context.CancelFunc) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.drafting {
+		return false
+	}
+	s.drafting = true
+	s.draftCancel = cancel
+	return true
+}
+
+// finishDraft clears the in-flight draft flag and releases the stored cancel
+// func by invoking it (idempotent — calling cancel after the context already
+// fired is a no-op). Called from the deferred cleanup of the goroutine
+// spawned after TryStartDraft returns true. Does NOT clear draftErr — the
+// last error stays on the session so the Planning card can show it.
+func (s *Session) finishDraft() {
+	s.mu.Lock()
+	cancel := s.draftCancel
+	s.drafting = false
+	s.draftCancel = nil
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// CancelDraft cancels the in-flight drafting subprocess if any. Safe to call
+// when no draft is in flight (no-op). Used by Manager.KillSession and
+// Manager.Shutdown to abort the subprocess promptly so the goroutine can
+// drain through finishDraft.
+func (s *Session) CancelDraft() {
+	s.mu.RLock()
+	cancel := s.draftCancel
+	s.mu.RUnlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// SetDraftError stores the latest drafting error (or nil to clear). Cleared
+// only when a subsequent draft succeeds; finishDraft does NOT clear it so
+// the Planning card can render the failure even after the goroutine exits.
+func (s *Session) SetDraftError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.draftErr = err
+}
+
+// DraftError returns the last drafting error, or nil if the most recent
+// drafting attempt succeeded (or no draft has run).
+func (s *Session) DraftError() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.draftErr
+}
+
+// PlanPath returns the absolute path to the session's plan markdown file
+// (<worktree>/.claude/plan.md). Always returns a path even if the file does
+// not exist — callers use HasPlan or ReadPlan to test for presence.
+func (s *Session) PlanPath() string {
+	return filepath.Join(s.Worktree.Path, ".claude", "plan.md")
+}
+
+// ReadPlan returns the contents of the session's plan file. Returns
+// ("", nil) if the file does not exist (no plan written yet) — callers
+// should treat absence and emptiness identically.
+func (s *Session) ReadPlan() (string, error) {
+	data, err := os.ReadFile(s.PlanPath())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("plan: reading %s: %w", s.PlanPath(), err)
+	}
+	return string(data), nil
+}
+
+// WritePlan writes content to the session's plan file using a temp+rename
+// for atomicity. Ensures <worktree>/.claude/ exists, and on first write
+// also appends ".claude/" to the worktree's root .gitignore if not already
+// covered, so the plan stays out of the eventual PR diff. Concurrent reads
+// during a write see either the old content or the new content, never a
+// partial write — os.Rename is atomic on Unix.
+func (s *Session) WritePlan(content string) error {
+	planDir := filepath.Join(s.Worktree.Path, ".claude")
+	if err := os.MkdirAll(planDir, 0o755); err != nil {
+		return fmt.Errorf("plan: creating %s: %w", planDir, err)
+	}
+
+	// Best effort: gitignore management must not block writing the plan.
+	// Stderr writes during an active TUI alt-screen scramble the rendered
+	// UI, so the error is swallowed here — the worst case is the plan
+	// shows up in `git status`, which is recoverable.
+	_ = s.ensureClaudeIgnored()
+
+	planPath := s.PlanPath()
+	tmp, err := os.CreateTemp(planDir, "plan-*.md.tmp")
+	if err != nil {
+		return fmt.Errorf("plan: creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("plan: writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("plan: closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, planPath); err != nil {
+		return fmt.Errorf("plan: renaming temp file to %s: %w", planPath, err)
+	}
+	committed = true
+	return nil
+}
+
+// HasPlan reports whether the session's plan file exists on disk.
+func (s *Session) HasPlan() bool {
+	_, err := os.Stat(s.PlanPath())
+	return err == nil
+}
+
+// ensureClaudeIgnored appends ".claude/" to the worktree's root .gitignore
+// if not already covered. Writes the file even if it didn't exist previously.
+// Errors are returned but treated as non-fatal by WritePlan — the worst case
+// is the plan shows up in `git status`, which the user can fix manually.
+func (s *Session) ensureClaudeIgnored() error {
+	gitignorePath := filepath.Join(s.Worktree.Path, ".gitignore")
+	existing, err := os.ReadFile(gitignorePath)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("plan: reading %s: %w", gitignorePath, err)
+	}
+	if claudeIgnoreCovered(string(existing)) {
+		return nil
+	}
+	addition := ".claude/\n"
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		addition = "\n" + addition
+	}
+	combined := append(existing, []byte(addition)...)
+	if err := os.WriteFile(gitignorePath, combined, 0o644); err != nil {
+		return fmt.Errorf("plan: writing %s: %w", gitignorePath, err)
+	}
+	return nil
+}
+
+// claudeIgnoreCovered reports whether body of a .gitignore already excludes
+// the .claude/ directory. Only matches the exact patterns ".claude/" and
+// ".claude" — fancier glob analysis would risk a false positive that misses
+// a duplicate-add edge case. Comments (lines starting with `#`) are skipped.
+func claudeIgnoreCovered(body string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if trimmed == ".claude" || trimmed == ".claude/" {
+			return true
+		}
+	}
+	return false
 }
 
 // LastOutputTime returns the most recent lastOutput time across all non-shell

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -757,6 +758,114 @@ func TestSession_SetTaskSummary_EmptyStringStillSetsHasSummary(t *testing.T) {
 	}
 }
 
+// --- Drafting state machine tests ---
+
+func TestSession_TryStartDraft_FirstCallReturnsTrue(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	cancelled := false
+	cancel := func() { cancelled = true }
+	if !s.TryStartDraft(cancel) {
+		t.Error("TryStartDraft() should return true on first call")
+	}
+	if !s.IsDrafting() {
+		t.Error("IsDrafting() should be true after TryStartDraft returns true")
+	}
+	if cancelled {
+		t.Error("cancel should not have fired yet — only on finishDraft / CancelDraft")
+	}
+}
+
+func TestSession_TryStartDraft_ReturnsFalseIfDrafting(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	if !s.TryStartDraft(func() {}) {
+		t.Fatal("expected true on first call")
+	}
+	if s.TryStartDraft(func() {}) {
+		t.Error("TryStartDraft() should return false while drafting is in flight")
+	}
+}
+
+func TestSession_FinishDraft_ClearsFlagAndCallsCancel(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+
+	cancelCalls := 0
+	if !s.TryStartDraft(func() { cancelCalls++ }) {
+		t.Fatal("expected true on first call")
+	}
+
+	s.finishDraft()
+	if s.IsDrafting() {
+		t.Error("IsDrafting() should be false after finishDraft")
+	}
+	if cancelCalls != 1 {
+		t.Errorf("cancel calls = %d, want 1 (finishDraft must release the context)", cancelCalls)
+	}
+
+	// After finish, a fresh draft is allowed.
+	if !s.TryStartDraft(func() {}) {
+		t.Error("TryStartDraft should be allowed after finishDraft")
+	}
+}
+
+func TestSession_CancelDraft_NoOpWhenNotDrafting(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	// Should not panic; nothing to cancel.
+	s.CancelDraft()
+}
+
+func TestSession_CancelDraft_FiresStoredCancel(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+
+	cancelCalls := 0
+	if !s.TryStartDraft(func() { cancelCalls++ }) {
+		t.Fatal("expected true on first call")
+	}
+
+	s.CancelDraft()
+	if cancelCalls != 1 {
+		t.Errorf("CancelDraft cancel calls = %d, want 1", cancelCalls)
+	}
+
+	// finishDraft after CancelDraft should still fire cancel — the stored
+	// cancel func has not been cleared yet because finishDraft owns the
+	// clearing, not CancelDraft. The runtime guarantees double-cancel is
+	// safe per the context package spec.
+	s.finishDraft()
+	if cancelCalls != 2 {
+		t.Errorf("after finishDraft, cancel calls = %d, want 2", cancelCalls)
+	}
+}
+
+func TestSession_DraftError_RoundTrip(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	if s.DraftError() != nil {
+		t.Errorf("DraftError() = %v, want nil initially", s.DraftError())
+	}
+	want := fmt.Errorf("boom")
+	s.SetDraftError(want)
+	if got := s.DraftError(); got != want {
+		t.Errorf("DraftError() = %v, want %v", got, want)
+	}
+	s.SetDraftError(nil)
+	if s.DraftError() != nil {
+		t.Error("DraftError() should be cleared after SetDraftError(nil)")
+	}
+}
+
+func TestSession_FinishDraft_DoesNotClearDraftError(t *testing.T) {
+	// finishDraft only clears the in-flight flag; the last error stays so
+	// the Planning card can render the failure even after the goroutine exits.
+	s := newSession("id", "name", &git.WorktreeInfo{})
+	if !s.TryStartDraft(func() {}) {
+		t.Fatal("expected true on first call")
+	}
+	s.SetDraftError(fmt.Errorf("subprocess died"))
+	s.finishDraft()
+	if s.DraftError() == nil {
+		t.Error("finishDraft should not clear DraftError")
+	}
+}
+
 // --- LastOutputTime tests ---
 
 func TestSession_LastOutputTime_ZeroWithNoAgents(t *testing.T) {
@@ -906,5 +1015,210 @@ func TestSession_IsReviewable_IgnoresShellWhenOtherAgentsReviewable(t *testing.T
 	s := makeReviewableSession(t, []Status{StatusIdle}, true)
 	if !s.IsReviewable() {
 		t.Error("IsReviewable() = false, want true (shell agent should be ignored)")
+	}
+}
+
+// --- Plan persistence tests ---
+
+func TestSession_PlanPath(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	want := filepath.Join(dir, ".claude", "plan.md")
+	if got := s.PlanPath(); got != want {
+		t.Errorf("PlanPath() = %q, want %q", got, want)
+	}
+}
+
+func TestSession_HasPlan_FalseInitially(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	if s.HasPlan() {
+		t.Error("HasPlan() should be false before any WritePlan")
+	}
+}
+
+func TestSession_ReadPlan_ReturnsEmptyWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	got, err := s.ReadPlan()
+	if err != nil {
+		t.Fatalf("ReadPlan: %v", err)
+	}
+	if got != "" {
+		t.Errorf("ReadPlan() = %q, want \"\" for missing plan file", got)
+	}
+}
+
+func TestSession_WritePlan_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	const body = "# Goal\nDo a thing\n\n## Tasks\n- [ ] one\n"
+	if err := s.WritePlan(body); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	if !s.HasPlan() {
+		t.Error("HasPlan() should report true after WritePlan")
+	}
+	got, err := s.ReadPlan()
+	if err != nil {
+		t.Fatalf("ReadPlan: %v", err)
+	}
+	if got != body {
+		t.Errorf("plan = %q, want %q", got, body)
+	}
+}
+
+func TestSession_WritePlan_CreatesClaudeDir(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	if err := s.WritePlan("# Goal\nx"); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	claudeDir := filepath.Join(dir, ".claude")
+	info, err := os.Stat(claudeDir)
+	if err != nil {
+		t.Fatalf("stat .claude: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error(".claude should be a directory")
+	}
+}
+
+func TestSession_WritePlan_AtomicReplace(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+
+	if err := s.WritePlan("v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WritePlan("v2"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.ReadPlan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v2" {
+		t.Errorf("after second write, plan = %q, want v2", got)
+	}
+
+	// No .tmp files should be left behind.
+	entries, err := os.ReadDir(filepath.Join(dir, ".claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestSession_WritePlan_AppendsToGitignoreWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte("node_modules\n.baton/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.WritePlan("body"); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+
+	got, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), ".claude/") {
+		t.Errorf(".gitignore missing .claude/ after WritePlan; got=%q", string(got))
+	}
+}
+
+func TestSession_WritePlan_GitignoreUntouchedWhenAlreadyCovered(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	const original = ".claude/\nnode_modules\n"
+	if err := os.WriteFile(gitignorePath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.WritePlan("body"); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+
+	got, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Errorf(".gitignore was modified despite already covering .claude/\nbefore=%q\nafter=%q", original, string(got))
+	}
+}
+
+func TestSession_WritePlan_GitignoreCreatedWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+
+	if err := s.WritePlan("body"); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	got, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(got), ".claude/") {
+		t.Errorf("freshly-created .gitignore missing .claude/; got=%q", string(got))
+	}
+}
+
+func TestSession_WritePlan_NoTrailingNewlineInGitignore(t *testing.T) {
+	// Pre-existing .gitignore without a trailing newline must get one inserted
+	// before the ".claude/" line so it lands on its own line.
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte("node_modules"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.WritePlan("body"); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+
+	got, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "node_modules\n.claude/") {
+		t.Errorf(".gitignore should have .claude/ on its own line; got=%q", string(got))
+	}
+}
+
+func TestClaudeIgnoreCovered(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"empty", "", false},
+		{"unrelated", "node_modules\n.baton/\n", false},
+		{"with slash", ".claude/\n", true},
+		{"without slash", ".claude\n", true},
+		{"surrounded", "node_modules\n.claude/\nfoo\n", true},
+		{"comment matching", "# .claude/\n", false},
+		{"prefix match should not trigger", ".claudefoo\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claudeIgnoreCovered(tc.body); got != tc.want {
+				t.Errorf("claudeIgnoreCovered(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

PR 1 of 3 implementing the plan-first planning phase. **Plumbing only — no user-visible change.** The editor, prompt modal, approve→spawn, and revise loop ship in PR 2/3.

Why now: METR's 2025 RCT shows experienced developers pay a 19% productivity tax on AI-driven verification, and the biggest lever is making the spec correct *before* the agent runs. The new flow turns Planning from a passive default into a deliberate, document-centric phase: a Sonnet-backed `claude -p` drafts a markdown plan at `<worktree>/.claude/plan.md`, the user edits/approves, and only then does the build agent spawn with the plan as its specification.

This PR lands the three plumbing pieces:

- **`PlanDrafter` (`internal/agent/planner.go`):** Interface with `Draft`/`Revise`. Default impl shells out to `claude -p --model claude-sonnet-4-6` with planning instructions piped on stdin. Mirrors the haikuname.go subprocess pattern — env stripped of baton hook wiring, `--strict-mcp-config`, `--bare` under API key, 60s `WaitDelay` cap. Sonnet (not Haiku) because planning quality compounds downstream.
- **Plan persistence (`internal/agent/session.go`):** `PlanPath`, `ReadPlan`, `WritePlan` (atomic temp+rename), `HasPlan`. Plan lives at `<worktree>/.claude/plan.md`. `WritePlan` ensures `.claude/` exists and best-effort appends `.claude/` to the worktree's `.gitignore` so the plan stays out of the eventual PR diff. No new persisted state — the file is the source of truth.
- **Drafting lifecycle (`lifecycle.go`, `session.go`, `manager.go`):** New `LifecycleDrafting` phase (restored as `LifecyclePlanning` since subprocesses don't survive detach). `Manager.StartDraft(sessionID, prompt)` validates inputs, transitions to Drafting synchronously, then runs the drafter in a goroutine tracked in `m.watchers`. Success: writes plan, transitions to Planning, clears `DraftError`. Failure: stays in Planning with `DraftError` set, no plan file. `KillSession` cancels in-flight drafts before tearing down the worktree. Drafting subprocesses do **not** count against `MaxConcurrentAgents` — they're transient text-generation calls, not long-lived agents.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./...` — agent suite clean (54s). Pre-existing failures in `internal/config` (XDG migration) and `internal/hook` (sun_path 104-byte limit on macOS temp dirs) are confirmed on baseline `060b64d` and unrelated to this PR.
- [x] Manual TUI: N/A — no UI surface in this PR.

Test coverage:

- 12 planner tests against fake-claude shell scripts (success, empty prompt, claude missing, non-zero exit, context timeout, env stripping, revise round-trip, Sonnet model assertion)
- 11 plan-persistence tests (path, present/absent, round-trip, atomic replace, .gitignore append/created/already-covered/no-trailing-newline, plus `claudeIgnoreCovered` table)
- 7 drafting state-machine unit tests (`TryStartDraft`, `finishDraft`, `CancelDraft`, `DraftError` round-trip)
- 13 manager integration tests against a stub drafter (success, immediate Drafting transition, drafter error, empty plan, double-dispatch rejection, KillSession cancels subprocess, Shutdown drains goroutine, no-drafter, unknown session, non-actionable prompt rejected, the `stillOpen` guard short-circuits `WritePlan` after KillSession, drafting doesn't count toward `AgentCount`)

## Checklist

- [x] Updated `changelog.d/plan-first-planning-plumbing.md`
- [x] New behavior has tests
- [x] New public API: `PlanDrafter`, `DraftRequest`, `ReviseRequest`, `DefaultPlanDrafter`, `LifecycleDrafting`, `Session.{PlanPath,ReadPlan,WritePlan,HasPlan,IsDrafting,TryStartDraft,CancelDraft,SetDraftError,DraftError}`, `Manager.{SetPlanDrafter,StartDraft}`, `ErrDraftInFlight`, `ErrPlanDrafterNotConfigured`, `ErrEmptyPrompt`, `ErrEmptyPlan`, `ErrEmptyCritique`, `PlanDraftTimeout`. The interface surface is what PR 2's TUI needs to drive the editor + prompt modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)