### PR TITLE
Fix shift+enter newline in new-session prompt modal

### DIFF
--- a/changelog.d/fix-prompt-modal-shift-enter.md
+++ b/changelog.d/fix-prompt-modal-shift-enter.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Shift+enter now inserts a newline in the new-session prompt modal, matching the footer hint. Bubbles' `InsertNewline` binding only listed `enter`/`ctrl+m`, and the modal intercepts plain `enter` as submit, so shift+enter previously fell through to the textarea's text-input path. The textarea's `InsertNewline` binding is extended in `newPromptModal` to also accept `shift+enter`.

--- a/internal/tui/promptmodal.go
+++ b/internal/tui/promptmodal.go
@@ -93,6 +93,12 @@ func newPromptModal() promptModalModel {
 	// will fail to compile — fix at that point with a v2-typed constant.
 	styles.Cursor.Color = ColorPrimary
 	ta.SetStyles(styles)
+	// Bubbles' default InsertNewline binding only lists "enter"/"ctrl+m",
+	// and the modal's Update intercepts plain "enter" as submit — so
+	// without extending the binding, shift+enter falls through to the
+	// textarea's text-input path and the literal modifier name gets
+	// typed. The footer advertises shift+enter for newline; honor that.
+	ta.KeyMap.InsertNewline.SetKeys("enter", "ctrl+m", "shift+enter")
 	return promptModalModel{textarea: ta}
 }
 
@@ -147,9 +153,9 @@ func (m *promptModalModel) Update(msg tea.Msg) tea.Cmd {
 				return promptModalSubmitMsg{prompt: val, skipPlanning: true}
 			}
 		case "enter":
-			// Plain enter submits via the planning path. Note: this means
-			// the textarea cannot insert newlines via enter — users wanting
-			// multi-line prompts use shift+enter (textarea default).
+			// Plain enter submits via the planning path. Multi-line
+			// prompts use shift+enter, which is wired into the textarea's
+			// InsertNewline binding in newPromptModal.
 			val := strings.TrimSpace(m.textarea.Value())
 			if val == "" {
 				return nil

--- a/internal/tui/promptmodal_test.go
+++ b/internal/tui/promptmodal_test.go
@@ -105,6 +105,31 @@ func TestPromptModal_EscCancels(t *testing.T) {
 	}
 }
 
+func TestPromptModal_ShiftEnterInsertsNewline(t *testing.T) {
+	m := newPromptModal()
+	m.SetSize(120, 40)
+	m.Open()
+	m.textarea.SetValue("first line")
+
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift, Text: "shift+enter"})
+	if cmd != nil {
+		// shift+enter must not produce a submit/cancel cmd; running it
+		// would surface that mistake.
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(promptModalSubmitMsg); ok {
+				t.Fatalf("shift+enter triggered submit; want newline insertion")
+			}
+		}
+	}
+	if !m.Active() {
+		t.Fatal("shift+enter must not close the modal")
+	}
+	m.textarea.InsertString("second line")
+	if got := m.textarea.Value(); !strings.Contains(got, "\n") {
+		t.Errorf("textarea value = %q, want a newline between the two lines", got)
+	}
+}
+
 func TestPromptModal_KeysDeferToTextareaWhenNotControl(t *testing.T) {
 	m := newPromptModal()
 	m.SetSize(120, 40)


### PR DESCRIPTION
## Summary

- The new-session prompt modal's footer advertises `shift+enter` for newline, but pressing it did nothing (or, depending on terminal, typed the literal modifier name into the textarea).
- Root cause: bubbles' default `InsertNewline` binding only lists `enter`/`ctrl+m`, and the modal's `Update` intercepts plain `enter` as submit — so `shift+enter` fell through to the textarea's text-input path with no `InsertNewline` match.
- Fix: extend the textarea's `InsertNewline` keymap in `newPromptModal` to also accept `shift+enter`. Single source of truth, no special-case in the modal's switch.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./internal/tui/...` (0 issues)
- [x] `go test -race ./internal/tui/` (all pass; pre-existing macOS-only `internal/hook` socket-path failures verified to predate this branch and are unrelated)
- [x] New regression test `TestPromptModal_ShiftEnterInsertsNewline`
- [ ] Manual TUI: open new-session modal with `n`, type a line, press shift+enter, type another line, confirm the textarea shows two lines and plain `enter` still submits.

## Checklist

- [x] Changelog fragment under `changelog.d/`
- [x] New behavior has a test
- [x] No new public API surface