### PR TITLE
Show repo name on dashboard session cards

### DIFF
--- a/changelog.d/add-repo-prefix-session-cards.md
+++ b/changelog.d/add-repo-prefix-session-cards.md
@@ -1,0 +1,3 @@
+### Added
+
+- Dashboard session cards in PLANNING / BUILDING / REVIEWING / SHIPPING now show the owning repo as a muted `<repo> › ` prefix on the name line, so cross-repo sessions with similar names stay unambiguous.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2579,10 +2579,12 @@ func (a *App) refreshAgentList() {
 			sort.Slice(sessions, func(i, j int) bool {
 				return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
 			})
+			repoName := a.activeRepoDisplayName()
 			for _, sess := range sessions {
 				items = append(items, listItem{
 					kind:     listItemSession,
 					repoPath: a.activeRepo,
+					repoName: repoName,
 					session:  sess,
 				})
 				for _, ag := range sess.Agents() {
@@ -2624,6 +2626,7 @@ func (a *App) refreshAgentList() {
 				items = append(items, listItem{
 					kind:     listItemSession,
 					repoPath: repo.Path,
+					repoName: repo.DisplayName(),
 					session:  sess,
 				})
 				for _, ag := range sess.Agents() {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -539,7 +539,7 @@ func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Co
 // Line 2: <stripe>   <description line 1 (muted; italic if pending)>
 // Line 3: <stripe>   <description line 2 or empty>  (always reserved)
 // Line 4: <stripe>   <branch [· detail]>        ... right-aligned <elapsed>
-func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected bool, width int) []string {
+func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName string, selected bool, width int) []string {
 	stripeColor := d.sessionFocusStripeColor(sess)
 	if selected {
 		stripeColor = ColorSecondary
@@ -548,14 +548,18 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, selected boo
 	const indent = "   "
 	const stripeIndentWidth = 4 // stripe (1) + 3 spaces
 
-	// --- Line 1: stripe + name, right-aligned status badge ---
-	// A "> " prefix on the name marks the selected card unambiguously even
-	// when stdout strips ANSI (e2e screenshots, terminal recordings).
-	name := sess.GetDisplayName()
-	if selected {
-		name = "> " + name
+	// --- Line 1: stripe + repo prefix + name, right-aligned status badge ---
+	// A "> " prefix marks the selected card unambiguously even when stdout
+	// strips ANSI (e2e screenshots, terminal recordings). The "> " stays
+	// leftmost so the muted repo prefix never gets between the cursor and the
+	// stripe.
+	nameStyled := lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(sess.GetDisplayName())
+	if repoName != "" {
+		nameStyled = StyleSubtle.Render(repoName+" › ") + nameStyled
 	}
-	nameStyled := lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(name)
+	if selected {
+		nameStyled = "> " + nameStyled
+	}
 	// Planning + Drafting phases get a dedicated badge + description because
 	// they have no agent yet — the regular sessionFocusStatus path is keyed
 	// off agent.Status and would render "0 active, 0 idle" for these rows.
@@ -1366,7 +1370,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, StyleSubtle.Render("PLANNING"))
 		for i, item := range planningItems {
 			selected := d.focusCursorSection == focusSectionPlanning && i == d.focusPlanningIdx
-			card := d.renderFocusSessionCard(item.session, selected, width)
+			card := d.renderFocusSessionCard(item.session, item.repoName, selected, width)
 			lines = append(lines, card...)
 			if i < len(planningItems)-1 {
 				lines = append(lines, "")
@@ -1380,7 +1384,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, StyleSubtle.Render("BUILDING"))
 		for i, item := range buildingItems {
 			selected := d.focusCursorSection == focusSectionBuilding && i == d.focusBuildingIdx
-			card := d.renderFocusSessionCard(item.session, selected, width)
+			card := d.renderFocusSessionCard(item.session, item.repoName, selected, width)
 			lines = append(lines, card...)
 			if i < len(buildingItems)-1 {
 				lines = append(lines, "")
@@ -1394,7 +1398,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, StyleSubtle.Render("REVIEWING"))
 		for i, item := range reviewSessions {
 			selected := d.focusCursorSection == focusSectionReview && i == d.focusReviewIdx
-			row := d.renderQueueRow(item.session, selected, ColorWarning, width)
+			row := d.renderQueueRow(item.session, item.repoName, selected, ColorWarning, width)
 			lines = append(lines, row...)
 			if i < len(reviewSessions)-1 {
 				lines = append(lines, "")
@@ -1408,7 +1412,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, StyleSubtle.Render("SHIPPING"))
 		for i, item := range shippingItems {
 			selected := d.focusCursorSection == focusSectionShipping && i == d.focusShippingIdx
-			row := d.renderQueueRow(item.session, selected, lipgloss.Color("#5ab58a"), width)
+			row := d.renderQueueRow(item.session, item.repoName, selected, lipgloss.Color("#5ab58a"), width)
 			lines = append(lines, row...)
 			if i < len(shippingItems)-1 {
 				lines = append(lines, "")
@@ -1424,7 +1428,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 // accent for the cursor stripe and prefix when selected (warning for review,
 // success for shipping). Used by both the REVIEWING and SHIPPING sections so
 // they share layout/age/prIndicator handling.
-func (d dashboardModel) renderQueueRow(sess *agent.Session, selected bool, selectedColor lipgloss.Color, width int) []string {
+func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName string, selected bool, selectedColor lipgloss.Color, width int) []string {
 	name := sess.GetDisplayName()
 	age := ""
 	if !sess.DoneAt().IsZero() {
@@ -1443,6 +1447,9 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, selected bool, selec
 	}
 
 	nameRendered := cardStyle.Render(name)
+	if repoName != "" {
+		nameRendered = StyleSubtle.Render(repoName+" › ") + nameRendered
+	}
 	// The (reviewing) tag distinguishes InReview rows in the merged Reviewing
 	// section so the user can tell which session is open in the panel.
 	if sess.LifecyclePhase() == agent.LifecycleInReview {

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/baton/internal/agent"
 	"github.com/muesli/termenv"
 )
@@ -158,5 +159,49 @@ func TestSessionFocusStatus_FinishedTakesPrecedence(t *testing.T) {
 	}
 	if strings.Contains(badge, "press m to review") {
 		t.Errorf("expected idle cue not to fire when DoneAt set, got %q", badge)
+	}
+}
+
+// TestRenderFocusSessionCard_RepoPrefix verifies that a non-empty repoName is
+// rendered as a "<repoName> › " prefix on the session card's name line. This
+// locks in the cross-repo disambiguation contract — without it, two sessions
+// with the same display name in different repos look identical on the
+// dashboard.
+func TestRenderFocusSessionCard_RepoPrefix(t *testing.T) {
+	sessA := agent.NewSessionForTest("s-a", "add-dark-mode")
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessB := agent.NewSessionForTest("s-b", "add-dark-mode")
+	sessB.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	d := newDashboardModel()
+	d.width = 120
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/a", repoName: "repoA", session: sessA},
+		{kind: listItemSession, repoPath: "/b", repoName: "repoB", session: sessB},
+	}
+
+	card := d.renderFocusSessionCard(sessA, "repoA", false, 120)
+	if len(card) == 0 {
+		t.Fatalf("expected at least one rendered line")
+	}
+	line1 := ansi.Strip(card[0])
+	if !strings.Contains(line1, "repoA › ") {
+		t.Errorf("expected repo prefix \"repoA › \" on line 1, got %q", line1)
+	}
+	if !strings.Contains(line1, "add-dark-mode") {
+		t.Errorf("expected session name on line 1, got %q", line1)
+	}
+	if idx := strings.Index(line1, "repoA › "); idx >= 0 {
+		nameIdx := strings.Index(line1, "add-dark-mode")
+		if nameIdx < idx {
+			t.Errorf("expected repo prefix to precede session name, got %q", line1)
+		}
+	}
+
+	// Empty repoName must not render the separator (defensive — the prefix is
+	// optional even though every real call passes a non-empty value).
+	bare := d.renderFocusSessionCard(sessA, "", false, 120)
+	if strings.Contains(ansi.Strip(bare[0]), "›") {
+		t.Errorf("empty repoName should not emit › separator, got %q", ansi.Strip(bare[0]))
 	}
 }

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -13,7 +13,9 @@ import (
 // TestRenderFocusActiveCursor verifies that the selected session card in focus
 // mode is visually distinct: the leading stripe glyph is rendered in
 // ColorSecondary (cyan) for the selected session and a different color for
-// unselected sessions. Selection is no longer signalled by a "> " chevron.
+// unselected sessions. The "> " chevron is also present on the selected row
+// (an ANSI-stripped fallback signal for screenshots / terminal recordings),
+// but the cyan stripe is the assertion this test owns.
 func TestRenderFocusActiveCursor(t *testing.T) {
 	// Force TrueColor so the rendered ANSI escapes carry the foreground color
 	// we want to assert against. Without this, lipgloss strips colors when
@@ -201,6 +203,44 @@ func TestRenderFocusSessionCard_RepoPrefix(t *testing.T) {
 	// Empty repoName must not render the separator (defensive — the prefix is
 	// optional even though every real call passes a non-empty value).
 	bare := d.renderFocusSessionCard(sessA, "", false, 120)
+	if strings.Contains(ansi.Strip(bare[0]), "›") {
+		t.Errorf("empty repoName should not emit › separator, got %q", ansi.Strip(bare[0]))
+	}
+}
+
+// TestRenderQueueRow_RepoPrefix verifies the same cross-repo disambiguation
+// for the REVIEWING / SHIPPING sections. renderQueueRow has independent
+// rendering from renderFocusSessionCard, so it needs its own coverage to
+// catch a silent regression in either path.
+func TestRenderQueueRow_RepoPrefix(t *testing.T) {
+	sess := agent.NewSessionForTest("s-a", "add-dark-mode")
+	sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
+
+	d := newDashboardModel()
+	d.width = 120
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/a", repoName: "repoA", session: sess},
+	}
+
+	row := d.renderQueueRow(sess, "repoA", false, ColorWarning, 120)
+	if len(row) == 0 {
+		t.Fatalf("expected at least one rendered line")
+	}
+	line1 := ansi.Strip(row[0])
+	if !strings.Contains(line1, "repoA › ") {
+		t.Errorf("expected repo prefix \"repoA › \" on line 1, got %q", line1)
+	}
+	if !strings.Contains(line1, "add-dark-mode") {
+		t.Errorf("expected session name on line 1, got %q", line1)
+	}
+	if idx := strings.Index(line1, "repoA › "); idx >= 0 {
+		nameIdx := strings.Index(line1, "add-dark-mode")
+		if nameIdx < idx {
+			t.Errorf("expected repo prefix to precede session name, got %q", line1)
+		}
+	}
+
+	bare := d.renderQueueRow(sess, "", false, ColorWarning, 120)
 	if strings.Contains(ansi.Strip(bare[0]), "›") {
 		t.Errorf("empty repoName should not emit › separator, got %q", ansi.Strip(bare[0]))
 	}


### PR DESCRIPTION
## Summary

- Dashboard session cards in PLANNING / BUILDING / REVIEWING / SHIPPING now render the owning repo as a muted `<repo> › ` prefix on the name line, so cross-repo sessions with the same display name (e.g. `add-dark-mode` in two repos) stay unambiguous.
- The `> ` selection cursor stays leftmost — order is `stripe → > → muted repo › → bold session name → status badge`.
- Prefix renders unconditionally (always-on per product direction); empty `repoName` is a defensive no-op.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/tui/...`
- [x] `go test -race ./...` — pre-existing `internal/config` (XDG migration) and `internal/hook` (macOS unix socket path length) failures reproduce on main and are unrelated.
- [x] New `TestRenderFocusSessionCard_RepoPrefix` locks in the prefix contract and the empty-repoName no-op.
- [ ] Manual TUI: run `./baton` with two repos registered, spawn a session in each, confirm the muted `<repoName> › <sessionName>` appears across all four sections and that long repo names don't break the right-aligned status badge.
- [ ] Manual TUI single-repo: run `./baton` in a single registered repo and confirm the prefix still renders without layout regression.

## Checklist

- [x] Changelog fragment added under `changelog.d/` (`add-repo-prefix-session-cards.md`)
- [x] New behavior has a render-prefix test in `internal/tui/focus_render_test.go`
- [x] No new public API surface — only the unexported `renderFocusSessionCard` / `renderQueueRow` signatures changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)