### PR TITLE
Fix inflated agent counts (quit warning + concurrency limit)

### DIFF
--- a/changelog.d/fix-inflated-agent-counts.md
+++ b/changelog.d/fix-inflated-agent-counts.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Quit no longer warns "agents running" when only shell agents or already-exited (Done/Error) agents remain, and the soft concurrent-agent limit no longer counts those toward the cap. `Manager.AgentCount` and `App.activeAgentCount` now exclude shells and exited agents; a new `Session.LiveAgentCount` captures the live-non-shell count for capacity checks.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1455,13 +1455,16 @@ func (m *Manager) stopHookServer() {
 	m.hookServer = nil
 }
 
-// AgentCount returns the total number of agents across all sessions.
+// AgentCount returns the total number of live, non-shell agents across all
+// sessions. Shells and naturally-exited (Done/Error) agents are excluded so
+// callers using this for capacity checks (the quit warning, soft concurrency
+// limits) don't count work that's already finished.
 func (m *Manager) AgentCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	count := 0
 	for _, s := range m.sessions {
-		count += s.AgentCount()
+		count += s.LiveAgentCount()
 	}
 	return count
 }

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -852,3 +852,41 @@ func TestManager_StartDraft_NoQuestionsByDefault(t *testing.T) {
 		return !sess.IsDrafting() && sess.HasPlan()
 	})
 }
+
+// TestManager_AgentCount_ExcludesExitedAgents pins the fix for the inflated
+// quit/concurrency warnings: an agent that exits with an error stays in the
+// session map (so the user can inspect it) but must not count toward
+// Manager.AgentCount, which is used to gate the "agents running" detach
+// confirmation and the soft concurrent-agent limit.
+func TestManager_AgentCount_ExcludesExitedAgents(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	sess, ag, err := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "exit 1") },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-ag.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for agent to exit")
+	}
+
+	if got := ag.Status(); got != StatusError {
+		t.Fatalf("expected StatusError after non-zero exit, got %s", got)
+	}
+	if got := sess.AgentCount(); got != 1 {
+		t.Errorf("session should retain exited agent in its map, got AgentCount=%d", got)
+	}
+	if got := mgr.AgentCount(); got != 0 {
+		t.Errorf("expected Manager.AgentCount=0 (exited agent must not count), got %d", got)
+	}
+	if got := sess.LiveAgentCount(); got != 0 {
+		t.Errorf("expected Session.LiveAgentCount=0 (exited agent must not count), got %d", got)
+	}
+}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -854,39 +854,54 @@ func TestManager_StartDraft_NoQuestionsByDefault(t *testing.T) {
 }
 
 // TestManager_AgentCount_ExcludesExitedAgents pins the fix for the inflated
-// quit/concurrency warnings: an agent that exits with an error stays in the
-// session map (so the user can inspect it) but must not count toward
+// quit/concurrency warnings: an agent that has exited stays in the session
+// map (so the user can inspect it) but must not count toward
 // Manager.AgentCount, which is used to gate the "agents running" detach
-// confirmation and the soft concurrent-agent limit.
+// confirmation and the soft concurrent-agent limit. Both Done (clean exit)
+// and Error (non-zero exit) are exercised so the symmetric arms of
+// LiveAgentCount's switch are both covered.
 func TestManager_AgentCount_ExcludesExitedAgents(t *testing.T) {
-	repo := setupTestRepo(t)
-	mgr := NewManager(repo, defaultTestSettings())
-	defer mgr.Shutdown()
-
-	sess, ag, err := mgr.CreateSessionWithCommand(
-		Config{Task: "test", Rows: 24, Cols: 80},
-		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "exit 1") },
-	)
-	if err != nil {
-		t.Fatal(err)
+	cases := []struct {
+		name    string
+		command string
+		want    Status
+	}{
+		{"error_exit", "exit 1", StatusError},
+		{"clean_exit", "exit 0", StatusDone},
 	}
 
-	select {
-	case <-ag.Done():
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for agent to exit")
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupTestRepo(t)
+			mgr := NewManager(repo, defaultTestSettings())
+			defer mgr.Shutdown()
 
-	if got := ag.Status(); got != StatusError {
-		t.Fatalf("expected StatusError after non-zero exit, got %s", got)
-	}
-	if got := sess.AgentCount(); got != 1 {
-		t.Errorf("session should retain exited agent in its map, got AgentCount=%d", got)
-	}
-	if got := mgr.AgentCount(); got != 0 {
-		t.Errorf("expected Manager.AgentCount=0 (exited agent must not count), got %d", got)
-	}
-	if got := sess.LiveAgentCount(); got != 0 {
-		t.Errorf("expected Session.LiveAgentCount=0 (exited agent must not count), got %d", got)
+			sess, ag, err := mgr.CreateSessionWithCommand(
+				Config{Task: "test", Rows: 24, Cols: 80},
+				func(name string) *exec.Cmd { return exec.Command("bash", "-c", tc.command) },
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			select {
+			case <-ag.Done():
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for agent to exit")
+			}
+
+			if got := ag.Status(); got != tc.want {
+				t.Fatalf("expected %s after %q, got %s", tc.want, tc.command, got)
+			}
+			if got := sess.AgentCount(); got != 1 {
+				t.Errorf("session should retain exited agent in its map, got AgentCount=%d", got)
+			}
+			if got := mgr.AgentCount(); got != 0 {
+				t.Errorf("expected Manager.AgentCount=0 (exited agent must not count), got %d", got)
+			}
+			if got := sess.LiveAgentCount(); got != 0 {
+				t.Errorf("expected Session.LiveAgentCount=0 (exited agent must not count), got %d", got)
+			}
+		})
 	}
 }

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -312,6 +312,27 @@ func (s *Session) AgentCount() int {
 	return len(s.agents)
 }
 
+// LiveAgentCount returns the number of non-shell agents whose status is
+// neither StatusDone nor StatusError. This is the right count for capacity
+// checks (concurrent-agent limits, the quit "agents running" warning) where
+// shells and naturally-exited agents shouldn't trigger the warning.
+func (s *Session) LiveAgentCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	count := 0
+	for _, a := range s.agents {
+		if a.IsShell {
+			continue
+		}
+		switch a.Status() {
+		case StatusDone, StatusError:
+			continue
+		}
+		count++
+	}
+	return count
+}
+
 // AgentStatusPriority returns a sortable rank for an agent's current status,
 // used by both Session.PrimaryAgent (deterministic pick for pipeline keys) and
 // the App-level focusLaunch auto-open pick. Order: Active > Waiting > Idle >

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3648,15 +3648,22 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 }
 
 // activeAgentCount returns the count of live non-shell agents across all repos.
-// Used to enforce the soft concurrent-agent limit in focus mode.
+// Used to enforce the soft concurrent-agent limit in focus mode. Excludes
+// agents that have already exited (Done/Error) so the limit reflects work in
+// flight, not historical sessions left visible for review.
 func (a *App) activeAgentCount() int {
 	count := 0
 	for _, mgr := range a.managers {
 		for _, sess := range mgr.ListSessions() {
 			for _, ag := range sess.Agents() {
-				if !ag.IsShell {
-					count++
+				if ag.IsShell {
+					continue
 				}
+				switch ag.Status() {
+				case agent.StatusDone, agent.StatusError:
+					continue
+				}
+				count++
 			}
 		}
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3648,24 +3648,14 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 }
 
 // activeAgentCount returns the count of live non-shell agents across all repos.
-// Used to enforce the soft concurrent-agent limit in focus mode. Excludes
-// agents that have already exited (Done/Error) so the limit reflects work in
-// flight, not historical sessions left visible for review.
+// Used to enforce the soft concurrent-agent limit in focus mode. Defers to
+// Manager.AgentCount, which already excludes shells and exited (Done/Error)
+// agents — keeping the "live" definition in one place so all three call sites
+// (quit guard, soft cap, repo-picker counts) can't drift apart.
 func (a *App) activeAgentCount() int {
 	count := 0
 	for _, mgr := range a.managers {
-		for _, sess := range mgr.ListSessions() {
-			for _, ag := range sess.Agents() {
-				if ag.IsShell {
-					continue
-				}
-				switch ag.Status() {
-				case agent.StatusDone, agent.StatusError:
-					continue
-				}
-				count++
-			}
-		}
+		count += mgr.AgentCount()
 	}
 	return count
 }


### PR DESCRIPTION
## Summary

- The quit confirmation warned \"agents running\" when only shells or already-exited Done/Error agents remained, because \`Manager.AgentCount\` returned \`len(s.agents)\`. Same bug inflated the \`MaxConcurrentAgents\` soft cap and the repo-picker counts.
- Added \`Session.LiveAgentCount()\` (non-shell, non-Done/Error) and routed \`Manager.AgentCount\` through it. \`Session.AgentCount()\` semantics are preserved — \`KillAgent\`'s auto-close guard (which removes the agent from the map first) still wants raw map size.
- \`App.activeAgentCount\` now also excludes Done/Error so the soft cap reflects work in flight, not historical sessions left visible for review.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`gofumpt -l .\` (clean)
- [x] \`golangci-lint run ./...\`
- [x] \`go test -race ./...\` (full repo green)
- [x] New \`TestManager_AgentCount_ExcludesExitedAgents\` pins the fix: spawn \`bash -c \"exit 1\"\`, await \`Done()\`, assert session retains the agent in its map (\`AgentCount==1\`) but \`Manager.AgentCount==0\` and \`Session.LiveAgentCount==0\`.
- [ ] Manual TUI: open 2 sessions, \`t\` to add a shell in one — repo picker shows 2, not 3; \`q\` after sessions are all dead/error — no \"agents running\" warning; spawn third agent only after two non-shell agents are *live* — warning still fires at the right threshold.

## Checklist

- [x] Updated changelog (fragment at \`changelog.d/fix-inflated-agent-counts.md\` per the repo convention)
- [x] New behavior has tests
- [x] No new public API surface beyond \`Session.LiveAgentCount\`, which is documented in its godoc