### PR TITLE
Add --allowed-tools to planner subprocess so ask_user doesn't hit permission gate

### DIFF
--- a/changelog.d/fix-planner-allowed-tools.md
+++ b/changelog.d/fix-planner-allowed-tools.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Planner subprocess now passes `--allowed-tools` alongside `--tools` so `ask_user` (and `WebFetch`/`WebSearch`) are auto-approved in the non-interactive `-p` session. Previously `--tools` only controlled tool visibility; without `--allowed-tools` the permission gate blocked the MCP call and the planner silently skipped clarifying questions.

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -215,12 +215,17 @@ func buildClaudePlannerArgs(model, questionSocket string) []string {
 		tools += "," + plannerQuestionToolName
 	}
 
+	// --tools filters which tools are visible (keeps Bash/Edit/Write hidden even
+	// if Claude's default set expands). --allowed-tools auto-approves those same
+	// tools so the non-interactive -p subprocess never hits a permission gate.
+	// Both flags are required: --tools alone only controls availability, not approval.
 	args = append(
 		args,
 		"--strict-mcp-config", "--mcp-config", mcpConfig,
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--tools", tools,
+		"--allowed-tools", tools,
 		"--setting-sources", "user,project",
 		"--exclude-dynamic-system-prompt-sections",
 	)

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -251,6 +251,7 @@ func TestBuildClaudePlannerArgs_UsesSonnet(t *testing.T) {
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--tools Read,Grep,Glob,LS,LSP,WebFetch,WebSearch",
+		"--allowed-tools Read,Grep,Glob,LS,LSP,WebFetch,WebSearch",
 		"--setting-sources user,project",
 	} {
 		if !strings.Contains(joined, want) {
@@ -335,19 +336,22 @@ func TestBuildClaudePlannerArgs_WithQuestionSocketRegistersMCPServer(t *testing.
 		t.Errorf("mcp server env[%s] = %q, want %q", PlannerQuestionSocketEnv, gotSocket, socketPath)
 	}
 
-	// The fully-qualified ask_user tool name must be on the --tools allowlist.
-	toolsIdx := -1
-	for i, a := range args {
-		if a == "--tools" {
-			toolsIdx = i
-			break
+	// The fully-qualified ask_user tool name must appear on both --tools and
+	// --allowed-tools so it is both exposed and auto-approved.
+	for _, flag := range []string{"--tools", "--allowed-tools"} {
+		idx := -1
+		for i, a := range args {
+			if a == flag {
+				idx = i
+				break
+			}
 		}
-	}
-	if toolsIdx < 0 || toolsIdx+1 >= len(args) {
-		t.Fatalf("argv missing --tools value")
-	}
-	if !strings.Contains(args[toolsIdx+1], plannerQuestionToolName) {
-		t.Errorf("--tools missing %q; got %q", plannerQuestionToolName, args[toolsIdx+1])
+		if idx < 0 || idx+1 >= len(args) {
+			t.Fatalf("argv missing %s value", flag)
+		}
+		if !strings.Contains(args[idx+1], plannerQuestionToolName) {
+			t.Errorf("%s missing %q; got %q", flag, plannerQuestionToolName, args[idx+1])
+		}
 	}
 }
 
@@ -368,18 +372,20 @@ func TestBuildClaudePlannerArgs_EmptySocketKeepsZeroServers(t *testing.T) {
 		t.Errorf("--mcp-config = %q, want canonical empty payload", args[mcpIdx+1])
 	}
 
-	toolsIdx := -1
-	for i, a := range args {
-		if a == "--tools" {
-			toolsIdx = i
-			break
+	for _, flag := range []string{"--tools", "--allowed-tools"} {
+		idx := -1
+		for i, a := range args {
+			if a == flag {
+				idx = i
+				break
+			}
 		}
-	}
-	if toolsIdx < 0 || toolsIdx+1 >= len(args) {
-		t.Fatalf("argv missing --tools value")
-	}
-	if strings.Contains(args[toolsIdx+1], "ask_user") {
-		t.Errorf("--tools should NOT include ask_user when socket is empty; got %q", args[toolsIdx+1])
+		if idx < 0 || idx+1 >= len(args) {
+			t.Fatalf("argv missing %s value", flag)
+		}
+		if strings.Contains(args[idx+1], "ask_user") {
+			t.Errorf("%s should NOT include ask_user when socket is empty; got %q", flag, args[idx+1])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- The planner subprocess (`claude -p`) was already passing `--tools` to filter which tools are visible, but `--tools` only controls availability — it does **not** auto-approve them. In a non-interactive `-p` session, any tool not on Claude's default safe list hits the interactive permission gate, which can never be satisfied, so `ask_user` (and `WebFetch`/`WebSearch`) calls were silently aborted.
- Added `--allowed-tools` with the same comma-separated list alongside `--tools`. This auto-approves those tools so the planner can actually call `ask_user` to surface clarifying questions and use `WebFetch`/`WebSearch` without stalling.
- `--tools` is kept in addition to `--allowed-tools` so Bash/Edit/Write remain invisible even if Claude's default tool set expands in the future.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: start a session with a deliberately ambiguous prompt (e.g. "make the dashboard better"), confirm the planner question editor surfaces a clarifying question and the typed answer reaches the model.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — added `changelog.d/fix-planner-allowed-tools.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description