### PR TITLE
Show spinner badge while PR draft is in flight

### DIFF
--- a/changelog.d/pr-draft-in-progress-feedback.md
+++ b/changelog.d/pr-draft-in-progress-feedback.md
@@ -1,0 +1,3 @@
+### Added
+
+- PR draft in-progress feedback: pressing `p` in the review panel now shows a spinning "drafting PR…" badge on the REVIEWING queue row and a spinner status line inside the review panel while the push+Haiku-draft pipeline runs (30–90s). The `p` hint is replaced with a dimmed "(in progress…)" so the user knows the action is already running.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3567,7 +3567,7 @@ func (a App) View() tea.View {
 	case ViewDashboard:
 		if a.dashboard.panelFocus == focusReview && a.reviewSession != nil {
 			entry := a.reviewDiffCache[a.reviewSession.ID]
-			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight))
+			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID))
 			v.AltScreen = true
 			return v
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -211,7 +211,8 @@ type App struct {
 	prCache         map[string]*prCacheEntry   // keyed by session ID
 	prPollStates    map[string]*prSessionState // keyed by session ID
 	prPollsInFlight int                        // count of concurrent in-flight polls
-	prDraftInFlight bool                       // true while startPRDraftCmd is running; prevents double-trigger
+	prDraftInFlight   bool   // true while startPRDraftCmd is running; prevents double-trigger
+	prDraftSessionID  string // ID of the session whose PR draft is in flight; "" when idle
 
 	// PR compose modal and its associated session context.
 	prComposeModal   prComposeModal
@@ -977,6 +978,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case prDraftReadyMsg:
 		a.prDraftInFlight = false
+		a.prDraftSessionID = ""
 		if msg.err != nil {
 			a.setError("PR draft failed: " + msg.err.Error())
 			return a, nil
@@ -1576,6 +1578,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return a, nil
 					}
 					a.prDraftInFlight = true
+					a.prDraftSessionID = sess.ID
 					repoPath := a.repoPathForSession(sess.ID)
 					a.setError("Pushing branch and drafting PR…")
 					return a, a.startPRDraftCmd(sess, repoPath, true)
@@ -2197,6 +2200,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return a, nil
 					}
 					a.prDraftInFlight = true
+					a.prDraftSessionID = sess.ID
 					repoPath := a.cursorSelectedRepoPath()
 					a.setError("Pushing branch and drafting PR…")
 					return a, a.startPRDraftCmd(sess, repoPath, false)
@@ -2942,6 +2946,7 @@ func (a *App) refreshAgentList() {
 	a.dashboard.focusReviewIdx = a.focusReviewIdx
 	a.dashboard.focusShippingIdx = a.focusShippingIdx
 	a.dashboard.focusCursorSection = a.focusCursorSection
+	a.dashboard.prDraftSessionID = a.prDraftSessionID
 	a.dashboard.activeRepoName = a.activeRepoDisplayName()
 	a.dashboard.activeRepoPath = a.activeRepo
 	a.dashboard.focusLaunchAgent = a.focusLaunchAgent
@@ -3279,6 +3284,7 @@ func (a *App) syncFocusCursorToDashboard() {
 	a.dashboard.focusReviewIdx = a.focusReviewIdx
 	a.dashboard.focusShippingIdx = a.focusShippingIdx
 	a.dashboard.focusCursorSection = a.focusCursorSection
+	a.dashboard.prDraftSessionID = a.prDraftSessionID
 }
 
 // activateFocusCursor opens the row currently under the fullscreen-focus
@@ -3561,7 +3567,7 @@ func (a App) View() tea.View {
 	case ViewDashboard:
 		if a.dashboard.panelFocus == focusReview && a.reviewSession != nil {
 			entry := a.reviewDiffCache[a.reviewSession.ID]
-			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor))
+			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight))
 			v.AltScreen = true
 			return v
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -207,12 +207,12 @@ type App struct {
 	diffStatsCache      map[string]*diffStatsEntry // keyed by session ID
 	diffRefreshInFlight bool
 
-	ghClient        *github.Client
-	prCache         map[string]*prCacheEntry   // keyed by session ID
-	prPollStates    map[string]*prSessionState // keyed by session ID
-	prPollsInFlight int                        // count of concurrent in-flight polls
-	prDraftInFlight   bool   // true while startPRDraftCmd is running; prevents double-trigger
-	prDraftSessionID  string // ID of the session whose PR draft is in flight; "" when idle
+	ghClient         *github.Client
+	prCache          map[string]*prCacheEntry   // keyed by session ID
+	prPollStates     map[string]*prSessionState // keyed by session ID
+	prPollsInFlight  int                        // count of concurrent in-flight polls
+	prDraftInFlight  bool                       // true while startPRDraftCmd is running; prevents double-trigger
+	prDraftSessionID string                     // ID of the session whose PR draft is in flight; "" when idle
 
 	// PR compose modal and its associated session context.
 	prComposeModal   prComposeModal

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -129,6 +129,7 @@ type dashboardModel struct {
 	focusReviewIdx         int            // index into reviewQueueSessions()
 	focusShippingIdx       int            // index into shippingSessions()
 	focusCursorSection     focusSection   // which fullscreen-focus section the cursor is on
+	prDraftSessionID       string         // session ID whose PR draft is in flight; "" when idle
 	activeRepoName         string         // display name of the active repo
 	activeRepoPath         string         // canonical path of the active repo (for pipeline filtering)
 	focusLaunchAgent       *agent.Agent   // agent open in focusLaunch terminal; nil otherwise
@@ -1536,14 +1537,18 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName string, sel
 	}
 
 	var taskDisplay string
-	origPrompt := sess.OriginalPrompt()
-	switch {
-	case sess.HasTaskSummary() && sess.TaskSummary() != "":
-		taskDisplay = cardStyle.Render(truncateVisible(sess.TaskSummary(), width-30))
-	case origPrompt != "":
-		taskDisplay = cardStyle.Render(truncateVisible(origPrompt, width-30))
-	default:
-		taskDisplay = cardStyle.Render("…")
+	if d.prDraftSessionID != "" && sess.ID == d.prDraftSessionID {
+		taskDisplay = lipgloss.NewStyle().Foreground(ColorWarning).Render(reviewSpinnerFrame() + " drafting PR…")
+	} else {
+		origPrompt := sess.OriginalPrompt()
+		switch {
+		case sess.HasTaskSummary() && sess.TaskSummary() != "":
+			taskDisplay = cardStyle.Render(truncateVisible(sess.TaskSummary(), width-30))
+		case origPrompt != "":
+			taskDisplay = cardStyle.Render(truncateVisible(origPrompt, width-30))
+		default:
+			taskDisplay = cardStyle.Render("…")
+		}
 	}
 	left2 := "  " + taskDisplay
 	line2 := left2

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -606,3 +606,32 @@ func TestPlanningStatusBadge_PhaseTransitions(t *testing.T) {
 type errAnything struct{}
 
 func (errAnything) Error() string { return "anything" }
+
+// TestRenderQueueRow_PRDraftBadge verifies that the "drafting PR…" spinner
+// badge appears on line 2 of a REVIEWING row when prDraftSessionID matches,
+// and that clearing prDraftSessionID restores the normal task display.
+func TestRenderQueueRow_PRDraftBadge(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-1", "fix-auth")
+	sess.SetOriginalPrompt("Fix the auth bug")
+	sess.MarkDone()
+
+	// With prDraftSessionID matching the session: badge should appear.
+	d := dashboardModel{prDraftSessionID: sess.ID}
+	rows := d.renderQueueRow(sess, "", false, ColorWarning, 80)
+	if len(rows) < 2 {
+		t.Fatalf("renderQueueRow returned %d lines, want 2", len(rows))
+	}
+	if !strings.Contains(ansi.Strip(rows[1]), "drafting PR") {
+		t.Errorf("in-flight row line 2 = %q, want 'drafting PR…'", rows[1])
+	}
+
+	// With prDraftSessionID cleared: normal prompt should appear.
+	d.prDraftSessionID = ""
+	rows = d.renderQueueRow(sess, "", false, ColorWarning, 80)
+	if strings.Contains(ansi.Strip(rows[1]), "drafting PR") {
+		t.Error("cleared state must not show badge; got 'drafting PR' on line 2")
+	}
+	if !strings.Contains(ansi.Strip(rows[1]), "Fix the auth bug") {
+		t.Errorf("cleared state line 2 = %q, want original prompt", rows[1])
+	}
+}

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -27,7 +27,8 @@ func reviewSpinnerFrame() string {
 // renderReviewPanel renders the fullscreen review panel for a session.
 // entry may be nil while diff stats are being fetched (shows loading placeholder).
 // cursor is the currently selected task row index (0-based among all task rows).
-func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int) string {
+// prDraftInFlight, when true, shows a spinner status line and disables the p hint.
+func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool) string {
 	var lines []string
 
 	// Header
@@ -72,7 +73,12 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	} else if len(entry.tasks) > 0 || len(entry.groups) > 0 {
 		// Overhead: header(1) + divider(1) + "ORIGINAL INTENT"(1) + intent(≤6) +
 		// blank(1) + divider(1) + blank(1) + divider(1) + hints(1) = 14 max.
-		taskListHeight := height - 14
+		// +1 when prDraftInFlight adds a spinner line above the footer.
+		overhead := 14
+		if prDraftInFlight {
+			overhead++
+		}
+		taskListHeight := height - overhead
 		if taskListHeight < 4 {
 			taskListHeight = 4
 		}
@@ -103,6 +109,12 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 		}
 	}
 
+	// In-flight PR draft status line
+	if prDraftInFlight {
+		draftStatus := lipgloss.NewStyle().Foreground(ColorWarning).Render(reviewSpinnerFrame() + " Pushing branch and drafting PR…")
+		lines = append(lines, draftStatus)
+	}
+
 	// Action footer
 	lines = append(lines, "")
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
@@ -110,8 +122,14 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	if len(entry.getGroups()) > 0 {
 		taskHint = "   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#f0c060")).Render("enter") + StyleSubtle.Render(" — view task diff")
 	}
+	var pHint string
+	if prDraftInFlight {
+		pHint = StyleSubtle.Render("p — (in progress…)")
+	} else {
+		pHint = lipgloss.NewStyle().Foreground(lipgloss.Color("#5ab58a")).Render("p") + StyleSubtle.Render(" — create or open PR")
+	}
 	hints := "  " +
-		lipgloss.NewStyle().Foreground(lipgloss.Color("#5ab58a")).Render("p") + StyleSubtle.Render(" — create or open PR") +
+		pHint +
 		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#7ec8e3")).Render("t") + StyleSubtle.Render(" — open agent terminal") +
 		"   " + StyleSubtle.Render("c — mark complete") +
 		"   " + StyleSubtle.Render("e — open in editor") +

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -21,7 +21,7 @@ func TestRenderReviewPanel_ShowsOriginalPrompt(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 213, Deletions: 34},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
 
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("review panel must show the original prompt")
@@ -36,7 +36,7 @@ func TestRenderReviewPanel_NilDiffEntry(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 
 	// nil entry — should not panic
-	output := renderReviewPanel(sess, nil, 120, 40, 0)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("must still show prompt even with nil diff entry")
 	}
@@ -82,7 +82,7 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
 
 	for _, want := range []string{
 		"open PR",
@@ -125,7 +125,7 @@ func TestRenderReviewPanel_TaskListShown(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("task list view must show PLAN TASKS header")
@@ -327,5 +327,25 @@ func TestReviewTaskCount(t *testing.T) {
 				t.Errorf("reviewTaskCount = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestRenderReviewPanel_PRDraftInFlight verifies that the spinner status line
+// and disabled p hint appear when prDraftInFlight is true.
+func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-1", "fix-auth")
+	sess.SetOriginalPrompt("Fix the auth bug")
+	sess.MarkDone()
+
+	output := renderReviewPanel(sess, nil, 120, 40, 0, true)
+
+	if !strings.Contains(output, "Pushing branch and drafting PR") {
+		t.Error("in-flight state must show draft spinner line")
+	}
+	if !strings.Contains(output, "in progress") {
+		t.Error("in-flight state must show disabled p hint")
+	}
+	if strings.Contains(output, "create or open PR") {
+		t.Error("in-flight state must not show normal p hint")
 	}
 }

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -283,7 +283,7 @@ func TestRenderTaskList_NoDiffFoundBadge(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
 
 	if !strings.Contains(output, "Write tests") {
 		t.Error("must render a row for task 2 even though it has no commits")


### PR DESCRIPTION
## Summary

- Pressing `p` in the review panel now shows visible in-progress feedback while the push+Haiku-draft pipeline runs (30–90s).
- The REVIEWING queue row shows a spinning `⣾ drafting PR…` badge (replaces the task summary on line 2) while the draft is in flight.
- Inside the review panel, a spinner status line (`⣾ Pushing branch and drafting PR…`) appears above the footer.
- The `p` hint is replaced with dimmed `p — (in progress…)` so the user knows the action is already running and `p` is gated.
- Both `p`-key set-sites (review panel and focusLaunch) are covered; the badge clears on `prDraftReadyMsg` (success or error).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: create a session → advance to REVIEWING → open review panel (`r`) → press `p` → confirm spinning badge on queue row and spinner line in panel → after 30-90s, confirm PR compose modal appears and indicators clear

## Checklist

- [x] Updated `changelog.d/` fragment added
- [x] New behavior has tests (`TestRenderReviewPanel_PRDraftInFlight`)
- [x] No new public API surface