### PR TITLE
Let plan drafter research codebase before drafting

### DIFF
--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -45,13 +45,17 @@ type ReviseRequest struct {
 // the plan editor expects (Goal / Context / Tasks / Verification / Not in
 // scope). Kept in lockstep with the editor's render so a renamed section
 // would be a code-coupled change, not a silent drift.
-const planDraftPrompt = `You are helping a developer plan a coding task before they hand it to an AI coding agent. Produce a concise markdown plan with these sections, in order:
+const planDraftPrompt = `You are helping a developer plan a coding task before they hand it to an AI coding agent. Your working directory is the developer's worktree root.
+
+You have a read-only toolset: Read, Grep, Glob, LS, LSP, WebFetch, WebSearch. Before writing the plan, USE THEM to ground your work in the real codebase — locate the files the task touches, scan the conventions in that area, and check related code or imports. A plan that names actual files, functions, and constraints is far more useful than one written from the prompt alone. You cannot write, edit, run shell commands, or call MCP servers; this is a research-then-draft pass, not an implementation.
+
+Once you've researched enough, produce a concise markdown plan with these sections, in order:
 
 # Goal
 One sentence: what is the developer trying to accomplish?
 
 ## Context
-2-3 sentences of background. What part of the system does this touch, and what constraints matter?
+2-3 sentences of background. What part of the system does this touch, and what constraints matter? Cite real file paths or symbols where relevant.
 
 ## Tasks
 A short checklist of the steps to ship this. Each task should be small and independently verifiable. Use markdown task syntax: - [ ] description.
@@ -62,7 +66,7 @@ How will the developer know the change works? Tests, manual checks, or both.
 ## Not in scope
 What this plan deliberately excludes.
 
-Keep the whole plan under 400 words. The developer will edit your output before approving — favor a short, clear plan they can refine over an exhaustive one. Output only the markdown plan; no preamble, no surrounding explanation.
+The 400-word cap applies to the PLAN OUTPUT only — research with the tools as much as you need; tool calls and what you read don't count toward the cap, so don't truncate research mid-flight to stay short. The developer will edit your output before approving — favor a short, clear, code-grounded plan they can refine over an exhaustive one. Output only the markdown plan; no preamble, no surrounding explanation, no summary of what you researched.
 
 The developer's task description follows.
 
@@ -71,7 +75,9 @@ The developer's task description follows.
 // planRevisePrompt frames each Revise call. The current plan and critique
 // are appended verbatim so the model sees the literal markdown it produced
 // earlier alongside the change request.
-const planRevisePrompt = `You are revising an existing plan for a coding task based on the developer's feedback. Output the full revised plan with the same five sections (Goal / Context / Tasks / Verification / Not in scope). Preserve sections, wording, and tasks the feedback does not touch — make small, surgical changes. Output only the markdown plan; no preamble.
+const planRevisePrompt = `You are revising an existing plan for a coding task based on the developer's feedback. Your working directory is the developer's worktree root, and you have the same read-only toolset as the original drafter (Read, Grep, Glob, LS, LSP, WebFetch, WebSearch). If the critique points at code or files the current plan didn't already cover, re-read the relevant source before revising — don't invent paths or symbols.
+
+Output the full revised plan with the same five sections (Goal / Context / Tasks / Verification / Not in scope). Preserve sections, wording, and tasks the feedback does not touch — make small, surgical changes. Keep the plan under 400 words; research and tool use don't count toward that cap. Output only the markdown plan; no preamble.
 
 CURRENT PLAN:
 `
@@ -128,8 +134,15 @@ func (d *defaultPlanDrafter) Revise(ctx context.Context, req ReviseRequest) (str
 
 // buildClaudePlannerArgs returns the argv (excluding the binary path) for a
 // one-shot planning subprocess. Mirrors buildClaudeHaikuArgs but uses Sonnet.
-// Tools stay disabled — the planner generates a markdown document, it does
-// not need to touch the filesystem or call MCP servers.
+// The drafter is given a read-only tool allowlist so it can research the
+// codebase (Read/Grep/Glob/LS/LSP) and pull external docs (WebFetch/WebSearch)
+// before producing the plan markdown. Writes, Bash, and MCP servers stay
+// blocked — the planner is a thinker, not an editor. Setting sources include
+// project so worktree-local CLAUDE.md guidance reaches the drafter.
+//
+// Under --bare (API-key path) the harness skips LSP and CLAUDE.md
+// auto-discovery regardless of these flags; that's accepted as a known
+// limitation. Read/Grep/Glob/LS still function in bare mode.
 //
 // The --mcp-config payload MUST be a JSON object containing an "mcpServers"
 // key (with an empty record as the value to declare zero servers). Claude's
@@ -147,8 +160,8 @@ func buildClaudePlannerArgs() []string {
 		"--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`,
 		"--disable-slash-commands",
 		"--no-session-persistence",
-		"--tools", "",
-		"--setting-sources", "user",
+		"--tools", "Read,Grep,Glob,LS,LSP,WebFetch,WebSearch",
+		"--setting-sources", "user,project",
 		"--exclude-dynamic-system-prompt-sections",
 	)
 	return args

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -247,8 +247,8 @@ func TestBuildClaudePlannerArgs_UsesSonnet(t *testing.T) {
 		"--strict-mcp-config",
 		"--disable-slash-commands",
 		"--no-session-persistence",
-		"--tools ",
-		"--setting-sources user",
+		"--tools Read,Grep,Glob,LS,LSP,WebFetch,WebSearch",
+		"--setting-sources user,project",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("argv missing %q; got %q", want, joined)


### PR DESCRIPTION
## Summary

- Plan drafter previously ran with `--tools \"\"` so Sonnet drafted plans from the user's prompt alone — ungrounded in actual code, leading to plans full of generic placeholders. This swaps in a read-only allowlist (`Read,Grep,Glob,LS,LSP,WebFetch,WebSearch`) so the drafter can investigate before producing markdown.
- Broadens `--setting-sources` from `user` to `user,project` so worktree-local `CLAUDE.md` reaches the drafter.
- Both `planDraftPrompt` and `planRevisePrompt` rewritten to instruct research-first. The 400-word cap is re-scoped to **plan output only** so the model doesn't truncate its research mid-flight to stay short. Five-section contract (`# Goal` / `## Context` / `## Tasks` / `## Verification` / `## Not in scope`) preserved verbatim — the editor in `internal/plan` parses on those headings.
- Writes, Bash, and MCP servers stay blocked. Under `--bare` (API-key path) the harness skips LSP/CLAUDE.md regardless of these flags; that's accepted as a known limitation noted in the comment.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean for changed files)
- [ ] `golangci-lint run ./...` (not run locally; CI will cover)
- [x] `go test ./internal/agent/ -run Plan -count=1` — all 12 Plan-pattern tests pass, including the updated \`TestBuildClaudePlannerArgs_UsesSonnet\` flag assertions
- [ ] Manual TUI: from a baton worktree with a real codebase, draft a plan with a prompt that requires file knowledge (e.g. \"refactor the X service\") and confirm the resulting plan references real file paths or function names from the worktree, not generic placeholders. This is the actual goal of the change.

## Checklist

- [ ] Updated \`CHANGELOG.md\` under \`[Unreleased]\` — intentionally deferred per the planning doc's \"Not In Scope\" (one-file follow-up if wanted).
- [x] New behavior has tests, or is documented as manual-test-only in \`CLAUDE.md\` — the flag-list change is covered by \`TestBuildClaudePlannerArgs_UsesSonnet\`; the prompt rewrite's effect is the manual-TUI step above.
- [x] No new public API surface without a note in the PR description — none.