### PR TITLE
Plan-first planning, PR 3: revise loop + Planning card + flip default on

### DIFF
--- a/changelog.d/plan-first-revise-and-card.md
+++ b/changelog.d/plan-first-revise-and-card.md
@@ -1,0 +1,10 @@
+### Added
+
+- Plan-first revise loop: pressing `r` in the plan editor and submitting a critique now invokes `Manager.RevisePlan`, which snapshots the current plan to `<worktree>/.claude/plan.prev.md`, calls `PlanDrafter.Revise` (Sonnet by default), and writes the revised plan in place. While revising, the editor renders a "Revising plan…" status with the current plan greyed out underneath. On failure, `Session.ReviseError` is set and the prior plan is left untouched.
+- `u` in the plan editor restores `plan.prev.md` over `plan.md` for single-step undo and removes the snapshot. The hint only renders when a snapshot exists.
+- Dashboard PLANNING card: drafting / revising sessions render a "✎ drafting…" or "✎ revising…" status badge; planned sessions render a "✎ N/M tasks" badge plus the first uncompleted task as the description; failed drafts surface a "✗ draft failed" badge with the error excerpt. `LifecycleDrafting` sessions now show up in the PLANNING section instead of being invisible until the draft lands.
+- `space`/`enter`/click on a PLANNING row opens the plan editor (previously fell through to `openSessionInFocusLaunch`, which is a no-op for sessions with no agent yet).
+
+### Changed
+
+- `DefaultPlanFirstEnabled` flipped to `true`. The `n` keybind opens the prompt modal + plan editor by default; users who want today's immediate-spawn behaviour can set `"plan_first_enabled": false` in global or per-repo config, or hold `ctrl+enter` on the modal to skip the plan step on a per-session basis.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -563,6 +563,119 @@ func (m *Manager) runDraft(ctx context.Context, sess *Session, drafter PlanDraft
 	m.emit(Event{Type: EventStatusChanged, SessionID: sess.ID})
 }
 
+// ErrReviseInFlight is returned when RevisePlan is called for a session that
+// already has an in-flight revising subprocess. Mirrors ErrDraftInFlight.
+var ErrReviseInFlight = errors.New("revise already in flight for session")
+
+// ErrNoPlanToRevise is returned when RevisePlan is called against a session
+// with no plan yet on disk. Without a current plan there is nothing for the
+// drafter to revise from — callers should run StartDraft first or hand-write
+// a plan in the editor.
+var ErrNoPlanToRevise = errors.New("no plan to revise")
+
+// RevisePlan runs an async revise pass against the session's current plan.
+// Saves the current plan to .claude/plan.prev.md before invoking the drafter
+// so the user can `u` to undo a single step, then calls PlanDrafter.Revise
+// and writes the result via Session.WritePlan. Mirrors StartDraft's
+// goroutine-tracked pattern: m.watchers ensures Shutdown drains cleanly,
+// CancelRevise / KillSession / Shutdown abort the subprocess. Drafting and
+// revising are mutually exclusive — Session.TryStartRevise returns false
+// while a draft is in flight.
+//
+// On success, sess.ReviseError() is nil and the editor reloads the new plan
+// via the EventStatusChanged the runner emits. On failure (drafter error,
+// empty output, write error), the prior plan is left in place and
+// ReviseError is set so the editor can render the failure inline.
+func (m *Manager) RevisePlan(sessionID, critique string) error {
+	m.mu.RLock()
+	sess := m.sessions[sessionID]
+	drafter := m.planDrafter
+	m.mu.RUnlock()
+
+	if sess == nil {
+		return fmt.Errorf("session %s not found", sessionID)
+	}
+	if drafter == nil {
+		return ErrPlanDrafterNotConfigured
+	}
+	if strings.TrimSpace(critique) == "" {
+		return ErrEmptyCritique
+	}
+
+	current, err := sess.ReadPlan()
+	if err != nil {
+		return fmt.Errorf("read plan: %w", err)
+	}
+	if strings.TrimSpace(current) == "" {
+		return ErrNoPlanToRevise
+	}
+
+	// Snapshot before we even gate, so a TryStartRevise=false from a racing
+	// caller doesn't corrupt the snapshot that's about to be used by the
+	// in-flight revise. The snapshot is benign on the failure path: the next
+	// successful revise will overwrite it before any user action would
+	// observe it as the undo target.
+	if err := sess.snapshotPlanToPrev(); err != nil {
+		return fmt.Errorf("snapshot plan: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), PlanDraftTimeout)
+	if !sess.TryStartRevise(cancel) {
+		cancel()
+		return ErrReviseInFlight
+	}
+
+	sess.SetReviseError(nil)
+	m.emit(Event{Type: EventStatusChanged, SessionID: sessionID})
+
+	m.watchers.Add(1)
+	go m.runRevise(ctx, sess, drafter, current, critique)
+	return nil
+}
+
+// runRevise executes a Revise call against drafter and writes the resulting
+// plan markdown via sess.WritePlan. Mirrors runDraft's gating pattern:
+// post-call still-open check, error coercion for empty output, always emits
+// EventStatusChanged so the UI repaints. On failure the prior plan is left
+// untouched and ReviseError is set; the user can retry via `r` or undo via
+// `u` (which restores the snapshot we wrote above).
+func (m *Manager) runRevise(ctx context.Context, sess *Session, drafter PlanDrafter, current, critique string) {
+	defer m.watchers.Done()
+	defer sess.finishRevise()
+
+	// Cancel the revising subprocess if the manager shuts down mid-call.
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+	go func() {
+		select {
+		case <-m.done:
+			sess.CancelRevise()
+		case <-doneCh:
+		}
+	}()
+
+	body, err := drafter.Revise(ctx, ReviseRequest{CurrentPlan: current, Critique: critique})
+
+	m.mu.RLock()
+	_, stillOpen := m.sessions[sess.ID]
+	m.mu.RUnlock()
+	if !stillOpen {
+		return
+	}
+
+	if err == nil && strings.TrimSpace(body) == "" {
+		err = errors.New("planner returned empty plan")
+	}
+	if err == nil {
+		if writeErr := sess.WritePlan(body); writeErr != nil {
+			err = writeErr
+		}
+	}
+
+	sess.SetReviseError(err)
+	m.emit(Event{Type: EventStatusChanged, SessionID: sess.ID})
+}
+
 // IsActionablePrompt reports whether prompt carries enough text for a
 // meaningful branch name. Empty/whitespace-only prompts and pure slash
 // commands (e.g. "/clear") return false.
@@ -1135,7 +1248,10 @@ func (m *Manager) KillSession(sessionID string) error {
 	// Cancel any in-flight plan-drafting subprocess so the goroutine drains
 	// before we remove the worktree. WritePlan would otherwise race with
 	// directory removal. CancelDraft is a no-op when no draft is running.
+	// Same applies to revising — both are bounded by m.watchers and write
+	// to the same .claude/ directory.
 	sess.CancelDraft()
+	sess.CancelRevise()
 
 	sess.KillAll()
 
@@ -1444,13 +1560,14 @@ func (m *Manager) closeSession(sessionID string, sess *Session) {
 	delete(m.sessions, sessionID)
 	m.mu.Unlock()
 
-	// Cancel any in-flight plan-drafting subprocess for symmetry with
-	// KillSession. The current pipeline never reaches closeSession with a
-	// draft running (drafting precedes building), but StartDraft does not
-	// enforce that precondition — without this call, Shutdown could block
-	// on m.watchers for up to PlanDraftTimeout if the gap is ever reached.
-	// CancelDraft is a no-op when no draft is running.
+	// Cancel any in-flight plan-drafting / revising subprocess for symmetry
+	// with KillSession. The current pipeline never reaches closeSession with
+	// a draft or revise running (both precede building), but StartDraft /
+	// RevisePlan do not enforce that precondition — without this call,
+	// Shutdown could block on m.watchers for up to PlanDraftTimeout if the
+	// gap is ever reached. Both Cancel* calls are no-ops when nothing's running.
 	sess.CancelDraft()
+	sess.CancelRevise()
 	sess.KillAll()
 	_ = sess.Cleanup(m.repoPath)
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -696,3 +696,47 @@ func TestManager_RevisePlan_KillSessionCancelsSubprocess(t *testing.T) {
 		t.Error("revise subprocess context was not cancelled by KillSession")
 	}
 }
+
+func TestManager_RevisePlan_ShutdownDrainsGoroutine(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+
+	finished := atomic.Bool{}
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		reviseFn: func(ctx context.Context, req ReviseRequest) (string, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err := sess.WritePlan("# Goal\nx\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.RevisePlan(sess.ID, "improve"); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, func() bool { return sess.IsRevising() })
+
+	go func() {
+		mgr.Shutdown()
+		finished.Store(true)
+	}()
+
+	// Shutdown must complete in bounded time even with a revise in flight.
+	// The runRevise goroutine is registered in m.watchers and listens on
+	// m.done — Shutdown closes m.done, the inner goroutine cancels the
+	// drafter context, and runRevise exits via its defer chain.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if finished.Load() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("Shutdown did not return within 3s while a revise was in flight")
+}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -446,3 +446,253 @@ func TestManager_StartDraft_DoesNotCountTowardAgentCount(t *testing.T) {
 		t.Errorf("AgentCount changed across StartDraft: before=%d after=%d (drafting must not count as an agent)", before, got)
 	}
 }
+
+func TestManager_RevisePlan_Success(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	const v1 = "# Goal\nv1\n\n## Tasks\n- [ ] one\n"
+	const v2 = "# Goal\nv2 (revised)\n\n## Tasks\n- [ ] one\n- [ ] two\n"
+	stub := &stubPlanDrafter{
+		reviseFn: func(ctx context.Context, req ReviseRequest) (string, error) {
+			if req.CurrentPlan != v1 {
+				return "", errors.New("unexpected current plan")
+			}
+			if req.Critique != "add a task" {
+				return "", errors.New("unexpected critique")
+			}
+			return v2, nil
+		},
+	}
+	mgr.SetPlanDrafter(stub)
+
+	sess, _, err := mgr.CreateSessionWithCommand(
+		Config{Task: "t", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sess.WritePlan(v1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.RevisePlan(sess.ID, "add a task"); err != nil {
+		t.Fatalf("RevisePlan: %v", err)
+	}
+	waitForCondition(t, 2*time.Second, func() bool { return !sess.IsRevising() })
+
+	got, err := sess.ReadPlan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != v2 {
+		t.Errorf("plan after revise = %q, want %q", got, v2)
+	}
+	if sess.ReviseError() != nil {
+		t.Errorf("ReviseError = %v, want nil", sess.ReviseError())
+	}
+	if !sess.HasPrevPlan() {
+		t.Error("HasPrevPlan should be true after a successful revise")
+	}
+	prev, restored, err := sess.RestorePrevPlan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !restored {
+		t.Fatal("RestorePrevPlan should restore after a revise")
+	}
+	if prev != v1 {
+		t.Errorf("snapshot = %q, want %q (pre-revise content)", prev, v1)
+	}
+}
+
+func TestManager_RevisePlan_DrafterErrorLeavesPlanUntouched(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	const v1 = "# Goal\nkeep me\n\n## Tasks\n- [ ] x\n"
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		reviseFn: func(ctx context.Context, req ReviseRequest) (string, error) {
+			return "", errors.New("boom")
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "t", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err := sess.WritePlan(v1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.RevisePlan(sess.ID, "improve"); err != nil {
+		t.Fatalf("RevisePlan: %v", err)
+	}
+	waitForCondition(t, 2*time.Second, func() bool { return !sess.IsRevising() })
+
+	got, _ := sess.ReadPlan()
+	if got != v1 {
+		t.Errorf("plan after failed revise = %q, want unchanged %q", got, v1)
+	}
+	if sess.ReviseError() == nil {
+		t.Error("ReviseError should be set after drafter failure")
+	}
+	// Snapshot is still around so the user can `u` to recover even after a
+	// failed revise — we don't drop it on error.
+	if !sess.HasPrevPlan() {
+		t.Error("HasPrevPlan should remain true after failed revise (snapshot preserved)")
+	}
+}
+
+func TestManager_RevisePlan_EmptyOutputTreatedAsError(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		reviseFn: func(ctx context.Context, req ReviseRequest) (string, error) {
+			return "   \n", nil
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "t", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err := sess.WritePlan("# Goal\nx\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.RevisePlan(sess.ID, "x"); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, 2*time.Second, func() bool { return !sess.IsRevising() })
+
+	if sess.ReviseError() == nil {
+		t.Error("ReviseError should be set when drafter returns empty output")
+	}
+}
+
+func TestManager_RevisePlan_DoubleDispatchReturnsErrReviseInFlight(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	release := make(chan struct{})
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		reviseFn: func(ctx context.Context, req ReviseRequest) (string, error) {
+			<-release
+			return "# Goal\nrevised\n", nil
+		},
+	})
+	defer close(release)
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "t", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err := sess.WritePlan("# Goal\nv1\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.RevisePlan(sess.ID, "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.RevisePlan(sess.ID, "second"); !errors.Is(err, ErrReviseInFlight) {
+		t.Errorf("second RevisePlan err = %v, want ErrReviseInFlight", err)
+	}
+}
+
+func TestManager_RevisePlan_NoPlanReturnsError(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		reviseFn: func(ctx context.Context, req ReviseRequest) (string, error) {
+			return "should not be called", nil
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "t", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+
+	if err := mgr.RevisePlan(sess.ID, "improve"); !errors.Is(err, ErrNoPlanToRevise) {
+		t.Errorf("RevisePlan err = %v, want ErrNoPlanToRevise", err)
+	}
+}
+
+func TestManager_RevisePlan_EmptyCritiqueRejected(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		reviseFn: func(ctx context.Context, req ReviseRequest) (string, error) {
+			return "x", nil
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "t", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err := sess.WritePlan("# Goal\nx\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range []string{"", "   ", "\t\n"} {
+		if err := mgr.RevisePlan(sess.ID, c); !errors.Is(err, ErrEmptyCritique) {
+			t.Errorf("RevisePlan(%q) err = %v, want ErrEmptyCritique", c, err)
+		}
+	}
+}
+
+func TestManager_RevisePlan_KillSessionCancelsSubprocess(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	release := make(chan struct{})
+	var observedCancel atomic.Bool
+	mgr.SetPlanDrafter(&stubPlanDrafter{
+		reviseFn: func(ctx context.Context, req ReviseRequest) (string, error) {
+			select {
+			case <-ctx.Done():
+				observedCancel.Store(true)
+				return "", ctx.Err()
+			case <-release:
+				return "# Goal\nx", nil
+			}
+		},
+	})
+
+	sess, _, _ := mgr.CreateSessionWithCommand(
+		Config{Task: "t", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	sessID := sess.ID
+	if err := sess.WritePlan("# Goal\nx\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.RevisePlan(sessID, "x"); err != nil {
+		t.Fatal(err)
+	}
+	waitForCondition(t, time.Second, func() bool { return sess.IsRevising() })
+
+	if err := mgr.KillSession(sessID); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+
+	waitForCondition(t, 2*time.Second, func() bool { return !sess.IsRevising() })
+	if !observedCancel.Load() {
+		t.Error("revise subprocess context was not cancelled by KillSession")
+	}
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -40,6 +40,9 @@ type Session struct {
 	drafting       bool   // true while a plan-drafting subprocess is in flight; gates double-dispatch
 	draftCancel    context.CancelFunc
 	draftErr       error // last drafting error, surfaced by the Planning card; cleared on successful draft
+	revising       bool  // true while a plan-revising subprocess is in flight; gates double-dispatch
+	reviseCancel   context.CancelFunc
+	reviseErr      error // last revise error, surfaced by the editor; cleared on successful revise
 }
 
 // newSession creates a session with the given worktree. New sessions land in
@@ -611,6 +614,15 @@ func NewSessionForTest(id, name string) *Session {
 	return newSession(id, name, &git.WorktreeInfo{})
 }
 
+// NewSessionForTestWithPath creates a Session whose worktree path is set, so
+// callers can exercise plan-file helpers (WritePlan, ReadPlan, HasPlan,
+// HasPrevPlan, RestorePrevPlan) without spinning up a real git worktree.
+// Intended for tests outside the agent package; production code constructs
+// sessions through the manager.
+func NewSessionForTestWithPath(id, name, worktreePath string) *Session {
+	return newSession(id, name, &git.WorktreeInfo{Path: worktreePath})
+}
+
 // AddTestAgent injects a synthetic agent with the given id/shell flag/status
 // into the session for use in tests outside the agent package. It bypasses the
 // normal PTY-spawning path so callers don't need a real subprocess to exercise
@@ -740,11 +752,82 @@ func (s *Session) DraftError() error {
 	return s.draftErr
 }
 
+// IsRevising reports whether a plan-revising subprocess is currently in flight.
+func (s *Session) IsRevising() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.revising
+}
+
+// TryStartRevise atomically returns true if a plan-revising subprocess should
+// start now, or false if one is already in flight. Mirrors TryStartDraft.
+// Drafting and revising are mutually exclusive — you cannot revise while a
+// draft is still landing — so this also returns false during drafting.
+// Callers that receive true must call finishRevise when done.
+func (s *Session) TryStartRevise(cancel context.CancelFunc) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.revising || s.drafting {
+		return false
+	}
+	s.revising = true
+	s.reviseCancel = cancel
+	return true
+}
+
+// finishRevise clears the in-flight revise flag and releases the stored cancel
+// func by invoking it (idempotent). Does NOT clear reviseErr.
+func (s *Session) finishRevise() {
+	s.mu.Lock()
+	cancel := s.reviseCancel
+	s.revising = false
+	s.reviseCancel = nil
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// CancelRevise cancels the in-flight revising subprocess if any. Safe to call
+// when no revise is in flight (no-op). Used by KillSession and Shutdown to
+// abort the subprocess promptly so the goroutine can drain through finishRevise.
+func (s *Session) CancelRevise() {
+	s.mu.RLock()
+	cancel := s.reviseCancel
+	s.mu.RUnlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// SetReviseError stores the latest revise error (or nil to clear). Cleared
+// when a subsequent revise succeeds; finishRevise does NOT clear it.
+func (s *Session) SetReviseError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reviseErr = err
+}
+
+// ReviseError returns the last revise error, or nil if the most recent revise
+// attempt succeeded (or no revise has run).
+func (s *Session) ReviseError() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.reviseErr
+}
+
 // PlanPath returns the absolute path to the session's plan markdown file
 // (<worktree>/.claude/plan.md). Always returns a path even if the file does
 // not exist — callers use HasPlan or ReadPlan to test for presence.
 func (s *Session) PlanPath() string {
 	return filepath.Join(s.Worktree.Path, ".claude", "plan.md")
+}
+
+// PrevPlanPath returns the absolute path to the session's previous-plan
+// snapshot (<worktree>/.claude/plan.prev.md). The file is written by
+// RevisePlan as a single-step undo target; RestorePrevPlan reads it back.
+func (s *Session) PrevPlanPath() string {
+	return filepath.Join(s.Worktree.Path, ".claude", "plan.prev.md")
 }
 
 // ReadPlan returns the contents of the session's plan file. Returns
@@ -810,6 +893,88 @@ func (s *Session) WritePlan(content string) error {
 func (s *Session) HasPlan() bool {
 	_, err := os.Stat(s.PlanPath())
 	return err == nil
+}
+
+// HasPrevPlan reports whether a previous-plan snapshot exists on disk.
+// Used by the editor to decide whether to render the `u` (undo) hint.
+func (s *Session) HasPrevPlan() bool {
+	_, err := os.Stat(s.PrevPlanPath())
+	return err == nil
+}
+
+// snapshotPlanToPrev reads the current plan.md and writes it to plan.prev.md
+// using a temp+rename so a concurrent reader never sees a partial write.
+// Used by Manager.RevisePlan before invoking the drafter so the user can
+// undo to the pre-revise version. Returns nil when no plan.md exists yet
+// (the revise path covers that case by falling through to "no undo target").
+func (s *Session) snapshotPlanToPrev() error {
+	current, err := s.ReadPlan()
+	if err != nil {
+		return err
+	}
+	if current == "" {
+		return nil
+	}
+	return s.writePrevPlan(current)
+}
+
+// writePrevPlan writes content to plan.prev.md atomically. Mirrors WritePlan
+// but does not touch .gitignore (the dir already exists by the time this is
+// called, since plan.md was just read).
+func (s *Session) writePrevPlan(content string) error {
+	planDir := filepath.Join(s.Worktree.Path, ".claude")
+	if err := os.MkdirAll(planDir, 0o755); err != nil {
+		return fmt.Errorf("plan: creating %s: %w", planDir, err)
+	}
+	prevPath := s.PrevPlanPath()
+	tmp, err := os.CreateTemp(planDir, "plan-prev-*.md.tmp")
+	if err != nil {
+		return fmt.Errorf("plan: creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("plan: writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("plan: closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, prevPath); err != nil {
+		return fmt.Errorf("plan: renaming temp file to %s: %w", prevPath, err)
+	}
+	committed = true
+	return nil
+}
+
+// RestorePrevPlan replaces plan.md with the contents of plan.prev.md and
+// removes the snapshot. Single-step undo only — after restore, the previous
+// plan is gone and a second `u` press is a no-op (HasPrevPlan returns false).
+// Returns ("", false, nil) when no snapshot exists, in which case the caller
+// renders the no-op hint. The restored plan content is returned so the editor
+// can refresh in-memory state without re-reading.
+func (s *Session) RestorePrevPlan() (string, bool, error) {
+	data, err := os.ReadFile(s.PrevPlanPath())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("plan: reading %s: %w", s.PrevPlanPath(), err)
+	}
+	prev := string(data)
+	if err := s.WritePlan(prev); err != nil {
+		return "", false, err
+	}
+	// Best effort: remove the snapshot so a second `u` doesn't loop. A failed
+	// remove leaves a stale snapshot but the next revise will overwrite it,
+	// so we surface the read/write success even if the cleanup misses.
+	_ = os.Remove(s.PrevPlanPath())
+	return prev, true, nil
 }
 
 // ensureClaudeIgnored appends ".claude/" to the worktree's root .gitignore

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -43,6 +43,14 @@ type Session struct {
 	revising       bool  // true while a plan-revising subprocess is in flight; gates double-dispatch
 	reviseCancel   context.CancelFunc
 	reviseErr      error // last revise error, surfaced by the editor; cleared on successful revise
+	// Plan-content cache, keyed by the most recent successful WritePlan.
+	// Populated lazily by CachedPlan() on first read so resumed sessions
+	// also benefit. The dashboard hot path (per-render Planning card)
+	// reads this instead of os.ReadFile to avoid a stat+read+parse cycle
+	// at every tick.
+	planCacheLoaded  bool
+	planCachePresent bool
+	planCacheContent string
 }
 
 // newSession creates a session with the given worktree. New sessions land in
@@ -886,6 +894,16 @@ func (s *Session) WritePlan(content string) error {
 		return fmt.Errorf("plan: renaming temp file to %s: %w", planPath, err)
 	}
 	committed = true
+
+	// Update the in-memory cache so the dashboard render path can skip
+	// os.Stat + os.ReadFile on subsequent ticks. Locking is brief; we
+	// only enter after the file write has succeeded.
+	s.mu.Lock()
+	s.planCacheLoaded = true
+	s.planCachePresent = true
+	s.planCacheContent = content
+	s.mu.Unlock()
+
 	return nil
 }
 
@@ -893,6 +911,62 @@ func (s *Session) WritePlan(content string) error {
 func (s *Session) HasPlan() bool {
 	_, err := os.Stat(s.PlanPath())
 	return err == nil
+}
+
+// CachedPlan returns the most recently written plan content along with a
+// flag indicating whether a plan exists. The cache is primed by WritePlan
+// (and indirectly by RestorePrevPlan, which calls WritePlan); on a
+// resumed session that was created before the cache existed, the first
+// call lazily loads from disk. Use this in hot paths like the dashboard
+// render loop instead of HasPlan() + ReadPlan(), which together do a
+// stat + read on every TUI tick.
+//
+// Returns ("", false) when no plan file exists. Read errors are not
+// surfaced — callers in render hot paths can't usefully react to them
+// and the plain ReadPlan() path is still available for callers that need
+// to handle errors explicitly.
+func (s *Session) CachedPlan() (string, bool) {
+	s.mu.RLock()
+	if s.planCacheLoaded {
+		content, present := s.planCacheContent, s.planCachePresent
+		s.mu.RUnlock()
+		return content, present
+	}
+	s.mu.RUnlock()
+
+	// Lazy load. Drop the read lock before doing I/O so a concurrent
+	// WritePlan can populate the cache while we read; if it does, we
+	// just observe its write on the next call.
+	data, err := os.ReadFile(s.PlanPath())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			s.mu.Lock()
+			if !s.planCacheLoaded {
+				s.planCacheLoaded = true
+				s.planCachePresent = false
+				s.planCacheContent = ""
+			}
+			s.mu.Unlock()
+			return "", false
+		}
+		// Any other error: don't poison the cache. Callers in render
+		// paths see ("", false) and fall back to their no-plan branch.
+		return "", false
+	}
+	content := string(data)
+
+	s.mu.Lock()
+	if !s.planCacheLoaded {
+		s.planCacheLoaded = true
+		s.planCachePresent = true
+		s.planCacheContent = content
+	} else {
+		// A WritePlan landed during our read; trust the cache.
+		content = s.planCacheContent
+	}
+	present := s.planCachePresent
+	s.mu.Unlock()
+	return content, present
 }
 
 // HasPrevPlan reports whether a previous-plan snapshot exists on disk.

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1319,3 +1319,85 @@ func TestSession_ReviseGate_DoubleDispatchRejected(t *testing.T) {
 		t.Error("IsRevising should be false after finishRevise")
 	}
 }
+
+func TestSession_CachedPlan_EmptyForFreshSession(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	plan, present := s.CachedPlan()
+	if present {
+		t.Errorf("CachedPlan() present=true for fresh session, want false")
+	}
+	if plan != "" {
+		t.Errorf("CachedPlan() plan=%q for fresh session, want empty", plan)
+	}
+}
+
+func TestSession_CachedPlan_PopulatedByWritePlan(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	const body = "# Goal\nDo a thing\n\n## Tasks\n- [ ] one\n"
+	if err := s.WritePlan(body); err != nil {
+		t.Fatal(err)
+	}
+	plan, present := s.CachedPlan()
+	if !present {
+		t.Fatal("CachedPlan() present=false after WritePlan")
+	}
+	if plan != body {
+		t.Errorf("CachedPlan() plan = %q, want %q", plan, body)
+	}
+}
+
+func TestSession_CachedPlan_LazyLoadsFromDisk(t *testing.T) {
+	// Resumed sessions don't go through WritePlan in the current process,
+	// so the first CachedPlan() call must lazy-load from disk.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const body = "# Goal\nresumed\n\n- [x] done\n- [ ] todo\n"
+	if err := os.WriteFile(filepath.Join(dir, ".claude", "plan.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	plan, present := s.CachedPlan()
+	if !present || plan != body {
+		t.Errorf("CachedPlan() = (%q, %v), want (%q, true)", plan, present, body)
+	}
+	// Second call must hit the cache. Truncate the file under the cache to
+	// confirm — if the cache works, we still see the cached body.
+	if err := os.WriteFile(filepath.Join(dir, ".claude", "plan.md"), []byte("changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	plan2, _ := s.CachedPlan()
+	if plan2 != body {
+		t.Errorf("second CachedPlan() = %q, want cached %q (cache miss)", plan2, body)
+	}
+}
+
+func TestSession_CachedPlan_RestorePrevPlanRefreshesCache(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	const v1 = "# Goal\nv1\n"
+	const v2 = "# Goal\nv2\n"
+	if err := s.WritePlan(v1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.snapshotPlanToPrev(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WritePlan(v2); err != nil {
+		t.Fatal(err)
+	}
+	plan, _ := s.CachedPlan()
+	if plan != v2 {
+		t.Fatalf("after WritePlan(v2), cache = %q, want %q", plan, v2)
+	}
+	if _, _, err := s.RestorePrevPlan(); err != nil {
+		t.Fatal(err)
+	}
+	plan, _ = s.CachedPlan()
+	if plan != v1 {
+		t.Errorf("after RestorePrevPlan, cache = %q, want %q", plan, v1)
+	}
+}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1222,3 +1222,100 @@ func TestClaudeIgnoreCovered(t *testing.T) {
 		})
 	}
 }
+
+func TestSession_HasPrevPlan_FalseInitially(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	if s.HasPrevPlan() {
+		t.Error("HasPrevPlan() should be false before any snapshot")
+	}
+}
+
+func TestSession_RestorePrevPlan_NoSnapshotIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	prev, restored, err := s.RestorePrevPlan()
+	if err != nil {
+		t.Fatalf("RestorePrevPlan: %v", err)
+	}
+	if restored {
+		t.Error("RestorePrevPlan should report restored=false when no snapshot exists")
+	}
+	if prev != "" {
+		t.Errorf("RestorePrevPlan prev = %q, want empty", prev)
+	}
+}
+
+func TestSession_SnapshotAndRestoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	const v1 = "# Goal\nv1 plan\n\n## Tasks\n- [ ] step\n"
+	if err := s.WritePlan(v1); err != nil {
+		t.Fatalf("WritePlan v1: %v", err)
+	}
+	if err := s.snapshotPlanToPrev(); err != nil {
+		t.Fatalf("snapshotPlanToPrev: %v", err)
+	}
+	if !s.HasPrevPlan() {
+		t.Fatal("HasPrevPlan should be true after snapshot")
+	}
+	const v2 = "# Goal\nv2 plan\n"
+	if err := s.WritePlan(v2); err != nil {
+		t.Fatalf("WritePlan v2: %v", err)
+	}
+	prev, restored, err := s.RestorePrevPlan()
+	if err != nil {
+		t.Fatalf("RestorePrevPlan: %v", err)
+	}
+	if !restored {
+		t.Error("RestorePrevPlan should report restored=true")
+	}
+	if prev != v1 {
+		t.Errorf("RestorePrevPlan prev = %q, want %q", prev, v1)
+	}
+	got, err := s.ReadPlan()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != v1 {
+		t.Errorf("plan after restore = %q, want %q", got, v1)
+	}
+	if s.HasPrevPlan() {
+		t.Error("HasPrevPlan should be false after restore (single-step undo)")
+	}
+}
+
+func TestSession_SnapshotEmptyPlanIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	if err := s.snapshotPlanToPrev(); err != nil {
+		t.Fatalf("snapshotPlanToPrev with no plan: %v", err)
+	}
+	if s.HasPrevPlan() {
+		t.Error("HasPrevPlan should be false when no plan exists to snapshot")
+	}
+}
+
+func TestSession_ReviseGate_RejectsWhileDrafting(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{Path: t.TempDir()})
+	if !s.TryStartDraft(func() {}) {
+		t.Fatal("TryStartDraft should succeed initially")
+	}
+	if s.TryStartRevise(func() {}) {
+		t.Error("TryStartRevise should return false while drafting")
+	}
+}
+
+func TestSession_ReviseGate_DoubleDispatchRejected(t *testing.T) {
+	s := newSession("id", "name", &git.WorktreeInfo{Path: t.TempDir()})
+	if !s.TryStartRevise(func() {}) {
+		t.Fatal("first TryStartRevise should succeed")
+	}
+	if s.TryStartRevise(func() {}) {
+		t.Error("second TryStartRevise should return false while revising")
+	}
+	s.finishRevise()
+	if s.IsRevising() {
+		t.Error("IsRevising should be false after finishRevise")
+	}
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -31,12 +31,13 @@ const (
 	// is substituted with the user's prompt before the call.
 	DefaultBranchNamePrompt = "Summarize this task into a 3-5 word git branch slug (lowercase, kebab-case, no prefix). Respond with ONLY the slug.\n\n{prompt}"
 
-	// DefaultPlanFirstEnabled gates the plan-first planning flow. When false
-	// (the default) the n keybind keeps today's behaviour: create a session
-	// and spawn the agent immediately. When true, n opens a prompt modal,
-	// drafts a plan via claude -p, and only spawns the agent after the user
-	// approves the plan.
-	DefaultPlanFirstEnabled = false
+	// DefaultPlanFirstEnabled gates the plan-first planning flow. When true
+	// (the default) the n keybind opens a prompt modal, drafts a plan via
+	// claude -p, and only spawns the agent after the user approves the plan.
+	// Users who prefer today's behaviour (immediate spawn) can set
+	// "plan_first_enabled": false in global or per-repo config, or use
+	// ctrl+enter on the modal to skip the planning step on a per-session basis.
+	DefaultPlanFirstEnabled = true
 
 	// DefaultBuildFromPlanPrompt is the initial prompt baton sends to the
 	// real agent when an approved plan is handed off. The agent is expected

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -104,10 +104,16 @@ func newSession(t *testing.T) *Session {
 		"[user]\n\tname = e2e-test\n\temail = e2e@test.local\n[init]\n\tdefaultBranch = main\n",
 	)
 
-	// Write global config: set agent_program to bash.
+	// Write global config: set agent_program to bash. plan_first_enabled is
+	// pinned to false here so the existing e2e tests (which press `n` and
+	// expect an immediate bash prompt in focusLaunch) keep working under
+	// the new default. The plan-first flow itself is exercised by unit
+	// tests in internal/agent and internal/tui; e2e tests target the
+	// session-creation path, not plan generation.
 	globalCfg := map[string]any{
 		"agent_program":      "bash",
 		"bypass_permissions": false,
+		"plan_first_enabled": false,
 	}
 	writeJSON(t, filepath.Join(home, ".baton", "config.json"), globalCfg)
 
@@ -115,6 +121,7 @@ func newSession(t *testing.T) *Session {
 	repoCfg := map[string]any{
 		"agent_program":      "bash",
 		"bypass_permissions": false,
+		"plan_first_enabled": false,
 	}
 	writeJSON(t, filepath.Join(repoDir, ".baton", "config.json"), repoCfg)
 

--- a/internal/e2e/hooks_test.go
+++ b/internal/e2e/hooks_test.go
@@ -63,13 +63,20 @@ func TestHookPipeline(t *testing.T) {
 	// Point both global and repo config at the stub so whichever baton reads
 	// wins, and pass BATON_E2E_BATON through tu so the stub can invoke the
 	// hook CLI without needing to know the binary path itself.
+	// plan_first_enabled is pinned off here for the same reason as in
+	// helpers_test.go: this test exercises the hook pipeline via `n` →
+	// immediate spawn, not the plan-first prompt-modal flow. Re-stating
+	// the override is necessary because this writeJSON overwrites the
+	// helper's config rather than merging with it.
 	writeJSON(t, filepath.Join(s.home, ".baton", "config.json"), map[string]any{
 		"agent_program":      stubPath,
 		"bypass_permissions": false,
+		"plan_first_enabled": false,
 	})
 	writeJSON(t, filepath.Join(s.repoDir, ".baton", "config.json"), map[string]any{
 		"agent_program":      stubPath,
 		"bypass_permissions": false,
+		"plan_first_enabled": false,
 	})
 	s.extraEnv = append(s.extraEnv, "BATON_E2E_BATON="+batonBin)
 	s.Start()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1602,6 +1602,14 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if err != nil {
 					return createResultMsg{err: err}
 				}
+				// Legacy n (PlanFirstEnabled=false) spawns the agent
+				// immediately, so the session belongs in BUILDING from the
+				// start. Without this transition the row would land in
+				// PLANNING, where the dashboard renders plan-status badges
+				// rather than agent activity. The skip path in
+				// submitPromptModal does the same — keeping both call sites
+				// consistent.
+				sess.SetLifecyclePhase(agent.LifecycleInProgress)
 				return createResultMsg{sessionID: sess.ID, agentID: ag.ID, isNewSession: true}
 			}
 
@@ -2146,6 +2154,10 @@ func (a App) updateBranchPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if err != nil {
 				return createResultMsg{err: err}
 			}
+			// Branch-picker sessions spawn an agent immediately on the
+			// chosen branch; they belong in BUILDING. See the legacy n
+			// path for the same rationale.
+			sess.SetLifecyclePhase(agent.LifecycleInProgress)
 			return createResultMsg{sessionID: sess.ID, agentID: ag.ID, isNewSession: true}
 		}
 
@@ -2197,6 +2209,9 @@ func (a App) updateRepoPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if err != nil {
 				return createResultMsg{err: err}
 			}
+			// Repo-picker sessions spawn an agent immediately; they
+			// belong in BUILDING. See the legacy n path for rationale.
+			sess.SetLifecyclePhase(agent.LifecycleInProgress)
 			return createResultMsg{sessionID: sess.ID, agentID: ag.ID, isNewSession: true}
 		}
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -579,8 +579,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			ps.lastRemoteSHA = ""
 			ps.lastSHACheck = time.Time{}
 		}
-		// If the editor is open on the session whose drafting just landed,
-		// refresh its content + drafting state so the placeholder swaps to
+		// If the editor is open on the session whose drafting/revising just
+		// landed, refresh its content + state so the placeholder swaps to
 		// the rendered plan without requiring a re-open.
 		if msg.event.Type == agent.EventStatusChanged && a.planEditor != nil &&
 			a.planEditor.sess != nil && a.planEditor.sess.ID == msg.event.SessionID {
@@ -590,6 +590,20 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.planEditor.Reload()
 				if derr := a.planEditor.sess.DraftError(); derr != nil {
 					a.planEditor.SetError("draft failed: " + derr.Error())
+				}
+			}
+			revising := a.planEditor.sess.IsRevising()
+			a.planEditor.SetRevising(revising)
+			if !revising {
+				if rerr := a.planEditor.sess.ReviseError(); rerr != nil {
+					a.planEditor.SetError("revise failed: " + rerr.Error())
+				} else if a.planEditor.sess.HasPlan() {
+					// Successful revise just rewrote plan.md — pick up the new
+					// content. We Reload unconditionally on draft completion;
+					// here we gate on HasPlan so a revise that errored before
+					// the drafter ran (no write happened) doesn't drop any
+					// in-progress textarea edits.
+					a.planEditor.Reload()
 				}
 			}
 		}
@@ -713,10 +727,63 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case planEditorReviseMsg:
-		// Revise loop ships in PR 3. Surface a clear placeholder so the
-		// editor's `r` keybind doesn't appear broken when used today.
-		if a.planEditor != nil {
-			a.planEditor.SetError("Revise lands in a follow-up PR.")
+		// Persist any unsaved textarea edits before revising so the drafter
+		// sees what the user is actually looking at, not the last-saved
+		// version. WritePlan errors flow up as an inline editor error and
+		// we abort the revise — otherwise the model would revise the wrong
+		// plan and overwrite the user's edits with the result.
+		if a.planEditor != nil && a.planEditor.dirty && a.planEditor.sess != nil {
+			val := a.planEditor.textarea.Value()
+			if err := a.planEditor.sess.WritePlan(val); err != nil {
+				a.planEditor.SetError("save plan: " + err.Error())
+				return a, nil
+			}
+			a.planEditor.plan = val
+			a.planEditor.dirty = false
+		}
+		repoPath := a.repoPathForSession(msg.sessionID)
+		if repoPath == "" {
+			repoPath = a.activeRepo
+		}
+		mgr := a.managers[repoPath]
+		if mgr == nil {
+			if a.planEditor != nil {
+				a.planEditor.SetError("session manager not found")
+			}
+			return a, nil
+		}
+		if err := mgr.RevisePlan(msg.sessionID, msg.critique); err != nil {
+			if a.planEditor != nil {
+				a.planEditor.SetError("revise: " + err.Error())
+			}
+			return a, nil
+		}
+		// Reflect the revising state immediately; the EventStatusChanged
+		// dispatch above will keep it in sync as the goroutine progresses.
+		if a.planEditor != nil && a.planEditor.sess != nil &&
+			a.planEditor.sess.ID == msg.sessionID {
+			a.planEditor.SetRevising(true)
+		}
+		return a, nil
+
+	case planEditorRestoreMsg:
+		// Single-step undo: restore plan.prev.md → plan.md and reload the
+		// editor. No-op when no snapshot exists.
+		if a.planEditor == nil || a.planEditor.sess == nil {
+			return a, nil
+		}
+		sess := a.planEditor.sess
+		if sess.ID != msg.sessionID {
+			return a, nil
+		}
+		_, restored, err := sess.RestorePrevPlan()
+		switch {
+		case err != nil:
+			a.planEditor.SetError("undo: " + err.Error())
+		case !restored:
+			a.planEditor.SetError("nothing to undo")
+		default:
+			a.planEditor.Reload()
 		}
 		return a, nil
 
@@ -2756,7 +2823,14 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 	sess := items[idx].session
 
 	switch a.focusCursorSection {
-	case focusSectionPlanning, focusSectionBuilding:
+	case focusSectionPlanning:
+		// Planning rows open the plan editor — there is no agent yet to drop
+		// into a focusLaunch terminal. Drafting sessions also live in the
+		// Planning section; the editor renders a "Drafting…" placeholder
+		// until the background draft lands and reloads.
+		a.openPlanEditor(sess)
+		return nil, true
+	case focusSectionBuilding:
 		return nil, a.openSessionInFocusLaunch(sess)
 	case focusSectionReview:
 		sess.SetLifecyclePhase(agent.LifecycleInReview)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -584,26 +584,23 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the rendered plan without requiring a re-open.
 		if msg.event.Type == agent.EventStatusChanged && a.planEditor != nil &&
 			a.planEditor.sess != nil && a.planEditor.sess.ID == msg.event.SessionID {
+			// Read both flags up-front so the Reload decision sees a coherent
+			// snapshot. RevisePlan emits EventStatusChanged synchronously with
+			// IsRevising=true (before runRevise spawns), so a naive
+			// "Reload when !drafting" path would reset scrollOff at the moment
+			// the revise banner appears. Only Reload when neither subprocess
+			// is in flight — that's the single state where plan.md is stable
+			// and the editor view should reflect disk.
 			drafting := a.planEditor.sess.IsDrafting()
+			revising := a.planEditor.sess.IsRevising()
 			a.planEditor.SetDrafting(drafting)
-			if !drafting {
+			a.planEditor.SetRevising(revising)
+			if !drafting && !revising {
 				a.planEditor.Reload()
 				if derr := a.planEditor.sess.DraftError(); derr != nil {
 					a.planEditor.SetError("draft failed: " + derr.Error())
-				}
-			}
-			revising := a.planEditor.sess.IsRevising()
-			a.planEditor.SetRevising(revising)
-			if !revising {
-				if rerr := a.planEditor.sess.ReviseError(); rerr != nil {
+				} else if rerr := a.planEditor.sess.ReviseError(); rerr != nil {
 					a.planEditor.SetError("revise failed: " + rerr.Error())
-				} else if a.planEditor.sess.HasPlan() {
-					// Successful revise just rewrote plan.md — pick up the new
-					// content. We Reload unconditionally on draft completion;
-					// here we gate on HasPlan so a revise that errored before
-					// the drafter ran (no write happened) doesn't drop any
-					// in-progress textarea edits.
-					a.planEditor.Reload()
 				}
 			}
 		}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -339,6 +339,12 @@ func TestPanelFocusSwitching(t *testing.T) {
 		t.Fatalf("Expected focusList after esc, got %v", app.dashboard.panelFocus)
 	}
 
+	// Sessions created by the legacy `n` path land in LifecyclePlanning by
+	// default. Planning rows now open the plan editor (PR3 wiring), so
+	// advance to Building with `b` before testing the focusLaunch entry.
+	model, _ = app.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
+	app = model.(App)
+
 	// Enter on the cursor-selected session re-opens focusLaunch.
 	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	app = model.(App)

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -652,6 +652,10 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected boo
 // or Drafting card. Priority: Drafting > Revising > DraftError > plan task
 // summary > "no plan yet". Drafting and revising are mutually exclusive at
 // the session level, so the fall-through ordering is unambiguous.
+//
+// Reads plan content via Session.CachedPlan to keep the per-render hot path
+// off os.Stat + os.ReadFile. Cache is invalidated by WritePlan, which the
+// drafter and revise paths both go through.
 func planningStatusBadge(sess *agent.Session) string {
 	if sess.IsDrafting() {
 		return lipgloss.NewStyle().Foreground(ColorWarning).Render("✎ drafting…")
@@ -662,12 +666,9 @@ func planningStatusBadge(sess *agent.Session) string {
 	if err := sess.DraftError(); err != nil {
 		return lipgloss.NewStyle().Foreground(ColorError).Render("✗ draft failed")
 	}
-	if !sess.HasPlan() {
+	plan, present := sess.CachedPlan()
+	if !present {
 		return StyleSubtle.Render("○ no plan yet")
-	}
-	plan, err := sess.ReadPlan()
-	if err != nil {
-		return StyleSubtle.Render("○ plan unreadable")
 	}
 	total, done := planTaskCounts(plan)
 	if total == 0 {
@@ -689,18 +690,22 @@ func planningDescription(sess *agent.Session) (string, bool) {
 		}
 		return "drafting plan…", true
 	}
+	if sess.IsRevising() {
+		// Match the badge ("✎ revising…") so the card reads as a unit.
+		// Without this branch the description would fall through to the
+		// pre-revise plan's first uncompleted task, which is technically
+		// correct but visually inconsistent with the badge.
+		return "revising plan…", true
+	}
 	if err := sess.DraftError(); err != nil {
 		return "draft failed: " + err.Error(), false
 	}
-	if !sess.HasPlan() {
+	plan, present := sess.CachedPlan()
+	if !present {
 		if p := sess.OriginalPrompt(); p != "" {
 			return p, true
 		}
 		return "no plan yet — press space to write one", true
-	}
-	plan, err := sess.ReadPlan()
-	if err != nil {
-		return "plan unreadable: " + err.Error(), false
 	}
 	if next := firstUncompletedTask(plan); next != "" {
 		return "next: " + next, false

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -366,9 +366,11 @@ func (d dashboardModel) sessionsInPhase(phases ...agent.LifecyclePhase) []listIt
 
 // planningSessions returns the sessions the user is still scoping. Planning is
 // the entry point for new work — sessions advance to Building (InProgress) once
-// the user presses 'b'.
+// the user presses 'b'. Drafting sessions (LifecycleDrafting) are included
+// here so they're visible from the dashboard while the background draft runs;
+// the card renderer detects the sub-phase and shows a "drafting…" badge.
 func (d dashboardModel) planningSessions() []listItem {
-	return d.sessionsInPhase(agent.LifecyclePlanning)
+	return d.sessionsInPhase(agent.LifecyclePlanning, agent.LifecycleDrafting)
 }
 
 // reviewQueueSessions returns listItems for sessions in ReadyForReview or
@@ -554,7 +556,17 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected boo
 		name = "> " + name
 	}
 	nameStyled := lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
-	badge := d.sessionFocusStatus(sess)
+	// Planning + Drafting phases get a dedicated badge + description because
+	// they have no agent yet — the regular sessionFocusStatus path is keyed
+	// off agent.Status and would render "0 active, 0 idle" for these rows.
+	phase := sess.LifecyclePhase()
+	planningPhase := phase == agent.LifecyclePlanning || phase == agent.LifecycleDrafting
+	var badge string
+	if planningPhase {
+		badge = planningStatusBadge(sess)
+	} else {
+		badge = d.sessionFocusStatus(sess)
+	}
 	line1 := rightAlign(stripe+" "+nameStyled, badge, width)
 
 	// --- Lines 2 and 3: description (always two lines) ---
@@ -562,7 +574,13 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected boo
 	if descBudget < 1 {
 		descBudget = 1
 	}
-	descText, descPending := focusTaskDescription(sess)
+	var descText string
+	var descPending bool
+	if planningPhase {
+		descText, descPending = planningDescription(sess)
+	} else {
+		descText, descPending = focusTaskDescription(sess)
+	}
 	descLine1, descLine2 := wrapTwoLines(descText, descBudget)
 	descStyle := StyleSubtle
 	if descPending {
@@ -628,6 +646,112 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected boo
 	line4 := rightAlign(bottomLeft, StyleSubtle.Render(elapsedStr), width)
 
 	return []string{line1, line2, line3, line4}
+}
+
+// planningStatusBadge renders the right-aligned status badge for a Planning
+// or Drafting card. Priority: Drafting > Revising > DraftError > plan task
+// summary > "no plan yet". Drafting and revising are mutually exclusive at
+// the session level, so the fall-through ordering is unambiguous.
+func planningStatusBadge(sess *agent.Session) string {
+	if sess.IsDrafting() {
+		return lipgloss.NewStyle().Foreground(ColorWarning).Render("✎ drafting…")
+	}
+	if sess.IsRevising() {
+		return lipgloss.NewStyle().Foreground(ColorWarning).Render("✎ revising…")
+	}
+	if err := sess.DraftError(); err != nil {
+		return lipgloss.NewStyle().Foreground(ColorError).Render("✗ draft failed")
+	}
+	if !sess.HasPlan() {
+		return StyleSubtle.Render("○ no plan yet")
+	}
+	plan, err := sess.ReadPlan()
+	if err != nil {
+		return StyleSubtle.Render("○ plan unreadable")
+	}
+	total, done := planTaskCounts(plan)
+	if total == 0 {
+		return lipgloss.NewStyle().Foreground(ColorPrimary).Render("✎ plan ready")
+	}
+	return lipgloss.NewStyle().Foreground(ColorPrimary).Render(
+		fmt.Sprintf("✎ %d/%d tasks", done, total),
+	)
+}
+
+// planningDescription chooses the description text for a Planning or Drafting
+// card. Drafting shows the prompt italicized; a successful draft surfaces the
+// first uncompleted task; a failed draft surfaces the error excerpt; an
+// orphan Planning row with no plan falls back to the original prompt.
+func planningDescription(sess *agent.Session) (string, bool) {
+	if sess.IsDrafting() {
+		if p := sess.OriginalPrompt(); p != "" {
+			return p, true
+		}
+		return "drafting plan…", true
+	}
+	if err := sess.DraftError(); err != nil {
+		return "draft failed: " + err.Error(), false
+	}
+	if !sess.HasPlan() {
+		if p := sess.OriginalPrompt(); p != "" {
+			return p, true
+		}
+		return "no plan yet — press space to write one", true
+	}
+	plan, err := sess.ReadPlan()
+	if err != nil {
+		return "plan unreadable: " + err.Error(), false
+	}
+	if next := firstUncompletedTask(plan); next != "" {
+		return "next: " + next, false
+	}
+	if p := sess.OriginalPrompt(); p != "" {
+		return p, false
+	}
+	return "plan ready — press a to approve", false
+}
+
+// planTaskCounts returns (total, done) for "- [ ]" / "- [x]" task list items
+// found anywhere in plan markdown. Tolerant of leading whitespace and either
+// case for the completion marker. Doesn't try to scope to a "## Tasks"
+// section — keeping the check section-agnostic means a renamed heading or a
+// freeform plan still gets a useful count.
+func planTaskCounts(plan string) (total, done int) {
+	for _, raw := range strings.Split(plan, "\n") {
+		line := strings.TrimLeft(raw, " \t")
+		if !strings.HasPrefix(line, "- [") {
+			continue
+		}
+		// Need at least "- [x] " to be a task line.
+		if len(line) < 6 || line[4] != ']' {
+			continue
+		}
+		total++
+		marker := line[3]
+		if marker == 'x' || marker == 'X' {
+			done++
+		}
+	}
+	return total, done
+}
+
+// firstUncompletedTask returns the text of the first "- [ ]" line in plan, or
+// "" if every task is done (or the plan has no task lines). Used by the
+// Planning card description so the user sees what's outstanding without
+// opening the editor.
+func firstUncompletedTask(plan string) string {
+	for _, raw := range strings.Split(plan, "\n") {
+		line := strings.TrimLeft(raw, " \t")
+		if !strings.HasPrefix(line, "- [ ]") {
+			continue
+		}
+		text := strings.TrimSpace(strings.TrimPrefix(line, "- [ ]"))
+		if text == "" {
+			continue
+		}
+		return text
+	}
+	return ""
 }
 
 // focusTaskDescription chooses the description string for a session card in

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/baton/internal/agent"
 	"github.com/devenjarvis/baton/internal/hook"
 )
@@ -483,3 +484,77 @@ func TestShippingSessions_OnlyShippingPhase(t *testing.T) {
 		t.Fatalf("expected exactly the shipping session, got %d entries", len(shipping))
 	}
 }
+
+func TestPlanTaskCounts(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		plan      string
+		wantTotal int
+		wantDone  int
+	}{
+		{"empty", "", 0, 0},
+		{"no tasks", "# Goal\nDo a thing\n", 0, 0},
+		{"all open", "# Goal\nx\n\n## Tasks\n- [ ] one\n- [ ] two\n", 2, 0},
+		{"mixed", "## Tasks\n- [x] done\n- [ ] open\n- [X] also done\n", 3, 2},
+		{"indented", "## Tasks\n  - [ ] indented\n\t- [x] tabbed\n", 2, 1},
+		{"prefix only is not a task", "- [ x] not a task\n- [ ] real\n", 1, 0},
+		{"non-task lines ignored", "narrative line\n## Tasks\n- [ ] a\nmore prose\n- [x] b\n", 2, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			total, done := planTaskCounts(tc.plan)
+			if total != tc.wantTotal || done != tc.wantDone {
+				t.Errorf("planTaskCounts(%q) = (%d, %d), want (%d, %d)",
+					tc.plan, total, done, tc.wantTotal, tc.wantDone)
+			}
+		})
+	}
+}
+
+func TestFirstUncompletedTask(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		plan string
+		want string
+	}{
+		{"empty", "", ""},
+		{"all done", "- [x] one\n- [X] two\n", ""},
+		{"first open", "- [x] done\n- [ ] next thing\n- [ ] later\n", "next thing"},
+		{"trims surrounding whitespace", "  - [ ]   trim me  \n", "trim me"},
+		{"skips blank task body", "- [ ]   \n- [ ] real one\n", "real one"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := firstUncompletedTask(tc.plan); got != tc.want {
+				t.Errorf("firstUncompletedTask(%q) = %q, want %q", tc.plan, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlanningStatusBadge_PhaseTransitions(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("id", "name", dir)
+	sess.SetLifecyclePhase(agent.LifecyclePlanning)
+
+	// No plan yet → "no plan yet" surface.
+	if got := planningStatusBadge(sess); !strings.Contains(ansi.Strip(got), "no plan yet") {
+		t.Errorf("badge for fresh planning session = %q, want 'no plan yet'", got)
+	}
+
+	// Plan with tasks → counts surface.
+	if err := sess.WritePlan("- [x] done\n- [ ] todo\n"); err != nil {
+		t.Fatal(err)
+	}
+	if got := planningStatusBadge(sess); !strings.Contains(ansi.Strip(got), "1/2 tasks") {
+		t.Errorf("badge with mixed tasks = %q, want '1/2 tasks'", got)
+	}
+
+	// Draft error supersedes the task count.
+	sess.SetDraftError(errAnything{})
+	if got := planningStatusBadge(sess); !strings.Contains(ansi.Strip(got), "draft failed") {
+		t.Errorf("badge with draft error = %q, want 'draft failed'", got)
+	}
+}
+
+type errAnything struct{}
+
+func (errAnything) Error() string { return "anything" }

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -76,6 +76,13 @@ type planEditorCloseMsg struct {
 	sessionID string
 }
 
+// planEditorRestoreMsg is emitted on `u` in scroll mode to restore the
+// previous plan from .claude/plan.prev.md (single-step undo). The App
+// handler delegates to Session.RestorePrevPlan and reloads the editor.
+type planEditorRestoreMsg struct {
+	sessionID string
+}
+
 // planEditorSavedMsg is emitted when ctrl+s completes; the App typically
 // just clears any pending error state.
 type planEditorSavedMsg struct {
@@ -258,6 +265,19 @@ func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
 		m.mode = planEditorModeReviseInput
 		m.reviseInput.SetValue("")
 		return m.reviseInput.Focus()
+	case "u":
+		if m.revising || m.sess == nil {
+			return nil
+		}
+		// Surface a friendly inline message instead of routing through the
+		// App when there's nothing to undo — saves a round-trip and keeps
+		// the no-op key press from looking broken.
+		if !m.sess.HasPrevPlan() {
+			m.errMsg = "nothing to undo"
+			return nil
+		}
+		sessID := m.sess.ID
+		return func() tea.Msg { return planEditorRestoreMsg{sessionID: sessID} }
 	case "a":
 		if m.revising || m.drafting || m.sess == nil {
 			return nil
@@ -461,6 +481,27 @@ func (m *planEditorModel) renderBody() string {
 	if m.drafting {
 		return StyleSubtle.Render("Drafting plan with claude -p… (esc to cancel)")
 	}
+	if m.revising {
+		// Show the current plan greyed out so the user has context for the
+		// in-flight critique, plus a status line at the top. Cleaner than a
+		// blank "Revising…" screen and lets the user keep reading.
+		all := m.planLines()
+		body := m.bodyHeight() - 1
+		if body < 1 {
+			body = 1
+		}
+		end := m.scrollOff + body
+		if end > len(all) {
+			end = len(all)
+		}
+		var rendered string
+		if len(all) == 0 {
+			rendered = StyleSubtle.Render("(no plan content)")
+		} else {
+			rendered = strings.Join(all[m.scrollOff:end], "\n")
+		}
+		return StyleActive.Render("Revising plan with claude -p…") + "\n" + StyleSubtle.Render(rendered)
+	}
 	all := m.planLines()
 	if len(all) == 0 {
 		return StyleSubtle.Render("(no plan content yet — press i to start writing or r to revise)")
@@ -495,8 +536,11 @@ func (m *planEditorModel) renderFooter() string {
 			StyleActive.Render("esc") + StyleSubtle.Render(" cancel")
 	default:
 		hints = StyleActive.Render("i") + StyleSubtle.Render(" edit  ") +
-			StyleActive.Render("r") + StyleSubtle.Render(" revise  ") +
-			StyleActive.Render("a") + StyleSubtle.Render(" approve  ") +
+			StyleActive.Render("r") + StyleSubtle.Render(" revise  ")
+		if m.sess != nil && m.sess.HasPrevPlan() {
+			hints += StyleActive.Render("u") + StyleSubtle.Render(" undo  ")
+		}
+		hints += StyleActive.Render("a") + StyleSubtle.Render(" approve  ") +
 			StyleActive.Render("q") + StyleSubtle.Render(" abandon  ") +
 			StyleActive.Render("esc") + StyleSubtle.Render(" back")
 	}


### PR DESCRIPTION
## Summary

Stacked on top of #148 (PR 2). Completes the plan-first planning flow.

- **Revise loop.** `r` in the plan editor now invokes `Manager.RevisePlan`, which snapshots the current plan to `.claude/plan.prev.md`, calls `PlanDrafter.Revise` (Sonnet by default), and writes the revised plan in place. The editor renders a "Revising plan with claude -p…" banner over the greyed-out current plan while the call is in flight.
- **Single-step undo.** `u` restores `.claude/plan.prev.md` over `plan.md` and removes the snapshot. Hint only renders when a snapshot exists.
- **Planning card on the dashboard.** The PLANNING section now includes `LifecycleDrafting` sessions and renders dedicated badges/descriptions for the planning phase: drafting/revising spinners, plan-ready summaries (`✎ N/M tasks` plus the first uncompleted task), and a `✗ draft failed` badge with the error excerpt. Activating a Planning row (space/enter/click) opens the plan editor instead of the no-op `focusLaunch` it fell through to before.
- **`PlanFirstEnabled` defaults to `true`** now that the loop is end-to-end. The `n` keybind opens the prompt modal + plan editor by default; `ctrl+enter` on the modal still skips planning per session, and `"plan_first_enabled": false` in config disables it globally.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./...` — three pre-existing failures unrelated to this PR (`TestServer*` in hook, `TestLoad_MigratesFromLegacyXDGPath` in config) reproduce on the base branch.
- [ ] Manual TUI: open a session via `n`, watch the draft land, `r` to revise, `u` to undo, `a` to approve and confirm spawn lands in BUILDING.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (changelog fragment `changelog.d/plan-first-revise-and-card.md`)
- [x] New behavior has tests (13 new tests: manager Revise×7, session RestorePrev/gates×6, dashboard parsers + planning badge×3)
- [x] No new public API surface without a note

## Notes for reviewers

- Stacks on `dkj/plan-editor-flow` (PR #148). Merge PR 2 first, then this auto-retargets to `main`.
- `Session.RestorePrevPlan` returns the restored content for callers who want to drop the in-memory plan state without re-reading from disk; the editor uses it via `Reload()` for simplicity.
- `Manager.CancelRevise` was added to the `KillSession`/`closeSession` shutdown sequence alongside the existing `CancelDraft` so revise subprocesses drain before worktree cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)