### PR TITLE
Make plan and agent Claude models user-configurable

### DIFF
--- a/changelog.d/add-configurable-models.md
+++ b/changelog.d/add-configurable-models.md
@@ -1,0 +1,3 @@
+### Added
+
+- Configurable Claude model for plan drafting and spawned agents. New global and per-repo settings `plan_model` (default `claude-sonnet-4-6`) and `agent_model` (default empty — let the Claude CLI pick) can be edited from the Plan Model and Agent Model fields in the global and per-repo config forms. The plan model is forwarded as `--model` to the plan drafter subprocess; the agent model is forwarded as `--model` to spawned `claude` agents (ignored for non-claude agent programs).

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -57,6 +57,11 @@ type Config struct {
 	RepoPath          string
 	BypassPermissions bool
 	AgentProgram      string // CLI program to spawn; defaults to "claude" if empty
+	// AgentModel, when non-empty, is forwarded as `--model <AgentModel>` to
+	// spawned `claude` agents. Empty means "no --model flag" (Claude CLI
+	// picks its own default). Ignored when AgentProgram is not `claude` —
+	// passing --model to a custom binary is undefined.
+	AgentModel string
 }
 
 // agentProgram returns the CLI program from cfg, defaulting to "claude".
@@ -179,6 +184,12 @@ func newResumedAgent(
 func buildResumeArgs(cfg Config, claudeSessionID string) []string {
 	var args []string
 
+	// --model goes before --dangerously-skip-permissions so flags stay
+	// grouped before the positional --resume/--continue/Task args.
+	if cfg.AgentModel != "" && supportsHooks(cfg) {
+		args = append(args, "--model", cfg.AgentModel)
+	}
+
 	if cfg.BypassPermissions {
 		args = append(args, "--dangerously-skip-permissions")
 	}
@@ -202,6 +213,12 @@ func buildSpawnArgs(cfg Config, worktreePath, socketPath string) ([]string, erro
 	args, err := buildHookArgs(cfg, worktreePath, socketPath)
 	if err != nil {
 		return nil, err
+	}
+	// --model goes before --dangerously-skip-permissions so flags stay
+	// grouped before the positional Task arg. Only applied when the program
+	// is claude — passing --model to a custom binary is undefined.
+	if cfg.AgentModel != "" && supportsHooks(cfg) {
+		args = append(args, "--model", cfg.AgentModel)
 	}
 	if cfg.BypassPermissions {
 		args = append(args, "--dangerously-skip-permissions")

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -602,6 +602,53 @@ func TestStopHookNoAskingQuestionWithoutTrailingQuestion(t *testing.T) {
 	}
 }
 
+func TestBuildSpawnArgs_AgentModel(t *testing.T) {
+	wt := t.TempDir()
+	tests := []struct {
+		name     string
+		cfg      Config
+		wantArgs []string
+	}{
+		{
+			name:     "model prepended for default claude program",
+			cfg:      Config{AgentModel: "claude-opus-4-7", BypassPermissions: true, Task: "do stuff"},
+			wantArgs: []string{"--model", "claude-opus-4-7", "--dangerously-skip-permissions", "do stuff"},
+		},
+		{
+			name:     "empty model no flag",
+			cfg:      Config{BypassPermissions: true, Task: "hi"},
+			wantArgs: []string{"--dangerously-skip-permissions", "hi"},
+		},
+		{
+			name:     "model ignored for non-claude program",
+			cfg:      Config{AgentProgram: "bash", AgentModel: "claude-opus-4-7", Task: "hi"},
+			wantArgs: []string{"hi"},
+		},
+		{
+			name:     "model without bypass or task",
+			cfg:      Config{AgentModel: "claude-sonnet-4-6"},
+			wantArgs: []string{"--model", "claude-sonnet-4-6"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Pass empty socketPath so buildHookArgs returns no --settings pair.
+			got, err := buildSpawnArgs(tt.cfg, wt, "")
+			if err != nil {
+				t.Fatalf("buildSpawnArgs error: %v", err)
+			}
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("expected %d args, got %d: %v", len(tt.wantArgs), len(got), got)
+			}
+			for i, want := range tt.wantArgs {
+				if got[i] != want {
+					t.Errorf("arg[%d]: expected %q, got %q (full=%v)", i, want, got[i], got)
+				}
+			}
+		})
+	}
+}
+
 func TestUserPromptSubmitClearsAskingQuestion(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo, defaultTestSettings())

--- a/internal/agent/detach_resume_test.go
+++ b/internal/agent/detach_resume_test.go
@@ -307,6 +307,24 @@ func TestBuildResumeArgs(t *testing.T) {
 			sessID:   "",
 			wantArgs: []string{"--continue", "hello"},
 		},
+		{
+			name:     "agent model prepended for claude",
+			cfg:      Config{AgentModel: "claude-opus-4-7", BypassPermissions: true, Task: "do stuff"},
+			sessID:   "uuid-123",
+			wantArgs: []string{"--model", "claude-opus-4-7", "--dangerously-skip-permissions", "--resume", "uuid-123", "do stuff"},
+		},
+		{
+			name:     "agent model ignored for non-claude program",
+			cfg:      Config{AgentProgram: "bash", AgentModel: "claude-opus-4-7", BypassPermissions: true},
+			sessID:   "uuid-456",
+			wantArgs: []string{"--dangerously-skip-permissions", "--resume", "uuid-456"},
+		},
+		{
+			name:     "empty agent model passes nothing",
+			cfg:      Config{AgentModel: "", Task: "hello"},
+			sessID:   "",
+			wantArgs: []string{"--continue", "hello"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -148,7 +148,7 @@ func NewManager(repoPath string, settings config.ResolvedSettings) *Manager {
 		done:             make(chan struct{}),
 		branchNamer:      DefaultBranchNamer(),
 		taskSummarizer:   DefaultTaskSummarizer(),
-		planDrafter:      DefaultPlanDrafter(),
+		planDrafter:      DefaultPlanDrafter(settings.PlanModel),
 		plannerQuestions: make(chan PlannerQuestion, 8),
 	}
 
@@ -880,10 +880,20 @@ func (m *Manager) FindAgentAndSession(agentID string) (*Agent, *Session) {
 
 // UpdateSettings replaces the manager's resolved settings.
 // New sessions will use the updated values; existing sessions are unaffected.
+//
+// If the resolved PlanModel changed and the current planDrafter is still the
+// package default (i.e. tests haven't injected a mock via SetPlanDrafter),
+// the drafter is rebuilt with the new model so the next StartDraft picks up
+// the change without requiring a baton restart. A test-injected drafter is
+// left alone — overriding it here would silently break SetPlanDrafter's
+// contract.
 func (m *Manager) UpdateSettings(s config.ResolvedSettings) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.settings = s
+	if d, ok := m.planDrafter.(*defaultPlanDrafter); ok && d.Model() != s.PlanModel {
+		m.planDrafter = DefaultPlanDrafter(s.PlanModel)
+	}
 }
 
 // Settings returns the current resolved settings.
@@ -1590,6 +1600,7 @@ func (m *Manager) ResumeSession(ss state.SessionState, cfg Config) error {
 			RepoPath:          m.repoPath,
 			BypassPermissions: cfg.BypassPermissions,
 			AgentProgram:      settings.AgentProgram,
+			AgentModel:        settings.AgentModel,
 		}
 
 		a, err := sess.AddAgentResumed(agentCfg, as.ClaudeSessionID)

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/devenjarvis/baton/internal/config"
 )
 
 // PlannerQuestionSocketEnv is the environment variable the planner Sonnet
@@ -17,8 +19,6 @@ import (
 // Exported so cmd/plannerquestion.go (and tests) can reference the same
 // name without hardcoding the string in two places.
 const PlannerQuestionSocketEnv = "BATON_PLANNER_QUESTION_SOCKET"
-
-const claudeSonnetModel = "claude-sonnet-4-6"
 
 // ErrEmptyPrompt is returned when Draft is called with an empty user prompt.
 var ErrEmptyPrompt = errors.New("planner: empty user prompt")
@@ -98,9 +98,11 @@ CURRENT PLAN:
 `
 
 // DefaultPlanDrafter returns a PlanDrafter that shells out to
-// `claude -p --model claude-sonnet-4-6` with the planning instruction piped
-// on stdin. Env stripped of baton hook wiring so the subprocess does not
-// register against the running TUI's hook socket as the parent agent.
+// `claude -p --model <model>` with the planning instruction piped on stdin.
+// An empty model falls back to config.DefaultPlanModel so callers that
+// haven't migrated to the parameterized form keep their existing behavior.
+// Env stripped of baton hook wiring so the subprocess does not register
+// against the running TUI's hook socket as the parent agent.
 //
 // Cancellation is caller-driven via ctx (no wall-clock timeout in the default
 // path): Sonnet drafting can take a couple of minutes on complex prompts and
@@ -108,15 +110,28 @@ CURRENT PLAN:
 // pass a cancel-only context so the only kill paths are user-initiated
 // (KillSession, manager shutdown, an explicit CancelDraft / CancelRevise).
 //
-// Sonnet (not Haiku) is intentional: planning quality compounds downstream,
-// since a fuzzier plan turns into a fuzzier agent run and more verification
-// tax. The cost of one extra one-shot subprocess at planning time is low
-// next to the human review time it saves later.
-func DefaultPlanDrafter() PlanDrafter {
-	return &defaultPlanDrafter{}
+// Sonnet (not Haiku) is the default for a reason: planning quality compounds
+// downstream, since a fuzzier plan turns into a fuzzier agent run and more
+// verification tax. The cost of one extra one-shot subprocess at planning
+// time is low next to the human review time it saves later. Users who want
+// to override this for cost or speed reasons can set plan_model in config.
+func DefaultPlanDrafter(model string) PlanDrafter {
+	if model == "" {
+		model = config.DefaultPlanModel
+	}
+	return &defaultPlanDrafter{model: model}
 }
 
-type defaultPlanDrafter struct{}
+type defaultPlanDrafter struct {
+	model string
+}
+
+// Model returns the model string this drafter was constructed with.
+// Used by the manager to detect whether a settings change requires
+// swapping in a fresh drafter.
+func (d *defaultPlanDrafter) Model() string {
+	return d.model
+}
 
 func (d *defaultPlanDrafter) Draft(ctx context.Context, req DraftRequest) (string, error) {
 	prompt := strings.TrimSpace(req.UserPrompt)
@@ -127,7 +142,7 @@ func (d *defaultPlanDrafter) Draft(ctx context.Context, req DraftRequest) (strin
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrClaudeNotFound, err)
 	}
-	return runClaudePlanner(ctx, claudePath, planDraftPrompt+prompt, req.QuestionSocket)
+	return runClaudePlanner(ctx, claudePath, d.model, planDraftPrompt+prompt, req.QuestionSocket)
 }
 
 func (d *defaultPlanDrafter) Revise(ctx context.Context, req ReviseRequest) (string, error) {
@@ -147,7 +162,7 @@ func (d *defaultPlanDrafter) Revise(ctx context.Context, req ReviseRequest) (str
 	// Revise does not surface ask_user — the user is already iterating on a
 	// concrete plan with the editor's revise input, so an interactive prompt
 	// would just compete for attention. Pass an empty socket path.
-	return runClaudePlanner(ctx, claudePath, instruction, "")
+	return runClaudePlanner(ctx, claudePath, d.model, instruction, "")
 }
 
 // plannerQuestionMCPName is the MCP-server key under which the planner
@@ -162,7 +177,8 @@ const plannerQuestionMCPName = "baton_planner_question"
 const plannerQuestionToolName = "mcp__" + plannerQuestionMCPName + "__ask_user"
 
 // buildClaudePlannerArgs returns the argv (excluding the binary path) for a
-// one-shot planning subprocess. Mirrors buildClaudeHaikuArgs but uses Sonnet.
+// one-shot planning subprocess. The model is parameterized so callers can
+// override the default; an empty model falls back to config.DefaultPlanModel.
 // The drafter is given a read-only tool allowlist so it can research the
 // codebase (Read/Grep/Glob/LS/LSP) and pull external docs (WebFetch/WebSearch)
 // before producing the plan markdown. Writes and Bash stay blocked — the
@@ -184,8 +200,11 @@ const plannerQuestionToolName = "mcp__" + plannerQuestionMCPName + "__ask_user"
 // `mcpServers: Invalid input: expected record, received undefined`, which
 // makes every planner subprocess exit 1 and surfaces as
 // `claude planner: exit status 1`. Do not simplify this back to "{}".
-func buildClaudePlannerArgs(questionSocket string) []string {
-	args := []string{"-p", "--model", claudeSonnetModel}
+func buildClaudePlannerArgs(model, questionSocket string) []string {
+	if model == "" {
+		model = config.DefaultPlanModel
+	}
+	args := []string{"-p", "--model", model}
 	if os.Getenv("ANTHROPIC_API_KEY") != "" {
 		args = append(args, "--bare")
 	}
@@ -243,14 +262,14 @@ func plannerMCPConfigJSON(questionSocket string) string {
 	return string(out)
 }
 
-// runClaudePlanner runs `claude -p --model claude-sonnet-4-6` with instruction
-// on stdin and returns the trimmed raw stdout (markdown). Strips baton's hook
+// runClaudePlanner runs `claude -p --model <model>` with instruction on
+// stdin and returns the trimmed raw stdout (markdown). Strips baton's hook
 // env so the subprocess does not register against the running TUI's hook
 // socket as the parent agent. When questionSocket is non-empty, the
 // BATON_PLANNER_QUESTION_SOCKET env is added so the spawned MCP bridge
 // (registered via buildClaudePlannerArgs) can dial back into baton.
-func runClaudePlanner(ctx context.Context, claudePath, instruction, questionSocket string) (string, error) {
-	cmd := exec.CommandContext(ctx, claudePath, buildClaudePlannerArgs(questionSocket)...)
+func runClaudePlanner(ctx context.Context, claudePath, model, instruction, questionSocket string) (string, error) {
+	cmd := exec.CommandContext(ctx, claudePath, buildClaudePlannerArgs(model, questionSocket)...)
 	cmd.Stdin = strings.NewReader(instruction)
 	env := sanitizedHaikuEnv(os.Environ())
 	if questionSocket != "" {

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/devenjarvis/baton/internal/config"
 )
 
 func TestDefaultPlanDrafter_DraftSuccess(t *testing.T) {
@@ -18,7 +20,7 @@ func TestDefaultPlanDrafter_DraftSuccess(t *testing.T) {
 	writeFakeClaude(t, dir, planMD, 0)
 	withPATH(t, dir)
 
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -32,7 +34,7 @@ func TestDefaultPlanDrafter_DraftSuccess(t *testing.T) {
 }
 
 func TestDefaultPlanDrafter_DraftEmptyPromptError(t *testing.T) {
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -50,7 +52,7 @@ func TestDefaultPlanDrafter_DraftPipesPromptVerbatim(t *testing.T) {
 	writeStdinCapturingClaude(t, dir, stdinFile, "# Goal\nstub")
 	withPATH(t, dir)
 
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -76,7 +78,7 @@ func TestDefaultPlanDrafter_DraftClaudeMissing(t *testing.T) {
 	empty := t.TempDir()
 	t.Setenv("PATH", empty)
 
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -91,7 +93,7 @@ func TestDefaultPlanDrafter_DraftNonZeroExitSurfacesStderr(t *testing.T) {
 	writeFakeClaude(t, dir, "noise", 1)
 	withPATH(t, dir)
 
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -115,7 +117,7 @@ func TestDefaultPlanDrafter_DraftContextCancel(t *testing.T) {
 	writeSlowClaude(t, dir, 10)
 	withPATH(t, dir)
 
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
@@ -138,7 +140,7 @@ func TestDefaultPlanDrafter_DraftStripsBatonHookEnv(t *testing.T) {
 	t.Setenv("BATON_HOOK_SOCKET", "/should/not/leak.sock")
 	t.Setenv("BATON_AGENT_ID", "should-not-leak")
 
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -164,7 +166,7 @@ func TestDefaultPlanDrafter_ReviseSuccess(t *testing.T) {
 	writeFakeClaude(t, dir, revised, 0)
 	withPATH(t, dir)
 
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -181,7 +183,7 @@ func TestDefaultPlanDrafter_ReviseSuccess(t *testing.T) {
 }
 
 func TestDefaultPlanDrafter_ReviseEmptyInputs(t *testing.T) {
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -201,7 +203,7 @@ func TestDefaultPlanDrafter_RevisePipesPlanAndCritique(t *testing.T) {
 	writeStdinCapturingClaude(t, dir, stdinFile, "# Goal\nrevised")
 	withPATH(t, dir)
 
-	d := DefaultPlanDrafter()
+	d := DefaultPlanDrafter("")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -229,12 +231,12 @@ func TestDefaultPlanDrafter_RevisePipesPlanAndCritique(t *testing.T) {
 
 func TestBuildClaudePlannerArgs_UsesSonnet(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
-	args := buildClaudePlannerArgs("")
+	args := buildClaudePlannerArgs("", "")
 	if args[0] != "-p" {
 		t.Errorf("first arg = %q, want -p", args[0])
 	}
-	if !containsPair(args, "--model", claudeSonnetModel) {
-		t.Errorf("missing --model %s; args=%v", claudeSonnetModel, args)
+	if !containsPair(args, "--model", config.DefaultPlanModel) {
+		t.Errorf("missing --model %s; args=%v", config.DefaultPlanModel, args)
 	}
 	for _, banned := range []string{"claude-haiku-4-5", "claude-haiku-3-5"} {
 		for _, a := range args {
@@ -287,7 +289,7 @@ func TestBuildClaudePlannerArgs_UsesSonnet(t *testing.T) {
 
 func TestBuildClaudePlannerArgs_WithQuestionSocketRegistersMCPServer(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
-	args := buildClaudePlannerArgs("/tmp/baton-q.sock")
+	args := buildClaudePlannerArgs("", "/tmp/baton-q.sock")
 
 	mcpIdx := -1
 	for i, a := range args {
@@ -338,7 +340,7 @@ func TestBuildClaudePlannerArgs_WithQuestionSocketRegistersMCPServer(t *testing.
 
 func TestBuildClaudePlannerArgs_EmptySocketKeepsZeroServers(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
-	args := buildClaudePlannerArgs("")
+	args := buildClaudePlannerArgs("", "")
 	mcpIdx := -1
 	for i, a := range args {
 		if a == "--mcp-config" {
@@ -371,16 +373,49 @@ func TestBuildClaudePlannerArgs_EmptySocketKeepsZeroServers(t *testing.T) {
 func TestBuildClaudePlannerArgs_BareGatedByAPIKey(t *testing.T) {
 	t.Run("with API key", func(t *testing.T) {
 		t.Setenv("ANTHROPIC_API_KEY", "sk-test")
-		args := buildClaudePlannerArgs("")
+		args := buildClaudePlannerArgs("", "")
 		if !contains(args, "--bare") {
 			t.Errorf("expected --bare with ANTHROPIC_API_KEY set; got %v", args)
 		}
 	})
 	t.Run("without API key", func(t *testing.T) {
 		t.Setenv("ANTHROPIC_API_KEY", "")
-		args := buildClaudePlannerArgs("")
+		args := buildClaudePlannerArgs("", "")
 		if contains(args, "--bare") {
 			t.Errorf("did not expect --bare without ANTHROPIC_API_KEY; got %v", args)
 		}
 	})
+}
+
+func TestBuildClaudePlannerArgs_CustomModel(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	args := buildClaudePlannerArgs("claude-haiku-4-5", "")
+	if !containsPair(args, "--model", "claude-haiku-4-5") {
+		t.Errorf("missing --model claude-haiku-4-5; args=%v", args)
+	}
+	for _, a := range args {
+		if a == config.DefaultPlanModel {
+			t.Errorf("custom model should not also include default %q; args=%v", config.DefaultPlanModel, args)
+		}
+	}
+}
+
+func TestDefaultPlanDrafter_EmptyModelFallsBackToDefault(t *testing.T) {
+	d, ok := DefaultPlanDrafter("").(*defaultPlanDrafter)
+	if !ok {
+		t.Fatalf("DefaultPlanDrafter(\"\") not *defaultPlanDrafter")
+	}
+	if d.Model() != config.DefaultPlanModel {
+		t.Errorf("Model() = %q, want %q", d.Model(), config.DefaultPlanModel)
+	}
+}
+
+func TestDefaultPlanDrafter_NonEmptyModelPreserved(t *testing.T) {
+	d, ok := DefaultPlanDrafter("claude-opus-4-7").(*defaultPlanDrafter)
+	if !ok {
+		t.Fatalf("DefaultPlanDrafter(\"claude-opus-4-7\") not *defaultPlanDrafter")
+	}
+	if d.Model() != "claude-opus-4-7" {
+		t.Errorf("Model() = %q, want claude-opus-4-7", d.Model())
+	}
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -16,8 +16,15 @@ const (
 	DefaultAgentProgram      = "claude"
 	DefaultWorktreeDir       = ".baton/worktrees"
 	DefaultSidebarWidth      = 30
-	MinSidebarWidth          = 20
-	MaxSidebarWidth          = 60
+
+	// DefaultPlanModel is the model used by the plan drafter subprocess.
+	// Sonnet (not Haiku) is intentional: planning quality compounds
+	// downstream — see the comment on agent.DefaultPlanDrafter for details.
+	// The agent package references this constant rather than declaring its
+	// own so the default stays a single source of truth.
+	DefaultPlanModel = "claude-sonnet-4-6"
+	MinSidebarWidth  = 20
+	MaxSidebarWidth  = 60
 
 	// Wellness defaults.
 	DefaultFocusSessionMinutes = 90
@@ -65,6 +72,8 @@ type GlobalSettings struct {
 	BranchPrefix      *string `json:"branch_prefix,omitempty"`
 	BranchNamePrompt  *string `json:"branch_name_prompt,omitempty"`
 	AgentProgram      *string `json:"agent_program,omitempty"`
+	AgentModel        *string `json:"agent_model,omitempty"`
+	PlanModel         *string `json:"plan_model,omitempty"`
 	IDECommand        *string `json:"ide_command,omitempty"`
 	SidebarWidth      *int    `json:"sidebar_width,omitempty"`
 
@@ -87,6 +96,8 @@ type RepoSettings struct {
 	BranchPrefix        *string `json:"branch_prefix,omitempty"`
 	BranchNamePrompt    *string `json:"branch_name_prompt,omitempty"`
 	AgentProgram        *string `json:"agent_program,omitempty"`
+	AgentModel          *string `json:"agent_model,omitempty"`
+	PlanModel           *string `json:"plan_model,omitempty"`
 	IDECommand          *string `json:"ide_command,omitempty"`
 	WorktreeDir         *string `json:"worktree_dir,omitempty"`
 	PlanFirstEnabled    *bool   `json:"plan_first_enabled,omitempty"`
@@ -102,9 +113,16 @@ type ResolvedSettings struct {
 	BranchPrefix      string
 	BranchNamePrompt  string
 	AgentProgram      string
-	IDECommand        string
-	WorktreeDir       string
-	SidebarWidth      int
+	// AgentModel is the --model flag value passed to spawned `claude`
+	// agents. Empty means "no --model flag" — the Claude CLI picks its
+	// own default.
+	AgentModel string
+	// PlanModel is the --model flag value passed to the plan drafter
+	// subprocess. Defaults to DefaultPlanModel.
+	PlanModel    string
+	IDECommand   string
+	WorktreeDir  string
+	SidebarWidth int
 
 	// Wellness settings.
 	FocusSessionMinutes int
@@ -126,6 +144,7 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		BranchPrefix:        DefaultBranchPrefix,
 		BranchNamePrompt:    DefaultBranchNamePrompt,
 		AgentProgram:        DefaultAgentProgram,
+		PlanModel:           DefaultPlanModel,
 		WorktreeDir:         DefaultWorktreeDir,
 		SidebarWidth:        DefaultSidebarWidth,
 		FocusSessionMinutes: DefaultFocusSessionMinutes,
@@ -154,6 +173,12 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		}
 		if global.AgentProgram != nil {
 			r.AgentProgram = *global.AgentProgram
+		}
+		if global.AgentModel != nil {
+			r.AgentModel = *global.AgentModel
+		}
+		if global.PlanModel != nil {
+			r.PlanModel = *global.PlanModel
 		}
 		if global.IDECommand != nil {
 			r.IDECommand = *global.IDECommand
@@ -196,6 +221,12 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		}
 		if repo.AgentProgram != nil {
 			r.AgentProgram = *repo.AgentProgram
+		}
+		if repo.AgentModel != nil {
+			r.AgentModel = *repo.AgentModel
+		}
+		if repo.PlanModel != nil {
+			r.PlanModel = *repo.PlanModel
 		}
 		if repo.IDECommand != nil {
 			r.IDECommand = *repo.IDECommand

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -561,6 +561,64 @@ func TestResolve_PlanFirst_GlobalOverride(t *testing.T) {
 	}
 }
 
+func TestResolve_Models_Defaults(t *testing.T) {
+	r := config.Resolve(nil, nil)
+	if r.PlanModel != config.DefaultPlanModel {
+		t.Errorf("PlanModel = %q, want %q", r.PlanModel, config.DefaultPlanModel)
+	}
+	if r.AgentModel != "" {
+		t.Errorf("AgentModel = %q, want empty (no --model flag)", r.AgentModel)
+	}
+}
+
+func TestResolve_Models_GlobalOverride(t *testing.T) {
+	g := &config.GlobalSettings{
+		PlanModel:  strPtr("claude-haiku-4-5"),
+		AgentModel: strPtr("claude-opus-4-7"),
+	}
+	r := config.Resolve(g, nil)
+	if r.PlanModel != "claude-haiku-4-5" {
+		t.Errorf("PlanModel = %q, want claude-haiku-4-5", r.PlanModel)
+	}
+	if r.AgentModel != "claude-opus-4-7" {
+		t.Errorf("AgentModel = %q, want claude-opus-4-7", r.AgentModel)
+	}
+}
+
+func TestResolve_Models_RepoOverridesGlobal(t *testing.T) {
+	g := &config.GlobalSettings{
+		PlanModel:  strPtr("global-plan"),
+		AgentModel: strPtr("global-agent"),
+	}
+	repo := &config.RepoSettings{
+		PlanModel:  strPtr("repo-plan"),
+		AgentModel: strPtr("repo-agent"),
+	}
+	r := config.Resolve(g, repo)
+	if r.PlanModel != "repo-plan" {
+		t.Errorf("PlanModel = %q, want repo-plan", r.PlanModel)
+	}
+	if r.AgentModel != "repo-agent" {
+		t.Errorf("AgentModel = %q, want repo-agent", r.AgentModel)
+	}
+}
+
+func TestGlobalSettings_Models_OmitsNilFields(t *testing.T) {
+	s := &config.GlobalSettings{}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	_ = json.Unmarshal(data, &m)
+	if _, ok := m["plan_model"]; ok {
+		t.Error("plan_model should be omitted when nil")
+	}
+	if _, ok := m["agent_model"]; ok {
+		t.Error("agent_model should be omitted when nil")
+	}
+}
+
 func TestResolve_PlanFirst_RepoOverridesGlobal(t *testing.T) {
 	g := &config.GlobalSettings{
 		PlanFirstEnabled:    boolPtr(true),

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -377,6 +377,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					Cols:              fixedW,
 					BypassPermissions: resolved.BypassPermissions,
 					AgentProgram:      resolved.AgentProgram,
+					AgentModel:        resolved.AgentModel,
 				},
 				sessions: bs.Sessions,
 			})
@@ -1149,6 +1150,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 							Cols:              a.dashboard.width,
 							BypassPermissions: resolved.BypassPermissions,
 							AgentProgram:      resolved.AgentProgram,
+							AgentModel:        resolved.AgentModel,
 						}
 						if newAg, err := mgr.AddAgent(a.focusLaunchSession.ID, cfg); err == nil {
 							a.focusLaunchAgent = newAg
@@ -1654,6 +1656,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Cols:              fixedW,
 				BypassPermissions: resolved.BypassPermissions,
 				AgentProgram:      resolved.AgentProgram,
+				AgentModel:        resolved.AgentModel,
 			}
 			return a, func() tea.Msg {
 				sess, ag, err := mgr.CreateSession(cfg)
@@ -1695,6 +1698,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Cols:              fixedW,
 				BypassPermissions: resolved.BypassPermissions,
 				AgentProgram:      resolved.AgentProgram,
+				AgentModel:        resolved.AgentModel,
 			}
 			sessionID := sess.ID
 			return a, func() tea.Msg {
@@ -2203,6 +2207,7 @@ func (a App) updateBranchPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Cols:              fixedW,
 			BypassPermissions: resolved.BypassPermissions,
 			AgentProgram:      resolved.AgentProgram,
+			AgentModel:        resolved.AgentModel,
 		}
 
 		branch := item.branch
@@ -2261,6 +2266,7 @@ func (a App) updateRepoPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Cols:              fixedW,
 			BypassPermissions: resolved.BypassPermissions,
 			AgentProgram:      resolved.AgentProgram,
+			AgentModel:        resolved.AgentModel,
 		}
 		return a, func() tea.Msg {
 			sess, ag, err := mgr.CreateSession(pickerCfg)
@@ -2326,6 +2332,14 @@ func (a *App) initRepoConfigForm(repoPath string) {
 	if rs.AgentProgram != nil {
 		agentProgram = *rs.AgentProgram
 	}
+	planModel := ""
+	if rs.PlanModel != nil {
+		planModel = *rs.PlanModel
+	}
+	agentModel := ""
+	if rs.AgentModel != nil {
+		agentModel = *rs.AgentModel
+	}
 	ideCommand := ""
 	if rs.IDECommand != nil {
 		ideCommand = *rs.IDECommand
@@ -2349,6 +2363,8 @@ func (a *App) initRepoConfigForm(repoPath string) {
 	fields = addTextInput(fields, "Default Branch", defaultBranch, "auto-detect", inputWidth)
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
+	fields = addTextInput(fields, "Plan Model", planModel, config.DefaultPlanModel, inputWidth)
+	fields = addTextInput(fields, "Agent Model", agentModel, "claude default", inputWidth)
 	fields = addEditorFields(fields, ideCommand)
 	fields = addTextInput(fields, "Worktree Directory", worktreeDir, config.DefaultWorktreeDir, inputWidth)
 
@@ -2377,6 +2393,12 @@ func (a App) extractRepoSettings() *config.RepoSettings {
 	}
 	if v := form.textValue("Agent Program"); v != "" {
 		s.AgentProgram = &v
+	}
+	if v := form.textValue("Plan Model"); v != "" {
+		s.PlanModel = &v
+	}
+	if v := form.textValue("Agent Model"); v != "" {
+		s.AgentModel = &v
 	}
 	if v := extractIDECommand(*form); v != "" {
 		s.IDECommand = &v
@@ -2995,6 +3017,7 @@ func (a *App) submitPromptModal(msg promptModalSubmitMsg) (tea.Model, tea.Cmd) {
 			Cols:              fixedW,
 			BypassPermissions: resolved.BypassPermissions,
 			AgentProgram:      resolved.AgentProgram,
+			AgentModel:        resolved.AgentModel,
 			Task:              prompt,
 		}
 		return a, func() tea.Msg {
@@ -3016,6 +3039,7 @@ func (a *App) submitPromptModal(msg promptModalSubmitMsg) (tea.Model, tea.Cmd) {
 		Cols:              fixedW,
 		BypassPermissions: resolved.BypassPermissions,
 		AgentProgram:      resolved.AgentProgram,
+		AgentModel:        resolved.AgentModel,
 	}
 	sess, err := mgr.CreateSessionForPlanning(cfg)
 	if err != nil {
@@ -3105,6 +3129,7 @@ func (a *App) approvePlanAndSpawn(msg planEditorApproveMsg) (tea.Model, tea.Cmd)
 		Cols:              fixedW,
 		BypassPermissions: resolved.BypassPermissions,
 		AgentProgram:      resolved.AgentProgram,
+		AgentModel:        resolved.AgentModel,
 		Task:              prompt,
 	}
 

--- a/internal/tui/globalconfig.go
+++ b/internal/tui/globalconfig.go
@@ -56,6 +56,14 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	if gs.AgentProgram != nil {
 		agentProgram = *gs.AgentProgram
 	}
+	planModel := ""
+	if gs.PlanModel != nil {
+		planModel = *gs.PlanModel
+	}
+	agentModel := ""
+	if gs.AgentModel != nil {
+		agentModel = *gs.AgentModel
+	}
 	ideCommand := ""
 	if gs.IDECommand != nil {
 		ideCommand = *gs.IDECommand
@@ -90,6 +98,8 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	fields = addTextInput(fields, "Default Branch", defaultBranch, "auto-detect", inputWidth)
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
+	fields = addTextInput(fields, "Plan Model", planModel, config.DefaultPlanModel, inputWidth)
+	fields = addTextInput(fields, "Agent Model", agentModel, "claude default", inputWidth)
 	fields = addEditorFields(fields, ideCommand)
 	fields = addTextInput(fields, "Sidebar Width", sidebarWidth, strconv.Itoa(config.DefaultSidebarWidth), inputWidth)
 	fields = addTextInput(fields, fieldFocusSession, focusSessionMinutes, strconv.Itoa(config.DefaultFocusSessionMinutes), inputWidth)
@@ -159,6 +169,12 @@ func (m globalConfigModel) extractSettings() *config.GlobalSettings {
 	}
 	if v := m.form.textValue("Agent Program"); v != "" {
 		s.AgentProgram = &v
+	}
+	if v := m.form.textValue("Plan Model"); v != "" {
+		s.PlanModel = &v
+	}
+	if v := m.form.textValue("Agent Model"); v != "" {
+		s.AgentModel = &v
 	}
 	if v := extractIDECommand(m.form); v != "" {
 		s.IDECommand = &v


### PR DESCRIPTION
## Summary

Add two optional config keys, both global with per-repo override, so users can pin or upgrade the Claude model used at planning time and at agent spawn time without editing source.

- `plan_model` (default `claude-sonnet-4-6`) — forwarded as `--model` to the plan drafter subprocess. `config.DefaultPlanModel` is the single source of truth; the previous hardcoded constant in `internal/agent/planner.go` was removed in favor of referencing it.
- `agent_model` (default empty) — forwarded as `--model` to spawned `claude` agents. Empty means no flag, letting the Claude CLI pick its default. Ignored when the agent program is not `claude` (passing `--model` to a custom binary is undefined).

Both fields surface as text inputs in the global and per-repo settings overlays. `Manager.UpdateSettings` swaps in a fresh `DefaultPlanDrafter` when the resolved plan model changes, but only when the current drafter is the package default — test mocks injected via `SetPlanDrafter` are left alone.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` (only the two pre-existing baseline failures remain — `TestLoad_MigratesFromLegacyXDGPath` and three hook-server bind tests in `/var/folders`, both fail on `main` too)
- [ ] Manual TUI:
  - Open global settings (`s`), set Plan Model to `claude-haiku-4-5`, save; start a planning session and confirm the drafter runs with Haiku.
  - Reset Plan Model to empty, save, repeat — should fall back to Sonnet.
  - Open per-repo settings, set Agent Model to a pinned model, save, advance a session to Building (`b`), verify with `/model` in the agent terminal.
  - Confirm `~/.baton/config.json` and `<repo>/.baton/config.json` persist `plan_model` / `agent_model` when set and omit them when cleared.

## Checklist

- [x] Added `changelog.d/add-configurable-models.md`
- [x] New behavior has tests (`Resolve()` layering, `buildSpawnArgs`/`buildResumeArgs` agent-model gating, `DefaultPlanDrafter("")` fallback, custom `buildClaudePlannerArgs(model)`)
- [x] No new public API surface beyond the new settings keys