### PR TITLE
Surface TodoWrite task progress on Building session cards

### DIFF
--- a/changelog.d/todo-progress-on-building-cards.md
+++ b/changelog.d/todo-progress-on-building-cards.md
@@ -1,0 +1,3 @@
+### Added
+
+- Building-phase session cards now surface TodoWrite progress at a glance. When a Claude agent calls `TodoWrite`, the dashboard card shows a `▸ done/total · N active` progress badge on line 1 (replacing the generic "N active, M idle" count) and the current in-progress task's active description on line 2, with the next pending task on line 3. Error and waiting status conditions still preempt the progress badge. Sessions without any TodoWrite events render unchanged.

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -69,13 +69,15 @@ func runHook(cmd *cobra.Command, args []string) error {
 
 	// Parse just the fields we route on; keep the rest in Raw so the server
 	// can inspect extras if it cares later. `message` is only populated by
-	// Notification payloads; `prompt` only by UserPromptSubmit — other kinds
-	// leave them empty.
+	// Notification payloads; `prompt` only by UserPromptSubmit; `tool_name`
+	// and `tool_input` only by PreToolUse — other kinds leave them empty.
 	var payload struct {
-		SessionID string `json:"session_id"`
-		CWD       string `json:"cwd"`
-		Message   string `json:"message"`
-		Prompt    string `json:"prompt"`
+		SessionID string          `json:"session_id"`
+		CWD       string          `json:"cwd"`
+		Message   string          `json:"message"`
+		Prompt    string          `json:"prompt"`
+		ToolName  string          `json:"tool_name"`
+		ToolInput json.RawMessage `json:"tool_input"`
 	}
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &payload); err != nil {
@@ -94,6 +96,10 @@ func runHook(cmd *cobra.Command, args []string) error {
 	}
 	if kind == hook.KindUserPromptSubmit {
 		e.Prompt = payload.Prompt
+	}
+	if kind == hook.KindPreToolUse {
+		e.ToolName = payload.ToolName
+		e.ToolInput = payload.ToolInput
 	}
 
 	if err := hook.SendEvent(socketPath, e); err != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,6 +16,13 @@ import (
 	bpty "github.com/devenjarvis/baton/internal/pty"
 	"github.com/devenjarvis/baton/internal/vt"
 )
+
+// TodoItem represents a single entry from a TodoWrite tool call.
+type TodoItem struct {
+	Content    string `json:"content"`
+	Status     string `json:"status"`
+	ActiveForm string `json:"activeForm"`
+}
 
 // Agent ties together a PTY and VT terminal into a managed unit.
 // Agents do not own worktrees — sessions do.
@@ -43,6 +51,9 @@ type Agent struct {
 	chimedForTurn    bool
 	sessionStartedAt time.Time
 	cleanExit        bool
+
+	todos          []TodoItem
+	todosUpdatedAt time.Time
 
 	done          chan struct{}
 	writeLoopDone chan struct{}
@@ -526,11 +537,23 @@ func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
 			return false
 		}
 		a.waitingReason = ""
+		todosChanged := false
+		if e.ToolName == "TodoWrite" && len(e.ToolInput) > 0 {
+			var inp struct {
+				Todos []TodoItem `json:"todos"`
+			}
+			if err := json.Unmarshal(e.ToolInput, &inp); err == nil {
+				a.todos = make([]TodoItem, len(inp.Todos))
+				copy(a.todos, inp.Todos)
+				a.todosUpdatedAt = time.Now()
+				todosChanged = true
+			}
+		}
 		if a.status != StatusActive {
 			a.status = StatusActive
 			return true
 		}
-		return false
+		return todosChanged
 	}
 	return false
 }
@@ -798,4 +821,34 @@ func (a *Agent) SetClaudeName(v bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.hasClaudeName = v
+}
+
+// Todos returns a snapshot of the agent's current todo list. Returns nil when
+// no TodoWrite has been received yet.
+func (a *Agent) Todos() []TodoItem {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if len(a.todos) == 0 {
+		return nil
+	}
+	out := make([]TodoItem, len(a.todos))
+	copy(out, a.todos)
+	return out
+}
+
+// SetTodos replaces the agent's todo list and records the update timestamp.
+func (a *Agent) SetTodos(items []TodoItem) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.todos = make([]TodoItem, len(items))
+	copy(a.todos, items)
+	a.todosUpdatedAt = time.Now()
+}
+
+// TodosUpdatedAt returns the time of the most recent SetTodos call, or the
+// zero value if no TodoWrite has been received.
+func (a *Agent) TodosUpdatedAt() time.Time {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.todosUpdatedAt
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -424,12 +424,12 @@ func (a *Agent) writeLoop() {
 }
 
 // OnHookEvent applies a Claude Code hook event to the agent's state.
-// Returns true if the agent's status changed as a result (so the manager
-// can emit EventStatusChanged).
+// Returns true if any display-relevant state changed (status or todos), so
+// the manager can emit EventStatusChanged to trigger a TUI repaint.
 //
 // Status transitions driven here replace the old statusLoop heuristic —
 // Claude's SessionStart/Stop/SessionEnd events are the authoritative signal.
-func (a *Agent) OnHookEvent(e hook.Event) (statusChanged bool) {
+func (a *Agent) OnHookEvent(e hook.Event) (changed bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -913,3 +913,99 @@ func TestSetTodos_GetTodos(t *testing.T) {
 		t.Error("Todos() should return a copy, not a reference to internal slice")
 	}
 }
+
+// TestOnHookEvent_TodoWrite_FromWaiting verifies that a PreToolUse/TodoWrite
+// when the agent is StatusWaiting (permission prompt just approved) transitions
+// the agent to Active AND sets todos.
+func TestOnHookEvent_TodoWrite_FromWaiting(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-todo-waiting", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Drive to Waiting via SessionStart + Notification.
+	a.OnHookEvent(hook.Event{Kind: hook.KindSessionStart, AgentID: a.ID})
+	a.OnHookEvent(hook.Event{Kind: hook.KindNotification, AgentID: a.ID, Message: "needs permission"})
+	if s := a.Status(); s != StatusWaiting {
+		t.Fatalf("expected Waiting before TodoWrite, got %s", s)
+	}
+
+	toolInput, _ := json.Marshal(map[string]any{
+		"todos": []map[string]any{
+			{"content": "build feature", "status": "in_progress", "activeForm": "Building feature"},
+		},
+	})
+	changed := a.OnHookEvent(hook.Event{
+		Kind:      hook.KindPreToolUse,
+		AgentID:   a.ID,
+		ToolName:  "TodoWrite",
+		ToolInput: json.RawMessage(toolInput),
+	})
+
+	if !changed {
+		t.Error("expected changed=true (status transition Waiting→Active)")
+	}
+	if s := a.Status(); s != StatusActive {
+		t.Errorf("expected Active after PreToolUse/TodoWrite from Waiting, got %s", s)
+	}
+	todos := a.Todos()
+	if len(todos) != 1 || todos[0].ActiveForm != "Building feature" {
+		t.Errorf("expected todos set from TodoWrite payload, got %+v", todos)
+	}
+}
+
+// TestOnHookEvent_TodoWrite_IgnoredOnDoneAgent verifies that a PreToolUse/TodoWrite
+// arriving after an agent has exited does not update its todo list.
+func TestOnHookEvent_TodoWrite_IgnoredOnDoneAgent(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-todo-done", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		// Exit immediately so the agent reaches StatusDone.
+		return exec.Command("bash", "-c", "exit 0")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the agent to exit naturally.
+	select {
+	case <-a.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for agent to exit")
+	}
+	if s := a.Status(); s != StatusDone {
+		t.Fatalf("expected Done after clean exit, got %s", s)
+	}
+
+	toolInput, _ := json.Marshal(map[string]any{
+		"todos": []map[string]any{
+			{"content": "late todo", "status": "in_progress", "activeForm": "Late"},
+		},
+	})
+	changed := a.OnHookEvent(hook.Event{
+		Kind:      hook.KindPreToolUse,
+		AgentID:   a.ID,
+		ToolName:  "TodoWrite",
+		ToolInput: json.RawMessage(toolInput),
+	})
+
+	if changed {
+		t.Error("expected changed=false for Done agent")
+	}
+	if len(a.Todos()) != 0 {
+		t.Errorf("expected no todos set on Done agent, got %+v", a.Todos())
+	}
+	if a.Status() != StatusDone {
+		t.Errorf("expected status to remain Done, got %s", a.Status())
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"strings"
@@ -792,5 +793,123 @@ func TestUserPromptSubmitClearsAskingQuestion(t *testing.T) {
 
 	if a.AskingQuestion() {
 		t.Error("expected AskingQuestion cleared after KindUserPromptSubmit")
+	}
+}
+
+// TestOnHookEvent_TodoWrite verifies that a PreToolUse event for TodoWrite
+// unmarshals the tool_input.todos array and stores it on the agent.
+func TestOnHookEvent_TodoWrite(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-todo-write", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed the agent as Active so the PreToolUse guard passes.
+	a.OnHookEvent(hook.Event{Kind: hook.KindSessionStart, AgentID: a.ID})
+
+	toolInput, _ := json.Marshal(map[string]any{
+		"todos": []map[string]any{
+			{"content": "write tests", "status": "in_progress", "activeForm": "Writing tests"},
+			{"content": "ship feature", "status": "pending", "activeForm": ""},
+		},
+	})
+
+	changed := a.OnHookEvent(hook.Event{
+		Kind:      hook.KindPreToolUse,
+		AgentID:   a.ID,
+		ToolName:  "TodoWrite",
+		ToolInput: json.RawMessage(toolInput),
+	})
+
+	if !changed {
+		t.Error("expected OnHookEvent to return true (repaint needed) after TodoWrite")
+	}
+
+	todos := a.Todos()
+	if len(todos) != 2 {
+		t.Fatalf("expected 2 todos, got %d", len(todos))
+	}
+	if todos[0].Status != "in_progress" {
+		t.Errorf("todos[0].Status: got %q, want %q", todos[0].Status, "in_progress")
+	}
+	if todos[0].ActiveForm != "Writing tests" {
+		t.Errorf("todos[0].ActiveForm: got %q, want %q", todos[0].ActiveForm, "Writing tests")
+	}
+	if todos[1].Content != "ship feature" {
+		t.Errorf("todos[1].Content: got %q, want %q", todos[1].Content, "ship feature")
+	}
+	if a.TodosUpdatedAt().IsZero() {
+		t.Error("expected TodosUpdatedAt to be set after TodoWrite")
+	}
+}
+
+// TestOnHookEvent_TodoWrite_NonTodoWritePreToolUse verifies that a PreToolUse
+// for a different tool does not populate todos.
+func TestOnHookEvent_TodoWrite_NonTodoWritePreToolUse(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "test-non-todo", Task: "test", Rows: 24, Cols: 80}
+	a, err := mgr.CreateWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a.OnHookEvent(hook.Event{Kind: hook.KindSessionStart, AgentID: a.ID})
+	a.OnHookEvent(hook.Event{
+		Kind:      hook.KindPreToolUse,
+		AgentID:   a.ID,
+		ToolName:  "Bash",
+		ToolInput: json.RawMessage(`{"command":"ls"}`),
+	})
+
+	if todos := a.Todos(); len(todos) != 0 {
+		t.Errorf("expected no todos for non-TodoWrite tool, got %d", len(todos))
+	}
+}
+
+// TestSetTodos_GetTodos verifies the Todos/SetTodos/TodosUpdatedAt round-trip
+// without needing the hook path.
+func TestSetTodos_GetTodos(t *testing.T) {
+	a := &Agent{}
+
+	if got := a.Todos(); got != nil {
+		t.Errorf("expected nil todos before SetTodos, got %v", got)
+	}
+	if !a.TodosUpdatedAt().IsZero() {
+		t.Error("expected zero TodosUpdatedAt before SetTodos")
+	}
+
+	items := []TodoItem{
+		{Content: "task one", Status: "in_progress", ActiveForm: "Doing task one"},
+		{Content: "task two", Status: "pending", ActiveForm: ""},
+	}
+	a.SetTodos(items)
+
+	got := a.Todos()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 todos, got %d", len(got))
+	}
+	if got[0].Content != items[0].Content || got[0].ActiveForm != items[0].ActiveForm {
+		t.Errorf("todos[0] mismatch: got %+v, want %+v", got[0], items[0])
+	}
+	if a.TodosUpdatedAt().IsZero() {
+		t.Error("expected non-zero TodosUpdatedAt after SetTodos")
+	}
+
+	// Verify the returned slice is a copy (mutation doesn't affect agent state).
+	got[0].Content = "mutated"
+	if a.Todos()[0].Content == "mutated" {
+		t.Error("Todos() should return a copy, not a reference to internal slice")
 	}
 }

--- a/internal/hook/event.go
+++ b/internal/hook/event.go
@@ -26,9 +26,10 @@ const (
 // supplied by the CLI wrapper from the BATON_AGENT_ID environment variable
 // so the server can dispatch to the right agent. Message is populated from
 // Notification payloads (empty for other kinds). Prompt is populated from
-// UserPromptSubmit payloads (empty for other kinds). Raw preserves the original
-// Claude JSON for forward-compatibility with fields the server doesn't
-// currently consume.
+// UserPromptSubmit payloads (empty for other kinds). ToolName and ToolInput
+// are populated from PreToolUse payloads (empty for other kinds). Raw preserves
+// the original Claude JSON for forward-compatibility with fields the server
+// doesn't currently consume.
 type Event struct {
 	Kind      Kind            `json:"kind"`
 	AgentID   string          `json:"agent_id"`
@@ -36,5 +37,7 @@ type Event struct {
 	CWD       string          `json:"cwd,omitempty"`
 	Message   string          `json:"message,omitempty"`
 	Prompt    string          `json:"prompt,omitempty"`
+	ToolName  string          `json:"tool_name,omitempty"`
+	ToolInput json.RawMessage `json:"tool_input,omitempty"`
 	Raw       json.RawMessage `json:"raw,omitempty"`
 }

--- a/internal/hook/server_test.go
+++ b/internal/hook/server_test.go
@@ -1,6 +1,7 @@
 package hook
 
 import (
+	"encoding/json"
 	"net"
 	"os"
 	"path/filepath"
@@ -132,6 +133,43 @@ func TestServerClosesEventsChannel(t *testing.T) {
 	_, ok := <-srv.Events()
 	if ok {
 		t.Error("expected events channel to be closed")
+	}
+}
+
+// TestPreToolUseRoundTrip verifies that ToolName and ToolInput survive the
+// JSON marshal/unmarshal path through the hook server.
+func TestPreToolUseRoundTrip(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "hook.sock")
+	srv, err := NewServer(socketPath)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	toolInput := json.RawMessage(`{"todos":[{"content":"write tests","status":"in_progress","activeForm":"Writing tests"}]}`)
+	want := Event{
+		Kind:      KindPreToolUse,
+		AgentID:   "session-1-agent-1",
+		ToolName:  "TodoWrite",
+		ToolInput: toolInput,
+	}
+	if err := SendEvent(socketPath, want); err != nil {
+		t.Fatalf("SendEvent: %v", err)
+	}
+
+	select {
+	case got := <-srv.Events():
+		if got.Kind != want.Kind {
+			t.Errorf("Kind: got %q, want %q", got.Kind, want.Kind)
+		}
+		if got.ToolName != want.ToolName {
+			t.Errorf("ToolName: got %q, want %q", got.ToolName, want.ToolName)
+		}
+		if string(got.ToolInput) != string(want.ToolInput) {
+			t.Errorf("ToolInput: got %q, want %q", got.ToolInput, want.ToolInput)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for event")
 	}
 }
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -800,7 +800,7 @@ func buildingProgressBadge(todos []agent.TodoItem, activeCount int) string {
 // active task's activeForm and line2 shows the next pending task. Otherwise
 // the text is word-wrapped into two lines by wrapTwoLines.
 func focusTaskDescription(sess *agent.Session, budget int) (line1, line2 string, pending bool) {
-	if sess.LifecyclePhase() == agent.LifecycleInProgress {
+	if sess.LifecyclePhase() == agent.LifecycleInProgress && !sess.IsReviewable() {
 		if ag := sess.PrimaryAgent(); ag != nil {
 			todos := ag.Todos()
 			if len(todos) > 0 {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -459,6 +459,13 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 	if !sess.DoneAt().IsZero() {
 		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ finished — awaiting prompt")
 	}
+	if sess.LifecyclePhase() == agent.LifecycleInProgress {
+		if ag := sess.PrimaryAgent(); ag != nil {
+			if badge := buildingProgressBadge(ag.Todos(), activeCount); badge != "" {
+				return badge
+			}
+		}
+	}
 	return StyleSubtle.Render(fmt.Sprintf("%d active, %d idle", activeCount, idleCount))
 }
 
@@ -578,14 +585,15 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	if descBudget < 1 {
 		descBudget = 1
 	}
-	var descText string
+	var descLine1, descLine2 string
 	var descPending bool
 	if planningPhase {
+		var descText string
 		descText, descPending = planningDescription(sess)
+		descLine1, descLine2 = wrapTwoLines(descText, descBudget)
 	} else {
-		descText, descPending = focusTaskDescription(sess)
+		descLine1, descLine2, descPending = focusTaskDescription(sess, descBudget)
 	}
-	descLine1, descLine2 := wrapTwoLines(descText, descBudget)
 	descStyle := StyleSubtle
 	if descPending {
 		descStyle = lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
@@ -763,22 +771,86 @@ func firstUncompletedTask(plan string) string {
 	return ""
 }
 
-// focusTaskDescription chooses the description string for a session card in
-// focus mode and reports whether it should render in pending (italic) style.
-// Mirrors the legacy renderFocusSessionCard switch so callers stay consistent
-// with sessionFocusStatus regarding which signal wins.
-func focusTaskDescription(sess *agent.Session) (text string, pending bool) {
+// buildingProgressBadge returns a styled "▸ done/total · N active" badge for
+// a Building-phase session that has received ≥1 TodoWrite. Returns "" when
+// todos is empty so the caller can fall back to the normal "N active, M idle"
+// string. Status conditions (error/waiting/asking) must preempt this badge —
+// the caller is responsible for that guard.
+func buildingProgressBadge(todos []agent.TodoItem, activeCount int) string {
+	if len(todos) == 0 {
+		return ""
+	}
+	total := len(todos)
+	done := 0
+	for _, t := range todos {
+		if t.Status == "completed" {
+			done++
+		}
+	}
+	badge := fmt.Sprintf("▸ %d/%d", done, total)
+	if activeCount > 0 {
+		badge += fmt.Sprintf(" · %d active", activeCount)
+	}
+	return StyleSubtle.Render(badge)
+}
+
+// focusTaskDescription chooses the description lines for a session card in
+// focus mode and reports whether they should render in pending (italic) style.
+// For Building-phase sessions that have received ≥1 TodoWrite, line1 shows the
+// active task's activeForm and line2 shows the next pending task. Otherwise
+// the text is word-wrapped into two lines by wrapTwoLines.
+func focusTaskDescription(sess *agent.Session, budget int) (line1, line2 string, pending bool) {
+	if sess.LifecyclePhase() == agent.LifecycleInProgress {
+		if ag := sess.PrimaryAgent(); ag != nil {
+			todos := ag.Todos()
+			if len(todos) > 0 {
+				var activeText, nextPending string
+				for _, t := range todos {
+					if t.Status == "in_progress" {
+						activeText = t.ActiveForm
+						if activeText == "" {
+							activeText = t.Content
+						}
+						break
+					}
+				}
+				for _, t := range todos {
+					if t.Status == "pending" {
+						nextPending = t.Content
+						break
+					}
+				}
+				if activeText == "" && nextPending != "" {
+					activeText = nextPending
+					nextPending = ""
+				}
+				if activeText != "" {
+					l1 := truncateVisible("▸ "+activeText, budget)
+					var l2 string
+					if nextPending != "" {
+						l2 = truncateVisible("next: "+nextPending, budget)
+					}
+					return l1, l2, false
+				}
+			}
+		}
+	}
+
 	origPrompt := sess.OriginalPrompt()
+	var text string
+	var pend bool
 	switch {
 	case sess.HasTaskSummary() && sess.TaskSummary() != "":
-		return sess.TaskSummary(), false
+		text, pend = sess.TaskSummary(), false
 	case sess.HasTaskSummary() && sess.TaskSummary() == "":
-		return origPrompt, false
+		text, pend = origPrompt, false
 	case !sess.HasTaskSummary() && origPrompt != "":
-		return origPrompt, true
+		text, pend = origPrompt, true
 	default:
-		return "…", false
+		text, pend = "…", false
 	}
+	l1, l2 := wrapTwoLines(text, budget)
+	return l1, l2, pend
 }
 
 // wrapTwoLines greedily word-wraps s into at most two lines of `budget`

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -359,6 +359,31 @@ func TestFocusTaskDescription_WithoutTodos(t *testing.T) {
 	}
 }
 
+// TestFocusTaskDescription_ReviewableFallsThrough verifies that stale todos
+// do not surface on lines 2-3 when the session IsReviewable (all agents Idle).
+// The badge on line 1 already shows "✓ idle — press m to review" in that state,
+// so todo lines would be contradictory.
+func TestFocusTaskDescription_ReviewableFallsThrough(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "my-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	sess.SetTaskSummary("implement oauth flow")
+	// Agent is Idle → IsReviewable() == true.
+	ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
+	ag.SetTodos([]agent.TodoItem{
+		{Content: "stale task", Status: "in_progress", ActiveForm: "Stale active work"},
+	})
+
+	line1, line2, _ := focusTaskDescription(sess, 80)
+	// Must NOT show the in_progress todo text.
+	if strings.Contains(line1, "Stale active work") || strings.Contains(line2, "Stale active work") {
+		t.Errorf("expected todo description suppressed for reviewable session, got line1=%q line2=%q", line1, line2)
+	}
+	// Should fall back to the task summary.
+	if !strings.Contains(line1, "implement oauth flow") {
+		t.Errorf("expected task summary fallback when reviewable, got %q", line1)
+	}
+}
+
 // TestRenderQueueRow_RepoPrefix verifies the same cross-repo disambiguation
 // for the REVIEWING / SHIPPING sections. renderQueueRow has independent
 // rendering from renderFocusSessionCard, so it needs its own coverage to

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -208,6 +208,157 @@ func TestRenderFocusSessionCard_RepoPrefix(t *testing.T) {
 	}
 }
 
+// TestBuildingProgressBadge verifies the badge string for various todo states.
+func TestBuildingProgressBadge(t *testing.T) {
+	tests := []struct {
+		name        string
+		todos       []agent.TodoItem
+		activeCount int
+		wantEmpty   bool
+		wantSubstr  string
+	}{
+		{
+			name:      "no todos returns empty",
+			todos:     nil,
+			wantEmpty: true,
+		},
+		{
+			name:        "2/5 with 1 active",
+			todos:       makeTodos(5, 2),
+			activeCount: 1,
+			wantSubstr:  "2/5",
+		},
+		{
+			name:        "active count included",
+			todos:       makeTodos(3, 0),
+			activeCount: 2,
+			wantSubstr:  "2 active",
+		},
+		{
+			name:        "no active count omitted when zero",
+			todos:       makeTodos(3, 1),
+			activeCount: 0,
+			wantSubstr:  "1/3",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildingProgressBadge(tc.todos, tc.activeCount)
+			if tc.wantEmpty {
+				if got != "" {
+					t.Errorf("expected empty badge, got %q", got)
+				}
+				return
+			}
+			plain := ansi.Strip(got)
+			if !strings.Contains(plain, tc.wantSubstr) {
+				t.Errorf("expected badge to contain %q, got %q", tc.wantSubstr, plain)
+			}
+		})
+	}
+}
+
+// makeTodos builds a slice of n TodoItems with done of them marked completed.
+func makeTodos(n, done int) []agent.TodoItem {
+	items := make([]agent.TodoItem, n)
+	for i := range items {
+		if i < done {
+			items[i] = agent.TodoItem{Content: "task", Status: "completed"}
+		} else {
+			items[i] = agent.TodoItem{Content: "task", Status: "pending"}
+		}
+	}
+	return items
+}
+
+// TestSessionFocusStatus_BuildingWithTodosShowsProgressBadge verifies that
+// sessionFocusStatus shows a "▸ done/total" progress badge for a Building
+// session that has received ≥1 TodoWrite, instead of the plain "N active, M idle".
+func TestSessionFocusStatus_BuildingWithTodosShowsProgressBadge(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "my-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+	ag.SetTodos([]agent.TodoItem{
+		{Content: "step one", Status: "completed", ActiveForm: ""},
+		{Content: "step two", Status: "in_progress", ActiveForm: "Doing step two"},
+		{Content: "step three", Status: "pending", ActiveForm: ""},
+	})
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	if !strings.Contains(badge, "1/3") {
+		t.Errorf("expected progress badge with 1/3, got %q", badge)
+	}
+	if strings.Contains(badge, "active, ") {
+		t.Errorf("expected progress badge to replace 'N active, M idle', got %q", badge)
+	}
+}
+
+// TestSessionFocusStatus_BuildingWithTodosErrorPreempts verifies that error
+// status still preempts the todo progress badge.
+func TestSessionFocusStatus_BuildingWithTodosErrorPreempts(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "my-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("a-1", false, agent.StatusError)
+	ag.SetTodos([]agent.TodoItem{
+		{Content: "step one", Status: "in_progress", ActiveForm: "Doing step one"},
+	})
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	if !strings.Contains(badge, "error") {
+		t.Errorf("expected error badge to preempt todos, got %q", badge)
+	}
+}
+
+// TestFocusTaskDescription_WithTodos verifies that focusTaskDescription returns
+// the in_progress todo's activeForm on line1 and the first pending todo on line2.
+func TestFocusTaskDescription_WithTodos(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "my-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+	ag.SetTodos([]agent.TodoItem{
+		{Content: "write unit tests", Status: "in_progress", ActiveForm: "Writing unit tests"},
+		{Content: "open PR", Status: "pending", ActiveForm: ""},
+	})
+	// PrimaryAgent() reads from session's agents map.
+	_ = ag
+
+	line1, line2, pending := focusTaskDescription(sess, 80)
+	if !strings.Contains(line1, "Writing unit tests") {
+		t.Errorf("line1 should contain active todo activeForm, got %q", line1)
+	}
+	if !strings.Contains(line2, "open PR") {
+		t.Errorf("line2 should contain next pending todo, got %q", line2)
+	}
+	if pending {
+		t.Error("expected pending=false for todo-driven description")
+	}
+}
+
+// TestFocusTaskDescription_WithoutTodos verifies that focusTaskDescription
+// falls back to the task summary / original prompt when no todos are present.
+func TestFocusTaskDescription_WithoutTodos(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "my-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	sess.SetTaskSummary("implement oauth flow")
+
+	line1, _, _ := focusTaskDescription(sess, 80)
+	if !strings.Contains(line1, "implement oauth flow") {
+		t.Errorf("expected task summary fallback, got %q", line1)
+	}
+}
+
 // TestRenderQueueRow_RepoPrefix verifies the same cross-repo disambiguation
 // for the REVIEWING / SHIPPING sections. renderQueueRow has independent
 // rendering from renderFocusSessionCard, so it needs its own coverage to


### PR DESCRIPTION
## Summary

- Building-phase session cards now show a \`▸ done/total · N active\` progress badge (line 1, right side) when the agent has called \`TodoWrite\` at least once — replaces the generic "N active, M idle" count for those rows. Error and waiting status conditions still preempt the badge.
- Line 2 of the card shows the current in-progress task's active description (\`▸ <activeForm>\`); line 3 shows the next pending task (\`next: <content>\`). Falls back to today's task-summary / original-prompt behavior when no \`TodoWrite\` has fired.
- Wires up the \`PreToolUse\` hook for real: \`hook.Event\` now carries \`ToolName\` and \`ToolInput\` (populated by \`cmd/hook.go\` for \`pre-tool-use\` payloads), and \`Agent.OnHookEvent\` unmarshals the todo list when \`ToolName == "TodoWrite"\`.
- Planning / Reviewing / Shipping cards and non-Claude agents with no hooks are unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [x] `go test -race ./...` (3 pre-existing failures in `internal/config` and `internal/hook/server.go` on `main`; all new tests pass)
- [x] Manual TUI: spawn a Building agent → run TodoWrite in the session → card shows `▸ 1/3` badge and current task on line 2

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — fragment added under `changelog.d/`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description — `TodoItem`, `Todos()`, `SetTodos()`, `TodosUpdatedAt()` are new exported symbols on `Agent`