### PR TITLE
Auto-promote sessions to Shipping when external PR is detected

### DIFF
--- a/changelog.d/detect-external-pr.md
+++ b/changelog.d/detect-external-pr.md
@@ -1,0 +1,3 @@
+### Added
+
+- Sessions in Building, ReadyForReview, or InReview phases now auto-advance to Shipping when the PR poller discovers an open PR opened outside baton (e.g. via `gh` or the GitHub web UI). The review panel closes if it was open for the promoted session.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1086,6 +1086,19 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			threads: msg.threads,
 			stack:   msg.stack,
 		}
+		// Auto-promote to Shipping when an open PR is discovered externally.
+		if msg.pr != nil && msg.pr.State == "open" {
+			if sess := a.sessionByID(msg.sessionID); sess != nil {
+				switch sess.LifecyclePhase() {
+				case agent.LifecycleInProgress, agent.LifecycleReadyForReview, agent.LifecycleInReview:
+					sess.SetLifecyclePhase(agent.LifecycleShipping)
+					if a.reviewSession != nil && a.reviewSession.ID == msg.sessionID {
+						a.dashboard.panelFocus = focusList
+						a.reviewSession = nil
+					}
+				}
+			}
+		}
 		// Detect PR merge/close and transition to Complete lifecycle phase.
 		if msg.pr != nil && (msg.pr.State == "merged" || msg.pr.State == "closed") {
 			repoPath := a.repoPathForSession(msg.sessionID)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2593,6 +2593,201 @@ func TestPRPollMsg_ExternalMergeClosesPanelAndTransitions(t *testing.T) {
 	}
 }
 
+// TestPRPollMsg_ExternalOpenPRPromotesBuildingToShipping verifies that a
+// session in LifecycleInProgress transitions to LifecycleShipping when the PR
+// poller discovers an open PR opened outside baton.
+func TestPRPollMsg_ExternalOpenPRPromotesBuildingToShipping(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("sess-build", "branch")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+
+	msg := prPollMsg{
+		sessionID: "sess-build",
+		pr:        &github.PRState{State: "open", Number: 7},
+	}
+	app.Update(msg)
+
+	if sess.LifecyclePhase() != agent.LifecycleShipping {
+		t.Errorf("session lifecycle = %v, want LifecycleShipping", sess.LifecyclePhase())
+	}
+}
+
+// TestPRPollMsg_ExternalOpenPRPromotesReadyForReviewToShipping verifies that a
+// session in LifecycleReadyForReview transitions to LifecycleShipping when the
+// PR poller discovers an open PR.
+func TestPRPollMsg_ExternalOpenPRPromotesReadyForReviewToShipping(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("sess-rfr", "branch")
+	sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+
+	msg := prPollMsg{
+		sessionID: "sess-rfr",
+		pr:        &github.PRState{State: "open", Number: 7},
+	}
+	app.Update(msg)
+
+	if sess.LifecyclePhase() != agent.LifecycleShipping {
+		t.Errorf("session lifecycle = %v, want LifecycleShipping", sess.LifecyclePhase())
+	}
+}
+
+// TestPRPollMsg_ExternalOpenPRPromotesInReviewToShipping_ClosesReviewPanel
+// verifies that a session in LifecycleInReview transitions to LifecycleShipping
+// and that the review panel closes if it was open for that session.
+func TestPRPollMsg_ExternalOpenPRPromotesInReviewToShipping_ClosesReviewPanel(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("sess-ir", "branch")
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.reviewSession = sess
+	app.dashboard.panelFocus = focusReview
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+
+	msg := prPollMsg{
+		sessionID: "sess-ir",
+		pr:        &github.PRState{State: "open", Number: 7},
+	}
+	model, _ := app.Update(msg)
+	got := model.(App)
+
+	if sess.LifecyclePhase() != agent.LifecycleShipping {
+		t.Errorf("session lifecycle = %v, want LifecycleShipping", sess.LifecyclePhase())
+	}
+	if got.dashboard.panelFocus != focusList {
+		t.Errorf("panelFocus = %v, want focusList", got.dashboard.panelFocus)
+	}
+	if got.reviewSession != nil {
+		t.Error("reviewSession should be nil after auto-promotion closes the panel")
+	}
+}
+
+// TestPRPollMsg_PlanningNotPromoted verifies that a session in
+// LifecyclePlanning does not transition when an open PR is discovered.
+func TestPRPollMsg_PlanningNotPromoted(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("sess-plan", "branch")
+	// LifecyclePlanning is the default; set explicitly for clarity.
+	sess.SetLifecyclePhase(agent.LifecyclePlanning)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+
+	msg := prPollMsg{
+		sessionID: "sess-plan",
+		pr:        &github.PRState{State: "open", Number: 7},
+	}
+	app.Update(msg)
+
+	if sess.LifecyclePhase() != agent.LifecyclePlanning {
+		t.Errorf("session lifecycle = %v, want LifecyclePlanning (no skip-ahead)", sess.LifecyclePhase())
+	}
+}
+
+// TestPRPollMsg_DraftingNotPromoted verifies that a session in
+// LifecycleDrafting does not transition when an open PR is discovered.
+func TestPRPollMsg_DraftingNotPromoted(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("sess-draft", "branch")
+	sess.SetLifecyclePhase(agent.LifecycleDrafting)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+
+	msg := prPollMsg{
+		sessionID: "sess-draft",
+		pr:        &github.PRState{State: "open", Number: 7},
+	}
+	app.Update(msg)
+
+	if sess.LifecyclePhase() != agent.LifecycleDrafting {
+		t.Errorf("session lifecycle = %v, want LifecycleDrafting (no skip-ahead)", sess.LifecyclePhase())
+	}
+}
+
+// TestPRPollMsg_AlreadyShippingNoOpOnOpenPR verifies that a session already in
+// LifecycleShipping is not re-transitioned (no-op) when an open PR arrives.
+func TestPRPollMsg_AlreadyShippingNoOpOnOpenPR(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("sess-ship", "branch")
+	sess.SetLifecyclePhase(agent.LifecycleShipping)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+
+	msg := prPollMsg{
+		sessionID: "sess-ship",
+		pr:        &github.PRState{State: "open", Number: 7},
+	}
+	app.Update(msg)
+
+	if sess.LifecyclePhase() != agent.LifecycleShipping {
+		t.Errorf("session lifecycle = %v, want LifecycleShipping (unchanged)", sess.LifecyclePhase())
+	}
+}
+
+// TestPRPollMsg_CompleteNotPromoted verifies that a session in
+// LifecycleComplete is not re-transitioned when an open PR arrives.
+func TestPRPollMsg_CompleteNotPromoted(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("sess-done", "branch")
+	sess.SetLifecyclePhase(agent.LifecycleComplete)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+
+	msg := prPollMsg{
+		sessionID: "sess-done",
+		pr:        &github.PRState{State: "open", Number: 7},
+	}
+	app.Update(msg)
+
+	if sess.LifecyclePhase() != agent.LifecycleComplete {
+		t.Errorf("session lifecycle = %v, want LifecycleComplete (unchanged)", sess.LifecyclePhase())
+	}
+}
+
 // TestMergePRMsg_ErrorSetsError verifies that a mergePRMsg error is surfaced.
 func TestMergePRMsg_ErrorSetsError(t *testing.T) {
 	app := NewApp()


### PR DESCRIPTION
## Summary

- When the PR poller discovers an open PR for a session's branch (opened via \`gh\`, the GitHub web UI, or any external tool), the session now automatically advances to the Shipping phase — no manual \`p\` key required.
- Sessions in Building (\`LifecycleInProgress\`), ReadyForReview, and InReview all transition to Shipping on the next poll that returns an open PR.
- The review panel closes automatically if it was open for the promoted session, mirroring the existing baton-created PR path.
- Planning and Drafting phases are excluded — no skip-past-Building allowed.
- Sessions already in Shipping or Complete are no-ops (no flicker, no double-transition).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` (pre-existing `internal/hook` socket failures on macOS tmpfs paths are unrelated to this change)
- [x] 7 new unit tests in `internal/tui/app_test.go` covering all phase combinations (Building→Shipping, ReadyForReview→Shipping, InReview→Shipping+panel-close, Planning no-op, Drafting no-op, Shipping no-op, Complete no-op)
- [ ] Manual TUI: launch baton, advance a session to Building with `b`, push the branch and open a PR with `gh pr create --fill`, observe the session row moves to SHIPPING within ~30s.
- [ ] Manual TUI: repeat with a session in ReadyForReview (`m` from a finished Building session) and with the review panel open (`r`) — confirm panel closes on auto-promotion.
- [ ] Manual TUI: repeat with a Planning session — confirm it stays in PLANNING.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — changelog fragment at `changelog.d/detect-external-pr.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description