### PR TITLE
Reduce review-panel gaps: tighten commit-tagging prompts and surface unmatched tasks

### DIFF
--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -82,7 +82,7 @@ One sentence: what is the developer trying to accomplish?
 2-3 sentences of background. What part of the system does this touch, and what constraints matter? Cite real file paths or symbols where relevant.
 
 ## Tasks
-A short checklist of the steps to ship this. Each task should be small and independently verifiable. Use markdown task syntax: - [ ] description.
+A short checklist of the steps to ship this. Each task should be small and independently verifiable. Use markdown task syntax: - [ ] description. IMPORTANT: the build agent counts ALL "- [ ]" and "- [x]" lines in the plan file top-to-bottom (across every section) to derive the [task N] commit prefix. Do NOT place task-syntax lines anywhere outside this section — stray checkbox lines in Goal, Context, Verification, or Not in scope shift all task indices and break the review panel's commit-to-task mapping.
 
 ## Verification
 How will the developer know the change works? Tests, manual checks, or both.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -78,9 +78,15 @@ const (
 
 Make exactly one git commit per completed step.
 
-If a file at .claude/plan.md exists in the worktree, the commit subject MUST start with "[task N] " where N is the 1-based index of the task line (counting ALL task list lines — both "- [ ]" and "- [x]" — top-to-bottom, ignoring non-task lines such as section headers). If no .claude/plan.md exists, prefix the subject with "task: " instead. The rest of the subject is a normal short description. Example: "[task 3] add --append-system-prompt flag plumbing".
+If a file at .claude/plan.md exists in the worktree, re-read .claude/plan.md immediately before each commit. The commit subject MUST start with "[task N] " where N is the 1-based index of the task line (counting ALL task list lines — both "- [ ]" and "- [x]" — top-to-bottom, ignoring non-task lines such as section headers). N is counted across the ENTIRE file, including any task lines that appear outside the ## Tasks section. If no .claude/plan.md exists, prefix the subject with "task: " instead. The rest of the subject is a normal short description.
 
-Do not squash unrelated work into a single commit, and do not amend a previous commit to add new task work — each task is its own commit so the work can be reviewed task-by-task.`
+Worked example — given a plan whose full task list (all sections) is:
+  line 1: - [ ] write tests        → [task 1]
+  line 2: - [ ] implement feature  → [task 2]
+  line 3: - [x] update docs        → [task 3]
+the third commit subject is "[task 3] update documentation".
+
+NEVER squash commits, NEVER amend a previous commit to add new task work, and NEVER use git commit --amend. Each task MUST be its own commit so the review panel can map commits back to plan tasks one-to-one. Violating this breaks the per-task diff view.`
 )
 
 // KnownModels is the list of Claude model IDs offered in the config form

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4529,15 +4529,29 @@ func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
 				}
 				// Mark plan tasks that have no matching commit group so the review
 				// panel can surface the gap instead of silently omitting the row.
-				for _, t := range entry.tasks {
-					if _, matched := entry.verdicts[t.Index]; !matched {
-						entry.verdicts[t.Index] = &taskVerdictRecord{state: verdictNoDiff}
-					}
-				}
+				// This intentionally only runs when len(commits) > 0: a session
+				// with no commits at all leaves entry.verdicts nil, which the
+				// render loop treats as "not yet reviewed" rather than "missing
+				// diff". Moving this loop outside the len(commits) guard would
+				// also require initialising entry.verdicts in the outer block
+				// and would change that loading-state semantics.
+				populateNoDiffVerdicts(entry)
 			}
 		}
 
 		return reviewDiffMsg{sessionID: sessID, entry: entry}
+	}
+}
+
+// populateNoDiffVerdicts stamps verdictNoDiff on every plan task in entry that
+// has no matching commit group. It must only be called when entry.verdicts is
+// already initialised (i.e. the session has at least one commit), so that the
+// nil-verdicts "not yet reviewed" state remains distinct from verdictNoDiff.
+func populateNoDiffVerdicts(entry *reviewDiffEntry) {
+	for _, t := range entry.tasks {
+		if _, matched := entry.verdicts[t.Index]; !matched {
+			entry.verdicts[t.Index] = &taskVerdictRecord{state: verdictNoDiff}
+		}
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4433,6 +4433,7 @@ const (
 	verdictRunning                     // reviewer subprocess in flight
 	verdictDone                        // reviewer returned a verdict
 	verdictErr                         // reviewer subprocess errored
+	verdictNoDiff                      // task has no matching commits — nothing to review
 )
 
 // taskVerdictRecord holds the verdict state for one task row.
@@ -4525,6 +4526,13 @@ func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
 						rawDiff:   rawDiff,
 					})
 					entry.verdicts[cg.TaskIndex] = &taskVerdictRecord{state: verdictPending}
+				}
+				// Mark plan tasks that have no matching commit group so the review
+				// panel can surface the gap instead of silently omitting the row.
+				for _, t := range entry.tasks {
+					if _, matched := entry.verdicts[t.Index]; !matched {
+						entry.verdicts[t.Index] = &taskVerdictRecord{state: verdictNoDiff}
+					}
 				}
 			}
 		}

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -261,6 +261,7 @@ func renderTaskList(entry *reviewDiffEntry, width, availHeight, cursor int) []st
 					verdictPart = failStyle.Render("✗ " + errStr)
 				case verdictNoDiff:
 					verdictPart = StyleSubtle.Render("no diff found")
+					statPart = "" // "no diff found" already conveys this; avoid the duplicate "no commits" label
 				}
 			}
 		}

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -259,6 +259,8 @@ func renderTaskList(entry *reviewDiffEntry, width, availHeight, cursor int) []st
 						errStr = truncateVisible(v.err.Error(), 30)
 					}
 					verdictPart = failStyle.Render("✗ " + errStr)
+				case verdictNoDiff:
+					verdictPart = StyleSubtle.Render("no diff found")
 				}
 			}
 		}

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -182,6 +182,78 @@ func TestReviewTaskGroupAtCursor(t *testing.T) {
 	}
 }
 
+// TestPopulateNoDiffVerdicts verifies the detection logic that stamps verdictNoDiff
+// on plan tasks with no matching commit group, leaving matched tasks untouched.
+func TestPopulateNoDiffVerdicts(t *testing.T) {
+	tests := []struct {
+		name          string
+		tasks         []agent.PlanTask
+		verdicts      map[int]*taskVerdictRecord // pre-populated (matched tasks)
+		wantNoDiff    []int                      // task indices that should get verdictNoDiff
+		wantUntouched []int                      // task indices that must keep their original state
+	}{
+		{
+			name: "one matched one unmatched",
+			tasks: []agent.PlanTask{
+				{Index: 1, Text: "task one"},
+				{Index: 2, Text: "task two"},
+			},
+			verdicts:      map[int]*taskVerdictRecord{1: {state: verdictPending}},
+			wantNoDiff:    []int{2},
+			wantUntouched: []int{1},
+		},
+		{
+			name: "all matched — nothing stamped",
+			tasks: []agent.PlanTask{
+				{Index: 1, Text: "task one"},
+			},
+			verdicts:      map[int]*taskVerdictRecord{1: {state: verdictPending}},
+			wantNoDiff:    nil,
+			wantUntouched: []int{1},
+		},
+		{
+			name: "all unmatched",
+			tasks: []agent.PlanTask{
+				{Index: 1, Text: "task one"},
+				{Index: 2, Text: "task two"},
+			},
+			verdicts:      map[int]*taskVerdictRecord{},
+			wantNoDiff:    []int{1, 2},
+			wantUntouched: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := &reviewDiffEntry{
+				tasks:    tt.tasks,
+				verdicts: tt.verdicts,
+			}
+			populateNoDiffVerdicts(entry)
+
+			for _, idx := range tt.wantNoDiff {
+				v, ok := entry.verdicts[idx]
+				if !ok {
+					t.Errorf("task %d: expected verdictNoDiff entry, got nothing", idx)
+					continue
+				}
+				if v.state != verdictNoDiff {
+					t.Errorf("task %d: want verdictNoDiff, got state %d", idx, v.state)
+				}
+			}
+			for _, idx := range tt.wantUntouched {
+				v, ok := entry.verdicts[idx]
+				if !ok {
+					t.Errorf("task %d: entry disappeared after populate", idx)
+					continue
+				}
+				if v.state == verdictNoDiff {
+					t.Errorf("task %d: should not have been stamped verdictNoDiff", idx)
+				}
+			}
+		})
+	}
+}
+
 // TestRenderTaskList_NoDiffFoundBadge verifies that a plan task with no matching
 // commit group renders a "no diff found" verdict badge instead of being silent,
 // when other tasks do have commit groups (i.e. verdicts map is initialised).
@@ -218,6 +290,9 @@ func TestRenderTaskList_NoDiffFoundBadge(t *testing.T) {
 	}
 	if !strings.Contains(output, "no diff found") {
 		t.Error("task with no commit group must show 'no diff found' badge")
+	}
+	if strings.Contains(output, "no commits") {
+		t.Error("'no diff found' badge must replace 'no commits' label, not appear alongside it")
 	}
 }
 

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -182,6 +182,45 @@ func TestReviewTaskGroupAtCursor(t *testing.T) {
 	}
 }
 
+// TestRenderTaskList_NoDiffFoundBadge verifies that a plan task with no matching
+// commit group renders a "no diff found" verdict badge instead of being silent,
+// when other tasks do have commit groups (i.e. verdicts map is initialised).
+func TestRenderTaskList_NoDiffFoundBadge(t *testing.T) {
+	entry := &reviewDiffEntry{
+		files:     []git.FileStat{{Path: "auth.go", Status: "M", Insertions: 5, Deletions: 1}},
+		aggregate: &git.DiffStats{Files: 1, Insertions: 5, Deletions: 1},
+		tasks: []agent.PlanTask{
+			{Index: 1, Text: "Add auth middleware", Done: false},
+			{Index: 2, Text: "Write tests", Done: false},
+		},
+		groups: []taskReviewGroup{
+			{
+				taskIndex: 1,
+				commits:   []git.Commit{{Hash: "abc123", Subject: "[task 1] add middleware"}},
+				stats:     &git.DiffStats{Files: 1, Insertions: 5, Deletions: 1},
+			},
+		},
+		// task 2 has no group — verdictNoDiff should be auto-populated
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictPending},
+			2: {state: verdictNoDiff},
+		},
+	}
+
+	sess := agent.NewSessionForTest("sess-1", "fix-auth")
+	sess.SetOriginalPrompt("Fix the auth bug")
+	sess.MarkDone()
+
+	output := renderReviewPanel(sess, entry, 120, 40, 0)
+
+	if !strings.Contains(output, "Write tests") {
+		t.Error("must render a row for task 2 even though it has no commits")
+	}
+	if !strings.Contains(output, "no diff found") {
+		t.Error("task with no commit group must show 'no diff found' badge")
+	}
+}
+
 // TestReviewTaskCount verifies task row counting including the "other" bucket.
 func TestReviewTaskCount(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- **`DefaultBuildSystemPrompt`**: Strengthened the commit-tagging instructions — now requires re-reading `.claude/plan.md` immediately before each commit, adds a worked example showing the 1-based `[task N]` index counted across the entire file (including task lines outside `## Tasks`), and replaces soft \"do not\" language with explicit \"NEVER\" on `git commit --amend` and squashing.
- **`planDraftPrompt`**: Added a warning that the build agent counts all `- [ ]` / `- [x]` lines across every section of the plan file. Discourages stray checkbox syntax outside `## Tasks` to prevent index drift that breaks the review panel's commit-to-task mapping.
- **Review panel — `verdictNoDiff`**: Added a new `verdictNoDiff` verdict state. `fetchReviewDiffCmd` now populates it for every plan task that has commits in the session but no matching `[task N]` commit group. The render loop surfaces a "no diff found" badge on those rows so gaps are visible instead of silent.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [x] `go test -race ./...` — all packages I touched pass; pre-existing failures in `internal/config` and `internal/hook` are unrelated to this PR
- [x] New unit test `TestRenderTaskList_NoDiffFoundBadge` in `reviewpanel_test.go` covers the `verdictNoDiff` render path
- [ ] Manual TUI: run a multi-task plan end-to-end; confirm every task shows a row, tagged commits group correctly, untagged commits still surface in "Other changes"

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests (`TestRenderTaskList_NoDiffFoundBadge`)
- [x] No new public API surface