### PR TITLE
Fix three planning flow bugs: cwd, --allowedTools typo, shift+enter

### DIFF
--- a/changelog.d/fix-planning-bugs.md
+++ b/changelog.d/fix-planning-bugs.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Planner subprocess now runs in the session's worktree directory instead of baton's process cwd. With multiple registered repos a plan drafted for repo B would previously research repo A's code; it now correctly reads the right codebase.
+- `--allowedTools` flag (camelCase) replaces the silently-dropped `--allowed-tools` (kebab). The kebab form was ignored by the Claude CLI, which caused the permission gate to block the planner's `mcp__baton_planner_question__ask_user` tool in non-interactive `-p` mode — the model would see a tool error and abandon any clarifying question rather than surfacing it to the editor.
+- `shift+enter` newline insertion in the prompt modal works correctly in Kitty-capable terminals. Bubbletea v2 always enables basic key disambiguation (Kitty protocol flag 1), which disambiguates `shift+enter` from plain `enter`; the modal already extended the `InsertNewline` binding to include `shift+enter` so no further code change was needed.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -631,7 +631,7 @@ func (m *Manager) runDraft(ctx context.Context, sess *Session, drafter PlanDraft
 		}
 	}()
 
-	body, err := drafter.Draft(ctx, DraftRequest{UserPrompt: prompt, QuestionSocket: qSocket})
+	body, err := drafter.Draft(ctx, DraftRequest{UserPrompt: prompt, QuestionSocket: qSocket, Cwd: sess.Worktree.Path})
 
 	// If the session has already been removed from the manager (e.g. by a
 	// completed KillSession), skip the post-draft writes — there is nothing
@@ -757,7 +757,7 @@ func (m *Manager) runRevise(ctx context.Context, sess *Session, drafter PlanDraf
 		}
 	}()
 
-	body, err := drafter.Revise(ctx, ReviseRequest{CurrentPlan: current, Critique: critique})
+	body, err := drafter.Revise(ctx, ReviseRequest{CurrentPlan: current, Critique: critique, Cwd: sess.Worktree.Path})
 
 	m.mu.RLock()
 	_, stillOpen := m.sessions[sess.ID]

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -43,15 +43,24 @@ type PlanDrafter interface {
 // internal/planner.Server in the running baton process. The drafter wires
 // it into the Sonnet subprocess as an MCP server so the planner can pause
 // and call ask_user; an empty value disables the feature for this draft.
+//
+// Cwd, when non-empty, sets the working directory for the Claude subprocess.
+// Set to sess.Worktree.Path so the planner reads the right codebase when
+// multiple repos are registered.
 type DraftRequest struct {
 	UserPrompt     string
 	QuestionSocket string
+	Cwd            string
 }
 
 // ReviseRequest is the input to PlanDrafter.Revise.
+//
+// Cwd, when non-empty, sets the working directory for the Claude subprocess.
+// Set to sess.Worktree.Path so the reviser operates in the correct repo.
 type ReviseRequest struct {
 	CurrentPlan string
 	Critique    string
+	Cwd         string
 }
 
 // planDraftPrompt frames each Draft call. The five fixed sections match what
@@ -142,7 +151,7 @@ func (d *defaultPlanDrafter) Draft(ctx context.Context, req DraftRequest) (strin
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrClaudeNotFound, err)
 	}
-	return runClaudePlanner(ctx, claudePath, d.model, planDraftPrompt+prompt, req.QuestionSocket)
+	return runClaudePlanner(ctx, claudePath, d.model, planDraftPrompt+prompt, req.QuestionSocket, req.Cwd)
 }
 
 func (d *defaultPlanDrafter) Revise(ctx context.Context, req ReviseRequest) (string, error) {
@@ -162,7 +171,7 @@ func (d *defaultPlanDrafter) Revise(ctx context.Context, req ReviseRequest) (str
 	// Revise does not surface ask_user — the user is already iterating on a
 	// concrete plan with the editor's revise input, so an interactive prompt
 	// would just compete for attention. Pass an empty socket path.
-	return runClaudePlanner(ctx, claudePath, d.model, instruction, "")
+	return runClaudePlanner(ctx, claudePath, d.model, instruction, "", req.Cwd)
 }
 
 // plannerQuestionMCPName is the MCP-server key under which the planner
@@ -282,7 +291,9 @@ func plannerMCPConfigJSON(questionSocket string) string {
 // socket as the parent agent. When questionSocket is non-empty, the
 // BATON_PLANNER_QUESTION_SOCKET env is added so the spawned MCP bridge
 // (registered via buildClaudePlannerArgs) can dial back into baton.
-func runClaudePlanner(ctx context.Context, claudePath, model, instruction, questionSocket string) (string, error) {
+// When cwd is non-empty, cmd.Dir is set so the subprocess reads the correct
+// repo when multiple repos are registered in baton.
+func runClaudePlanner(ctx context.Context, claudePath, model, instruction, questionSocket, cwd string) (string, error) {
 	cmd := exec.CommandContext(ctx, claudePath, buildClaudePlannerArgs(model, questionSocket)...)
 	cmd.Stdin = strings.NewReader(instruction)
 	env := sanitizedHaikuEnv(os.Environ())
@@ -290,6 +301,9 @@ func runClaudePlanner(ctx context.Context, claudePath, model, instruction, quest
 		env = append(env, PlannerQuestionSocketEnv+"="+questionSocket)
 	}
 	cmd.Env = env
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
 	cmd.WaitDelay = 500 * time.Millisecond
 
 	var stdout, stderr bytes.Buffer

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -216,7 +216,7 @@ func buildClaudePlannerArgs(model, questionSocket string) []string {
 	}
 
 	// --tools filters which tools are visible (keeps Bash/Edit/Write hidden even
-	// if Claude's default set expands). --allowed-tools auto-approves those same
+	// if Claude's default set expands). --allowedTools auto-approves those same
 	// tools so the non-interactive -p subprocess never hits a permission gate.
 	// Both flags are required: --tools alone only controls availability, not approval.
 	args = append(
@@ -225,7 +225,7 @@ func buildClaudePlannerArgs(model, questionSocket string) []string {
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--tools", tools,
-		"--allowed-tools", tools,
+		"--allowedTools", tools,
 		"--setting-sources", "user,project",
 		"--exclude-dynamic-system-prompt-sections",
 	)

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -160,6 +160,50 @@ func TestDefaultPlanDrafter_DraftStripsBatonHookEnv(t *testing.T) {
 	}
 }
 
+// writeCwdCapturingClaude writes a fake claude that writes its cwd to cwdFile
+// then prints stdout. Used to assert the planner sets cmd.Dir correctly.
+func writeCwdCapturingClaude(t *testing.T, dir, cwdFile, stdout string) {
+	t.Helper()
+	script := "#!/bin/sh\n" +
+		"cat >/dev/null\n" +
+		"pwd > " + shellSingleQuote(cwdFile) + "\n" +
+		"printf %s " + shellSingleQuote(stdout) + "\n"
+	path := filepath.Join(dir, "claude")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write cwd-capturing claude: %v", err)
+	}
+}
+
+func TestDefaultPlanDrafter_DraftForwardsWorktreeCwd(t *testing.T) {
+	dir := t.TempDir()
+	cwdFile := filepath.Join(dir, "cwd.txt")
+	writeCwdCapturingClaude(t, dir, cwdFile, "# Goal\nstub")
+	withPATH(t, dir)
+
+	targetDir := t.TempDir()
+	// Resolve symlinks so pwd output (real path) matches on macOS (/var → /private/var).
+	wantDir, err := filepath.EvalSymlinks(targetDir)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+
+	d := DefaultPlanDrafter("")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := d.Draft(ctx, DraftRequest{UserPrompt: "add dark mode", Cwd: targetDir}); err != nil {
+		t.Fatalf("Draft: %v", err)
+	}
+
+	got, err := os.ReadFile(cwdFile)
+	if err != nil {
+		t.Fatalf("read cwd file: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != wantDir {
+		t.Errorf("subprocess cwd = %q, want %q", strings.TrimSpace(string(got)), wantDir)
+	}
+}
+
 func TestDefaultPlanDrafter_ReviseSuccess(t *testing.T) {
 	dir := t.TempDir()
 	const revised = "# Goal\nRevised\n\n## Tasks\n- [ ] one\n- [ ] two"

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -251,7 +251,7 @@ func TestBuildClaudePlannerArgs_UsesSonnet(t *testing.T) {
 		"--disable-slash-commands",
 		"--no-session-persistence",
 		"--tools Read,Grep,Glob,LS,LSP,WebFetch,WebSearch",
-		"--allowed-tools Read,Grep,Glob,LS,LSP,WebFetch,WebSearch",
+		"--allowedTools Read,Grep,Glob,LS,LSP,WebFetch,WebSearch",
 		"--setting-sources user,project",
 	} {
 		if !strings.Contains(joined, want) {
@@ -337,8 +337,8 @@ func TestBuildClaudePlannerArgs_WithQuestionSocketRegistersMCPServer(t *testing.
 	}
 
 	// The fully-qualified ask_user tool name must appear on both --tools and
-	// --allowed-tools so it is both exposed and auto-approved.
-	for _, flag := range []string{"--tools", "--allowed-tools"} {
+	// --allowedTools so it is both exposed and auto-approved.
+	for _, flag := range []string{"--tools", "--allowedTools"} {
 		idx := -1
 		for i, a := range args {
 			if a == flag {
@@ -372,7 +372,7 @@ func TestBuildClaudePlannerArgs_EmptySocketKeepsZeroServers(t *testing.T) {
 		t.Errorf("--mcp-config = %q, want canonical empty payload", args[mcpIdx+1])
 	}
 
-	for _, flag := range []string{"--tools", "--allowed-tools"} {
+	for _, flag := range []string{"--tools", "--allowedTools"} {
 		idx := -1
 		for i, a := range args {
 			if a == flag {


### PR DESCRIPTION
## Summary

- **Planner cwd**: `runClaudePlanner` now sets `cmd.Dir` to the session's worktree path (passed via new `Cwd` field on `DraftRequest`/`ReviseRequest`, populated from `sess.Worktree.Path` in `runDraft`/`runRevise`). Previously, with multiple registered repos, a draft for repo B would research repo A's code since the subprocess inherited baton's process cwd.
- **`--allowedTools` flag**: Renamed from `--allowed-tools` (kebab, silently dropped by the Claude CLI) to `--allowedTools` (camelCase, documented). The kebab form was ignored, causing the permission gate to block `mcp__baton_planner_question__ask_user` in `-p` mode — the model saw a tool error and abandoned clarifying questions without surfacing them to the editor.
- **`shift+enter` in prompt modal**: No code change needed. Bubbletea v2 always enables basic Kitty keyboard disambiguation (flag 1 in `keyboardEnhancementsFlags`), so `shift+enter` is already reported distinctly from `enter` in Kitty-capable terminals. The modal's existing `InsertNewline` binding already covers `shift+enter`. Documented in the changelog.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] New test `TestDefaultPlanDrafter_DraftForwardsWorktreeCwd` asserts subprocess cwd matches the worktree path
- [x] Existing `TestBuildClaudePlannerArgs_*` tests updated to assert `--allowedTools` (camelCase)
- [ ] Manual TUI: shift+enter inserts newline in prompt modal on Kitty terminal; plan for repo B cites repo B paths

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — fragment added to `changelog.d/fix-planning-bugs.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description