### PR TITLE
Show plan progress on Building-phase session cards

### DIFF
--- a/changelog.d/plan-progress-on-building-cards.md
+++ b/changelog.d/plan-progress-on-building-cards.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Building-phase session cards now surface plan progress when a `.claude/plan.md` is present. The line-1 badge shows `▸ done/total · N active` derived from the plan's checkbox state, and a new line (directly above the branch row) shows `▸ <first open task> · next: <second open task>`, collapsing to `▸ <first open task>` when only one task remains and disappearing entirely when all tasks are done. The existing task-summary description on lines 2–3 is preserved. Sessions without a plan file (or where the plan has no checkbox lines) continue to use the TodoWrite-driven badge and description unchanged.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3100,7 +3100,7 @@ func (a *App) focusSectionItems(s focusSection) []listItem {
 //	rows 2..5:             pipeline widget (4 rows)
 //	row 6:                 blank
 //	(per non-empty section, in order Planning → Building → Reviewing → Shipping:)
-//	  label row + N rows per row (4 for Planning/Building cards, 2 for Reviewing/Shipping)
+//	  label row + N rows per item (4 for Planning, 4–5 for Building cards depending on plan progress, 2 for Reviewing/Shipping)
 //	  blank row between rows; trailing blank row before next section
 //
 // Returns (section, index, true) when the click landed on a session row,
@@ -3132,8 +3132,11 @@ func (a *App) pipelineHitTest(dashboardContentY int) (focusSection, int, bool) {
 			continue
 		}
 		cursor += labelRows
-		rowH := rowsPerItem(section)
-		for i := range items {
+		for i, item := range items {
+			rowH := rowsPerItem(section)
+			if section == focusSectionBuilding && item.session != nil && planProgressLine(item.session, 1) != "" {
+				rowH++
+			}
 			start := cursor
 			end := start + rowH
 			if dashboardContentY >= start && dashboardContentY < end {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -461,6 +461,15 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ finished — awaiting prompt")
 	}
 	if sess.LifecyclePhase() == agent.LifecycleInProgress {
+		if plan, present := sess.CachedPlan(); present {
+			if total, done := planTaskCounts(plan); total > 0 {
+				badge := fmt.Sprintf("▸ %d/%d", done, total)
+				if activeCount > 0 {
+					badge += fmt.Sprintf(" · %d active", activeCount)
+				}
+				return StyleSubtle.Render(badge)
+			}
+		}
 		if ag := sess.PrimaryAgent(); ag != nil {
 			if badge := buildingProgressBadge(ag.Todos(), activeCount); badge != "" {
 				return badge

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -546,16 +546,17 @@ func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Co
 	}
 }
 
-// renderFocusSessionCard returns exactly 4 lines for a session card in focus
-// mode. Each line begins with a colored vertical stripe (▎) whose color encodes
-// the dominant session state via sessionFocusStripeColor; the selected card
-// brightens the stripe to ColorSecondary. The card has fixed height so the
-// list layout is predictable regardless of summary length.
+// renderFocusSessionCard returns 4 lines for a session card in focus mode, or
+// 5 lines when a Building session has unfinished plan tasks. Each line begins
+// with a colored vertical stripe (▎) whose color encodes the dominant session
+// state via sessionFocusStripeColor; the selected card brightens the stripe to
+// ColorSecondary.
 //
 // Line 1: <stripe> <name (bold, ColorText)>     ... right-aligned <status badge>
 // Line 2: <stripe>   <description line 1 (muted; italic if pending)>
 // Line 3: <stripe>   <description line 2 or empty>  (always reserved)
-// Line 4: <stripe>   <branch [· detail]>        ... right-aligned <elapsed>
+// Line 4: <stripe>   ▸ <first open task> [· next: <second open>]  (plan-backed building only)
+// Line 4/5: <stripe>   <branch [· detail]>      ... right-aligned <elapsed>
 func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName string, selected bool, width int) []string {
 	stripeColor := d.sessionFocusStripeColor(sess)
 	if selected {
@@ -667,6 +668,10 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	}
 	line4 := rightAlign(bottomLeft, StyleSubtle.Render(elapsedStr), width)
 
+	if progress := planProgressLine(sess, descBudget); progress != "" {
+		progressLine := stripe + indent + StyleSubtle.Render(progress)
+		return []string{line1, line2, line3, progressLine, line4}
+	}
 	return []string{line1, line2, line3, line4}
 }
 
@@ -804,6 +809,40 @@ func secondUncompletedTask(plan string) string {
 		}
 	}
 	return ""
+}
+
+// planProgressLine returns the text content for the optional task-progress
+// line on a Building session card ("▸ first open · next: second open"),
+// truncated to budget display cells. Returns "" when the line should be
+// omitted: session is not LifecycleInProgress, it is reviewable (all tasks
+// done), it has no plan, the plan has no task lines, or all tasks are already
+// done (firstUncompletedTask returns ""). The first-open-task approximation is
+// intentional — deriving the in-flight task from git commits would require
+// per-tick git I/O that the plan cache avoids.
+func planProgressLine(sess *agent.Session, budget int) string {
+	if sess.LifecyclePhase() != agent.LifecycleInProgress {
+		return ""
+	}
+	if sess.IsReviewable() {
+		return ""
+	}
+	plan, present := sess.CachedPlan()
+	if !present {
+		return ""
+	}
+	total, _ := planTaskCounts(plan)
+	if total == 0 {
+		return ""
+	}
+	first := firstUncompletedTask(plan)
+	if first == "" {
+		return ""
+	}
+	text := "▸ " + first
+	if second := secondUncompletedTask(plan); second != "" {
+		text += " · next: " + second
+	}
+	return truncateVisible(text, budget)
 }
 
 // buildingProgressBadge returns a styled "▸ done/total · N active" badge for

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -830,10 +830,6 @@ func planProgressLine(sess *agent.Session, budget int) string {
 	if !present {
 		return ""
 	}
-	total, _ := planTaskCounts(plan)
-	if total == 0 {
-		return ""
-	}
 	first := firstUncompletedTask(plan)
 	if first == "" {
 		return ""

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -772,6 +772,31 @@ func firstUncompletedTask(plan string) string {
 	return ""
 }
 
+// secondUncompletedTask returns the text of the second "- [ ]" line in plan,
+// or "" if fewer than two open tasks exist. Uses the same whitespace-trimming
+// and blank-body-skipping rules as firstUncompletedTask so both helpers agree
+// on what constitutes a valid open task. The "second open task" approximation
+// is intentional — deriving the truly-in-flight task from git commits would
+// require per-tick git I/O that the plan cache exists to avoid.
+func secondUncompletedTask(plan string) string {
+	count := 0
+	for _, raw := range strings.Split(plan, "\n") {
+		line := strings.TrimLeft(raw, " \t")
+		if !strings.HasPrefix(line, "- [ ]") {
+			continue
+		}
+		text := strings.TrimSpace(strings.TrimPrefix(line, "- [ ]"))
+		if text == "" {
+			continue
+		}
+		count++
+		if count == 2 {
+			return text
+		}
+	}
+	return ""
+}
+
 // buildingProgressBadge returns a styled "▸ done/total · N active" badge for
 // a Building-phase session that has received ≥1 TodoWrite. Returns "" when
 // todos is empty so the caller can fall back to the normal "N active, M idle"

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -578,6 +578,29 @@ func TestFirstUncompletedTask(t *testing.T) {
 	}
 }
 
+func TestSecondUncompletedTask(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		plan string
+		want string
+	}{
+		{"empty", "", ""},
+		{"no tasks", "# just a header\n", ""},
+		{"one open task only", "- [ ] only task\n", ""},
+		{"all done", "- [x] one\n- [X] two\n", ""},
+		{"two open tasks", "- [ ] first\n- [ ] second\n", "second"},
+		{"closed between two open", "- [ ] first\n- [x] done\n- [ ] second\n", "second"},
+		{"trims surrounding whitespace", "- [ ] first\n  - [ ]   trim me  \n", "trim me"},
+		{"skips blank task body", "- [ ] first\n- [ ]   \n- [ ] real second\n", "real second"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := secondUncompletedTask(tc.plan); got != tc.want {
+				t.Errorf("secondUncompletedTask(%q) = %q, want %q", tc.plan, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPlanningStatusBadge_PhaseTransitions(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("id", "name", dir)

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -421,3 +421,85 @@ func TestRenderQueueRow_RepoPrefix(t *testing.T) {
 		t.Errorf("empty repoName should not emit › separator, got %q", ansi.Strip(bare[0]))
 	}
 }
+
+// TestSessionFocusStatus_BuildingWithPlanShowsProgressBadge verifies that a
+// Building session backed by a plan file shows "▸ done/total · N active" on
+// the badge, not the plain "N active, M idle" fallback.
+func TestSessionFocusStatus_BuildingWithPlanShowsProgressBadge(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	if err := sess.WritePlan("- [x] one\n- [ ] two\n- [ ] three\n"); err != nil {
+		t.Fatal(err)
+	}
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	if !strings.Contains(badge, "1/3") {
+		t.Errorf("expected plan progress badge '1/3', got %q", badge)
+	}
+	if !strings.Contains(badge, "1 active") {
+		t.Errorf("expected '1 active' in plan badge, got %q", badge)
+	}
+}
+
+// TestSessionFocusStatus_BuildingWithPlanPreemptedByError verifies that an
+// error badge still wins over the plan-derived progress badge.
+func TestSessionFocusStatus_BuildingWithPlanPreemptedByError(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	if err := sess.WritePlan("- [x] one\n- [ ] two\n- [ ] three\n"); err != nil {
+		t.Fatal(err)
+	}
+	ag := sess.AddTestAgent("a-1", false, agent.StatusError)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	if !strings.Contains(badge, "error") {
+		t.Errorf("expected error badge to preempt plan progress, got %q", badge)
+	}
+	if strings.Contains(badge, "1/3") {
+		t.Errorf("plan progress badge must not appear when agent has error, got %q", badge)
+	}
+}
+
+// TestSessionFocusStatus_BuildingWithPlanAllDoneReviewablePrefersReviewBadge
+// verifies that when all plan tasks are done and the session is reviewable, the
+// "✓ idle — press m to review" badge wins over the plan "done/total" badge
+// (Spec #6).
+func TestSessionFocusStatus_BuildingWithPlanAllDoneReviewablePrefersReviewBadge(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	if err := sess.WritePlan("- [x] one\n- [x] two\n"); err != nil {
+		t.Fatal(err)
+	}
+	// Idle agent → IsReviewable() == true and DoneAt is zero.
+	ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	if !strings.Contains(badge, "press m to review") {
+		t.Errorf("expected review badge to win when all tasks done + reviewable, got %q", badge)
+	}
+	if strings.Contains(badge, "2/2") {
+		t.Errorf("plan progress badge must not appear when reviewable, got %q", badge)
+	}
+}

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -422,6 +422,116 @@ func TestRenderQueueRow_RepoPrefix(t *testing.T) {
 	}
 }
 
+// TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine verifies
+// that a Building session with a plan and open tasks produces a 5-line card
+// where the description (lines 2–3) is preserved and the new line 4 shows
+// "▸ first open · next: second open", with the branch/elapsed row moved to
+// line 5.
+func TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	sess.SetTaskSummary("implement oauth flow")
+	if err := sess.WritePlan("- [x] done thing\n- [ ] write tests\n- [ ] open PR\n"); err != nil {
+		t.Fatal(err)
+	}
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 100)
+	if len(card) != 5 {
+		t.Fatalf("expected 5-line card for plan-backed building session, got %d lines: %v", len(card), card)
+	}
+	if !strings.Contains(ansi.Strip(card[1]), "implement oauth flow") {
+		t.Errorf("line 2 should show description (task summary), got %q", ansi.Strip(card[1]))
+	}
+	line4 := ansi.Strip(card[3])
+	if !strings.Contains(line4, "write tests") {
+		t.Errorf("line 4 should contain first open task, got %q", line4)
+	}
+	if !strings.Contains(line4, "next: open PR") {
+		t.Errorf("line 4 should contain 'next: open PR', got %q", line4)
+	}
+}
+
+// TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix verifies
+// that when only one open task remains, the task-progress line shows "▸ task"
+// without a "next:" suffix.
+func TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	if err := sess.WritePlan("- [x] done\n- [ ] last task\n"); err != nil {
+		t.Fatal(err)
+	}
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 100)
+	if len(card) != 5 {
+		t.Fatalf("expected 5-line card with single open task, got %d lines", len(card))
+	}
+	line4 := ansi.Strip(card[3])
+	if !strings.Contains(line4, "last task") {
+		t.Errorf("line 4 should contain open task name, got %q", line4)
+	}
+	if strings.Contains(line4, "next:") {
+		t.Errorf("line 4 must not have 'next:' with single open task, got %q", line4)
+	}
+}
+
+// TestRenderFocusSessionCard_PlanWithNoOpenTasksStaysFourLines verifies that a
+// plan where all tasks are done produces a 4-line card (no task-progress line).
+func TestRenderFocusSessionCard_PlanWithNoOpenTasksStaysFourLines(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	if err := sess.WritePlan("- [x] one\n- [x] two\n"); err != nil {
+		t.Fatal(err)
+	}
+	ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 100)
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card when all tasks done, got %d lines", len(card))
+	}
+}
+
+// TestRenderFocusSessionCard_NoPlanStaysFourLines verifies that a session with
+// no worktree path (and therefore no plan) produces the regular 4-line card.
+func TestRenderFocusSessionCard_NoPlanStaysFourLines(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "my-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 100)
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card with no plan, got %d lines", len(card))
+	}
+}
+
 // TestSessionFocusStatus_BuildingWithPlanShowsProgressBadge verifies that a
 // Building session backed by a plan file shows "▸ done/total · N active" on
 // the badge, not the plain "N active, M idle" fallback.

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -585,6 +585,32 @@ func TestSessionFocusStatus_BuildingWithPlanPreemptedByError(t *testing.T) {
 	}
 }
 
+// TestSessionFocusStatus_BuildingWithPlanPreemptedByWaiting verifies that a
+// waiting badge still wins over the plan-derived progress badge.
+func TestSessionFocusStatus_BuildingWithPlanPreemptedByWaiting(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	if err := sess.WritePlan("- [x] one\n- [ ] two\n- [ ] three\n"); err != nil {
+		t.Fatal(err)
+	}
+	ag := sess.AddTestAgent("a-1", false, agent.StatusWaiting)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	if !strings.Contains(badge, "waiting") {
+		t.Errorf("expected waiting badge to preempt plan progress, got %q", badge)
+	}
+	if strings.Contains(badge, "1/3") {
+		t.Errorf("plan progress badge must not appear when agent is waiting, got %q", badge)
+	}
+}
+
 // TestSessionFocusStatus_BuildingWithPlanAllDoneReviewablePrefersReviewBadge
 // verifies that when all plan tasks are done and the session is reviewable, the
 // "✓ idle — press m to review" badge wins over the plan "done/total" badge


### PR DESCRIPTION
## Summary

- Building-phase session cards now derive a \`▸ done/total · N active\` progress badge directly from \`.claude/plan.md\` checkbox state, replacing the generic "N active, M idle" count when a plan is present. Error/waiting/reviewable conditions still preempt the plan badge.
- A new optional line is inserted above the branch/elapsed row showing \`▸ <first open task> · next: <second open task>\`, collapsing to \`▸ <first open task>\` when only one task remains and disappearing entirely when all tasks are ticked. The existing task-summary description on lines 2–3 is preserved, so the card grows from 4 to 5 lines only when there is meaningful progress to surface.
- Sessions with no plan file (or zero task-checkbox lines) continue using the TodoWrite-driven badge and description unchanged — no regression to the existing path.
- Adds \`secondUncompletedTask\` helper (mirrors \`firstUncompletedTask\`) and \`planProgressLine\` helper for the card line, both using the same checkbox-counting rules as \`planTaskCounts\` so badge, task-progress line, review panel \`[task N]\` mapping, and \`ParsePlanTasks\` all agree.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/tui/` — all new and existing tests pass
- [x] `go test -race ./...` — only pre-existing failures in `internal/config` and `internal/hook` (macOS unix socket path length / XDG migration; unrelated to this PR)
- [ ] Manual TUI: launch baton, plan-first a multi-task change, press `b` to advance to BUILDING; confirm the card shows `▸ done/total · N active` on line 1 and `▸ <first open task> · next: <second>` on line 4; tick a checkbox in `plan.md` and confirm both update within a TUI tick.
- [ ] Manual TUI: let all tasks complete; confirm the card collapses to 4 lines and line-1 badge shows `✓ idle — press m to review`.
- [ ] Manual TUI: spawn a Building session with no plan (legacy path); confirm unchanged 4-line layout with TodoWrite-driven badge.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — changelog fragment added to `changelog.d/`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description