### PR TITLE
Drop wall-clock timeout on plan drafting / revising

### DIFF
--- a/changelog.d/fix-plan-draft-silent-timeout.md
+++ b/changelog.d/fix-plan-draft-silent-timeout.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Plan drafting and revising no longer fail silently with `claude planner: signal: killed (stderr="")` after ~60s. The wall-clock `PlanDraftTimeout` that wrapped the Sonnet subprocess has been removed: drafting can legitimately take a couple of minutes on complex prompts, and the user is actively waiting for the editor — there is no other concurrent work the budget was protecting. Cancellation is still wired up via `KillSession`, manager shutdown, and explicit `CancelDraft` / `CancelRevise`, so the user remains in control of when to bail.

--- a/internal/agent/main_test.go
+++ b/internal/agent/main_test.go
@@ -47,12 +47,5 @@ func TestMain(m *testing.M) {
 	haikuSummaryOverallTimeout = 3 * time.Second
 	haikuSummaryBackoff = []time.Duration{}
 
-	// Plan drafting is one-shot (no retry), so the production 60s ceiling is
-	// just the wall-clock budget a hung subprocess would burn in tests
-	// before surfacing. Shrink to 5s — long enough that legitimate stub
-	// drafters don't race the deadline, short enough that a regression
-	// causing Draft to block forever surfaces quickly.
-	PlanDraftTimeout = 5 * time.Second
-
 	os.Exit(m.Run())
 }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -493,7 +493,11 @@ func (m *Manager) StartDraft(sessionID, prompt string) error {
 		return fmt.Errorf("prompt is empty or non-actionable")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), PlanDraftTimeout)
+	// No wall-clock timeout: Sonnet drafting can legitimately take minutes on
+	// complex prompts and the user is actively waiting for the editor. The
+	// only cancellation paths are user-initiated — KillSession, manager
+	// shutdown via m.done in runDraft, or an explicit CancelDraft.
+	ctx, cancel := context.WithCancel(context.Background())
 	if !sess.TryStartDraft(cancel) {
 		cancel()
 		return ErrDraftInFlight
@@ -619,7 +623,10 @@ func (m *Manager) RevisePlan(sessionID, critique string) error {
 		return fmt.Errorf("snapshot plan: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), PlanDraftTimeout)
+	// No wall-clock timeout for the same reason as StartDraft: revise is a
+	// Sonnet call the user is actively waiting on. User cancels via the TUI;
+	// closeSession / KillSession / Shutdown propagate via m.done in runRevise.
+	ctx, cancel := context.WithCancel(context.Background())
 	if !sess.TryStartRevise(cancel) {
 		cancel()
 		return ErrReviseInFlight
@@ -1564,8 +1571,9 @@ func (m *Manager) closeSession(sessionID string, sess *Session) {
 	// with KillSession. The current pipeline never reaches closeSession with
 	// a draft or revise running (both precede building), but StartDraft /
 	// RevisePlan do not enforce that precondition — without this call,
-	// Shutdown could block on m.watchers for up to PlanDraftTimeout if the
-	// gap is ever reached. Both Cancel* calls are no-ops when nothing's running.
+	// Shutdown would block on m.watchers indefinitely if the gap is ever
+	// reached, since drafting has no wall-clock timeout. Both Cancel* calls
+	// are no-ops when nothing's running.
 	sess.CancelDraft()
 	sess.CancelRevise()
 	sess.KillAll()

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -13,11 +13,6 @@ import (
 
 const claudeSonnetModel = "claude-sonnet-4-6"
 
-// PlanDraftTimeout bounds a single Draft or Revise subprocess. Plan generation
-// is one-shot (no retry), so this is also the wall-clock budget the user
-// waits before the editor opens. Declared as var so tests can shrink it.
-var PlanDraftTimeout = 60 * time.Second
-
 // ErrEmptyPrompt is returned when Draft is called with an empty user prompt.
 var ErrEmptyPrompt = errors.New("planner: empty user prompt")
 
@@ -83,9 +78,14 @@ CURRENT PLAN:
 
 // DefaultPlanDrafter returns a PlanDrafter that shells out to
 // `claude -p --model claude-sonnet-4-6` with the planning instruction piped
-// on stdin. Mirrors DefaultBranchNamer's approach: bounded per-call context,
-// env stripped of baton hook wiring so the subprocess does not register
-// against the running TUI's hook socket as the parent agent.
+// on stdin. Env stripped of baton hook wiring so the subprocess does not
+// register against the running TUI's hook socket as the parent agent.
+//
+// Cancellation is caller-driven via ctx (no wall-clock timeout in the default
+// path): Sonnet drafting can take a couple of minutes on complex prompts and
+// the user is actively waiting for the editor — manager StartDraft / Revise
+// pass a cancel-only context so the only kill paths are user-initiated
+// (KillSession, manager shutdown, an explicit CancelDraft / CancelRevise).
 //
 // Sonnet (not Haiku) is intentional: planning quality compounds downstream,
 // since a fuzzier plan turns into a fuzzier agent run and more verification

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -103,7 +103,13 @@ func TestDefaultPlanDrafter_DraftNonZeroExitSurfacesStderr(t *testing.T) {
 	}
 }
 
-func TestDefaultPlanDrafter_DraftContextTimeout(t *testing.T) {
+// TestDefaultPlanDrafter_DraftContextCancel verifies that an external
+// cancellation (caller's ctx) kills the subprocess promptly. The production
+// flow has no wall-clock timeout, so cancellation only ever comes from the
+// user (KillSession, manager shutdown, explicit CancelDraft) — but the
+// underlying mechanism is the same as a context expiring, which is what
+// this test exercises with a short deadline as a stand-in for a user cancel.
+func TestDefaultPlanDrafter_DraftContextCancel(t *testing.T) {
 	dir := t.TempDir()
 	writeSlowClaude(t, dir, 10)
 	withPATH(t, dir)
@@ -115,10 +121,10 @@ func TestDefaultPlanDrafter_DraftContextTimeout(t *testing.T) {
 	start := time.Now()
 	_, err := d.Draft(ctx, DraftRequest{UserPrompt: "add dark mode"})
 	if err == nil {
-		t.Fatal("expected timeout error")
+		t.Fatal("expected error from canceled context")
 	}
 	if elapsed := time.Since(start); elapsed > 3*time.Second {
-		t.Errorf("Draft waited %v after 200ms timeout (expected to be killed promptly)", elapsed)
+		t.Errorf("Draft waited %v after context cancellation (expected to be killed promptly)", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

- The 60s `PlanDraftTimeout` was killing in-flight Sonnet drafting subprocesses with SIGKILL, which left no chance to flush stderr — the user saw the cryptic `claude planner: signal: killed (stderr="")` after ~60s and the Planning card silently failed.
- Sonnet drafting on a moderately complex prompt clocks in at 35–40s in local testing and gets noticeably slower with longer prompts and user-skill metadata loading via `--setting-sources user`. Closer to the 60s wire than the budget allowed.
- Drafting is one-shot, the user is actively waiting for the editor, and there is no other concurrent work the budget was protecting — a wall-clock timeout is the wrong control surface. Replace `context.WithTimeout` with `context.WithCancel` in both `StartDraft` and `RevisePlan` so the only kill paths are user-initiated (`KillSession`, manager shutdown via `m.done` in `runDraft`/`runRevise`, or an explicit `CancelDraft` / `CancelRevise`).
- Drops the `PlanDraftTimeout` var entirely, the `TestMain` shrink in `internal/agent/main_test.go`, and renames `TestDefaultPlanDrafter_DraftContextTimeout` → `DraftContextCancel` (still useful — it verifies the subprocess dies promptly when a caller cancels, which is exactly the user-cancel path).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l internal/agent/` (clean)
- [x] `go test -race ./internal/agent/...` (passes, 56s)
- [x] `go test ./...` (passes apart from pre-existing `internal/hook` unix-socket failures on macOS that also fail on `main`)
- [ ] Manual: kick off a planning session in baton, verify the editor opens after Sonnet finishes drafting (no 60s wall) and that `KillSession` / shutdown still cancel an in-flight draft promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)