### PR TITLE
Fix planner's broken --mcp-config payload

### DIFF
--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -130,6 +130,13 @@ func (d *defaultPlanDrafter) Revise(ctx context.Context, req ReviseRequest) (str
 // one-shot planning subprocess. Mirrors buildClaudeHaikuArgs but uses Sonnet.
 // Tools stay disabled — the planner generates a markdown document, it does
 // not need to touch the filesystem or call MCP servers.
+//
+// The --mcp-config payload MUST be a JSON object containing an "mcpServers"
+// key (with an empty record as the value to declare zero servers). Claude's
+// strict schema validator rejects a bare "{}" with
+// `mcpServers: Invalid input: expected record, received undefined`, which
+// makes every planner subprocess exit 1 and surfaces as
+// `claude planner: exit status 1`. Do not simplify this back to "{}".
 func buildClaudePlannerArgs() []string {
 	args := []string{"-p", "--model", claudeSonnetModel}
 	if os.Getenv("ANTHROPIC_API_KEY") != "" {
@@ -137,7 +144,7 @@ func buildClaudePlannerArgs() []string {
 	}
 	args = append(
 		args,
-		"--strict-mcp-config", "--mcp-config", "{}",
+		"--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`,
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--tools", "",

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -238,7 +239,6 @@ func TestBuildClaudePlannerArgs_UsesSonnet(t *testing.T) {
 	joined := strings.Join(args, " ")
 	for _, want := range []string{
 		"--strict-mcp-config",
-		"--mcp-config {}",
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--tools ",
@@ -247,6 +247,34 @@ func TestBuildClaudePlannerArgs_UsesSonnet(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("argv missing %q; got %q", want, joined)
 		}
+	}
+
+	// --mcp-config must be a JSON object with an "mcpServers" record. A bare
+	// "{}" is rejected by claude's strict schema validator (regression guard
+	// for the silent planner failure).
+	mcpIdx := -1
+	for i, a := range args {
+		if a == "--mcp-config" {
+			mcpIdx = i
+			break
+		}
+	}
+	if mcpIdx < 0 {
+		t.Fatalf("argv missing --mcp-config; got %v", args)
+	}
+	if mcpIdx+1 >= len(args) {
+		t.Fatalf("--mcp-config has no value; got %v", args)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(args[mcpIdx+1]), &cfg); err != nil {
+		t.Fatalf("--mcp-config value %q not valid JSON: %v", args[mcpIdx+1], err)
+	}
+	servers, ok := cfg["mcpServers"]
+	if !ok {
+		t.Errorf("--mcp-config value %q missing required \"mcpServers\" key", args[mcpIdx+1])
+	}
+	if _, ok := servers.(map[string]any); !ok {
+		t.Errorf("--mcp-config \"mcpServers\" must be an object; got %T (%v)", servers, servers)
 	}
 }
 


### PR DESCRIPTION
## Summary

- The planner passed `--mcp-config "{}"` to `claude -p`. Newer Claude CLIs reject that with `mcpServers: Invalid input: expected record, received undefined` and exit 1, so every plan draft/revise surfaced as `claude planner: exit status 1` to the user.
- Switch the payload to `{"mcpServers":{}}` (the same form `buildClaudeHaikuArgs` already uses) and lift the warning comment from `haikuname.go` onto `planner.go` so a future refactor doesn't simplify it back.
- Replace the brittle `"--mcp-config {}"` substring assertion in `planner_test.go` with the same JSON regression guard the haikuname suite has — parse the value and require an `mcpServers` object.

This is the same regression that #146 fixed for the Haiku branch namer; the planner code path was added afterward and missed the same lesson.

## Test plan
- [x] `go test ./internal/agent/...` passes locally
- [ ] CI green
- [ ] Manually trigger plan-draft from baton TUI and confirm no more `claude planner: exit status 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)