### PR TITLE
Convert Plan Model and Agent Model config fields to dropdowns

### DIFF
--- a/changelog.d/model-fields-as-dropdowns.md
+++ b/changelog.d/model-fields-as-dropdowns.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The Plan Model and Agent Model fields in the global and per-repo config forms are now dropdowns populated with the current Claude model IDs (`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`), cycled with `←`/`→`. Agent Model also offers a blank option meaning "claude default" so it can be left unset. Users who need a model not in the list can still edit `~/.config/baton/settings.json` (or `.baton/settings.json`) directly.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -68,6 +68,21 @@ If a file at .claude/plan.md exists in the worktree, the commit subject MUST sta
 Do not squash unrelated work into a single commit, and do not amend a previous commit to add new task work — each task is its own commit so the work can be reviewed task-by-task.`
 )
 
+// KnownModels is the list of Claude model IDs offered in the config form
+// dropdowns for fields that pass `--model` to a real subprocess (e.g. the
+// plan drafter). The first entry is the form's default selection.
+var KnownModels = []string{
+	"claude-opus-4-7",
+	"claude-sonnet-4-6",
+	"claude-haiku-4-5-20251001",
+}
+
+// KnownAgentModels is the option list for the Agent Model dropdown. The
+// leading empty string represents "claude default" — when selected, no
+// `--model` flag is forwarded to the spawned agent and Claude picks its own
+// default.
+var KnownAgentModels = append([]string{""}, KnownModels...)
+
 // ClampSidebarWidth returns w constrained to [MinSidebarWidth, MaxSidebarWidth].
 func ClampSidebarWidth(w int) int {
 	if w < MinSidebarWidth {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2369,8 +2369,8 @@ func (a *App) initRepoConfigForm(repoPath string) {
 	fields = addTextInput(fields, "Default Branch", defaultBranch, "auto-detect", inputWidth)
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
-	fields = addTextInput(fields, "Plan Model", planModel, config.DefaultPlanModel, inputWidth)
-	fields = addTextInput(fields, "Agent Model", agentModel, "claude default", inputWidth)
+	fields = addSelect(fields, "Plan Model", config.KnownModels, optionIndex(config.KnownModels, planModel))
+	fields = addSelect(fields, "Agent Model", config.KnownAgentModels, optionIndex(config.KnownAgentModels, agentModel))
 	fields = addEditorFields(fields, ideCommand)
 	fields = addTextInput(fields, "Worktree Directory", worktreeDir, config.DefaultWorktreeDir, inputWidth)
 
@@ -2400,10 +2400,10 @@ func (a App) extractRepoSettings() *config.RepoSettings {
 	if v := form.textValue("Agent Program"); v != "" {
 		s.AgentProgram = &v
 	}
-	if v := form.textValue("Plan Model"); v != "" {
+	if v := form.selectValue("Plan Model"); v != "" {
 		s.PlanModel = &v
 	}
-	if v := form.textValue("Agent Model"); v != "" {
+	if v := form.selectValue("Agent Model"); v != "" {
 		s.AgentModel = &v
 	}
 	if v := extractIDECommand(*form); v != "" {

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -271,3 +271,14 @@ func (f configForm) selectIndex(label string) int {
 	}
 	return 0
 }
+
+// optionIndex returns the index of value in options, or 0 if not present.
+// Used to compute the initial selection for a fieldSelect.
+func optionIndex(options []string, value string) int {
+	for i, o := range options {
+		if o == value {
+			return i
+		}
+	}
+	return 0
+}

--- a/internal/tui/globalconfig.go
+++ b/internal/tui/globalconfig.go
@@ -98,8 +98,8 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	fields = addTextInput(fields, "Default Branch", defaultBranch, "auto-detect", inputWidth)
 	fields = addTextInput(fields, "Branch Prefix", branchPrefix, config.DefaultBranchPrefix, inputWidth)
 	fields = addTextInput(fields, "Agent Program", agentProgram, config.DefaultAgentProgram, inputWidth)
-	fields = addTextInput(fields, "Plan Model", planModel, config.DefaultPlanModel, inputWidth)
-	fields = addTextInput(fields, "Agent Model", agentModel, "claude default", inputWidth)
+	fields = addSelect(fields, "Plan Model", config.KnownModels, optionIndex(config.KnownModels, planModel))
+	fields = addSelect(fields, "Agent Model", config.KnownAgentModels, optionIndex(config.KnownAgentModels, agentModel))
 	fields = addEditorFields(fields, ideCommand)
 	fields = addTextInput(fields, "Sidebar Width", sidebarWidth, strconv.Itoa(config.DefaultSidebarWidth), inputWidth)
 	fields = addTextInput(fields, fieldFocusSession, focusSessionMinutes, strconv.Itoa(config.DefaultFocusSessionMinutes), inputWidth)
@@ -170,10 +170,10 @@ func (m globalConfigModel) extractSettings() *config.GlobalSettings {
 	if v := m.form.textValue("Agent Program"); v != "" {
 		s.AgentProgram = &v
 	}
-	if v := m.form.textValue("Plan Model"); v != "" {
+	if v := m.form.selectValue("Plan Model"); v != "" {
 		s.PlanModel = &v
 	}
-	if v := m.form.textValue("Agent Model"); v != "" {
+	if v := m.form.selectValue("Agent Model"); v != "" {
 		s.AgentModel = &v
 	}
 	if v := extractIDECommand(m.form); v != "" {


### PR DESCRIPTION
## Summary

- Replaces the free-form text inputs for **Plan Model** and **Agent Model** in both the global and per-repo config forms with `fieldSelect` dropdowns populated from a curated list of current Claude model IDs (`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`).
- Agent Model also offers a leading blank option (rendered as an empty value) so the field can stay unset and let the Claude CLI pick its own default.
- Adds `KnownModels` / `KnownAgentModels` in `internal/config/settings.go` so the option list lives next to `DefaultPlanModel` rather than in the TUI layer.
- Power users who need a model not in the list can still edit `~/.config/baton/settings.json` (or `.baton/settings.json`) directly — the form just covers the common case so users don't have to remember the exact model ID string.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [x] `go test -race ./internal/tui/ ./internal/config/` — `internal/tui` passes; the only failure in `internal/config` (`TestLoad_MigratesFromLegacyXDGPath`) reproduces on `main` and is unrelated to this change.
- [ ] Manual TUI: open global settings (`s`), confirm Plan Model and Agent Model render as `< value >` chevron controls and cycle with `←`/`→`. Repeat in per-repo settings. Save with each model selected and verify the JSON contains the right string. Save with Agent Model on the blank option and verify `agent_model` is absent from the JSON.

## Checklist

- [x] Added a `changelog.d/` fragment (`model-fields-as-dropdowns.md`)
- [x] Existing form-field code paths already covered by `internal/tui` tests; no new test surface introduced
- [x] No new public API surface