### PR TITLE
Add build-phase system prompt for TodoWrite + per-task commits

### DIFF
--- a/changelog.d/add-build-phase-system-prompt.md
+++ b/changelog.d/add-build-phase-system-prompt.md
@@ -1,0 +1,3 @@
+### Added
+
+- Build-phase agents now receive a system prompt (via Claude's `--append-system-prompt` flag) instructing them to (a) use the `TodoWrite` tool to break work into atomic steps and (b) commit one git commit per step with a parseable subject prefix — `[task N]` when a `.claude/plan.md` exists (where `N` is the 1-based plan task index), or `task:` otherwise. This lays the groundwork for surfacing TodoWrite progress on dashboard rows and filtering review diffs by plan task. New global and per-repo `build_system_prompt` setting overrides the default.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -62,6 +62,12 @@ type Config struct {
 	// picks its own default). Ignored when AgentProgram is not `claude` —
 	// passing --model to a custom binary is undefined.
 	AgentModel string
+	// BuildSystemPrompt, when non-empty, is forwarded as
+	// `--append-system-prompt <BuildSystemPrompt>` to spawned `claude`
+	// agents. Empty means no flag. Ignored when AgentProgram is not
+	// `claude` — passing --append-system-prompt to a custom binary is
+	// undefined.
+	BuildSystemPrompt string
 }
 
 // agentProgram returns the CLI program from cfg, defaulting to "claude".
@@ -190,6 +196,13 @@ func buildResumeArgs(cfg Config, claudeSessionID string) []string {
 		args = append(args, "--model", cfg.AgentModel)
 	}
 
+	// Re-attach the build-phase prompt on resume too. Anthropic doesn't
+	// promise that --append-system-prompt persists across --resume, and
+	// duplicating identical text is harmless if it does.
+	if cfg.BuildSystemPrompt != "" && supportsHooks(cfg) {
+		args = append(args, "--append-system-prompt", cfg.BuildSystemPrompt)
+	}
+
 	if cfg.BypassPermissions {
 		args = append(args, "--dangerously-skip-permissions")
 	}
@@ -219,6 +232,9 @@ func buildSpawnArgs(cfg Config, worktreePath, socketPath string) ([]string, erro
 	// is claude — passing --model to a custom binary is undefined.
 	if cfg.AgentModel != "" && supportsHooks(cfg) {
 		args = append(args, "--model", cfg.AgentModel)
+	}
+	if cfg.BuildSystemPrompt != "" && supportsHooks(cfg) {
+		args = append(args, "--append-system-prompt", cfg.BuildSystemPrompt)
 	}
 	if cfg.BypassPermissions {
 		args = append(args, "--dangerously-skip-permissions")

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -649,6 +649,125 @@ func TestBuildSpawnArgs_AgentModel(t *testing.T) {
 	}
 }
 
+func TestBuildSpawnArgs_BuildSystemPrompt(t *testing.T) {
+	wt := t.TempDir()
+	tests := []struct {
+		name     string
+		cfg      Config
+		wantArgs []string
+	}{
+		{
+			name: "prompt set emits flag",
+			cfg: Config{
+				BuildSystemPrompt: "use TodoWrite and commit per task",
+				BypassPermissions: true,
+				Task:              "do work",
+			},
+			wantArgs: []string{
+				"--append-system-prompt", "use TodoWrite and commit per task",
+				"--dangerously-skip-permissions",
+				"do work",
+			},
+		},
+		{
+			name:     "empty prompt no flag",
+			cfg:      Config{BypassPermissions: true, Task: "hi"},
+			wantArgs: []string{"--dangerously-skip-permissions", "hi"},
+		},
+		{
+			name: "prompt ignored for non-claude program",
+			cfg: Config{
+				AgentProgram:      "bash",
+				BuildSystemPrompt: "ignored",
+				Task:              "hi",
+			},
+			wantArgs: []string{"hi"},
+		},
+		{
+			name: "model and prompt both prepend, model first",
+			cfg: Config{
+				AgentModel:        "claude-opus-4-7",
+				BuildSystemPrompt: "p",
+				Task:              "t",
+			},
+			wantArgs: []string{
+				"--model", "claude-opus-4-7",
+				"--append-system-prompt", "p",
+				"t",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildSpawnArgs(tt.cfg, wt, "")
+			if err != nil {
+				t.Fatalf("buildSpawnArgs error: %v", err)
+			}
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("expected %d args, got %d: %v", len(tt.wantArgs), len(got), got)
+			}
+			for i, want := range tt.wantArgs {
+				if got[i] != want {
+					t.Errorf("arg[%d]: expected %q, got %q (full=%v)", i, want, got[i], got)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildResumeArgs_BuildSystemPrompt(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      Config
+		sid      string
+		wantArgs []string
+	}{
+		{
+			name: "prompt set emits flag on resume",
+			cfg: Config{
+				BuildSystemPrompt: "use TodoWrite",
+				BypassPermissions: true,
+			},
+			sid:      "abc123",
+			wantArgs: []string{"--append-system-prompt", "use TodoWrite", "--dangerously-skip-permissions", "--resume", "abc123"},
+		},
+		{
+			name:     "empty prompt no flag on resume",
+			cfg:      Config{BypassPermissions: true},
+			sid:      "abc123",
+			wantArgs: []string{"--dangerously-skip-permissions", "--resume", "abc123"},
+		},
+		{
+			name:     "prompt ignored for non-claude program on resume",
+			cfg:      Config{AgentProgram: "bash", BuildSystemPrompt: "ignored"},
+			sid:      "",
+			wantArgs: []string{"--continue"},
+		},
+		{
+			name: "model and prompt both prepend on resume, model first",
+			cfg: Config{
+				AgentModel:        "claude-opus-4-7",
+				BuildSystemPrompt: "p",
+			},
+			sid:      "sid",
+			wantArgs: []string{"--model", "claude-opus-4-7", "--append-system-prompt", "p", "--resume", "sid"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildResumeArgs(tt.cfg, tt.sid)
+			if len(got) != len(tt.wantArgs) {
+				t.Fatalf("expected %d args, got %d: %v", len(tt.wantArgs), len(got), got)
+			}
+			for i, want := range tt.wantArgs {
+				if got[i] != want {
+					t.Errorf("arg[%d]: expected %q, got %q (full=%v)", i, want, got[i], got)
+				}
+			}
+		})
+	}
+}
+
 func TestUserPromptSubmitClearsAskingQuestion(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo, defaultTestSettings())

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -50,6 +50,22 @@ const (
 	// real agent when an approved plan is handed off. The agent is expected
 	// to read .claude/plan.md and execute it.
 	DefaultBuildFromPlanPrompt = "Read .claude/plan.md and execute the plan. Update task checkboxes as you complete them. Stop when all tasks are complete or when you need a decision."
+
+	// DefaultBuildSystemPrompt is appended (via Claude's
+	// --append-system-prompt flag) to every Building-phase agent. It tells
+	// Claude to (a) plan via TodoWrite so progress can be scraped through
+	// PostToolUse hooks, and (b) commit per task with a parseable subject
+	// prefix so commits can be mapped back to plan tasks during review. The
+	// "[task N]" indexing matches the "- [ ]" / "- [x]" counting in
+	// internal/tui/dashboard.go's planTaskCounts so the prompt and the
+	// future parser agree on what counts as a task line.
+	DefaultBuildSystemPrompt = `When you start a non-trivial task in this session, use the TodoWrite tool first to break the work into ordered, atomic steps and update item status as you progress.
+
+Make exactly one git commit per completed step.
+
+If a file at .claude/plan.md exists in the worktree, the commit subject MUST start with "[task N] " where N is the 1-based index of the corresponding "- [ ]" line in that file (counting only task list lines, top-to-bottom, ignoring section headers). If no .claude/plan.md exists, prefix the subject with "task: " instead. The rest of the subject is a normal short description. Example: "[task 3] add --append-system-prompt flag plumbing".
+
+Do not squash unrelated work into a single commit, and do not amend a previous commit to add new task work — each task is its own commit so the work can be reviewed task-by-task.`
 )
 
 // ClampSidebarWidth returns w constrained to [MinSidebarWidth, MaxSidebarWidth].
@@ -86,6 +102,7 @@ type GlobalSettings struct {
 	// Plan-first planning. Both fields are also overridable per-repo.
 	PlanFirstEnabled    *bool   `json:"plan_first_enabled,omitempty"`
 	BuildFromPlanPrompt *string `json:"build_from_plan_prompt,omitempty"`
+	BuildSystemPrompt   *string `json:"build_system_prompt,omitempty"`
 }
 
 // RepoSettings holds per-repo overrides stored at <repo>/.baton/config.json.
@@ -102,6 +119,7 @@ type RepoSettings struct {
 	WorktreeDir         *string `json:"worktree_dir,omitempty"`
 	PlanFirstEnabled    *bool   `json:"plan_first_enabled,omitempty"`
 	BuildFromPlanPrompt *string `json:"build_from_plan_prompt,omitempty"`
+	BuildSystemPrompt   *string `json:"build_system_prompt,omitempty"`
 }
 
 // ResolvedSettings is the fully merged configuration with no nil pointers.
@@ -133,6 +151,10 @@ type ResolvedSettings struct {
 	// Plan-first planning.
 	PlanFirstEnabled    bool
 	BuildFromPlanPrompt string
+	// BuildSystemPrompt is forwarded as `--append-system-prompt <text>` to
+	// the spawned `claude` agent at every Building-phase spawn site (and
+	// resume). Empty means no flag.
+	BuildSystemPrompt string
 }
 
 // Resolve merges global and repo settings over built-in defaults.
@@ -153,6 +175,7 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		MaxReviewBacklog:    DefaultMaxReviewBacklog,
 		PlanFirstEnabled:    DefaultPlanFirstEnabled,
 		BuildFromPlanPrompt: DefaultBuildFromPlanPrompt,
+		BuildSystemPrompt:   DefaultBuildSystemPrompt,
 	}
 
 	if global != nil {
@@ -204,6 +227,9 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		if global.BuildFromPlanPrompt != nil {
 			r.BuildFromPlanPrompt = *global.BuildFromPlanPrompt
 		}
+		if global.BuildSystemPrompt != nil {
+			r.BuildSystemPrompt = *global.BuildSystemPrompt
+		}
 	}
 
 	if repo != nil {
@@ -239,6 +265,9 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		}
 		if repo.BuildFromPlanPrompt != nil {
 			r.BuildFromPlanPrompt = *repo.BuildFromPlanPrompt
+		}
+		if repo.BuildSystemPrompt != nil {
+			r.BuildSystemPrompt = *repo.BuildSystemPrompt
 		}
 	}
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -63,7 +63,7 @@ const (
 
 Make exactly one git commit per completed step.
 
-If a file at .claude/plan.md exists in the worktree, the commit subject MUST start with "[task N] " where N is the 1-based index of the corresponding "- [ ]" line in that file (counting only task list lines, top-to-bottom, ignoring section headers). If no .claude/plan.md exists, prefix the subject with "task: " instead. The rest of the subject is a normal short description. Example: "[task 3] add --append-system-prompt flag plumbing".
+If a file at .claude/plan.md exists in the worktree, the commit subject MUST start with "[task N] " where N is the 1-based index of the task line (counting ALL task list lines — both "- [ ]" and "- [x]" — top-to-bottom, ignoring non-task lines such as section headers). If no .claude/plan.md exists, prefix the subject with "task: " instead. The rest of the subject is a normal short description. Example: "[task 3] add --append-system-prompt flag plumbing".
 
 Do not squash unrelated work into a single commit, and do not amend a previous commit to add new task work — each task is its own commit so the work can be reviewed task-by-task.`
 )

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -636,3 +636,39 @@ func TestResolve_PlanFirst_RepoOverridesGlobal(t *testing.T) {
 		t.Errorf("BuildFromPlanPrompt = %q, want repo", r.BuildFromPlanPrompt)
 	}
 }
+
+func TestResolve_BuildSystemPrompt_Default(t *testing.T) {
+	r := config.Resolve(nil, nil)
+	if r.BuildSystemPrompt != config.DefaultBuildSystemPrompt {
+		t.Errorf("BuildSystemPrompt = %q, want default", r.BuildSystemPrompt)
+	}
+}
+
+func TestResolve_BuildSystemPrompt_GlobalOverride(t *testing.T) {
+	g := &config.GlobalSettings{BuildSystemPrompt: strPtr("custom")}
+	r := config.Resolve(g, nil)
+	if r.BuildSystemPrompt != "custom" {
+		t.Errorf("BuildSystemPrompt = %q, want %q", r.BuildSystemPrompt, "custom")
+	}
+}
+
+func TestResolve_BuildSystemPrompt_RepoOverridesGlobal(t *testing.T) {
+	g := &config.GlobalSettings{BuildSystemPrompt: strPtr("global")}
+	repo := &config.RepoSettings{BuildSystemPrompt: strPtr("repo")}
+	r := config.Resolve(g, repo)
+	if r.BuildSystemPrompt != "repo" {
+		t.Errorf("BuildSystemPrompt = %q, want repo", r.BuildSystemPrompt)
+	}
+}
+
+// An empty-string override is honored as a deliberate disable. The build
+// path keys flag emission off `BuildSystemPrompt != ""`, so this lets users
+// opt out by setting "build_system_prompt": "" in their config without
+// requiring a separate boolean toggle.
+func TestResolve_BuildSystemPrompt_EmptyStringDisables(t *testing.T) {
+	g := &config.GlobalSettings{BuildSystemPrompt: strPtr("")}
+	r := config.Resolve(g, nil)
+	if r.BuildSystemPrompt != "" {
+		t.Errorf("BuildSystemPrompt = %q, want empty (disabled)", r.BuildSystemPrompt)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -378,6 +378,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					BypassPermissions: resolved.BypassPermissions,
 					AgentProgram:      resolved.AgentProgram,
 					AgentModel:        resolved.AgentModel,
+					BuildSystemPrompt: resolved.BuildSystemPrompt,
 				},
 				sessions: bs.Sessions,
 			})
@@ -1151,6 +1152,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 							BypassPermissions: resolved.BypassPermissions,
 							AgentProgram:      resolved.AgentProgram,
 							AgentModel:        resolved.AgentModel,
+							BuildSystemPrompt: resolved.BuildSystemPrompt,
 						}
 						if newAg, err := mgr.AddAgent(a.focusLaunchSession.ID, cfg); err == nil {
 							a.focusLaunchAgent = newAg
@@ -1657,6 +1659,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				BypassPermissions: resolved.BypassPermissions,
 				AgentProgram:      resolved.AgentProgram,
 				AgentModel:        resolved.AgentModel,
+				BuildSystemPrompt: resolved.BuildSystemPrompt,
 			}
 			return a, func() tea.Msg {
 				sess, ag, err := mgr.CreateSession(cfg)
@@ -1699,6 +1702,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				BypassPermissions: resolved.BypassPermissions,
 				AgentProgram:      resolved.AgentProgram,
 				AgentModel:        resolved.AgentModel,
+				BuildSystemPrompt: resolved.BuildSystemPrompt,
 			}
 			sessionID := sess.ID
 			return a, func() tea.Msg {
@@ -2208,6 +2212,7 @@ func (a App) updateBranchPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			BypassPermissions: resolved.BypassPermissions,
 			AgentProgram:      resolved.AgentProgram,
 			AgentModel:        resolved.AgentModel,
+			BuildSystemPrompt: resolved.BuildSystemPrompt,
 		}
 
 		branch := item.branch
@@ -2267,6 +2272,7 @@ func (a App) updateRepoPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			BypassPermissions: resolved.BypassPermissions,
 			AgentProgram:      resolved.AgentProgram,
 			AgentModel:        resolved.AgentModel,
+			BuildSystemPrompt: resolved.BuildSystemPrompt,
 		}
 		return a, func() tea.Msg {
 			sess, ag, err := mgr.CreateSession(pickerCfg)
@@ -3018,6 +3024,7 @@ func (a *App) submitPromptModal(msg promptModalSubmitMsg) (tea.Model, tea.Cmd) {
 			BypassPermissions: resolved.BypassPermissions,
 			AgentProgram:      resolved.AgentProgram,
 			AgentModel:        resolved.AgentModel,
+			BuildSystemPrompt: resolved.BuildSystemPrompt,
 			Task:              prompt,
 		}
 		return a, func() tea.Msg {
@@ -3130,6 +3137,7 @@ func (a *App) approvePlanAndSpawn(msg planEditorApproveMsg) (tea.Model, tea.Cmd)
 		BypassPermissions: resolved.BypassPermissions,
 		AgentProgram:      resolved.AgentProgram,
 		AgentModel:        resolved.AgentModel,
+		BuildSystemPrompt: resolved.BuildSystemPrompt,
 		Task:              prompt,
 	}
 


### PR DESCRIPTION
Inject a Claude system prompt at every Building-phase agent spawn (and
resume) via the --append-system-prompt CLI flag. The prompt directs
Claude to (a) plan via TodoWrite so progress can be scraped through
PostToolUse hooks in a follow-up, and (b) commit per task with a
parseable subject prefix — "[task N]" when .claude/plan.md exists
(matching planTaskCounts indexing), or "task:" otherwise — so future
review code can map commits to plan tasks.

Mirrors BuildFromPlanPrompt plumbing: new BuildSystemPrompt field on
GlobalSettings/RepoSettings/ResolvedSettings with a default constant,
new agent.Config.BuildSystemPrompt threaded through all 8 Build-phase
spawn sites (resume, focusLaunch AddAgent, legacy n skip, c AddAgent,
branch picker, repo picker, submit-modal skip, approvePlanAndSpawn).
Shell-agent and CreateSessionForPlanning sites are intentionally left
untouched; the planner subprocess uses its own argv path so it does
not pick up the build prompt.

https://claude.ai/code/session_01F6xAMPq67RERghEYRDMt2N