### PR TITLE
Polish new-session prompt modal: paste, cursor, layout

### DIFF
--- a/changelog.d/polish-prompt-modal.md
+++ b/changelog.d/polish-prompt-modal.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Pasting (cmd+v / bracketed paste) into the new-session prompt modal now inserts the clipboard content into the textarea instead of being silently swallowed.
+- The active line in the prompt modal no longer renders with a near-black background on dark terminals — bubbles' default `CursorLine` highlight has been stripped so the textarea reads uniformly.
+
+### Changed
+
+- The new-session prompt modal (`n` when plan-first is enabled) has a polished layout: a "NEW SESSION / Planning →" header band, a rotating header prompt, an example-shape placeholder inside the textarea, a Baton-purple cursor, and a two-line aligned key-chip footer that surfaces `shift+enter` for newlines alongside `enter`, `ctrl+enter`, and `esc`.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.6
+	charm.land/lipgloss/v2 v2.0.3
 	github.com/alecthomas/chroma/v2 v2.24.1
 	github.com/bluekeyes/go-gitdiff v0.8.1
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -19,7 +20,6 @@ require (
 )
 
 require (
-	charm.land/lipgloss/v2 v2.0.3 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -999,6 +999,13 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case tea.PasteMsg:
+		// Prompt modal consumes paste while open (same precedence as the
+		// KeyPressMsg branch below) so cmd+v / bracketed paste inserts into
+		// the textarea instead of being swallowed by the focusLaunch path.
+		if a.promptModal.Active() {
+			cmd := a.promptModal.Update(msg)
+			return a, cmd
+		}
 		if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
 			a.focusLaunchAgent.Paste(msg.Content)
 			return a, nil

--- a/internal/tui/promptmodal.go
+++ b/internal/tui/promptmodal.go
@@ -7,6 +7,10 @@ import (
 
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	// Two lipgloss versions intentionally: the v1 import drives Baton's
+	// layout helpers (StyleTitle, JoinVertical, etc.), while xlipgloss is
+	// the v2 type the bubbles/v2 textarea exposes in its Styles struct —
+	// we only need it to construct the empty CursorLine override below.
 	xlipgloss "charm.land/lipgloss/v2"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -83,6 +87,10 @@ func newPromptModal() promptModalModel {
 	// identically to every other line.
 	styles := ta.Styles()
 	styles.Focused.CursorLine = xlipgloss.NewStyle()
+	// ColorPrimary is a v1 lipgloss.Color; it satisfies the v2
+	// CursorStyle.Color field (image/color.Color) via its RGBA() method.
+	// If a future bubbles upgrade tightens the interface, this assignment
+	// will fail to compile — fix at that point with a v2-typed constant.
 	styles.Cursor.Color = ColorPrimary
 	ta.SetStyles(styles)
 	return promptModalModel{textarea: ta}

--- a/internal/tui/promptmodal.go
+++ b/internal/tui/promptmodal.go
@@ -1,22 +1,27 @@
 package tui
 
 import (
+	"fmt"
+	"math/rand/v2"
 	"strings"
 
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	xlipgloss "charm.land/lipgloss/v2"
 	"github.com/charmbracelet/lipgloss"
 )
 
-// promptModalModel is the centered "What are you working on?" textarea modal
-// that opens when PlanFirstEnabled is on and the user presses `n`. It owns
-// its own multi-line textarea and emits one of the three messages below
-// when the user submits or cancels.
+// promptModalModel is the centered prompt modal that opens when
+// PlanFirstEnabled is on and the user presses `n`. It owns its own
+// multi-line textarea and emits one of the messages below when the user
+// submits or cancels.
 type promptModalModel struct {
-	active   bool
-	textarea textarea.Model
-	width    int // viewport width — used to clamp modal width
-	height   int // viewport height
+	active         bool
+	textarea       textarea.Model
+	width          int // viewport width — used to clamp modal width
+	height         int // viewport height
+	titleIdx       int // index into promptModalTitles, picked at Open()
+	placeholderIdx int // index into promptModalPlaceholders, picked at Open()
 }
 
 // promptModalSubmitMsg fires when the user accepts the prompt. SkipPlanning
@@ -37,13 +42,49 @@ const (
 	promptModalCharLimit = 4000
 )
 
+// promptModalTitles rotate through the modal header. Short and imperative,
+// each one nudges toward Baton's one-primary-goal-per-block frame.
+var promptModalTitles = []string{
+	"What do you want to build?",
+	"What's today's primary goal?",
+	"What's the one thing?",
+	"What does done look like?",
+	"What's the next move?",
+	"What should we ship?",
+	"What would make this block count?",
+	"Define the goal.",
+}
+
+// promptModalPlaceholders show concrete task shapes inside the textarea so
+// a first-time user has a model of what a planner-friendly prompt looks
+// like.
+var promptModalPlaceholders = []string{
+	"e.g. Add a dark-mode toggle to the settings page",
+	"e.g. Fix the flaky test in foo_test.go",
+	"e.g. Migrate auth from sessions to JWT",
+	"e.g. Wire up file upload to S3",
+	"e.g. Add unit tests for the shutdown sequence",
+	"e.g. Refactor the dashboard render path",
+}
+
+// pickPrompt is the indirection tests use to make rotation deterministic.
+// Production wires through to math/rand/v2's IntN.
+var pickPrompt = func(n int) int { return rand.IntN(n) }
+
 func newPromptModal() promptModalModel {
 	ta := textarea.New()
-	ta.Placeholder = "Describe what you're working on…"
 	ta.Prompt = ""
 	ta.ShowLineNumbers = false
 	ta.CharLimit = promptModalCharLimit
 	ta.SetHeight(promptModalRows)
+	// Strip bubbles' default focused CursorLine background — on dark
+	// terminals it paints a near-black rectangle over Baton's #111827 bg.
+	// The cursor itself signals position; the active line should read
+	// identically to every other line.
+	styles := ta.Styles()
+	styles.Focused.CursorLine = xlipgloss.NewStyle()
+	styles.Cursor.Color = ColorPrimary
+	ta.SetStyles(styles)
 	return promptModalModel{textarea: ta}
 }
 
@@ -55,10 +96,15 @@ func (m *promptModalModel) SetSize(w, h int) {
 	m.textarea.SetWidth(modalWidth(w) - 4) // leave room for border + padding
 }
 
-// Open shows the modal, focuses the textarea, and clears any prior content.
+// Open shows the modal, focuses the textarea, clears any prior content,
+// and picks a fresh title/placeholder pairing for this session. The pair
+// stays stable across re-renders within one open session.
 func (m *promptModalModel) Open() tea.Cmd {
 	m.active = true
 	m.textarea.SetValue("")
+	m.titleIdx = pickPrompt(len(promptModalTitles))
+	m.placeholderIdx = pickPrompt(len(promptModalPlaceholders))
+	m.textarea.Placeholder = promptModalPlaceholders[m.placeholderIdx]
 	m.textarea.SetWidth(modalWidth(m.width) - 4)
 	return m.textarea.Focus()
 }
@@ -73,7 +119,7 @@ func (m *promptModalModel) Close() {
 func (m *promptModalModel) Active() bool { return m.active }
 
 // Update routes a tea.Msg to the modal. Returns the cmd to run; non-key
-// messages are forwarded to the textarea (e.g. cursor blink ticks).
+// messages are forwarded to the textarea (e.g. cursor blink ticks, paste).
 func (m *promptModalModel) Update(msg tea.Msg) tea.Cmd {
 	if !m.active {
 		return nil
@@ -112,22 +158,20 @@ func (m *promptModalModel) Update(msg tea.Msg) tea.Cmd {
 }
 
 // View renders the modal centered over the supplied background body.
-// background should be the rendered dashboard content; Place draws the
-// modal over a blank canvas of the configured viewport size, so the caller
-// must keep using View only when the modal is active.
+// The caller is responsible for only invoking View while the modal is
+// active.
 func (m *promptModalModel) View() string {
 	w := modalWidth(m.width)
-	title := StyleTitle.Render("What are you working on?")
-	hint := StyleSubtle.Render(
-		"enter — draft a plan first   ctrl+enter — skip planning, run now   esc — cancel",
-	)
+	innerW := w - 4 // matches textarea width: border (2) + padding (2)
 	body := lipgloss.JoinVertical(
 		lipgloss.Left,
-		title,
+		promptModalHeader(innerW),
+		"",
+		StyleTitle.Render(promptModalTitles[m.titleIdx]),
 		"",
 		m.textarea.View(),
 		"",
-		hint,
+		promptModalFooter(),
 	)
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -135,6 +179,41 @@ func (m *promptModalModel) View() string {
 		Padding(0, 1).
 		Width(w).
 		Render(body)
+}
+
+// promptModalHeader returns "NEW SESSION" justified left and "Planning →"
+// justified right across innerW columns.
+func promptModalHeader(innerW int) string {
+	left := StyleSubtle.Render("NEW SESSION")
+	right := StyleSubtle.Render("Planning →")
+	gap := innerW - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Left, left, strings.Repeat(" ", gap), right)
+}
+
+// promptModalFooter renders the two-line key chip footer with column
+// widths derived from the longest glyphs ("ctrl+enter", "shift+enter",
+// "run now (skip plan)") so columns line up regardless of which keys
+// they describe.
+func promptModalFooter() string {
+	const (
+		col1Key  = 10 // len("ctrl+enter")
+		col1Desc = 19 // len("run now (skip plan)")
+		col2Key  = 11 // len("shift+enter")
+	)
+	keyChip := func(s string, w int) string {
+		return StyleTitle.Render(fmt.Sprintf("%-*s", w, s))
+	}
+	descChip := func(s string, w int) string {
+		return StyleSubtle.Render(fmt.Sprintf("%-*s", w, s))
+	}
+	line1 := keyChip("enter", col1Key) + " " + descChip("draft a plan", col1Desc) +
+		"  " + keyChip("shift+enter", col2Key) + " " + StyleSubtle.Render("newline")
+	line2 := keyChip("ctrl+enter", col1Key) + " " + descChip("run now (skip plan)", col1Desc) +
+		"  " + keyChip("esc", col2Key) + " " + StyleSubtle.Render("cancel")
+	return lipgloss.JoinVertical(lipgloss.Left, line1, line2)
 }
 
 func modalWidth(viewportW int) int {

--- a/internal/tui/promptmodal_test.go
+++ b/internal/tui/promptmodal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	xlipgloss "charm.land/lipgloss/v2"
 )
 
 func TestPromptModal_OpenFocusesAndClearsValue(t *testing.T) {
@@ -130,5 +131,75 @@ func TestModalWidth_Clamps(t *testing.T) {
 	// Narrow viewport: must leave 2 cols of margin so border fits.
 	if w := modalWidth(40); w > 38 {
 		t.Errorf("modalWidth(40) = %d, want <= 38 (viewport-2 clamp)", w)
+	}
+}
+
+func TestPromptModal_PasteForwardsToTextarea(t *testing.T) {
+	m := newPromptModal()
+	m.SetSize(120, 40)
+	m.Open()
+
+	cmd := m.Update(tea.PasteMsg{Content: "pasted clipboard text"})
+	_ = cmd
+	if got := m.textarea.Value(); !strings.Contains(got, "pasted clipboard text") {
+		t.Errorf("textarea value = %q, want it to contain pasted content", got)
+	}
+}
+
+func TestPromptModal_OpenPicksStablePairAndRotates(t *testing.T) {
+	prev := pickPrompt
+	defer func() { pickPrompt = prev }()
+
+	picks := []int{2, 5, 0, 3}
+	calls := 0
+	pickPrompt = func(n int) int {
+		i := picks[calls] % n
+		calls++
+		return i
+	}
+
+	m := newPromptModal()
+	m.SetSize(120, 40)
+	m.Open()
+	if m.titleIdx != 2 {
+		t.Errorf("first open titleIdx = %d, want 2", m.titleIdx)
+	}
+	if m.placeholderIdx != 5 {
+		t.Errorf("first open placeholderIdx = %d, want 5", m.placeholderIdx)
+	}
+	wantTitle := promptModalTitles[2]
+	wantPH := promptModalPlaceholders[5]
+
+	view1 := m.View()
+	view2 := m.View()
+	if view1 != view2 {
+		t.Error("View() must be stable across renders within one open session")
+	}
+	if !strings.Contains(view1, wantTitle) {
+		t.Errorf("view does not contain selected title %q", wantTitle)
+	}
+	if m.textarea.Placeholder != wantPH {
+		t.Errorf("textarea.Placeholder = %q, want %q", m.textarea.Placeholder, wantPH)
+	}
+
+	m.Close()
+	m.Open()
+	if m.titleIdx != 0 {
+		t.Errorf("second open titleIdx = %d, want 0", m.titleIdx)
+	}
+	if m.placeholderIdx != 3 {
+		t.Errorf("second open placeholderIdx = %d, want 3", m.placeholderIdx)
+	}
+}
+
+func TestPromptModal_FocusedCursorLineHasNoBackground(t *testing.T) {
+	m := newPromptModal()
+	bg := m.textarea.Styles().Focused.CursorLine.GetBackground()
+	// An untouched style returns NoColor{} from GetBackground; the bubbles
+	// default would return a real Color. Compare to a fresh empty style's
+	// background to avoid coupling the test to NoColor's exact type.
+	want := xlipgloss.NewStyle().GetBackground()
+	if bg != want {
+		t.Errorf("CursorLine background = %v, want %v (no background)", bg, want)
 	}
 }

--- a/internal/tui/promptmodal_test.go
+++ b/internal/tui/promptmodal_test.go
@@ -140,7 +140,12 @@ func TestPromptModal_PasteForwardsToTextarea(t *testing.T) {
 	m.Open()
 
 	cmd := m.Update(tea.PasteMsg{Content: "pasted clipboard text"})
-	_ = cmd
+	// Bubbles v2 commits paste synchronously today, but run any returned
+	// cmd anyway so this test doesn't silently false-positive if a future
+	// bubbles release flips paste to async.
+	if cmd != nil {
+		cmd()
+	}
 	if got := m.textarea.Value(); !strings.Contains(got, "pasted clipboard text") {
 		t.Errorf("textarea value = %q, want it to contain pasted content", got)
 	}


### PR DESCRIPTION
## Summary

Polishes the "What are you working on?" modal that opens on `n` when plan-first is enabled. Three concrete fixes:

- **Paste was broken.** `tea.PasteMsg` was only routed to focusLaunch — the modal never saw paste events, so cmd+v / bracketed paste silently did nothing. Now the modal consumes paste while active (same precedence as the existing `KeyPressMsg` branch).
- **Active line had a near-black background.** bubbles' default focused `CursorLine` style sets `Background(Color("0"))` on dark terminals, which painted a rectangle over Baton's `#111827` bg. The override strips it; the cursor itself signals position. Cursor color is now `ColorPrimary` (Baton purple) instead of bubbles' default gray.
- **Layout felt like a stock textarea.** New: a "NEW SESSION / Planning →" header band, a rotating header prompt drawn from a curated 8-item list, an example-shape placeholder (`e.g. Add a dark-mode toggle…`) inside the textarea, and a two-line aligned key-chip footer that surfaces `shift+enter` for newlines alongside `enter`, `ctrl+enter`, and `esc`.

The plan editor (`planeditor.go`) has the same `CursorLine` issue — intentionally deferred to keep this PR tight.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `go test -race ./internal/tui/...`
- [ ] Manual TUI:
  - Press `n` → modal opens. Title rotates across openings; placeholder shows a concrete `e.g. …` example.
  - Active line has no rectangular background highlight; cursor is purple.
  - cmd+v inserts clipboard content.
  - shift+enter inserts a newline; enter submits via planning path; ctrl+enter submits via skip path; esc cancels.
  - Resize while modal is open — title/placeholder do NOT change mid-session.

## Checklist

- [x] Updated `changelog.d/` (fragment: `polish-prompt-modal.md`)
- [x] New behavior has tests (paste forwarding, stable rotation via `pickPrompt` hook, empty `CursorLine` background)
- [x] No new public API surface