### PR TITLE
Rebuild REVIEWING phase as plan-driven task-by-task review surface

### DIFF
--- a/changelog.d/plan-driven-review-panel.md
+++ b/changelog.d/plan-driven-review-panel.md
@@ -1,0 +1,11 @@
+### Added
+
+- Review panel now shows a per-task task list when the session has a plan, mapping each `[task N]` commit group to its plan task with commit counts, insertion/deletion counts, and a verdict badge.
+- A Sonnet reviewer subprocess runs automatically for each task group when the review panel opens, producing a `pass` / `concerns` / `fail` verdict with a one-sentence rationale. The reviewer model is configurable via `reviewer_model` in global or per-repo config.
+- `enter` / `space` on a task row opens the existing diff browser filtered to that task's commits; `esc` returns to the task list.
+- `j` / `k` navigate the task list rows.
+- Sessions without a plan still show the aggregate file-centric view.
+
+### Changed
+
+- `renderReviewPanel` now accepts cursor, width, and height parameters; the review panel renders as a scrollable task list rather than a split file/shape view when plan data is available.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -76,6 +76,7 @@ type Manager struct {
 	branchNamer    BranchNamer
 	taskSummarizer TaskSummarizer
 	planDrafter    PlanDrafter
+	reviewerAgent  ReviewerAgent
 
 	// plannerQuestions aggregates ask_user calls from every in-flight draft's
 	// per-session question server. The TUI App reads from PlannerQuestions()
@@ -149,6 +150,7 @@ func NewManager(repoPath string, settings config.ResolvedSettings) *Manager {
 		branchNamer:      DefaultBranchNamer(),
 		taskSummarizer:   DefaultTaskSummarizer(),
 		planDrafter:      DefaultPlanDrafter(settings.PlanModel),
+		reviewerAgent:    DefaultReviewerAgent(settings.ReviewerModel),
 		plannerQuestions: make(chan PlannerQuestion, 8),
 	}
 
@@ -204,6 +206,22 @@ func (m *Manager) SetPlanDrafter(p PlanDrafter) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.planDrafter = p
+}
+
+// SetReviewerAgent overrides the ReviewerAgent used for per-task code review
+// subprocesses. Intended for tests so they can stub out the Sonnet subprocess.
+// Safe to call while the manager is running — the agent is swapped atomically.
+func (m *Manager) SetReviewerAgent(r ReviewerAgent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reviewerAgent = r
+}
+
+// ReviewerAgent returns the current ReviewerAgent under a read lock.
+func (m *Manager) ReviewerAgent() ReviewerAgent {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.reviewerAgent
 }
 
 // getTaskSummarizer returns the current TaskSummarizer under a read lock.

--- a/internal/agent/reviewer.go
+++ b/internal/agent/reviewer.go
@@ -96,24 +96,18 @@ func buildReviewPrompt(req ReviewRequest) string {
 	return fmt.Sprintf(reviewPromptTemplate, prompt, req.TaskIndex, req.TaskText, diff)
 }
 
-func (r *defaultReviewerAgent) Review(ctx context.Context, req ReviewRequest) (ReviewVerdict, error) {
-	claudePath, err := exec.LookPath("claude")
-	if err != nil {
-		return ReviewVerdict{}, fmt.Errorf("%w: %v", ErrClaudeNotFound, err)
-	}
-
-	model := r.model
-	if model == "" {
-		model = config.DefaultReviewerModel
-	}
-
+// buildReviewerArgs returns the argv (excluding the binary path) for the
+// reviewer subprocess. Mirrors buildClaudeHaikuArgs / buildClaudePlannerArgs:
+// read-only tools only, no MCP servers, no session persistence. --bare is
+// added when ANTHROPIC_API_KEY is set (disables hooks, keychain reads, etc.).
+func buildReviewerArgs(model string) []string {
 	args := []string{"-p", "--model", model}
 	if os.Getenv("ANTHROPIC_API_KEY") != "" {
 		args = append(args, "--bare")
 	}
-	// Read-only tools only — the reviewer inspects code, it does not write it.
 	tools := "Read,Grep,Glob,LS"
-	args = append(args,
+	args = append(
+		args,
 		"--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`,
 		"--disable-slash-commands",
 		"--no-session-persistence",
@@ -122,8 +116,16 @@ func (r *defaultReviewerAgent) Review(ctx context.Context, req ReviewRequest) (R
 		"--setting-sources", "user,project",
 		"--exclude-dynamic-system-prompt-sections",
 	)
+	return args
+}
 
-	cmd := exec.CommandContext(ctx, claudePath, args...)
+func (r *defaultReviewerAgent) Review(ctx context.Context, req ReviewRequest) (ReviewVerdict, error) {
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return ReviewVerdict{}, fmt.Errorf("%w: %v", ErrClaudeNotFound, err)
+	}
+
+	cmd := exec.CommandContext(ctx, claudePath, buildReviewerArgs(r.model)...)
 	cmd.Stdin = strings.NewReader(buildReviewPrompt(req))
 	cmd.Env = sanitizedHaikuEnv(os.Environ())
 	cmd.WaitDelay = 500 * time.Millisecond

--- a/internal/agent/reviewer.go
+++ b/internal/agent/reviewer.go
@@ -1,0 +1,178 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/devenjarvis/baton/internal/config"
+)
+
+// VerdictKind is the outcome of a per-task review.
+type VerdictKind string
+
+const (
+	// VerdictPass means the diff clearly fulfills the task.
+	VerdictPass VerdictKind = "pass"
+	// VerdictConcerns means the diff addresses the task but has notable gaps or risks.
+	VerdictConcerns VerdictKind = "concerns"
+	// VerdictFail means the diff does not fulfill the task or introduces clear regressions.
+	VerdictFail VerdictKind = "fail"
+)
+
+// ReviewVerdict is the outcome of a ReviewerAgent.Review call.
+type ReviewVerdict struct {
+	Kind      VerdictKind
+	Rationale string // 1-2 sentence explanation
+}
+
+// ReviewRequest is the input to ReviewerAgent.Review.
+type ReviewRequest struct {
+	TaskIndex      int
+	TaskText       string
+	TaskDiff       string
+	OriginalPrompt string
+}
+
+// ReviewerAgent reviews a single task's diff and returns a verdict.
+// Implementations may shell out to a binary, mock the call for tests, or
+// call an API directly. The method accepts a context for cancellation.
+type ReviewerAgent interface {
+	Review(ctx context.Context, req ReviewRequest) (ReviewVerdict, error)
+}
+
+// DefaultReviewerAgent returns a ReviewerAgent that shells out to
+// `claude -p --model <model>`. An empty model falls back to
+// config.DefaultReviewerModel. The subprocess inherits a sanitized env so
+// baton hook wiring doesn't bleed into the reviewer subprocess.
+func DefaultReviewerAgent(model string) ReviewerAgent {
+	if model == "" {
+		model = config.DefaultReviewerModel
+	}
+	return &defaultReviewerAgent{model: model}
+}
+
+type defaultReviewerAgent struct {
+	model string
+}
+
+// reviewPromptTemplate is sent to the reviewer subprocess on stdin.
+// The concrete task fields are interpolated by buildReviewPrompt.
+const reviewPromptTemplate = `You are a code reviewer checking whether a code diff fulfills a specific task.
+
+ORIGINAL INTENT:
+%s
+
+TASK #%d:
+%s
+
+DIFF:
+%s
+
+Review the diff and decide:
+- "pass" — the diff clearly fulfills this task
+- "concerns" — the diff addresses this task but has notable gaps, risks, or incomplete work
+- "fail" — the diff does not fulfill this task or introduces clear regressions
+
+Respond with EXACTLY this format (no other text):
+VERDICT: <pass|concerns|fail>
+RATIONALE: <one or two sentences explaining your verdict>
+`
+
+func buildReviewPrompt(req ReviewRequest) string {
+	prompt := strings.TrimSpace(req.OriginalPrompt)
+	if prompt == "" {
+		prompt = "(no original intent recorded)"
+	}
+	diff := strings.TrimSpace(req.TaskDiff)
+	if diff == "" {
+		diff = "(no diff — task may have no committed changes)"
+	}
+	return fmt.Sprintf(reviewPromptTemplate, prompt, req.TaskIndex, req.TaskText, diff)
+}
+
+func (r *defaultReviewerAgent) Review(ctx context.Context, req ReviewRequest) (ReviewVerdict, error) {
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return ReviewVerdict{}, fmt.Errorf("%w: %v", ErrClaudeNotFound, err)
+	}
+
+	model := r.model
+	if model == "" {
+		model = config.DefaultReviewerModel
+	}
+
+	args := []string{"-p", "--model", model}
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		args = append(args, "--bare")
+	}
+	// Read-only tools only — the reviewer inspects code, it does not write it.
+	tools := "Read,Grep,Glob,LS"
+	args = append(args,
+		"--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`,
+		"--disable-slash-commands",
+		"--no-session-persistence",
+		"--tools", tools,
+		"--allowed-tools", tools,
+		"--setting-sources", "user,project",
+		"--exclude-dynamic-system-prompt-sections",
+	)
+
+	cmd := exec.CommandContext(ctx, claudePath, args...)
+	cmd.Stdin = strings.NewReader(buildReviewPrompt(req))
+	cmd.Env = sanitizedHaikuEnv(os.Environ())
+	cmd.WaitDelay = 500 * time.Millisecond
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return ReviewVerdict{}, fmt.Errorf("claude reviewer: %w (stderr=%q)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	return parseReviewerOutput(strings.TrimSpace(stdout.String()))
+}
+
+// parseReviewerOutput extracts the VERDICT and RATIONALE lines from the
+// reviewer subprocess output. It is lenient: if the output does not match the
+// expected format exactly, it returns VerdictConcerns with the raw output as
+// the rationale so callers always get a usable verdict rather than an error.
+func parseReviewerOutput(output string) (ReviewVerdict, error) {
+	var kind VerdictKind
+	var rationale string
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToUpper(line), "VERDICT:") {
+			v := strings.TrimSpace(line[len("VERDICT:"):])
+			switch strings.ToLower(v) {
+			case "pass":
+				kind = VerdictPass
+			case "concerns":
+				kind = VerdictConcerns
+			case "fail":
+				kind = VerdictFail
+			default:
+				kind = VerdictConcerns
+			}
+		} else if strings.HasPrefix(strings.ToUpper(line), "RATIONALE:") {
+			rationale = strings.TrimSpace(line[len("RATIONALE:"):])
+		}
+	}
+
+	if kind == "" {
+		// Reviewer output was not in the expected format.
+		if output == "" {
+			return ReviewVerdict{}, errors.New("reviewer: empty output")
+		}
+		return ReviewVerdict{Kind: VerdictConcerns, Rationale: output}, nil
+	}
+
+	return ReviewVerdict{Kind: kind, Rationale: rationale}, nil
+}

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -113,14 +113,61 @@ func TestGroupCommitsByTask_NoOtherBucket(t *testing.T) {
 	}
 }
 
+// TestBuildReviewerArgs_NoBare verifies --bare is absent without an API key.
+func TestBuildReviewerArgs_NoBare(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	args := buildReviewerArgs("claude-sonnet-4-6")
+	for _, a := range args {
+		if a == "--bare" {
+			t.Error("--bare must not be present when ANTHROPIC_API_KEY is unset")
+		}
+	}
+}
+
+// TestBuildReviewerArgs_BareWithKey verifies --bare is present when ANTHROPIC_API_KEY is set.
+func TestBuildReviewerArgs_BareWithKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	args := buildReviewerArgs("claude-sonnet-4-6")
+	hasBare := false
+	for _, a := range args {
+		if a == "--bare" {
+			hasBare = true
+		}
+	}
+	if !hasBare {
+		t.Error("expected --bare when ANTHROPIC_API_KEY is set")
+	}
+}
+
+// TestBuildReviewerArgs_RequiredFlags verifies the read-only tool flags and
+// no-session-persistence are always present.
+func TestBuildReviewerArgs_RequiredFlags(t *testing.T) {
+	args := buildReviewerArgs("claude-sonnet-4-6")
+	want := map[string]bool{
+		"--no-session-persistence": false,
+		"--tools":                  false,
+		"--allowed-tools":          false,
+	}
+	for _, a := range args {
+		if _, ok := want[a]; ok {
+			want[a] = true
+		}
+	}
+	for flag, found := range want {
+		if !found {
+			t.Errorf("expected flag %q in buildReviewerArgs output", flag)
+		}
+	}
+}
+
 // TestParseReviewerOutput covers the structured VERDICT/RATIONALE format.
 func TestParseReviewerOutput(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantKind  VerdictKind
-		wantRat   string
-		wantErr   bool
+		name     string
+		input    string
+		wantKind VerdictKind
+		wantRat  string
+		wantErr  bool
 	}{
 		{
 			name:     "pass verdict",

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -1,0 +1,222 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devenjarvis/baton/internal/git"
+)
+
+// TestParsePlanTasks verifies that ParsePlanTasks extracts tasks with correct
+// indices, text, and done flags using the same counting rules as planTaskCounts.
+func TestParsePlanTasks(t *testing.T) {
+	plan := `# Goal
+Do a thing.
+
+## Tasks
+- [ ] First task
+- [x] Second task (done)
+- [ ] Third task
+
+## Not in scope
+Nothing.
+`
+	tasks := ParsePlanTasks(plan)
+	if len(tasks) != 3 {
+		t.Fatalf("want 3 tasks, got %d", len(tasks))
+	}
+	tests := []struct {
+		idx  int
+		text string
+		done bool
+	}{
+		{1, "First task", false},
+		{2, "Second task (done)", true},
+		{3, "Third task", false},
+	}
+	for i, tt := range tests {
+		got := tasks[i]
+		if got.Index != tt.idx {
+			t.Errorf("task %d: Index = %d, want %d", i, got.Index, tt.idx)
+		}
+		if got.Text != tt.text {
+			t.Errorf("task %d: Text = %q, want %q", i, got.Text, tt.text)
+		}
+		if got.Done != tt.done {
+			t.Errorf("task %d: Done = %v, want %v", i, got.Done, tt.done)
+		}
+	}
+}
+
+// TestParsePlanTasks_EmptyPlan verifies no crash or panic on empty input.
+func TestParsePlanTasks_EmptyPlan(t *testing.T) {
+	tasks := ParsePlanTasks("")
+	if len(tasks) != 0 {
+		t.Errorf("empty plan: want 0 tasks, got %d", len(tasks))
+	}
+}
+
+// TestGroupCommitsByTask verifies that commits are bucketed correctly by
+// [task N] prefix, with the "other" bucket receiving untagged commits.
+func TestGroupCommitsByTask(t *testing.T) {
+	commits := []git.Commit{
+		{Hash: "aaa", Subject: "[task 2] add widget"},
+		{Hash: "bbb", Subject: "[task 1] scaffold"},
+		{Hash: "ccc", Subject: "fixup: typo"},
+		{Hash: "ddd", Subject: "[task 2] add tests"},
+		{Hash: "eee", Subject: "[Task 3] final polish"},
+	}
+	groups := GroupCommitsByTask(commits)
+
+	// Expect 3 task groups + 1 "other" group = 4 total.
+	if len(groups) != 4 {
+		t.Fatalf("want 4 groups, got %d: %v", len(groups), groups)
+	}
+
+	// Groups are sorted: task 1, task 2, task 3, other (index 0) last.
+	byIndex := make(map[int]CommitGroup, len(groups))
+	for _, g := range groups {
+		byIndex[g.TaskIndex] = g
+	}
+
+	if len(byIndex[1].Commits) != 1 {
+		t.Errorf("task 1: want 1 commit, got %d", len(byIndex[1].Commits))
+	}
+	if len(byIndex[2].Commits) != 2 {
+		t.Errorf("task 2: want 2 commits, got %d", len(byIndex[2].Commits))
+	}
+	if len(byIndex[3].Commits) != 1 {
+		t.Errorf("task 3: want 1 commit, got %d", len(byIndex[3].Commits))
+	}
+	if len(byIndex[0].Commits) != 1 || byIndex[0].Commits[0].Subject != "fixup: typo" {
+		t.Errorf("other: want 1 commit with subject 'fixup: typo', got %v", byIndex[0].Commits)
+	}
+
+	// Verify ordering: last group must be "other".
+	if groups[len(groups)-1].TaskIndex != 0 {
+		t.Errorf("other group must be last, got taskIndex=%d", groups[len(groups)-1].TaskIndex)
+	}
+}
+
+// TestGroupCommitsByTask_NoOtherBucket verifies that no extra group is created
+// when every commit has a [task N] prefix.
+func TestGroupCommitsByTask_NoOtherBucket(t *testing.T) {
+	commits := []git.Commit{
+		{Hash: "aaa", Subject: "[task 1] scaffold"},
+		{Hash: "bbb", Subject: "[task 1] tests"},
+	}
+	groups := GroupCommitsByTask(commits)
+	for _, g := range groups {
+		if g.TaskIndex == 0 {
+			t.Errorf("unexpected 'other' group: %v", g.Commits)
+		}
+	}
+}
+
+// TestParseReviewerOutput covers the structured VERDICT/RATIONALE format.
+func TestParseReviewerOutput(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantKind  VerdictKind
+		wantRat   string
+		wantErr   bool
+	}{
+		{
+			name:     "pass verdict",
+			input:    "VERDICT: pass\nRATIONALE: All good.",
+			wantKind: VerdictPass,
+			wantRat:  "All good.",
+		},
+		{
+			name:     "concerns verdict",
+			input:    "VERDICT: concerns\nRATIONALE: Missing edge case.",
+			wantKind: VerdictConcerns,
+			wantRat:  "Missing edge case.",
+		},
+		{
+			name:     "fail verdict",
+			input:    "VERDICT: fail\nRATIONALE: Not implemented.",
+			wantKind: VerdictFail,
+			wantRat:  "Not implemented.",
+		},
+		{
+			name:     "case insensitive verdict",
+			input:    "VERDICT: PASS\nRATIONALE: OK.",
+			wantKind: VerdictPass,
+			wantRat:  "OK.",
+		},
+		{
+			name:     "unknown verdict falls back to concerns",
+			input:    "VERDICT: maybe\nRATIONALE: Unsure.",
+			wantKind: VerdictConcerns,
+			wantRat:  "Unsure.",
+		},
+		{
+			name:    "empty output returns error",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:     "unstructured output returns concerns with raw text",
+			input:    "something went wrong",
+			wantKind: VerdictConcerns,
+			wantRat:  "something went wrong",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := parseReviewerOutput(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if v.Kind != tt.wantKind {
+				t.Errorf("Kind = %q, want %q", v.Kind, tt.wantKind)
+			}
+			if v.Rationale != tt.wantRat {
+				t.Errorf("Rationale = %q, want %q", v.Rationale, tt.wantRat)
+			}
+		})
+	}
+}
+
+// fakeReviewerAgent is a ReviewerAgent stub for tests.
+type fakeReviewerAgent struct {
+	verdict ReviewVerdict
+	err     error
+}
+
+func (f *fakeReviewerAgent) Review(_ context.Context, _ ReviewRequest) (ReviewVerdict, error) {
+	return f.verdict, f.err
+}
+
+// TestManagerSetReviewerAgent verifies that SetReviewerAgent swaps the agent
+// visible via ReviewerAgent() and that a custom stub can be injected.
+func TestManagerSetReviewerAgent(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	stub := &fakeReviewerAgent{verdict: ReviewVerdict{Kind: VerdictPass, Rationale: "stub"}}
+	mgr.SetReviewerAgent(stub)
+
+	got := mgr.ReviewerAgent()
+	if got != stub {
+		t.Error("ReviewerAgent() did not return the injected stub")
+	}
+
+	ctx := context.Background()
+	v, err := got.Review(ctx, ReviewRequest{TaskIndex: 1, TaskText: "anything"})
+	if err != nil {
+		t.Fatalf("stub.Review error: %v", err)
+	}
+	if v.Kind != VerdictPass {
+		t.Errorf("stub verdict Kind = %q, want pass", v.Kind)
+	}
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -845,6 +845,37 @@ func (s *Session) ReviseError() error {
 	return s.reviseErr
 }
 
+// PlanTask is a single task item parsed from a plan file.
+type PlanTask struct {
+	Index int    // 1-based, counting all "- [ ]" and "- [x]" lines top-to-bottom
+	Text  string // task description without the leading "- [ ] " or "- [x] "
+	Done  bool   // true if marked [x] or [X]
+}
+
+// ParsePlanTasks extracts ordered task items from plan markdown using the same
+// counting rules as planTaskCounts in internal/tui/dashboard.go:
+// every "- [ ]" or "- [x]" line (leading whitespace stripped) is a task,
+// indexed 1-based in the order they appear. Section headers are ignored.
+func ParsePlanTasks(plan string) []PlanTask {
+	var tasks []PlanTask
+	idx := 0
+	for _, raw := range strings.Split(plan, "\n") {
+		line := strings.TrimLeft(raw, " \t")
+		if !strings.HasPrefix(line, "- [") {
+			continue
+		}
+		if len(line) < 6 || line[4] != ']' {
+			continue
+		}
+		idx++
+		marker := line[3]
+		done := marker == 'x' || marker == 'X'
+		text := strings.TrimSpace(line[5:])
+		tasks = append(tasks, PlanTask{Index: idx, Text: text, Done: done})
+	}
+	return tasks
+}
+
 // PlanPath returns the absolute path to the session's plan markdown file
 // (<worktree>/.claude/plan.md). Always returns a path even if the file does
 // not exist — callers use HasPlan or ReadPlan to test for presence.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -874,6 +876,60 @@ func ParsePlanTasks(plan string) []PlanTask {
 		tasks = append(tasks, PlanTask{Index: idx, Text: text, Done: done})
 	}
 	return tasks
+}
+
+// taskSubjectRE matches "[task N]" at the start of a commit subject where N is
+// a positive integer. Case-insensitive so "[Task 3]" is also accepted.
+var taskSubjectRE = regexp.MustCompile(`(?i)^\[task\s+(\d+)\]`)
+
+// CommitGroup holds the commits associated with a single plan task (or the
+// "other" bucket for commits without a recognizable [task N] prefix).
+type CommitGroup struct {
+	// TaskIndex is 1-based and matches the PlanTask.Index it belongs to.
+	// Zero means the group is the "Other changes" bucket (no [task N] prefix
+	// and/or uncommitted working-tree changes).
+	TaskIndex int
+	Commits   []git.Commit
+}
+
+// GroupCommitsByTask partitions commits by their "[task N]" subject prefix.
+// Commits without the prefix land in a group with TaskIndex=0 ("Other
+// changes"). Within each group, commits preserve their input order (oldest
+// first). The returned slice is sorted by TaskIndex ascending, with the
+// TaskIndex=0 group appended last so it renders at the bottom of the review
+// task list.
+func GroupCommitsByTask(commits []git.Commit) []CommitGroup {
+	byIndex := make(map[int]*CommitGroup)
+	for _, c := range commits {
+		idx := 0
+		if m := taskSubjectRE.FindStringSubmatch(c.Subject); m != nil {
+			if n, err := strconv.Atoi(m[1]); err == nil && n > 0 {
+				idx = n
+			}
+		}
+		if byIndex[idx] == nil {
+			byIndex[idx] = &CommitGroup{TaskIndex: idx}
+		}
+		byIndex[idx].Commits = append(byIndex[idx].Commits, c)
+	}
+
+	// Collect and sort task-indexed groups; append "other" (0) last.
+	var groups []CommitGroup
+	var otherGroup *CommitGroup
+	for idx, g := range byIndex {
+		if idx == 0 {
+			otherGroup = g
+		} else {
+			groups = append(groups, *g)
+		}
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].TaskIndex < groups[j].TaskIndex
+	})
+	if otherGroup != nil {
+		groups = append(groups, *otherGroup)
+	}
+	return groups
 }
 
 // PlanPath returns the absolute path to the session's plan markdown file

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -859,7 +859,7 @@ type PlanTask struct {
 // every "- [ ]" or "- [x]" line (leading whitespace stripped) is a task,
 // indexed 1-based in the order they appear. Section headers are ignored.
 func ParsePlanTasks(plan string) []PlanTask {
-	var tasks []PlanTask
+	tasks := make([]PlanTask, 0, 16)
 	idx := 0
 	for _, raw := range strings.Split(plan, "\n") {
 		line := strings.TrimLeft(raw, " \t")

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -936,6 +936,9 @@ func GroupCommitsByTask(commits []git.Commit) []CommitGroup {
 // (<worktree>/.claude/plan.md). Always returns a path even if the file does
 // not exist — callers use HasPlan or ReadPlan to test for presence.
 func (s *Session) PlanPath() string {
+	if s.Worktree == nil {
+		return ""
+	}
 	return filepath.Join(s.Worktree.Path, ".claude", "plan.md")
 }
 
@@ -943,6 +946,9 @@ func (s *Session) PlanPath() string {
 // snapshot (<worktree>/.claude/plan.prev.md). The file is written by
 // RevisePlan as a single-step undo target; RestorePrevPlan reads it back.
 func (s *Session) PrevPlanPath() string {
+	if s.Worktree == nil {
+		return ""
+	}
 	return filepath.Join(s.Worktree.Path, ".claude", "plan.prev.md")
 }
 
@@ -1045,7 +1051,11 @@ func (s *Session) CachedPlan() (string, bool) {
 	// Lazy load. Drop the read lock before doing I/O so a concurrent
 	// WritePlan can populate the cache while we read; if it does, we
 	// just observe its write on the next call.
-	data, err := os.ReadFile(s.PlanPath())
+	planPath := s.PlanPath()
+	if planPath == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(planPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			s.mu.Lock()

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -28,8 +28,8 @@ const (
 	// Sonnet matches the planner default — reviewer output quality directly affects
 	// the developer's confidence in the review verdict.
 	DefaultReviewerModel = "claude-sonnet-4-6"
-	MinSidebarWidth  = 20
-	MaxSidebarWidth  = 60
+	MinSidebarWidth      = 20
+	MaxSidebarWidth      = 60
 
 	// Wellness defaults.
 	DefaultFocusSessionMinutes = 90
@@ -166,8 +166,8 @@ type ResolvedSettings struct {
 	// subprocesses. Defaults to DefaultReviewerModel.
 	ReviewerModel string
 	IDECommand    string
-	WorktreeDir  string
-	SidebarWidth int
+	WorktreeDir   string
+	SidebarWidth  int
 
 	// Wellness settings.
 	FocusSessionMinutes int

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -23,6 +23,11 @@ const (
 	// The agent package references this constant rather than declaring its
 	// own so the default stays a single source of truth.
 	DefaultPlanModel = "claude-sonnet-4-6"
+
+	// DefaultReviewerModel is the model used by the per-task reviewer subprocess.
+	// Sonnet matches the planner default — reviewer output quality directly affects
+	// the developer's confidence in the review verdict.
+	DefaultReviewerModel = "claude-sonnet-4-6"
 	MinSidebarWidth  = 20
 	MaxSidebarWidth  = 60
 
@@ -114,6 +119,9 @@ type GlobalSettings struct {
 	MaxConcurrentAgents *int `json:"max_concurrent_agents,omitempty"`
 	MaxReviewBacklog    *int `json:"max_review_backlog,omitempty"`
 
+	// ReviewerModel overrides the model used for per-task review subprocesses.
+	ReviewerModel *string `json:"reviewer_model,omitempty"`
+
 	// Plan-first planning. Both fields are also overridable per-repo.
 	PlanFirstEnabled    *bool   `json:"plan_first_enabled,omitempty"`
 	BuildFromPlanPrompt *string `json:"build_from_plan_prompt,omitempty"`
@@ -130,6 +138,7 @@ type RepoSettings struct {
 	AgentProgram        *string `json:"agent_program,omitempty"`
 	AgentModel          *string `json:"agent_model,omitempty"`
 	PlanModel           *string `json:"plan_model,omitempty"`
+	ReviewerModel       *string `json:"reviewer_model,omitempty"`
 	IDECommand          *string `json:"ide_command,omitempty"`
 	WorktreeDir         *string `json:"worktree_dir,omitempty"`
 	PlanFirstEnabled    *bool   `json:"plan_first_enabled,omitempty"`
@@ -152,8 +161,11 @@ type ResolvedSettings struct {
 	AgentModel string
 	// PlanModel is the --model flag value passed to the plan drafter
 	// subprocess. Defaults to DefaultPlanModel.
-	PlanModel    string
-	IDECommand   string
+	PlanModel string
+	// ReviewerModel is the --model flag value passed to per-task reviewer
+	// subprocesses. Defaults to DefaultReviewerModel.
+	ReviewerModel string
+	IDECommand    string
 	WorktreeDir  string
 	SidebarWidth int
 
@@ -182,6 +194,7 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		BranchNamePrompt:    DefaultBranchNamePrompt,
 		AgentProgram:        DefaultAgentProgram,
 		PlanModel:           DefaultPlanModel,
+		ReviewerModel:       DefaultReviewerModel,
 		WorktreeDir:         DefaultWorktreeDir,
 		SidebarWidth:        DefaultSidebarWidth,
 		FocusSessionMinutes: DefaultFocusSessionMinutes,
@@ -217,6 +230,9 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		}
 		if global.PlanModel != nil {
 			r.PlanModel = *global.PlanModel
+		}
+		if global.ReviewerModel != nil {
+			r.ReviewerModel = *global.ReviewerModel
 		}
 		if global.IDECommand != nil {
 			r.IDECommand = *global.IDECommand
@@ -268,6 +284,9 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		}
 		if repo.PlanModel != nil {
 			r.PlanModel = *repo.PlanModel
+		}
+		if repo.ReviewerModel != nil {
+			r.ReviewerModel = *repo.ReviewerModel
 		}
 		if repo.IDECommand != nil {
 			r.IDECommand = *repo.IDECommand

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -21,7 +21,8 @@ type Commit struct {
 func LogCommitsAgainstBase(wt *WorktreeInfo) ([]Commit, error) {
 	// %x1f separates fields within one record; %x1e terminates each record.
 	// This avoids ambiguity with newlines in commit bodies.
-	out, err := runGit(wt.Path, "log",
+	out, err := runGit(
+		wt.Path, "log",
 		"--format=format:%H%x1f%s%x1f%b%x1e",
 		"--reverse",
 		wt.BaseBranch+"..HEAD",
@@ -32,7 +33,7 @@ func LogCommitsAgainstBase(wt *WorktreeInfo) ([]Commit, error) {
 	if strings.TrimSpace(out) == "" {
 		return nil, nil
 	}
-	var commits []Commit
+	commits := make([]Commit, 0, 32)
 	for _, record := range strings.Split(out, "\x1e") {
 		record = strings.TrimSpace(record)
 		if record == "" {
@@ -59,34 +60,38 @@ func LogCommitsAgainstBase(wt *WorktreeInfo) ([]Commit, error) {
 
 // DiffForCommits returns per-file stats, aggregate stats, and raw unified diff
 // for an arbitrary slice of commit hashes in the given worktree. The hashes
-// are assumed to be in oldest-first order and to form a contiguous run on their
-// branch; the diff is computed as `git diff <first>^..<last>` so intermediate
-// commits collapse into a single coherent change set. An empty slice returns
-// zero values. A single hash uses `<hash>^..<hash>` which equals `git show`.
+// must be in oldest-first order but need not be contiguous — each commit is
+// diffed individually (hash^..hash) and the results are concatenated. This
+// ensures correctness when task commits are interleaved with other tasks'
+// commits in the log.
 func DiffForCommits(wt *WorktreeInfo, hashes []string) ([]FileStat, *DiffStats, string, error) {
 	if len(hashes) == 0 {
 		return nil, &DiffStats{}, "", nil
 	}
-	first, last := hashes[0], hashes[len(hashes)-1]
-	rangeSpec := first + "^.." + last
 
-	rawDiff, err := runGitRaw(wt.Path, "diff", rangeSpec)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("diff for commits: %w", err)
-	}
-
-	numstatOut, err := runGit(wt.Path, "diff", "--numstat", "--diff-filter=AMD", rangeSpec)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("diff numstat for commits: %w", err)
-	}
-	nameStatusOut, err := runGit(wt.Path, "diff", "--name-status", "--diff-filter=AMD", rangeSpec)
-	if err != nil {
-		return nil, nil, "", fmt.Errorf("diff name-status for commits: %w", err)
-	}
-
+	var rawDiffSb strings.Builder
 	fileMap := make(map[string]*FileStat)
-	parseNumstat(numstatOut, fileMap)
-	parseNameStatus(nameStatusOut, fileMap)
+
+	for _, h := range hashes {
+		rangeSpec := h + "^.." + h
+
+		raw, err := runGitRaw(wt.Path, "diff", rangeSpec)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("diff for commits: %w", err)
+		}
+		rawDiffSb.WriteString(raw)
+
+		numstatOut, err := runGit(wt.Path, "diff", "--numstat", "--diff-filter=AMD", rangeSpec)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("diff numstat for commits: %w", err)
+		}
+		nameStatusOut, err := runGit(wt.Path, "diff", "--name-status", "--diff-filter=AMD", rangeSpec)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("diff name-status for commits: %w", err)
+		}
+		parseNumstat(numstatOut, fileMap)
+		parseNameStatus(nameStatusOut, fileMap)
+	}
 
 	result := make([]FileStat, 0, len(fileMap))
 	agg := &DiffStats{}
@@ -98,7 +103,7 @@ func DiffForCommits(wt *WorktreeInfo, hashes []string) ([]FileStat, *DiffStats, 
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i].Path < result[j].Path })
 
-	return result, agg, rawDiff, nil
+	return result, agg, rawDiffSb.String(), nil
 }
 
 // DiffStats holds summary statistics for a diff.

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -7,6 +7,56 @@ import (
 	"strings"
 )
 
+// Commit holds metadata for a single git commit.
+type Commit struct {
+	Hash    string
+	Subject string
+	Body    string
+}
+
+// LogCommitsAgainstBase returns commits reachable from HEAD but not from
+// BaseBranch, ordered oldest-first (natural review order). The worktree path
+// is used as the working directory so the command runs in the right context
+// even when the repo root is elsewhere.
+func LogCommitsAgainstBase(wt *WorktreeInfo) ([]Commit, error) {
+	// %x1f separates fields within one record; %x1e terminates each record.
+	// This avoids ambiguity with newlines in commit bodies.
+	out, err := runGit(wt.Path, "log",
+		"--format=format:%H%x1f%s%x1f%b%x1e",
+		"--reverse",
+		wt.BaseBranch+"..HEAD",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("log commits: %w", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return nil, nil
+	}
+	var commits []Commit
+	for _, record := range strings.Split(out, "\x1e") {
+		record = strings.TrimSpace(record)
+		if record == "" {
+			continue
+		}
+		parts := strings.SplitN(record, "\x1f", 3)
+		c := Commit{}
+		if len(parts) > 0 {
+			c.Hash = strings.TrimSpace(parts[0])
+		}
+		if len(parts) > 1 {
+			c.Subject = strings.TrimSpace(parts[1])
+		}
+		if len(parts) > 2 {
+			c.Body = strings.TrimSpace(parts[2])
+		}
+		if c.Hash == "" {
+			continue
+		}
+		commits = append(commits, c)
+	}
+	return commits, nil
+}
+
 // DiffStats holds summary statistics for a diff.
 type DiffStats struct {
 	Files      int

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -57,6 +57,50 @@ func LogCommitsAgainstBase(wt *WorktreeInfo) ([]Commit, error) {
 	return commits, nil
 }
 
+// DiffForCommits returns per-file stats, aggregate stats, and raw unified diff
+// for an arbitrary slice of commit hashes in the given worktree. The hashes
+// are assumed to be in oldest-first order and to form a contiguous run on their
+// branch; the diff is computed as `git diff <first>^..<last>` so intermediate
+// commits collapse into a single coherent change set. An empty slice returns
+// zero values. A single hash uses `<hash>^..<hash>` which equals `git show`.
+func DiffForCommits(wt *WorktreeInfo, hashes []string) ([]FileStat, *DiffStats, string, error) {
+	if len(hashes) == 0 {
+		return nil, &DiffStats{}, "", nil
+	}
+	first, last := hashes[0], hashes[len(hashes)-1]
+	rangeSpec := first + "^.." + last
+
+	rawDiff, err := runGitRaw(wt.Path, "diff", rangeSpec)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("diff for commits: %w", err)
+	}
+
+	numstatOut, err := runGit(wt.Path, "diff", "--numstat", "--diff-filter=AMD", rangeSpec)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("diff numstat for commits: %w", err)
+	}
+	nameStatusOut, err := runGit(wt.Path, "diff", "--name-status", "--diff-filter=AMD", rangeSpec)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("diff name-status for commits: %w", err)
+	}
+
+	fileMap := make(map[string]*FileStat)
+	parseNumstat(numstatOut, fileMap)
+	parseNameStatus(nameStatusOut, fileMap)
+
+	result := make([]FileStat, 0, len(fileMap))
+	agg := &DiffStats{}
+	for _, fs := range fileMap {
+		result = append(result, *fs)
+		agg.Files++
+		agg.Insertions += fs.Insertions
+		agg.Deletions += fs.Deletions
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Path < result[j].Path })
+
+	return result, agg, rawDiff, nil
+}
+
 // DiffStats holds summary statistics for a diff.
 type DiffStats struct {
 	Files      int

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1419,6 +1419,32 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.reviewTaskCursor--
 				}
 				return a, nil
+			case "enter", "space":
+				// Drill into the selected task's diff. Opens the diff browser
+				// filtered to the commits for that task; esc returns to the
+				// task list (handled by diffCloseMsg).
+				entry := a.reviewDiffCache[a.reviewSession.ID]
+				if entry == nil || len(entry.groups) == 0 {
+					return a, nil
+				}
+				group := reviewTaskGroupAtCursor(entry, a.reviewTaskCursor)
+				if group == nil || group.rawDiff == "" {
+					return a, nil
+				}
+				m, err := diffmodel.Parse(group.rawDiff)
+				if err != nil {
+					a.setError(err.Error())
+					return a, nil
+				}
+				taskLabel := a.reviewSession.GetDisplayName()
+				if group.taskIndex > 0 {
+					taskLabel += fmt.Sprintf(" · task %d", group.taskIndex)
+				} else {
+					taskLabel += " · other changes"
+				}
+				a.view = ViewDiff
+				a.diff = newDiffModel(taskLabel, m, a.width, a.height-1)
+				return a, nil
 			}
 			// All other keys are no-ops in review panel.
 			return a, nil
@@ -3448,6 +3474,35 @@ func (a *App) repoPathForSession(sessionID string) string {
 		}
 	}
 	return ""
+}
+
+// reviewTaskGroupAtCursor returns the taskReviewGroup at position cursor in the
+// review task list, following the same row ordering as renderTaskList: plan
+// tasks in index order, then the "Other changes" group (taskIndex == 0) last.
+// Returns nil if cursor is out of range or no groups exist.
+func reviewTaskGroupAtCursor(entry *reviewDiffEntry, cursor int) *taskReviewGroup {
+	if entry == nil {
+		return nil
+	}
+	groupByIdx := make(map[int]*taskReviewGroup, len(entry.groups))
+	for i := range entry.groups {
+		g := &entry.groups[i]
+		groupByIdx[g.taskIndex] = g
+	}
+	row := 0
+	for _, t := range entry.tasks {
+		if row == cursor {
+			return groupByIdx[t.Index]
+		}
+		row++
+	}
+	// Check "Other changes" row.
+	if g, ok := groupByIdx[0]; ok {
+		if row == cursor {
+			return g
+		}
+	}
+	return nil
 }
 
 // reviewTaskCount returns the number of task rows in a review entry (plan tasks

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -154,6 +154,7 @@ type App struct {
 	focusBreakAnimFrame    int
 	reviewDiffCache        map[string]*reviewDiffEntry // keyed by session ID
 	reviewSession          *agent.Session              // session currently open in review panel
+	reviewTaskCursor       int                         // selected task row in the review task list
 	planEditor             *planEditorModel            // non-nil while panelFocus == focusPlanEditor
 	promptModal            promptModalModel            // overlay for plan-first new-session prompt
 
@@ -1403,6 +1404,21 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}()
 				}
 				return a, nil
+			case "j", "down":
+				// Move cursor down in the task list.
+				if entry := a.reviewDiffCache[a.reviewSession.ID]; entry != nil {
+					max := reviewTaskCount(entry) - 1
+					if a.reviewTaskCursor < max {
+						a.reviewTaskCursor++
+					}
+				}
+				return a, nil
+			case "k", "up":
+				// Move cursor up in the task list.
+				if a.reviewTaskCursor > 0 {
+					a.reviewTaskCursor--
+				}
+				return a, nil
 			}
 			// All other keys are no-ops in review panel.
 			return a, nil
@@ -1519,6 +1535,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				sess := reviewItems[idx].session
 				sess.SetLifecyclePhase(agent.LifecycleInReview)
 				a.reviewSession = sess
+				a.reviewTaskCursor = 0
 				a.dashboard.panelFocus = focusReview
 				// Fetch diff stats if not already cached.
 				if _, ok := a.reviewDiffCache[sess.ID]; !ok {
@@ -2980,6 +2997,7 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 	case focusSectionReview:
 		sess.SetLifecyclePhase(agent.LifecycleInReview)
 		a.reviewSession = sess
+		a.reviewTaskCursor = 0
 		a.dashboard.panelFocus = focusReview
 		if _, ok := a.reviewDiffCache[sess.ID]; !ok {
 			return a.fetchReviewDiffCmd(sess), true
@@ -3215,7 +3233,7 @@ func (a App) View() tea.View {
 	case ViewDashboard:
 		if a.dashboard.panelFocus == focusReview && a.reviewSession != nil {
 			entry := a.reviewDiffCache[a.reviewSession.ID]
-			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width))
+			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor))
 			v.AltScreen = true
 			return v
 		}
@@ -3430,6 +3448,22 @@ func (a *App) repoPathForSession(sessionID string) string {
 		}
 	}
 	return ""
+}
+
+// reviewTaskCount returns the number of task rows in a review entry (plan tasks
+// plus the "other" group if present).
+func reviewTaskCount(entry *reviewDiffEntry) int {
+	if entry == nil {
+		return 0
+	}
+	n := len(entry.tasks)
+	for _, g := range entry.groups {
+		if g.taskIndex == 0 {
+			n++ // "Other changes" row
+			break
+		}
+	}
+	return n
 }
 
 // sessionByID returns the Session with the given ID across all managed repos,

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -984,6 +985,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				if len(cmds) > 0 {
 					return a, tea.Batch(cmds...)
+				}
+				// Reviewer unavailable (nil reviewer or nil session): mark all
+				// pending verdicts as error so they don't stay at "···" forever.
+				for _, rec := range msg.entry.verdicts {
+					if rec.state == verdictPending {
+						rec.state = verdictErr
+						rec.err = errors.New("reviewer unavailable")
+					}
 				}
 			}
 		}
@@ -3896,7 +3905,7 @@ type reviewDiffEntry struct {
 
 	// Plan-driven fields; non-nil only when the session has a plan.
 	tasks    []agent.PlanTask
-	groups   []taskReviewGroup        // per-task + "other" commit groups
+	groups   []taskReviewGroup          // per-task + "other" commit groups
 	verdicts map[int]*taskVerdictRecord // keyed by taskIndex (0 = other)
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -957,6 +957,50 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case reviewDiffMsg:
 		if msg.err == nil && msg.entry != nil {
 			a.reviewDiffCache[msg.sessionID] = msg.entry
+			// If the entry has task groups, dispatch a reviewer per group.
+			if len(msg.entry.groups) > 0 {
+				repoPath := a.repoPathForSession(msg.sessionID)
+				if repoPath == "" {
+					repoPath = a.activeRepo
+				}
+				var cmds []tea.Cmd
+				mgr := a.managers[repoPath]
+				var reviewer agent.ReviewerAgent
+				if mgr != nil {
+					reviewer = mgr.ReviewerAgent()
+				}
+				if reviewer != nil {
+					sess := a.sessionByID(msg.sessionID)
+					if sess != nil {
+						for _, g := range msg.entry.groups {
+							// Mark running before dispatching so the spinner shows.
+							if v, ok := msg.entry.verdicts[g.taskIndex]; ok {
+								v.state = verdictRunning
+							}
+							cmds = append(cmds, a.reviewTaskCmd(sess, g, reviewer))
+						}
+					}
+				}
+				if len(cmds) > 0 {
+					return a, tea.Batch(cmds...)
+				}
+			}
+		}
+		return a, nil
+
+	case reviewVerdictMsg:
+		entry := a.reviewDiffCache[msg.sessionID]
+		if entry != nil && entry.verdicts != nil {
+			rec := entry.verdicts[msg.taskIndex]
+			if rec != nil {
+				if msg.err != nil {
+					rec.state = verdictErr
+					rec.err = msg.err
+				} else {
+					rec.state = verdictDone
+					rec.verdict = msg.verdict
+				}
+			}
 		}
 		return a, nil
 
@@ -3388,6 +3432,26 @@ func (a *App) repoPathForSession(sessionID string) string {
 	return ""
 }
 
+// sessionByID returns the Session with the given ID across all managed repos,
+// or nil if not found.
+func (a *App) sessionByID(sessionID string) *agent.Session {
+	if a.cfg == nil {
+		return nil
+	}
+	for _, repo := range a.cfg.Repos {
+		mgr := a.managers[repo.Path]
+		if mgr == nil {
+			continue
+		}
+		for _, sess := range mgr.ListSessions() {
+			if sess.ID == sessionID {
+				return sess
+			}
+		}
+	}
+	return nil
+}
+
 // cleanStaleCaches removes diff stats and PR cache entries for sessions that no longer exist.
 func (a *App) cleanStaleCaches() {
 	activeSessions := make(map[string]bool)
@@ -3709,10 +3773,42 @@ func (a *App) writeWellnessLog() {
 	_, _ = f.WriteString(string(data) + "\n")
 }
 
+// verdictState tracks the progress of a per-task reviewer subprocess.
+type verdictState int
+
+const (
+	verdictPending verdictState = iota // reviewer not yet dispatched
+	verdictRunning                     // reviewer subprocess in flight
+	verdictDone                        // reviewer returned a verdict
+	verdictErr                         // reviewer subprocess errored
+)
+
+// taskVerdictRecord holds the verdict state for one task row.
+type taskVerdictRecord struct {
+	state   verdictState
+	verdict agent.ReviewVerdict
+	err     error
+}
+
+// taskReviewGroup holds one plan task's commits and their resolved diff stats.
+type taskReviewGroup struct {
+	taskIndex int
+	commits   []git.Commit
+	files     []git.FileStat
+	stats     *git.DiffStats
+	rawDiff   string
+}
+
 // reviewDiffEntry caches diff stats for a session in the review panel.
 type reviewDiffEntry struct {
+	// Aggregate file stats (always populated, even when no plan exists).
 	files     []git.FileStat
 	aggregate *git.DiffStats
+
+	// Plan-driven fields; non-nil only when the session has a plan.
+	tasks    []agent.PlanTask
+	groups   []taskReviewGroup        // per-task + "other" commit groups
+	verdicts map[int]*taskVerdictRecord // keyed by taskIndex (0 = other)
 }
 
 // reviewDiffMsg carries the result of an async review diff fetch.
@@ -3722,7 +3818,18 @@ type reviewDiffMsg struct {
 	err       error
 }
 
-// fetchReviewDiffCmd returns a Cmd that fetches diff stats for a session to populate the review cache.
+// reviewVerdictMsg carries the result of a single per-task reviewer subprocess.
+type reviewVerdictMsg struct {
+	sessionID string
+	taskIndex int
+	verdict   agent.ReviewVerdict
+	err       error
+}
+
+// fetchReviewDiffCmd returns a Cmd that fetches diff stats for a session to
+// populate the review cache. When the session has a plan, it also computes
+// per-task commit groups and per-group diff stats so the review panel can
+// render a task-by-task view.
 func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
 	sessID := sess.ID
 	wt := sess.Worktree
@@ -3734,12 +3841,77 @@ func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
 	if repoPath == "" {
 		repoPath = a.activeRepo
 	}
+	planContent, hasPlan := sess.CachedPlan()
 	return func() tea.Msg {
 		files, agg, err := git.GetPerFileDiffStats(repoPath, wt)
 		if err != nil {
 			return reviewDiffMsg{sessionID: sessID, err: err}
 		}
-		return reviewDiffMsg{sessionID: sessID, entry: &reviewDiffEntry{files: files, aggregate: agg}}
+		entry := &reviewDiffEntry{files: files, aggregate: agg}
+
+		if hasPlan && planContent != "" {
+			entry.tasks = agent.ParsePlanTasks(planContent)
+			commits, logErr := git.LogCommitsAgainstBase(wt)
+			if logErr == nil && len(commits) > 0 {
+				commitGroups := agent.GroupCommitsByTask(commits)
+				entry.groups = make([]taskReviewGroup, 0, len(commitGroups))
+				entry.verdicts = make(map[int]*taskVerdictRecord)
+				for _, cg := range commitGroups {
+					hashes := make([]string, len(cg.Commits))
+					for i, c := range cg.Commits {
+						hashes[i] = c.Hash
+					}
+					gFiles, gStats, rawDiff, diffErr := git.DiffForCommits(wt, hashes)
+					if diffErr != nil {
+						gStats = &git.DiffStats{}
+					}
+					entry.groups = append(entry.groups, taskReviewGroup{
+						taskIndex: cg.TaskIndex,
+						commits:   cg.Commits,
+						files:     gFiles,
+						stats:     gStats,
+						rawDiff:   rawDiff,
+					})
+					entry.verdicts[cg.TaskIndex] = &taskVerdictRecord{state: verdictPending}
+				}
+			}
+		}
+
+		return reviewDiffMsg{sessionID: sessID, entry: entry}
+	}
+}
+
+// reviewTaskCmd returns a Cmd that runs a reviewer subprocess for one task
+// group and returns a reviewVerdictMsg when done.
+func (a App) reviewTaskCmd(sess *agent.Session, group taskReviewGroup, reviewer agent.ReviewerAgent) tea.Cmd {
+	sessID := sess.ID
+	originalPrompt := sess.OriginalPrompt()
+	taskIndex := group.taskIndex
+	rawDiff := group.rawDiff
+
+	// Find task text from the entry if available.
+	taskText := fmt.Sprintf("Task %d", taskIndex)
+	if taskIndex == 0 {
+		taskText = "Other changes"
+	} else if entry := a.reviewDiffCache[sessID]; entry != nil {
+		for _, t := range entry.tasks {
+			if t.Index == taskIndex {
+				taskText = t.Text
+				break
+			}
+		}
+	}
+
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+		verdict, err := reviewer.Review(ctx, agent.ReviewRequest{
+			TaskIndex:      taskIndex,
+			TaskText:       taskText,
+			TaskDiff:       rawDiff,
+			OriginalPrompt: originalPrompt,
+		})
+		return reviewVerdictMsg{sessionID: sessID, taskIndex: taskIndex, verdict: verdict, err: err}
 	}
 }
 

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -70,7 +70,13 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	if entry == nil {
 		lines = append(lines, StyleSubtle.Render("loading diff stats…"))
 	} else if len(entry.tasks) > 0 || len(entry.groups) > 0 {
-		lines = append(lines, renderTaskList(entry, width, cursor)...)
+		// Overhead: header(1) + divider(1) + "ORIGINAL INTENT"(1) + intent(≤6) +
+		// blank(1) + divider(1) + blank(1) + divider(1) + hints(1) = 14 max.
+		taskListHeight := height - 14
+		if taskListHeight < 4 {
+			taskListHeight = 4
+		}
+		lines = append(lines, renderTaskList(entry, width, taskListHeight, cursor)...)
 	} else {
 		// No plan — fall back to the aggregate file view.
 		leftWidth := (width - 4) / 2
@@ -125,11 +131,11 @@ func (e *reviewDiffEntry) getGroups() []taskReviewGroup {
 	return e.groups
 }
 
-// renderTaskList renders the scrollable per-task review rows.
-func renderTaskList(entry *reviewDiffEntry, width, cursor int) []string {
-	var lines []string
-	lines = append(lines, StyleSubtle.Render("PLAN TASKS"))
-	lines = append(lines, "")
+// renderTaskList renders the scrollable per-task review rows. availHeight
+// controls the visible window; the list scrolls so the cursor stays visible.
+func renderTaskList(entry *reviewDiffEntry, width, availHeight, cursor int) []string {
+	const headerLines = 2 // "PLAN TASKS" + blank
+	header := []string{StyleSubtle.Render("PLAN TASKS"), ""}
 
 	// Build a merged view: one row per plan task, plus the "Other changes" group.
 	type row struct {
@@ -145,7 +151,7 @@ func renderTaskList(entry *reviewDiffEntry, width, cursor int) []string {
 		groupByIdx[g.taskIndex] = g
 	}
 
-	var rows []row
+	rows := make([]row, 0, len(entry.tasks)+1)
 	for _, t := range entry.tasks {
 		g := groupByIdx[t.Index]
 		rows = append(rows, row{taskIndex: t.Index, taskText: t.Text, group: g})
@@ -153,6 +159,22 @@ func renderTaskList(entry *reviewDiffEntry, width, cursor int) []string {
 	// Append "other" group if it exists.
 	if other, ok := groupByIdx[0]; ok {
 		rows = append(rows, row{taskIndex: 0, taskText: "Other changes", group: other})
+	}
+
+	// Compute visible window so the cursor stays centred.
+	rowsH := availHeight - headerLines
+	if rowsH < 1 {
+		rowsH = 1
+	}
+	offset := cursor - rowsH/2
+	if offset < 0 {
+		offset = 0
+	}
+	if offset+rowsH > len(rows) {
+		offset = len(rows) - rowsH
+		if offset < 0 {
+			offset = 0
+		}
 	}
 
 	cursorStyle := lipgloss.NewStyle().
@@ -165,7 +187,15 @@ func renderTaskList(entry *reviewDiffEntry, width, cursor int) []string {
 	subtleGreen := lipgloss.NewStyle().Foreground(lipgloss.Color("#7ed321"))
 	subtleRed := lipgloss.NewStyle().Foreground(lipgloss.Color("#e74c3c"))
 
-	for i, r := range rows {
+	end := offset + rowsH
+	if end > len(rows) {
+		end = len(rows)
+	}
+	lines := make([]string, 0, headerLines+end-offset)
+	lines = append(lines, header...)
+
+	for i := offset; i < end; i++ {
+		r := rows[i]
 		selected := i == cursor
 
 		// Task index label and text.

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -14,9 +14,20 @@ import (
 	"github.com/devenjarvis/baton/internal/git"
 )
 
+// spinnerFrames is the braille spinner sequence used while a verdict is running.
+var spinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
+
+// reviewSpinnerFrame returns the current spinner character based on wall time.
+// Using time.Now() keeps all running rows in sync without needing a tick counter.
+func reviewSpinnerFrame() string {
+	frame := int(time.Now().UnixMilli()/100) % len(spinnerFrames)
+	return spinnerFrames[frame]
+}
+
 // renderReviewPanel renders the fullscreen review panel for a session.
 // entry may be nil while diff stats are being fetched (shows loading placeholder).
-func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width int) string {
+// cursor is the currently selected task row index (0-based among all task rows).
+func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int) string {
 	var lines []string
 
 	// Header
@@ -55,16 +66,17 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width int) s
 	lines = append(lines, "")
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
 
-	// Changes
+	// Body: task list (if plan exists) or legacy file-centric view.
 	if entry == nil {
 		lines = append(lines, StyleSubtle.Render("loading diff stats…"))
+	} else if len(entry.tasks) > 0 || len(entry.groups) > 0 {
+		lines = append(lines, renderTaskList(entry, width, cursor)...)
 	} else {
+		// No plan — fall back to the aggregate file view.
 		leftWidth := (width - 4) / 2
 		rightWidth := width - leftWidth - 4
-
 		leftLines := renderFocusList(entry, leftWidth)
 		rightLines := renderReviewShape(entry, rightWidth)
-
 		maxRows := len(leftLines)
 		if len(rightLines) > maxRows {
 			maxRows = len(rightLines)
@@ -88,16 +100,170 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width int) s
 	// Action footer
 	lines = append(lines, "")
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	taskHint := ""
+	if len(entry.getGroups()) > 0 {
+		taskHint = "   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#f0c060")).Render("enter") + StyleSubtle.Render(" — view task diff")
+	}
 	hints := "  " +
 		lipgloss.NewStyle().Foreground(lipgloss.Color("#5ab58a")).Render("p") + StyleSubtle.Render(" — open PR in GitHub") +
 		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#7ec8e3")).Render("t") + StyleSubtle.Render(" — open agent terminal") +
 		"   " + StyleSubtle.Render("c — mark complete") +
 		"   " + StyleSubtle.Render("e — open in editor") +
 		"   " + StyleSubtle.Render("d — defer") +
+		taskHint +
 		"   " + StyleSubtle.Render("ESC — back to focus")
 	lines = append(lines, hints)
 
 	return strings.Join(lines, "\n")
+}
+
+// getGroups safely returns groups, even on a nil entry.
+func (e *reviewDiffEntry) getGroups() []taskReviewGroup {
+	if e == nil {
+		return nil
+	}
+	return e.groups
+}
+
+// renderTaskList renders the scrollable per-task review rows.
+func renderTaskList(entry *reviewDiffEntry, width, cursor int) []string {
+	var lines []string
+	lines = append(lines, StyleSubtle.Render("PLAN TASKS"))
+	lines = append(lines, "")
+
+	// Build a merged view: one row per plan task, plus the "Other changes" group.
+	type row struct {
+		taskIndex int
+		taskText  string
+		group     *taskReviewGroup // may be nil if no commits for this task
+	}
+
+	// Index groups by taskIndex for O(1) lookup.
+	groupByIdx := make(map[int]*taskReviewGroup, len(entry.groups))
+	for i := range entry.groups {
+		g := &entry.groups[i]
+		groupByIdx[g.taskIndex] = g
+	}
+
+	var rows []row
+	for _, t := range entry.tasks {
+		g := groupByIdx[t.Index]
+		rows = append(rows, row{taskIndex: t.Index, taskText: t.Text, group: g})
+	}
+	// Append "other" group if it exists.
+	if other, ok := groupByIdx[0]; ok {
+		rows = append(rows, row{taskIndex: 0, taskText: "Other changes", group: other})
+	}
+
+	cursorStyle := lipgloss.NewStyle().
+		Background(lipgloss.Color("#2a2a3a")).
+		Bold(true)
+	checkStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#5ab58a"))
+	concernStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#f0c060"))
+	failStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#e74c3c"))
+	spinStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#9b7fdb"))
+	subtleGreen := lipgloss.NewStyle().Foreground(lipgloss.Color("#7ed321"))
+	subtleRed := lipgloss.NewStyle().Foreground(lipgloss.Color("#e74c3c"))
+
+	for i, r := range rows {
+		selected := i == cursor
+
+		// Task index label and text.
+		label := fmt.Sprintf("[%d]", r.taskIndex)
+		if r.taskIndex == 0 {
+			label = "[?]"
+		}
+		labelW := 5
+		labelPart := StyleSubtle.Render(fmt.Sprintf("%-*s", labelW, label))
+
+		maxTextW := width - labelW - 30
+		if maxTextW < 10 {
+			maxTextW = 10
+		}
+		textPart := truncateVisible(r.taskText, maxTextW)
+
+		// Commit count + stats.
+		statPart := ""
+		if r.group != nil && r.group.stats != nil {
+			st := r.group.stats
+			commitCount := len(r.group.commits)
+			statPart = fmt.Sprintf("%d commit", commitCount)
+			if commitCount != 1 {
+				statPart += "s"
+			}
+			if st.Insertions > 0 || st.Deletions > 0 {
+				statPart += "  " +
+					subtleGreen.Render(fmt.Sprintf("+%d", st.Insertions)) +
+					" " +
+					subtleRed.Render(fmt.Sprintf("-%d", st.Deletions))
+			}
+		} else if r.group == nil {
+			statPart = StyleSubtle.Render("no commits")
+		}
+
+		// Verdict badge.
+		verdictPart := ""
+		if entry.verdicts != nil {
+			if v, ok := entry.verdicts[r.taskIndex]; ok {
+				switch v.state {
+				case verdictPending:
+					verdictPart = StyleSubtle.Render("···")
+				case verdictRunning:
+					verdictPart = spinStyle.Render(reviewSpinnerFrame())
+				case verdictDone:
+					switch v.verdict.Kind {
+					case agent.VerdictPass:
+						verdictPart = checkStyle.Render("✓ pass")
+					case agent.VerdictConcerns:
+						verdictPart = concernStyle.Render("! concerns")
+					case agent.VerdictFail:
+						verdictPart = failStyle.Render("✗ fail")
+					}
+					if v.verdict.Rationale != "" {
+						rationale := truncateVisible(v.verdict.Rationale, width-12)
+						verdictPart += "  " + StyleSubtle.Render(rationale)
+					}
+				case verdictErr:
+					errStr := "err"
+					if v.err != nil {
+						errStr = truncateVisible(v.err.Error(), 30)
+					}
+					verdictPart = failStyle.Render("✗ " + errStr)
+				}
+			}
+		}
+
+		// Assemble the row.
+		rowText := labelPart + " " + textPart
+		if verdictPart != "" {
+			// Right-align verdict badge in the remaining space.
+			usedW := labelW + 1 + ansi.StringWidth(textPart)
+			spaceW := width - 4 - usedW - ansi.StringWidth(statPart) - ansi.StringWidth(verdictPart) - 3
+			if spaceW < 1 {
+				spaceW = 1
+			}
+			rowText += strings.Repeat(" ", spaceW) + statPart + "  " + verdictPart
+		} else if statPart != "" {
+			usedW := labelW + 1 + ansi.StringWidth(textPart)
+			spaceW := width - 4 - usedW - ansi.StringWidth(statPart)
+			if spaceW < 1 {
+				spaceW = 1
+			}
+			rowText += strings.Repeat(" ", spaceW) + statPart
+		}
+
+		if selected {
+			// Pad to full width for background highlight.
+			padW := width - 4 - ansi.StringWidth(rowText)
+			if padW < 0 {
+				padW = 0
+			}
+			rowText = cursorStyle.Render(rowText + strings.Repeat(" ", padW))
+		}
+		lines = append(lines, "  "+rowText)
+	}
+
+	return lines
 }
 
 // renderFocusList returns left-column lines: total + top files + also-changed.

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -163,8 +163,8 @@ func TestReviewTaskGroupAtCursor(t *testing.T) {
 	}{
 		{0, 1, false},
 		{1, 2, false},
-		{2, 0, false},  // "Other changes"
-		{3, 0, true},   // out of range
+		{2, 0, false}, // "Other changes"
+		{3, 0, true},  // out of range
 	}
 	for _, tt := range tests {
 		got := reviewTaskGroupAtCursor(entry, tt.cursor)

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -21,7 +21,7 @@ func TestRenderReviewPanel_ShowsOriginalPrompt(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 213, Deletions: 34},
 	}
 
-	output := renderReviewPanel(sess, entry, 120)
+	output := renderReviewPanel(sess, entry, 120, 40, 0)
 
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("review panel must show the original prompt")
@@ -36,7 +36,7 @@ func TestRenderReviewPanel_NilDiffEntry(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 
 	// nil entry — should not panic
-	output := renderReviewPanel(sess, nil, 120)
+	output := renderReviewPanel(sess, nil, 120, 40, 0)
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("must still show prompt even with nil diff entry")
 	}
@@ -82,7 +82,7 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120)
+	output := renderReviewPanel(sess, nil, 120, 40, 0)
 
 	for _, want := range []string{
 		"open PR",
@@ -95,5 +95,123 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Errorf("footer must advertise %q; got:\n%s", want, output)
 		}
+	}
+}
+
+// TestRenderReviewPanel_TaskListShown verifies that when the entry has plan
+// tasks, the review panel renders a task list instead of the file-centric view.
+func TestRenderReviewPanel_TaskListShown(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-1", "fix-auth")
+	sess.SetOriginalPrompt("Fix the auth bug")
+	sess.MarkDone()
+
+	entry := &reviewDiffEntry{
+		files:     []git.FileStat{{Path: "auth.go", Status: "M", Insertions: 10, Deletions: 2}},
+		aggregate: &git.DiffStats{Files: 1, Insertions: 10, Deletions: 2},
+		tasks: []agent.PlanTask{
+			{Index: 1, Text: "Add auth middleware", Done: false},
+			{Index: 2, Text: "Write tests", Done: false},
+		},
+		groups: []taskReviewGroup{
+			{
+				taskIndex: 1,
+				commits:   []git.Commit{{Hash: "abc123", Subject: "[task 1] add middleware"}},
+				stats:     &git.DiffStats{Files: 1, Insertions: 10, Deletions: 2},
+			},
+		},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictPass, Rationale: "looks good"}},
+			2: {state: verdictPending},
+		},
+	}
+
+	output := renderReviewPanel(sess, entry, 120, 40, 0)
+
+	if !strings.Contains(output, "PLAN TASKS") {
+		t.Error("task list view must show PLAN TASKS header")
+	}
+	if !strings.Contains(output, "Add auth middleware") {
+		t.Error("must show task 1 text")
+	}
+	if !strings.Contains(output, "Write tests") {
+		t.Error("must show task 2 text")
+	}
+	if !strings.Contains(output, "pass") {
+		t.Error("must show verdict badge for task 1")
+	}
+}
+
+// TestReviewTaskGroupAtCursor checks that the correct group is returned for
+// each cursor position in the task list ordering.
+func TestReviewTaskGroupAtCursor(t *testing.T) {
+	g1 := taskReviewGroup{taskIndex: 1, commits: []git.Commit{{Hash: "a"}}}
+	g2 := taskReviewGroup{taskIndex: 2, commits: []git.Commit{{Hash: "b"}}}
+	gOther := taskReviewGroup{taskIndex: 0, commits: []git.Commit{{Hash: "c"}}}
+
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{
+			{Index: 1, Text: "Task one"},
+			{Index: 2, Text: "Task two"},
+		},
+		groups: []taskReviewGroup{g1, g2, gOther},
+	}
+
+	tests := []struct {
+		cursor    int
+		wantIndex int
+		wantNil   bool
+	}{
+		{0, 1, false},
+		{1, 2, false},
+		{2, 0, false},  // "Other changes"
+		{3, 0, true},   // out of range
+	}
+	for _, tt := range tests {
+		got := reviewTaskGroupAtCursor(entry, tt.cursor)
+		if tt.wantNil {
+			if got != nil {
+				t.Errorf("cursor %d: want nil, got taskIndex=%d", tt.cursor, got.taskIndex)
+			}
+		} else {
+			if got == nil {
+				t.Errorf("cursor %d: want taskIndex=%d, got nil", tt.cursor, tt.wantIndex)
+			} else if got.taskIndex != tt.wantIndex {
+				t.Errorf("cursor %d: want taskIndex=%d, got %d", tt.cursor, tt.wantIndex, got.taskIndex)
+			}
+		}
+	}
+}
+
+// TestReviewTaskCount verifies task row counting including the "other" bucket.
+func TestReviewTaskCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry *reviewDiffEntry
+		want  int
+	}{
+		{"nil entry", nil, 0},
+		{"no tasks no groups", &reviewDiffEntry{}, 0},
+		{
+			"two tasks no other",
+			&reviewDiffEntry{
+				tasks: []agent.PlanTask{{Index: 1}, {Index: 2}},
+			},
+			2,
+		},
+		{
+			"two tasks with other",
+			&reviewDiffEntry{
+				tasks:  []agent.PlanTask{{Index: 1}, {Index: 2}},
+				groups: []taskReviewGroup{{taskIndex: 0}},
+			},
+			3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reviewTaskCount(tt.entry); got != tt.want {
+				t.Errorf("reviewTaskCount = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Rewrites the REVIEWING panel from a file-centric view into a scrollable per-task list, mapping each `[task N]` commit group to its plan task with commit counts, +/- stats, and a verdict badge
- Adds a Sonnet reviewer subprocess (`ReviewerAgent`) that runs automatically for each task group on panel entry, producing `pass` / `concerns` / `fail` verdicts with a one-sentence rationale; model is configurable via `reviewer_model` in global or per-repo config
- Adds `enter`/`space` drill-in from a task row to the existing diff browser filtered to that task's commits, with `esc` returning to the task list; `j`/`k` navigate rows; sessions without a plan fall back to the aggregate file view

## New helpers added

- `git.LogCommitsAgainstBase(wt)` — ordered commits between base and worktree HEAD
- `git.DiffForCommits(wt, hashes)` — per-file stats + raw diff for a commit range
- `agent.ParsePlanTasks(plan)` — extracts ordered `(index, text, done)` from plan markdown (shared source of truth with dashboard `planTaskCounts`)
- `agent.GroupCommitsByTask(commits)` — buckets commits by `[task N]` subject prefix; untagged commits → "Other changes" group
- `agent.ReviewerAgent` interface + `defaultReviewerAgent` Sonnet impl (mirrors `defaultPlanDrafter`)
- `manager.SetReviewerAgent` / `manager.ReviewerAgent()` for test injection

## Test plan

- [ ] `go test -race ./...` passes (pre-existing `config`/`hook` failures are unrelated to this PR)
- [ ] `go vet ./...` clean
- [ ] New unit tests: `TestParsePlanTasks`, `TestGroupCommitsByTask`, `TestParseReviewerOutput`, `TestManagerSetReviewerAgent`, `TestRenderReviewPanel_TaskListShown`, `TestReviewTaskGroupAtCursor`, `TestReviewTaskCount`
- [ ] Manual: advance a planned session to Reviewing → confirm task rows render with commit counts → verdicts populate as subprocesses finish → `enter` on a task row opens filtered diff → `esc` returns to task list
- [ ] Sessions without a plan still show the aggregate file/shape view

🤖 Generated with [Claude Code](https://claude.com/claude-code)