### PR TITLE
Pass planner question socket through the MCP server env map

### DIFF
--- a/changelog.d/fix-planner-question-mcp-env.md
+++ b/changelog.d/fix-planner-question-mcp-env.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Planner clarifying questions now actually surface in the plan editor. The `BATON_PLANNER_QUESTION_SOCKET` value is written into the MCP server entry's `env` map in `--mcp-config`, so the `baton planner-question-server` child receives the socket path regardless of how Claude Code manages env inheritance for MCP subprocess hosts. Previously the socket path was only set on the parent `claude` process, the MCP child dialed an empty path and exited silently, and `ask_user` failed as a tool error the planner moved past.

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -230,8 +230,14 @@ func buildClaudePlannerArgs(model, questionSocket string) []string {
 // plannerMCPConfigJSON renders the --mcp-config payload. With an empty
 // socket path it returns the canonical `{"mcpServers":{}}` shape required
 // by claude's strict validator. With a socket path it adds a single server
-// entry that re-execs the running baton binary as the question bridge; the
-// socket itself is passed via env on the parent so the child inherits it.
+// entry that re-execs the running baton binary as the question bridge.
+//
+// The socket path is also written into the server entry's env map so it
+// reaches the MCP child reliably. Setting it on the parent claude process
+// alone is not enough: Claude Code does not always forward its full env to
+// MCP subprocess hosts, and a missing BATON_PLANNER_QUESTION_SOCKET makes
+// the bridge exit silently — the planner then sees ask_user as a tool error
+// and moves past without surfacing the question to the editor.
 func plannerMCPConfigJSON(questionSocket string) string {
 	if questionSocket == "" {
 		return `{"mcpServers":{}}`
@@ -252,6 +258,9 @@ func plannerMCPConfigJSON(questionSocket string) string {
 			plannerQuestionMCPName: map[string]any{
 				"command": bin,
 				"args":    []string{"planner-question-server"},
+				"env": map[string]any{
+					PlannerQuestionSocketEnv: questionSocket,
+				},
 			},
 		},
 	}

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -289,7 +289,8 @@ func TestBuildClaudePlannerArgs_UsesSonnet(t *testing.T) {
 
 func TestBuildClaudePlannerArgs_WithQuestionSocketRegistersMCPServer(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
-	args := buildClaudePlannerArgs("", "/tmp/baton-q.sock")
+	const socketPath = "/tmp/baton-q.sock"
+	args := buildClaudePlannerArgs("", socketPath)
 
 	mcpIdx := -1
 	for i, a := range args {
@@ -320,6 +321,18 @@ func TestBuildClaudePlannerArgs_WithQuestionSocketRegistersMCPServer(t *testing.
 	gotArgs, _ := server["args"].([]any)
 	if !reflect.DeepEqual(gotArgs, wantArgs) {
 		t.Errorf("mcp server args = %v, want %v", gotArgs, wantArgs)
+	}
+
+	// The MCP server entry must explicitly carry the socket path in its env
+	// map so Claude Code passes it to the spawned MCP child regardless of
+	// how it manages parent-env inheritance for subprocess hosts.
+	env, ok := server["env"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcp server entry missing env map: %v", server)
+	}
+	gotSocket, _ := env[PlannerQuestionSocketEnv].(string)
+	if gotSocket != socketPath {
+		t.Errorf("mcp server env[%s] = %q, want %q", PlannerQuestionSocketEnv, gotSocket, socketPath)
 	}
 
 	// The fully-qualified ask_user tool name must be on the --tools allowlist.


### PR DESCRIPTION
## Summary

- The planner spawns `baton planner-question-server` as a stdio MCP child so the Sonnet drafter can call `ask_user` mid-plan; that child reads `BATON_PLANNER_QUESTION_SOCKET` to know which unix socket to dial back into baton. We were only setting it on the parent `claude` process env, on the assumption Claude Code forwards its full env to MCP subprocess hosts. It does not always — the child saw an empty path, exited silently, and the planner saw `ask_user` as a tool error. Clarifying questions never reached the plan editor.
- Fix: write the socket path into the MCP server entry's `env` field in the `--mcp-config` JSON, so the value reaches the child regardless of how Claude manages parent-env inheritance for MCP hosts.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean for changed files)
- [ ] `golangci-lint run ./...`
- [x] `go test ./internal/agent/ ./cmd/`
- [x] `go test -race ./...` (planner-MCP code path passes; pre-existing failures in `internal/config` legacy-XDG migration and `internal/hook` socket-path-length tests are unrelated and reproduce on `main` in this worktree)
- [ ] Manual TUI: start baton, create a planning session with a deliberately vague prompt (e.g. "add auth"), confirm the question modal appears in the plan editor, that `enter` submits and drafting resumes, and that `esc` skips and drafting resumes.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (added `changelog.d/fix-planner-question-mcp-env.md` fragment)
- [x] New behavior has tests (`TestBuildClaudePlannerArgs_WithQuestionSocketRegistersMCPServer` now asserts the env map carries the socket path)
- [x] No new public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)