### PR TITLE
Stop resurrecting completed sessions on relaunch

### DIFF
--- a/changelog.d/fix-session-cleanup-on-complete.md
+++ b/changelog.d/fix-session-cleanup-on-complete.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Completed sessions (merged PR, external merge, or 'c' in review panel) now remove their worktree and disappear from the manager immediately, rather than persisting until the next `baton` launch. `Detach()` filters out any lingering `LifecycleComplete` sessions and cleans up their worktrees during quit.

--- a/internal/agent/detach_resume_test.go
+++ b/internal/agent/detach_resume_test.go
@@ -83,6 +83,71 @@ func TestDetachEmptyReturnsNil(t *testing.T) {
 	}
 }
 
+func TestDetachSkipsCompleteSessionsAndCleansWorktree(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sessComplete, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessKeep, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	completePath := sessComplete.Worktree.Path
+	keepPath := sessKeep.Worktree.Path
+	keepID := sessKeep.ID
+
+	sessComplete.SetLifecyclePhase(LifecycleComplete)
+
+	bs := mgr.Detach()
+	if bs == nil {
+		t.Fatal("expected non-nil BatonState when one non-complete session remains")
+	}
+	if len(bs.Sessions) != 1 {
+		t.Fatalf("expected 1 session in snapshot, got %d", len(bs.Sessions))
+	}
+	if bs.Sessions[0].ID != keepID {
+		t.Errorf("expected snapshotted session ID %s, got %s", keepID, bs.Sessions[0].ID)
+	}
+
+	// Complete session's worktree must be removed.
+	if _, err := os.Stat(completePath); !os.IsNotExist(err) {
+		t.Errorf("complete session worktree should have been removed, but Stat returned: %v", err)
+	}
+
+	// Non-complete session's worktree must be preserved.
+	if _, err := os.Stat(keepPath); os.IsNotExist(err) {
+		t.Error("non-complete session worktree should still exist after detach")
+	}
+}
+
+func TestDetachAllCompleteReturnsNil(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.SetLifecyclePhase(LifecycleComplete)
+
+	bs := mgr.Detach()
+	if bs != nil {
+		t.Errorf("expected nil BatonState when all sessions are complete, got %+v", bs)
+	}
+}
+
 func TestDetachSaveLoadRoundTrip(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo, defaultTestSettings())

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1518,9 +1518,19 @@ func (m *Manager) Detach() *state.BatonState {
 	}
 	m.mu.RUnlock()
 
-	// Snapshot state before killing agents.
-	sessionStates := make([]state.SessionState, 0, len(sessions))
+	// Partition: complete sessions are cleaned up; others are snapshotted.
+	var toSnapshot, toClean []*Session
 	for _, s := range sessions {
+		if s.LifecyclePhase() == LifecycleComplete {
+			toClean = append(toClean, s)
+		} else {
+			toSnapshot = append(toSnapshot, s)
+		}
+	}
+
+	// Snapshot state before killing agents.
+	sessionStates := make([]state.SessionState, 0, len(toSnapshot))
+	for _, s := range toSnapshot {
 		var doneAt *time.Time
 		if t := s.DoneAt(); !t.IsZero() {
 			doneAt = &t
@@ -1551,10 +1561,22 @@ func (m *Manager) Detach() *state.BatonState {
 		sessionStates = append(sessionStates, ss)
 	}
 
-	// Kill all agents but do NOT call Cleanup (preserve worktrees).
+	// Kill complete sessions and remove their worktrees.
+	var cleanWg sync.WaitGroup
+	cleanWg.Add(len(toClean))
+	for _, s := range toClean {
+		go func() {
+			defer cleanWg.Done()
+			s.KillAll()
+			_ = s.Cleanup(m.repoPath)
+		}()
+	}
+	cleanWg.Wait()
+
+	// Kill agents for snapshotted sessions but do NOT call Cleanup (preserve worktrees).
 	var wg sync.WaitGroup
-	wg.Add(len(sessions))
-	for _, s := range sessions {
+	wg.Add(len(toSnapshot))
+	for _, s := range toSnapshot {
 		go func() {
 			defer wg.Done()
 			s.KillAll()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -76,6 +76,16 @@ type killResultMsg struct {
 	err       error
 }
 
+// filterNotFound returns nil if err's message contains "not found", otherwise
+// returns err unchanged. Used to suppress benign double-cleanup races where two
+// concurrent paths both try to KillSession the same session.
+func filterNotFound(err error) error {
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		return nil
+	}
+	return err
+}
+
 // diffStatsMsg carries the result of an async diff stats refresh.
 type diffStatsMsg struct {
 	sessionID string
@@ -1135,19 +1145,25 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.setError("merge failed: " + msg.err.Error())
 			return a, nil
 		}
-		// Transition the session to Complete immediately rather than waiting for
-		// the next PR poll to detect the merged state.
-		repoPath := a.repoPathForSession(msg.sessionID)
-		if repoPath != "" {
-			if mgr := a.managers[repoPath]; mgr != nil {
-				if sess := mgr.GetSession(msg.sessionID); sess != nil {
-					sess.SetLifecyclePhase(agent.LifecycleComplete)
-				}
-			}
-		}
 		a.shippingSession = nil
 		a.dashboard.panelFocus = focusList
-		return a, nil
+		repoPath := a.repoPathForSession(msg.sessionID)
+		if repoPath == "" {
+			return a, nil
+		}
+		mgr := a.managers[repoPath]
+		if mgr == nil || mgr.GetSession(msg.sessionID) == nil {
+			return a, nil
+		}
+		sessID := msg.sessionID
+		a.closingSessions[sessID] = true
+		return a, func() tea.Msg {
+			return killResultMsg{
+				scope:     killScopeSession,
+				sessionID: sessID,
+				err:       filterNotFound(mgr.KillSession(sessID)),
+			}
+		}
 
 	case resumeDoneMsg:
 		for _, repoPath := range msg.repoPaths {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1622,12 +1622,27 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			case "c":
 				// Mark complete without a PR (e.g. design docs, exploratory
-				// branches). Closes the panel.
+				// branches). Closes the panel and cleans up the session.
 				sess := a.reviewSession
-				sess.SetLifecyclePhase(agent.LifecycleComplete)
 				a.dashboard.panelFocus = focusList
 				a.reviewSession = nil
-				return a, nil
+				repoPath := a.repoPathForSession(sess.ID)
+				if repoPath == "" {
+					return a, nil
+				}
+				mgr := a.managers[repoPath]
+				if mgr == nil || mgr.GetSession(sess.ID) == nil {
+					return a, nil
+				}
+				sessID := sess.ID
+				a.closingSessions[sessID] = true
+				return a, func() tea.Msg {
+					return killResultMsg{
+						scope:     killScopeSession,
+						sessionID: sessID,
+						err:       filterNotFound(mgr.KillSession(sessID)),
+					}
+				}
 			case "e":
 				// Open in editor — same pattern as the existing "i" key handler.
 				sess := a.reviewSession

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1096,19 +1096,28 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			threads: msg.threads,
 			stack:   msg.stack,
 		}
-		// Detect PR merge/close and transition to Complete lifecycle phase.
+		// Detect PR merge/close and trigger async session cleanup.
+		var cmds []tea.Cmd
 		if msg.pr != nil && (msg.pr.State == "merged" || msg.pr.State == "closed") {
 			repoPath := a.repoPathForSession(msg.sessionID)
 			if repoPath != "" {
 				if mgr := a.managers[repoPath]; mgr != nil {
 					if sess := mgr.GetSession(msg.sessionID); sess != nil {
 						if sess.LifecyclePhase() == agent.LifecycleShipping {
-							sess.SetLifecyclePhase(agent.LifecycleComplete)
 							// Close the shipping panel if this session is currently open in it.
 							if a.shippingSession != nil && a.shippingSession.ID == msg.sessionID {
 								a.shippingSession = nil
 								a.dashboard.panelFocus = focusList
 							}
+							sessID := msg.sessionID
+							a.closingSessions[sessID] = true
+							cmds = append(cmds, func() tea.Msg {
+								return killResultMsg{
+									scope:     killScopeSession,
+									sessionID: sessID,
+									err:       filterNotFound(mgr.KillSession(sessID)),
+								}
+							})
 						}
 					}
 				}
@@ -1138,7 +1147,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			ps.lastCheckState = newState
 		}
 		a.updateDashboardPRCache()
-		return a, nil
+		return a, tea.Batch(cmds...)
 
 	case mergePRMsg:
 		if msg.err != nil {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1965,9 +1965,8 @@ func TestFocusMode_RKey_NonEmptyQueue_OpensReviewPanel(t *testing.T) {
 }
 
 // TestReviewPanel_CKey_MarksComplete verifies that pressing "c" in the review
-// panel transitions the session to LifecycleComplete and closes the panel.
-// This unblocks workflows where a session has no PR (design docs, exploration)
-// and the user wants to take it off the review queue.
+// panel closes the panel and clears reviewSession. When no manager is wired up
+// (makeFocusModeMRApp), cleanup is a no-op but the panel still closes.
 func TestReviewPanel_CKey_MarksComplete(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
@@ -1977,14 +1976,55 @@ func TestReviewPanel_CKey_MarksComplete(t *testing.T) {
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 	app = model.(App)
 
-	if sessR.LifecyclePhase() != agent.LifecycleComplete {
-		t.Errorf("expected sessR phase=Complete, got %v", sessR.LifecyclePhase())
-	}
 	if app.dashboard.panelFocus != focusList {
 		t.Errorf("expected panelFocus=focusList after c, got %v", app.dashboard.panelFocus)
 	}
 	if app.reviewSession != nil {
 		t.Errorf("expected reviewSession cleared, got %v", app.reviewSession)
+	}
+}
+
+// TestReviewPanel_CMarkCompleteClosesSession verifies that pressing "c" in the
+// review panel triggers async session cleanup via KillSession, removing the
+// session from the manager and its worktree.
+func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("sess-review", "review")
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.reviewSession = sess
+	app.dashboard.panelFocus = focusReview
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	got := model.(App)
+
+	if got.dashboard.panelFocus != focusList {
+		t.Errorf("expected panelFocus=focusList after c, got %v", got.dashboard.panelFocus)
+	}
+	if got.reviewSession != nil {
+		t.Errorf("expected reviewSession cleared after c, got %v", got.reviewSession)
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd to trigger async session cleanup after marking complete")
+	}
+
+	// Run the cleanup cmd and dispatch the resulting killResultMsg.
+	killMsg := cmd()
+	model2, _ := got.Update(killMsg)
+	got2 := model2.(App)
+
+	if mgr.GetSession("sess-review") != nil {
+		t.Error("session should be removed from manager after marking complete")
+	}
+	if got2.closingSessions["sess-review"] {
+		t.Error("closingSessions should be cleared after killResultMsg")
 	}
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2527,7 +2527,7 @@ func TestActivateFocusCursor_Shipping_NoPREntry(t *testing.T) {
 }
 
 // TestMergePRMsg_ClosesPanel verifies that a successful mergePRMsg closes the
-// shipping panel, clears shippingSession, and transitions the session to Complete.
+// shipping panel, clears shippingSession, and triggers async session cleanup.
 func TestMergePRMsg_ClosesPanel(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTest("sess-1", "ship")
@@ -2543,7 +2543,7 @@ func TestMergePRMsg_ClosesPanel(t *testing.T) {
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
-	model, _ := app.Update(mergePRMsg{sessionID: "sess-1"})
+	model, cmd := app.Update(mergePRMsg{sessionID: "sess-1"})
 	got := model.(App)
 
 	if got.dashboard.panelFocus == focusShipping {
@@ -2552,8 +2552,20 @@ func TestMergePRMsg_ClosesPanel(t *testing.T) {
 	if got.shippingSession != nil {
 		t.Error("shippingSession should be nil after merge")
 	}
-	if sess.LifecyclePhase() != agent.LifecycleComplete {
-		t.Errorf("session lifecycle = %v, want LifecycleComplete", sess.LifecyclePhase())
+	if cmd == nil {
+		t.Fatal("expected a cmd to trigger async session cleanup after merge")
+	}
+
+	// Run the cleanup cmd and dispatch the resulting killResultMsg.
+	killMsg := cmd()
+	model2, _ := got.Update(killMsg)
+	got2 := model2.(App)
+
+	if mgr.GetSession("sess-1") != nil {
+		t.Error("session should be removed from manager after merge cleanup")
+	}
+	if got2.closingSessions["sess-1"] {
+		t.Error("closingSessions should be cleared after killResultMsg")
 	}
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2571,7 +2571,7 @@ func TestMergePRMsg_ClosesPanel(t *testing.T) {
 
 // TestPRPollMsg_ExternalMergeClosesPanelAndTransitions verifies that when the
 // PR poller detects an external merge while the shipping panel is open, the
-// panel closes and the session transitions to LifecycleComplete.
+// panel closes and async session cleanup is triggered.
 func TestPRPollMsg_ExternalMergeClosesPanelAndTransitions(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTest("sess-ext", "ship")
@@ -2591,7 +2591,7 @@ func TestPRPollMsg_ExternalMergeClosesPanelAndTransitions(t *testing.T) {
 		sessionID: "sess-ext",
 		pr:        &github.PRState{State: "merged"},
 	}
-	model, _ := app.Update(msg)
+	model, cmd := app.Update(msg)
 	got := model.(App)
 
 	if got.dashboard.panelFocus == focusShipping {
@@ -2600,8 +2600,66 @@ func TestPRPollMsg_ExternalMergeClosesPanelAndTransitions(t *testing.T) {
 	if got.shippingSession != nil {
 		t.Error("shippingSession should be nil after external merge")
 	}
-	if sess.LifecyclePhase() != agent.LifecycleComplete {
-		t.Errorf("session lifecycle = %v, want LifecycleComplete", sess.LifecyclePhase())
+	if cmd == nil {
+		t.Fatal("expected a cmd to trigger async session cleanup after external merge")
+	}
+
+	// Run the cleanup cmd and dispatch the resulting killResultMsg.
+	killMsg := cmd()
+	model2, _ := got.Update(killMsg)
+	got2 := model2.(App)
+
+	if mgr.GetSession("sess-ext") != nil {
+		t.Error("session should be removed from manager after external merge cleanup")
+	}
+	if got2.closingSessions["sess-ext"] {
+		t.Error("closingSessions should be cleared after killResultMsg")
+	}
+}
+
+// TestPRPollMsg_ExternalCloseCleansSession verifies that a "closed" PR state
+// triggers the same async session cleanup as a "merged" state.
+func TestPRPollMsg_ExternalCloseCleansSession(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("sess-closed", "ship")
+	sess.SetLifecyclePhase(agent.LifecycleShipping)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.shippingSession = sess
+	app.dashboard.panelFocus = focusShipping
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+
+	msg := prPollMsg{
+		sessionID: "sess-closed",
+		pr:        &github.PRState{State: "closed"},
+	}
+	model, cmd := app.Update(msg)
+	got := model.(App)
+
+	if got.dashboard.panelFocus == focusShipping {
+		t.Error("shipping panel should close when PR is closed")
+	}
+	if got.shippingSession != nil {
+		t.Error("shippingSession should be nil after PR close")
+	}
+	if cmd == nil {
+		t.Fatal("expected a cmd to trigger async session cleanup after PR close")
+	}
+
+	killMsg := cmd()
+	model2, _ := got.Update(killMsg)
+	got2 := model2.(App)
+
+	if mgr.GetSession("sess-closed") != nil {
+		t.Error("session should be removed from manager after PR close cleanup")
+	}
+	if got2.closingSessions["sess-closed"] {
+		t.Error("closingSessions should be cleared after killResultMsg")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Completed sessions (merged PR, externally-merged PR, or 'c' in the review panel) now remove their worktree and disappear from the manager immediately rather than lingering until the next `baton` launch
- `Manager.Detach()` filters out `LifecycleComplete` sessions and calls `KillAll()`+`Cleanup()` on them during quit, so they never appear in `state.json`
- `mergePRMsg`, `prPollMsg` (merged/closed state), and the review panel `'c'` key all now use the existing `closingSessions + KillSession` async pattern instead of `SetLifecyclePhase(Complete)` — the session row disappears from the dashboard identically to an explicit `X` kill
- A `filterNotFound` helper suppresses "not found" errors from concurrent cleanup races (e.g. manual merge + poll firing simultaneously)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (pre-existing failures in `internal/config` and `internal/hook` are unrelated)
- [x] New tests: `TestDetachSkipsCompleteSessionsAndCleansWorktree`, `TestDetachAllCompleteReturnsNil` (agent package)
- [x] Updated tests: `TestMergePRMsg_ClosesPanel`, `TestPRPollMsg_ExternalMergeClosesPanelAndTransitions` now assert async cleanup via `killResultMsg`
- [x] New tests: `TestPRPollMsg_ExternalCloseCleansSession`, `TestReviewPanel_CMarkCompleteClosesSession`
- [ ] Manual TUI: merge a real PR via `m`, observe row disappears and `.baton/worktrees/<name>/` is removed; relaunch `baton` and confirm session is absent

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description