### PR TITLE
Fix TodoWrite progress badge on Building-phase dashboard cards

### DIFF
--- a/changelog.d/fix-todowrite-progress-badge.md
+++ b/changelog.d/fix-todowrite-progress-badge.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- TodoWrite progress badge now appears on Building-phase dashboard cards during real Claude runs — PreToolUse hook was never firing because the generated settings file lacked the required `matcher` field; added `matcher: "*"` to the PreToolUse entry
+- TodoItem unmarshalling no longer silently swallows errors; unmarshal failures are logged to stderr when `BATON_HOOK_DEBUG` is set
+- TodoItem now accepts both `activeForm` (camelCase) and `active_form` (snake_case) keys for forward compatibility
+
+### Added
+
+- `BATON_HOOK_DEBUG` env var: when set, writes timestamped PreToolUse event details to `.baton/logs/hooks.log` and TodoWrite unmarshal results to stderr for diagnostics

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/devenjarvis/baton/internal/hook"
 	"github.com/spf13/cobra"
@@ -102,8 +104,29 @@ func runHook(cmd *cobra.Command, args []string) error {
 		e.ToolInput = payload.ToolInput
 	}
 
+	if os.Getenv("BATON_HOOK_DEBUG") != "" {
+		hookDebugLog(socketPath, kind, payload.ToolName, e.ToolInput, raw)
+	}
+
 	if err := hook.SendEvent(socketPath, e); err != nil {
 		fmt.Fprintln(os.Stderr, "baton hook: forwarding event:", err)
 	}
 	return nil
+}
+
+// hookDebugLog appends a debug line to .baton/logs/hooks.log when BATON_HOOK_DEBUG is set.
+// socketPath is used to derive the .baton directory — it lives at <repo>/.baton/hook.sock.
+func hookDebugLog(socketPath string, kind hook.Kind, toolName string, toolInput json.RawMessage, raw []byte) {
+	dir := filepath.Join(filepath.Dir(socketPath), "logs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "hooks.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	ts := time.Now().Format(time.RFC3339)
+	fmt.Fprintf(f, "%s kind=%s tool_name=%q tool_input_len=%d raw_len=%d\n",
+		ts, kind, toolName, len(toolInput), len(raw))
 }

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -125,8 +125,8 @@ func hookDebugLog(socketPath string, kind hook.Kind, toolName string, toolInput 
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	ts := time.Now().Format(time.RFC3339)
-	fmt.Fprintf(f, "%s kind=%s tool_name=%q tool_input_len=%d raw_len=%d\n",
+	_, _ = fmt.Fprintf(f, "%s kind=%s tool_name=%q tool_input_len=%d raw_len=%d\n",
 		ts, kind, toolName, len(toolInput), len(raw))
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -24,6 +24,28 @@ type TodoItem struct {
 	ActiveForm string `json:"activeForm"`
 }
 
+// UnmarshalJSON handles both the camelCase "activeForm" key Claude currently
+// emits and the snake_case "active_form" alternative, whichever arrives first.
+func (t *TodoItem) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		Content         string `json:"content"`
+		Status          string `json:"status"`
+		ActiveFormCamel string `json:"activeForm"`
+		ActiveFormSnake string `json:"active_form"`
+	}
+	var w wire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	t.Content = w.Content
+	t.Status = w.Status
+	t.ActiveForm = w.ActiveFormCamel
+	if t.ActiveForm == "" {
+		t.ActiveForm = w.ActiveFormSnake
+	}
+	return nil
+}
+
 // Agent ties together a PTY and VT terminal into a managed unit.
 // Agents do not own worktrees — sessions do.
 type Agent struct {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -542,11 +542,18 @@ func (a *Agent) OnHookEvent(e hook.Event) (changed bool) {
 			var inp struct {
 				Todos []TodoItem `json:"todos"`
 			}
-			if err := json.Unmarshal(e.ToolInput, &inp); err == nil {
+			if err := json.Unmarshal(e.ToolInput, &inp); err != nil {
+				if os.Getenv("BATON_HOOK_DEBUG") != "" {
+					fmt.Fprintf(os.Stderr, "baton: TodoWrite unmarshal err=%v input=%s\n", err, e.ToolInput)
+				}
+			} else {
 				a.todos = make([]TodoItem, len(inp.Todos))
 				copy(a.todos, inp.Todos)
 				a.todosUpdatedAt = time.Now()
 				todosChanged = true
+				if os.Getenv("BATON_HOOK_DEBUG") != "" {
+					fmt.Fprintf(os.Stderr, "baton: TodoWrite populated todos=%d\n", len(a.todos))
+				}
 			}
 		}
 		if a.status != StatusActive {

--- a/internal/agent/hook_integration_test.go
+++ b/internal/agent/hook_integration_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
@@ -380,6 +381,131 @@ func TestNotificationIgnoredWhenIdle(t *testing.T) {
 	if got := ag.Status(); got != StatusIdle {
 		t.Errorf("expected Idle to be preserved after stray Notification, got %s", got)
 	}
+}
+
+// TestPreToolUseTodoWritePopulatesTodos is the primary regression test for the
+// TodoWrite progress-badge feature. It feeds the exact JSON shape Claude emits
+// through the full hook path (SendEvent → Manager → OnHookEvent) and asserts
+// that Todos() is populated with the expected items.
+func TestPreToolUseTodoWritePopulatesTodos(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "todo-write", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindSessionStart,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent SessionStart: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive) {
+		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
+	}
+
+	// Exact JSON shape Claude emits for a TodoWrite PreToolUse event.
+	todoInput := json.RawMessage(`{"todos":[` +
+		`{"content":"write unit tests","status":"in_progress","activeForm":"writing unit tests"},` +
+		`{"content":"run tests","status":"pending"}` +
+		`]}`)
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:      hook.KindPreToolUse,
+		AgentID:   ag.ID,
+		ToolName:  "TodoWrite",
+		ToolInput: todoInput,
+	}); err != nil {
+		t.Fatalf("SendEvent PreToolUse TodoWrite: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		todos := ag.Todos()
+		if len(todos) >= 2 {
+			if todos[0].Status != "in_progress" {
+				t.Errorf("todos[0].Status = %q, want %q", todos[0].Status, "in_progress")
+			}
+			if todos[0].ActiveForm != "writing unit tests" {
+				t.Errorf("todos[0].ActiveForm = %q, want %q", todos[0].ActiveForm, "writing unit tests")
+			}
+			if todos[1].Status != "pending" {
+				t.Errorf("todos[1].Status = %q, want %q", todos[1].Status, "pending")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out: Todos() never populated (len=%d)", len(ag.Todos()))
+}
+
+// TestPreToolUseTodoWrite_SnakeCaseActiveForm verifies that TodoItem correctly
+// accepts the snake_case "active_form" key as a fallback for "activeForm".
+func TestPreToolUseTodoWrite_SnakeCaseActiveForm(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	cfg := Config{Name: "todo-snake", Task: "test", Rows: 24, Cols: 80}
+	_, ag, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 5")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-mgr.Events():
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for EventCreated")
+	}
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:    hook.KindSessionStart,
+		AgentID: ag.ID,
+	}); err != nil {
+		t.Fatalf("SendEvent SessionStart: %v", err)
+	}
+	if !waitForStatus(t, ag, StatusActive) {
+		t.Fatalf("expected Active after SessionStart, got %s", ag.Status())
+	}
+
+	// Use snake_case active_form key to exercise the fallback path.
+	todoInput := json.RawMessage(`{"todos":[` +
+		`{"content":"refactor auth","status":"in_progress","active_form":"refactoring auth"}` +
+		`]}`)
+
+	if err := hook.SendEvent(mgr.HookSocketPath(), hook.Event{
+		Kind:      hook.KindPreToolUse,
+		AgentID:   ag.ID,
+		ToolName:  "TodoWrite",
+		ToolInput: todoInput,
+	}); err != nil {
+		t.Fatalf("SendEvent PreToolUse TodoWrite: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		todos := ag.Todos()
+		if len(todos) >= 1 {
+			if todos[0].ActiveForm != "refactoring auth" {
+				t.Errorf("ActiveForm = %q, want %q", todos[0].ActiveForm, "refactoring auth")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out: Todos() never populated with snake_case active_form")
 }
 
 // TestDoneAgentIgnoresLateNotification verifies a Done agent stays Done

--- a/internal/hook/settings.go
+++ b/internal/hook/settings.go
@@ -17,7 +17,12 @@ type settingsSchema struct {
 }
 
 type hookMatcher struct {
-	Hooks []hookCommand `json:"hooks"`
+	// Matcher filters which tool calls trigger this hook entry. Required for
+	// PreToolUse — without it Claude Code does not fire the hook. Use "*" to
+	// match all tool calls. Omitted (empty) for lifecycle hooks (SessionStart,
+	// Stop, etc.) where the event type alone is the filter.
+	Matcher string        `json:"matcher,omitempty"`
+	Hooks   []hookCommand `json:"hooks"`
 }
 
 type hookCommand struct {
@@ -50,7 +55,7 @@ func WriteHooksFile(path string) error {
 			"SessionEnd":       {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook session-end"}}}},
 			"Notification":     {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook notification"}}}},
 			"UserPromptSubmit": {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook user-prompt-submit"}}}},
-			"PreToolUse":       {{Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook pre-tool-use"}}}},
+			"PreToolUse":       {{Matcher: "*", Hooks: []hookCommand{{Type: "command", Command: batonPath + " hook pre-tool-use"}}}},
 		},
 	}
 

--- a/internal/hook/settings_test.go
+++ b/internal/hook/settings_test.go
@@ -44,6 +44,12 @@ func TestWriteHooksFile(t *testing.T) {
 		batonPath = resolved
 	}
 
+	// PreToolUse must have matcher="*" so Claude fires it for all tool calls;
+	// lifecycle hooks (SessionStart, Stop, etc.) need no matcher.
+	wantMatcher := map[string]string{
+		"PreToolUse": "*",
+	}
+
 	for _, event := range wantEvents {
 		matchers, ok := parsed.Hooks[event]
 		if !ok {
@@ -53,6 +59,9 @@ func TestWriteHooksFile(t *testing.T) {
 		if len(matchers) != 1 {
 			t.Errorf("event %q: expected 1 matcher, got %d", event, len(matchers))
 			continue
+		}
+		if m := wantMatcher[event]; m != "" && matchers[0].Matcher != m {
+			t.Errorf("event %q: expected matcher %q, got %q", event, m, matchers[0].Matcher)
 		}
 		if len(matchers[0].Hooks) != 1 {
 			t.Errorf("event %q: expected 1 hook, got %d", event, len(matchers[0].Hooks))


### PR DESCRIPTION
## Summary

- **Root cause fix**: the generated Claude settings file was missing the required `matcher` field on the `PreToolUse` hook entry — without it, Claude Code never fires the hook at all, so `TodoWrite` tool input never reached `OnHookEvent`. Added `matcher: "*"` to the `hookMatcher` struct and emits it only for `PreToolUse` (lifecycle hooks like `SessionStart`/`Stop` use event-type filtering alone and are unaffected via `omitempty`).
- **Defensive fix**: added `UnmarshalJSON` to `TodoItem` so both `"activeForm"` (camelCase, what Claude currently emits) and `"active_form"` (snake_case fallback) are accepted.
- **Diagnostics**: `BATON_HOOK_DEBUG=1` now writes timestamped event lines to `.baton/logs/hooks.log` (tool name, input/raw byte lengths) and unmarshal results/errors to stderr — useful for confirming the hook pipeline is wired end-to-end without adding permanent noise.
- Unmarshal errors are no longer silently swallowed; they surface under the debug flag.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (3 pre-existing failures in `internal/config` and `internal/hook` unrelated to this PR; all agent, tui, and hook-settings tests pass)
- [x] `TestWriteHooksFile` now asserts `matcher == "*"` for `PreToolUse`
- [x] `TestPreToolUseTodoWritePopulatesTodos` — full dispatch path: `SendEvent → Manager → OnHookEvent → Todos()` with camelCase JSON
- [x] `TestPreToolUseTodoWrite_SnakeCaseActiveForm` — exercises the `active_form` snake_case fallback
- [ ] Manual TUI: spawn a Building agent, send a prompt that triggers `TodoWrite`, confirm card line 1 shows `▸ N/M`, line 2 shows the in-progress `activeForm`, line 3 shows the next pending task

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description