### PR TITLE
Stop tui tests from launching a real browser

### DIFF
--- a/changelog.d/fix-tests-opening-browser.md
+++ b/changelog.d/fix-tests-opening-browser.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `internal/tui` tests no longer launch a real browser. `openURL` is now a package-level `var` so PR-click and Shipping-activate tests can swap in a no-op override for the duration of the test.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3766,7 +3766,8 @@ func ensureGitignore(path string) {
 }
 
 // openURL opens the given URL in the system's default browser. Fire-and-forget.
-func openURL(url string) error {
+// Declared as a var so tests can swap in a no-op to avoid launching a real browser.
+var openURL = func(url string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2193,6 +2193,10 @@ func TestPrimaryAgent_PrefersActiveOverIdle(t *testing.T) {
 // double-click that opens the review panel. The fix is to reset
 // lastPipelineClick after the PR-activation early return.
 func TestPipelinePRClickResetsDoubleClick(t *testing.T) {
+	origOpenURL := openURL
+	openURL = func(string) error { return nil }
+	defer func() { openURL = origOpenURL }()
+
 	sessR := agent.NewSessionForTest("r", "review-r")
 	sessR.SetLifecyclePhase(agent.LifecycleReadyForReview)
 
@@ -2443,10 +2447,12 @@ func TestBKey_OutsidePlanning_FallsThroughToBreak(t *testing.T) {
 // enter (or double-clicking) a Shipping row with a cached PR URL takes the
 // PR-open branch: it returns ok=true without dropping the user into
 // focusLaunch, so they end up in the browser rather than back-to-back agent
-// terminal + browser tab. openURL itself fires fire-and-forget and may launch
-// a real browser in the test environment — the existing review-queue PR-click
-// tests rely on the same pattern, so we stay consistent.
+// terminal + browser tab.
 func TestActivateFocusCursor_Shipping_OpensPRWhenURLCached(t *testing.T) {
+	origOpenURL := openURL
+	openURL = func(string) error { return nil }
+	defer func() { openURL = origOpenURL }()
+
 	sessS := agent.NewSessionForTest("s", "ship-s")
 	sessS.SetLifecyclePhase(agent.LifecycleShipping)
 


### PR DESCRIPTION
## Summary

- `openURL` in `internal/tui/app.go` was a top-level function. Two tests in `app_test.go` (`TestPipelinePRClickResetsDoubleClick` and `TestActivateFocusCursor_Shipping_OpensPRWhenURLCached`) seeded `prCache` entries with real-looking URLs and triggered code paths that called `openURL`, which shells out to `open`/`xdg-open` — popping a browser tab on every `go test` run.
- Converted `func openURL` to `var openURL = func(...)` so tests can swap in a no-op override. No call sites change — all four callers already use `openURL(...)` syntax.
- Added the no-op override to the two affected tests and removed the stale comment that previously accepted browser launch as a known limitation.

## Test plan

- [x] `go vet ./internal/tui/...`
- [x] `gofumpt -l internal/tui/app.go internal/tui/app_test.go` (clean)
- [x] `go test ./internal/tui/... -run 'TestPipelinePRClickResetsDoubleClick|TestActivateFocusCursor_Shipping_OpensPRWhenURLCached' -v` — both pass without opening a browser
- [x] `go test -race ./internal/tui/...` — green

## Checklist

- [x] Added a changelog fragment under `changelog.d/`
- [x] New behavior has tests (the existing tests now exercise the override)
- [x] No new public API surface