### PR TITLE
Fix p-key PR compose flow: modal over review panel, concurrent push+draft, drop error banner

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3612,9 +3612,11 @@ func (a App) View() tea.View {
 	case ViewDashboard:
 		if a.dashboard.panelFocus == focusReview && a.reviewSession != nil {
 			entry := a.reviewDiffCache[a.reviewSession.ID]
-			panelStr := renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID)
+			var panelStr string
 			if a.prComposeModal.Active() {
 				panelStr = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, a.prComposeModal.View())
+			} else {
+				panelStr = renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID)
 			}
 			v := tea.NewView(panelStr)
 			v.AltScreen = true
@@ -4714,6 +4716,12 @@ func (a *App) startPRDraftCmd(sess *agent.Session, repoPath string, transitionSh
 		worktree := sess.Worktree
 
 		// Push and draft concurrently; total latency = max(push, drafter).
+		// innerCtx is cancelled by push failure so a fast push error (e.g. auth
+		// failure) immediately aborts the expensive Haiku subprocess rather than
+		// waiting out the full 90s parent timeout.
+		innerCtx, innerCancel := context.WithCancel(ctx)
+		defer innerCancel()
+
 		var (
 			pushErr  error
 			draftErr error
@@ -4726,6 +4734,7 @@ func (a *App) startPRDraftCmd(sess *agent.Session, repoPath string, transitionSh
 			defer wg.Done()
 			if err := git.Push(worktreePath, branch); err != nil {
 				pushErr = fmt.Errorf("push branch: %w", err)
+				innerCancel()
 			}
 		}()
 		go func() {
@@ -4759,16 +4768,15 @@ func (a *App) startPRDraftCmd(sess *agent.Session, repoPath string, transitionSh
 
 			drafter := agent.DefaultPRDrafter()
 			var err error
-			draft, err = drafter(ctx, commits, diffstat, taskPrompt, template)
+			draft, err = drafter(innerCtx, commits, diffstat, taskPrompt, template)
 			if err != nil {
 				draftErr = fmt.Errorf("draft PR: %w", err)
 			}
 		}()
 		wg.Wait()
 
-		if pushErr != nil && draftErr != nil {
-			return prDraftReadyMsg{sessionID: sessionID, err: errors.Join(pushErr, draftErr)}
-		}
+		// If push failed, drafter may have been cancelled via innerCtx — return
+		// only the push error; the drafter error is expected noise in that case.
 		if pushErr != nil {
 			return prDraftReadyMsg{sessionID: sessionID, err: pushErr}
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4708,52 +4708,74 @@ func (a *App) startPRDraftCmd(sess *agent.Session, repoPath string, transitionSh
 			return prDraftReadyMsg{sessionID: sessionID, err: fmt.Errorf("parse remote url: %w", err)}
 		}
 
-		// Push the branch (first push sets upstream tracking).
-		if pushErr := git.Push(worktreePath, branch); pushErr != nil {
-			return prDraftReadyMsg{sessionID: sessionID, err: fmt.Errorf("push branch: %w", pushErr)}
-		}
-
-		// Determine base branch.
+		// Determine base branch (local, no network).
 		base := sess.Worktree.BaseBranch
 		if base == "" {
 			base = "main"
 		}
+		worktree := sess.Worktree
 
-		// Gather commits against base for the drafter context.
-		commits := ""
-		if cs, logErr := git.LogCommitsAgainstBase(sess.Worktree); logErr == nil && len(cs) > 0 {
-			var sb strings.Builder
-			for _, c := range cs {
-				sb.WriteString(c.Subject)
-				sb.WriteString("\n")
-				if c.Body != "" {
-					sb.WriteString(c.Body)
-					sb.WriteString("\n")
-				}
+		// Push and draft concurrently; total latency = max(push, drafter).
+		var (
+			pushErr  error
+			draftErr error
+			draft    *agent.PRDraft
+			wg       sync.WaitGroup
+		)
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := git.Push(worktreePath, branch); err != nil {
+				pushErr = fmt.Errorf("push branch: %w", err)
 			}
-			commits = strings.TrimSpace(sb.String())
+		}()
+		go func() {
+			defer wg.Done()
+			commits := ""
+			if cs, logErr := git.LogCommitsAgainstBase(worktree); logErr == nil && len(cs) > 0 {
+				var sb strings.Builder
+				for _, c := range cs {
+					sb.WriteString(c.Subject)
+					sb.WriteString("\n")
+					if c.Body != "" {
+						sb.WriteString(c.Body)
+						sb.WriteString("\n")
+					}
+				}
+				commits = strings.TrimSpace(sb.String())
+			}
+
+			diffstat := ""
+			if stats, statsErr := git.GetDiffStats(repoPath, worktree); statsErr == nil {
+				diffstat = fmt.Sprintf("%d file(s) changed, +%d -%d lines",
+					stats.Files, stats.Insertions, stats.Deletions)
+			}
+
+			template := git.FindPRTemplate(worktreePath)
+
+			taskPrompt := sess.TaskSummary()
+			if taskPrompt == "" {
+				taskPrompt = sess.GetDisplayName()
+			}
+
+			drafter := agent.DefaultPRDrafter()
+			var err error
+			draft, err = drafter(ctx, commits, diffstat, taskPrompt, template)
+			if err != nil {
+				draftErr = fmt.Errorf("draft PR: %w", err)
+			}
+		}()
+		wg.Wait()
+
+		if pushErr != nil && draftErr != nil {
+			return prDraftReadyMsg{sessionID: sessionID, err: errors.Join(pushErr, draftErr)}
 		}
-
-		// Diff stats for context.
-		diffstat := ""
-		if stats, statsErr := git.GetDiffStats(repoPath, sess.Worktree); statsErr == nil {
-			diffstat = fmt.Sprintf("%d file(s) changed, +%d -%d lines",
-				stats.Files, stats.Insertions, stats.Deletions)
+		if pushErr != nil {
+			return prDraftReadyMsg{sessionID: sessionID, err: pushErr}
 		}
-
-		// PR template (optional).
-		template := git.FindPRTemplate(worktreePath)
-
-		// Session's original task prompt for drafter context.
-		taskPrompt := sess.TaskSummary()
-		if taskPrompt == "" {
-			taskPrompt = sess.GetDisplayName()
-		}
-
-		drafter := agent.DefaultPRDrafter()
-		draft, err := drafter(ctx, commits, diffstat, taskPrompt, template)
-		if err != nil {
-			return prDraftReadyMsg{sessionID: sessionID, err: fmt.Errorf("draft PR: %w", err)}
+		if draftErr != nil {
+			return prDraftReadyMsg{sessionID: sessionID, err: draftErr}
 		}
 
 		return prDraftReadyMsg{

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1580,7 +1580,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.prDraftInFlight = true
 					a.prDraftSessionID = sess.ID
 					repoPath := a.repoPathForSession(sess.ID)
-					a.setError("Pushing branch and drafting PR…")
 					return a, a.startPRDraftCmd(sess, repoPath, true)
 				}
 				return a, nil
@@ -2202,7 +2201,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.prDraftInFlight = true
 					a.prDraftSessionID = sess.ID
 					repoPath := a.cursorSelectedRepoPath()
-					a.setError("Pushing branch and drafting PR…")
 					return a, a.startPRDraftCmd(sess, repoPath, false)
 				}
 			}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3614,7 +3614,11 @@ func (a App) View() tea.View {
 	case ViewDashboard:
 		if a.dashboard.panelFocus == focusReview && a.reviewSession != nil {
 			entry := a.reviewDiffCache[a.reviewSession.ID]
-			v := tea.NewView(renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID))
+			panelStr := renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID)
+			if a.prComposeModal.Active() {
+				panelStr = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, a.prComposeModal.View())
+			}
+			v := tea.NewView(panelStr)
 			v.AltScreen = true
 			return v
 		}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2059,9 +2059,10 @@ func TestReviewPanel_PKey_NoPR_DoesNotOrphan(t *testing.T) {
 	app = model.(App)
 
 	// Pressing p with no open PR now starts the push+draft pipeline.
-	// The status message should indicate progress, not an error.
-	if !strings.Contains(app.err, "Pushing") {
-		t.Errorf("expected progress message containing 'Pushing', got %q", app.err)
+	// The in-flight flag must be set; no error banner should appear.
+	if !app.prDraftInFlight || app.prDraftSessionID != sessR.ID {
+		t.Errorf("expected prDraftInFlight=true and prDraftSessionID=%q, got inFlight=%v sessionID=%q",
+			sessR.ID, app.prDraftInFlight, app.prDraftSessionID)
 	}
 
 	// Press ESC to close the panel — session stays InReview.
@@ -2214,9 +2215,10 @@ func TestPipeline_PKey_NoPRStartsDraft(t *testing.T) {
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
 	app = model.(App)
-	// p with no cached PR starts the draft flow — progress message should appear.
-	if !strings.Contains(app.err, "Pushing") {
-		t.Errorf("expected progress message containing 'Pushing', got %q", app.err)
+	// p with no cached PR starts the draft flow — in-flight flag must be set.
+	if !app.prDraftInFlight || app.prDraftSessionID != sess.ID {
+		t.Errorf("expected prDraftInFlight=true and prDraftSessionID=%q, got inFlight=%v sessionID=%q",
+			sess.ID, app.prDraftInFlight, app.prDraftSessionID)
 	}
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2017,6 +2017,32 @@ func TestReviewPanel_TKey_NoAgents_ShowsError(t *testing.T) {
 	}
 }
 
+// TestReviewPanel_ComposeModalRendersOverPanel verifies that when the
+// prComposeModal is active while panelFocus == focusReview, View() renders the
+// modal centered over the panel instead of the bare review panel.
+func TestReviewPanel_ComposeModalRendersOverPanel(t *testing.T) {
+	sessR := agent.NewSessionForTest("s", "ship-it")
+	sessR.SetLifecyclePhase(agent.LifecycleInReview)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.reviewSession = sessR
+	app.dashboard.panelFocus = focusReview
+	app.prComposeModal.SetSize(120, 39)
+	_ = app.prComposeModal.Open("My PR Title", "My PR Body", false)
+
+	v := app.View()
+	if !strings.Contains(v.Content, "My PR Title") {
+		t.Errorf("expected view to contain %q, got content: %q", "My PR Title", v.Content)
+	}
+	if !strings.Contains(v.Content, "CREATE PR") {
+		t.Errorf("expected view to contain %q, got content: %q", "CREATE PR", v.Content)
+	}
+}
+
 // TestReviewPanel_PKey_NoPR_DoesNotOrphan verifies that pressing "p" with no
 // PR cached starts the draft flow (shows progress text) and does NOT make the
 // session unreachable. The session must still be in LifecycleInReview so


### PR DESCRIPTION
## Summary

- **Bug fix**: pressing \`p\` from the review panel now correctly renders the PR compose modal after the async draft completes. Root cause: the \`focusReview\` branch in \`View()\` returned early (just \`renderReviewPanel\`) without checking \`prComposeModal.Active()\`, so the modal was set but never shown.
- **Perf**: \`startPRDraftCmd\` now runs \`git push\` and the Haiku PR drafter concurrently under a \`sync.WaitGroup\`. Total wall-clock latency drops from \`push + drafter\` to \`max(push, drafter)\`.
- **UX cleanup**: removed the redundant \`setError("Pushing branch and drafting PR…")\` call from both the review-panel and pipeline \`p\` handlers — the in-panel spinner (\`renderReviewPanel\`) and pipeline-row badge (\`dashboard.prDraftSessionID\`) are the correct in-flight indicators.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (tui package)
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [x] New test: `TestReviewPanel_ComposeModalRendersOverPanel` — was failing before, passes after the `View()` fix
- [x] Migrated: `TestReviewPanel_PKey_NoPR_DoesNotOrphan` and `TestPipeline_PKey_NoPRStartsDraft` now assert `prDraftInFlight`/`prDraftSessionID` state instead of the removed error banner string
- [ ] Manual TUI: drive a session to `LifecycleReadyForReview`, press `p`, confirm spinner appears then modal overlays the review panel with Haiku-drafted title/body; confirm no red "Error: Pushing…" banner

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests (`TestReviewPanel_ComposeModalRendersOverPanel`)
- [x] No new public API surface