### PR TITLE
Refresh Building session cards: mtime-keyed plan cache, progress bar, status glyph, and branch chip

### DIFF
--- a/changelog.d/building-card-progress-refresh.md
+++ b/changelog.d/building-card-progress-refresh.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Building session cards now reflect checkbox toggles made directly by the build agent in `.claude/plan.md` (via Claude's Edit tool). `CachedPlan` is keyed on the file's mtime and re-reads the file whenever the mtime changes, so the progress bar advances within one 100ms tick instead of staying frozen until `WritePlan` was called.
+
+### Changed
+
+- Building session cards have a new layout: a real progress bar (colored `ColorSuccess` at 100%, `ColorPrimary` otherwise) with a muted `done/total` count now appears on line 1's right side instead of the plain `▸ N/M` text badge.
+- Line 1 leads with a single status glyph that mirrors the stripe color: `✗` error, `⏸` waiting, `?` idle-asking, `✓` reviewable/finished, `⚡` active, `○` otherwise.
+- Lines 2–3 show the active task with a `▸` bold prefix and the next pending task with a `↳ next:` muted-italic prefix, sourced from the session's in-progress TodoItem (falling back to the first uncompleted plan checkbox when no todos are active).
+- Line 4 renders the branch as a dark-background chip with a `🌿` prefix and elapsed time with a `⏱` prefix.
+- All cards are now a uniform 4 lines; the previous 5-line variant for plan-backed Building sessions has been removed.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -45,14 +45,17 @@ type Session struct {
 	revising       bool  // true while a plan-revising subprocess is in flight; gates double-dispatch
 	reviseCancel   context.CancelFunc
 	reviseErr      error // last revise error, surfaced by the editor; cleared on successful revise
-	// Plan-content cache, keyed by the most recent successful WritePlan.
+	// Plan-content cache, keyed by the mtime of the last observed plan.md.
 	// Populated lazily by CachedPlan() on first read so resumed sessions
-	// also benefit. The dashboard hot path (per-render Planning card)
-	// reads this instead of os.ReadFile to avoid a stat+read+parse cycle
-	// at every tick.
+	// also benefit. The dashboard hot path (per-render Building card) stats
+	// plan.md each tick; if the mtime is unchanged it returns the cached
+	// content without a ReadFile. This lets the build agent's external
+	// checkbox edits (via Claude's Edit tool, bypassing WritePlan) show
+	// through within one tick.
 	planCacheLoaded  bool
 	planCachePresent bool
 	planCacheContent string
+	planCacheMTime   time.Time
 }
 
 // newSession creates a session with the given worktree. New sessions land in
@@ -1009,13 +1012,17 @@ func (s *Session) WritePlan(content string) error {
 	}
 	committed = true
 
-	// Update the in-memory cache so the dashboard render path can skip
-	// os.Stat + os.ReadFile on subsequent ticks. Locking is brief; we
-	// only enter after the file write has succeeded.
+	// Record mtime alongside content so CachedPlan's mtime check skips
+	// the ReadFile on the immediate next tick.
+	var mtime time.Time
+	if fi, err2 := os.Stat(planPath); err2 == nil {
+		mtime = fi.ModTime()
+	}
 	s.mu.Lock()
 	s.planCacheLoaded = true
 	s.planCachePresent = true
 	s.planCacheContent = content
+	s.planCacheMTime = mtime
 	s.mu.Unlock()
 
 	return nil
@@ -1028,58 +1035,69 @@ func (s *Session) HasPlan() bool {
 }
 
 // CachedPlan returns the most recently written plan content along with a
-// flag indicating whether a plan exists. The cache is primed by WritePlan
-// (and indirectly by RestorePrevPlan, which calls WritePlan); on a
-// resumed session that was created before the cache existed, the first
-// call lazily loads from disk. Use this in hot paths like the dashboard
-// render loop instead of HasPlan() + ReadPlan(), which together do a
-// stat + read on every TUI tick.
+// flag indicating whether a plan exists. The cache is keyed by the mtime of
+// plan.md: each call stats the file; if the mtime is unchanged the cached
+// content is returned without a ReadFile. This lets external edits (e.g. the
+// build agent toggling checkboxes via Claude's Edit tool, bypassing WritePlan)
+// show through within one 100ms dashboard tick.
 //
-// Returns ("", false) when no plan file exists. Read errors are not
-// surfaced — callers in render hot paths can't usefully react to them
-// and the plain ReadPlan() path is still available for callers that need
-// to handle errors explicitly.
+// Returns ("", false) when no plan file exists. Read errors are not surfaced —
+// callers in render hot paths can't usefully react to them.
 func (s *Session) CachedPlan() (string, bool) {
+	planPath := s.PlanPath()
+	if planPath == "" {
+		return "", false
+	}
+
+	fi, err := os.Stat(planPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			s.mu.Lock()
+			s.planCacheLoaded = true
+			s.planCachePresent = false
+			s.planCacheContent = ""
+			s.planCacheMTime = time.Time{}
+			s.mu.Unlock()
+			return "", false
+		}
+		// Other stat error: return cached value if we have one so a transient
+		// I/O hiccup doesn't blank the dashboard.
+		s.mu.RLock()
+		content, present := s.planCacheContent, s.planCachePresent
+		s.mu.RUnlock()
+		return content, present
+	}
+
+	mtime := fi.ModTime()
+
 	s.mu.RLock()
-	if s.planCacheLoaded {
+	if s.planCacheLoaded && mtime.Equal(s.planCacheMTime) {
 		content, present := s.planCacheContent, s.planCachePresent
 		s.mu.RUnlock()
 		return content, present
 	}
 	s.mu.RUnlock()
 
-	// Lazy load. Drop the read lock before doing I/O so a concurrent
-	// WritePlan can populate the cache while we read; if it does, we
-	// just observe its write on the next call.
-	planPath := s.PlanPath()
-	if planPath == "" {
-		return "", false
-	}
+	// mtime changed (or first call): read the file outside any lock.
 	data, err := os.ReadFile(planPath)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			s.mu.Lock()
-			if !s.planCacheLoaded {
-				s.planCacheLoaded = true
-				s.planCachePresent = false
-				s.planCacheContent = ""
-			}
-			s.mu.Unlock()
-			return "", false
-		}
-		// Any other error: don't poison the cache. Callers in render
-		// paths see ("", false) and fall back to their no-plan branch.
-		return "", false
+		// Don't poison the cache on a transient read error.
+		s.mu.RLock()
+		content, present := s.planCacheContent, s.planCachePresent
+		s.mu.RUnlock()
+		return content, present
 	}
 	content := string(data)
 
 	s.mu.Lock()
-	if !s.planCacheLoaded {
+	// Only update if this mtime is at least as recent as what we have,
+	// so a concurrent WritePlan with a later mtime is never regressed.
+	if !mtime.Before(s.planCacheMTime) {
 		s.planCacheLoaded = true
 		s.planCachePresent = true
 		s.planCacheContent = content
+		s.planCacheMTime = mtime
 	} else {
-		// A WritePlan landed during our read; trust the cache.
 		content = s.planCacheContent
 	}
 	present := s.planCachePresent

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -1052,12 +1052,20 @@ func (s *Session) CachedPlan() (string, bool) {
 	fi, err := os.Stat(planPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			s.mu.Lock()
-			s.planCacheLoaded = true
-			s.planCachePresent = false
-			s.planCacheContent = ""
-			s.planCacheMTime = time.Time{}
-			s.mu.Unlock()
+			// Skip the write lock if the cache already reflects "absent" — the
+			// common case for Planning-phase sessions before a plan is written,
+			// where CachedPlan is called on every 100ms render tick.
+			s.mu.RLock()
+			alreadyAbsent := s.planCacheLoaded && !s.planCachePresent
+			s.mu.RUnlock()
+			if !alreadyAbsent {
+				s.mu.Lock()
+				s.planCacheLoaded = true
+				s.planCachePresent = false
+				s.planCacheContent = ""
+				s.planCacheMTime = time.Time{}
+				s.mu.Unlock()
+			}
 			return "", false
 		}
 		// Other stat error: return cached value if we have one so a transient

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1375,6 +1375,42 @@ func TestSession_CachedPlan_LazyLoadsFromDisk(t *testing.T) {
 	}
 }
 
+func TestSession_CachedPlan_RereadsOnExternalMtimeChange(t *testing.T) {
+	// The build agent edits plan.md directly via Claude's Edit tool, bypassing
+	// WritePlan. CachedPlan must detect the mtime change and re-read the file.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const body1 = "# Goal\noriginal\n\n- [ ] task one\n"
+	planPath := filepath.Join(dir, ".claude", "plan.md")
+	if err := os.WriteFile(planPath, []byte(body1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
+	plan, present := s.CachedPlan()
+	if !present || plan != body1 {
+		t.Fatalf("CachedPlan() = (%q, %v), want (%q, true)", plan, present, body1)
+	}
+
+	// Simulate build agent toggling a checkbox via external file write.
+	const body2 = "# Goal\noriginal\n\n- [x] task one\n"
+	if err := os.WriteFile(planPath, []byte(body2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Bump mtime to the future so even coarse-grained filesystems detect the change.
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(planPath, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	plan2, _ := s.CachedPlan()
+	if plan2 != body2 {
+		t.Errorf("after external mtime bump, CachedPlan() = %q, want %q", plan2, body2)
+	}
+}
+
 func TestSession_CachedPlan_RestorePrevPlanRefreshesCache(t *testing.T) {
 	dir := t.TempDir()
 	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1356,7 +1356,8 @@ func TestSession_CachedPlan_LazyLoadsFromDisk(t *testing.T) {
 		t.Fatal(err)
 	}
 	const body = "# Goal\nresumed\n\n- [x] done\n- [ ] todo\n"
-	if err := os.WriteFile(filepath.Join(dir, ".claude", "plan.md"), []byte(body), 0o644); err != nil {
+	planPath := filepath.Join(dir, ".claude", "plan.md")
+	if err := os.WriteFile(planPath, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	s := newSession("id", "name", &git.WorktreeInfo{Path: dir})
@@ -1364,14 +1365,36 @@ func TestSession_CachedPlan_LazyLoadsFromDisk(t *testing.T) {
 	if !present || plan != body {
 		t.Errorf("CachedPlan() = (%q, %v), want (%q, true)", plan, present, body)
 	}
-	// Second call must hit the cache. Truncate the file under the cache to
-	// confirm — if the cache works, we still see the cached body.
-	if err := os.WriteFile(filepath.Join(dir, ".claude", "plan.md"), []byte("changed"), 0o644); err != nil {
+
+	// Second call with unchanged mtime must return the cached content without
+	// re-reading (cache hit). Overwrite the file content but keep the mtime
+	// identical so the stat check sees no change.
+	fi, err := os.Stat(planPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origMtime := fi.ModTime()
+	const bodyChanged = "# Goal\nresumed\n\n- [x] done\n- [x] todo\n"
+	if err := os.WriteFile(planPath, []byte(bodyChanged), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Restore original mtime to simulate an unchanged file.
+	if err := os.Chtimes(planPath, origMtime, origMtime); err != nil {
 		t.Fatal(err)
 	}
 	plan2, _ := s.CachedPlan()
 	if plan2 != body {
-		t.Errorf("second CachedPlan() = %q, want cached %q (cache miss)", plan2, body)
+		t.Errorf("same mtime: CachedPlan() = %q, want cached %q", plan2, body)
+	}
+
+	// Now bump mtime to the future — the cache must re-read and return the new content.
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(planPath, future, future); err != nil {
+		t.Fatal(err)
+	}
+	plan3, _ := s.CachedPlan()
+	if plan3 != bodyChanged {
+		t.Errorf("bumped mtime: CachedPlan() = %q, want new content %q", plan3, bodyChanged)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3176,11 +3176,8 @@ func (a *App) pipelineHitTest(dashboardContentY int) (focusSection, int, bool) {
 			continue
 		}
 		cursor += labelRows
-		for i, item := range items {
+		for i := range items {
 			rowH := rowsPerItem(section)
-			if section == focusSectionBuilding && item.session != nil && planProgressLine(item.session, 1) != "" {
-				rowH++
-			}
 			start := cursor
 			end := start + rowH
 			if dashboardContentY >= start && dashboardContentY < end {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -916,36 +916,6 @@ func secondUncompletedTask(plan string) string {
 	return ""
 }
 
-// planProgressLine returns the text content for the optional task-progress
-// line on a Building session card ("▸ first open · next: second open"),
-// truncated to budget display cells. Returns "" when the line should be
-// omitted: session is not LifecycleInProgress, it is reviewable (all tasks
-// done), it has no plan, the plan has no task lines, or all tasks are already
-// done (firstUncompletedTask returns ""). The first-open-task approximation is
-// intentional — deriving the in-flight task from git commits would require
-// per-tick git I/O that the plan cache avoids.
-func planProgressLine(sess *agent.Session, budget int) string {
-	if sess.LifecyclePhase() != agent.LifecycleInProgress {
-		return ""
-	}
-	if sess.IsReviewable() {
-		return ""
-	}
-	plan, present := sess.CachedPlan()
-	if !present {
-		return ""
-	}
-	first := firstUncompletedTask(plan)
-	if first == "" {
-		return ""
-	}
-	text := "▸ " + first
-	if second := secondUncompletedTask(plan); second != "" {
-		text += " · next: " + second
-	}
-	return truncateVisible(text, budget)
-}
-
 
 // focusTaskDescription chooses the description lines for a session card in
 // focus mode and reports whether they should render in pending (italic) style.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -745,28 +745,39 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 			waitingReason = item.agent.WaitingReason()
 		}
 	}
-	bottomLeftText := branch
+	// Build the detail string (idle time or waiting reason) shown after the chip.
+	var detailStr string
 	switch {
 	case waitingReason != "":
-		if branch != "" {
-			bottomLeftText = branch + " · " + waitingReason
-		} else {
-			bottomLeftText = waitingReason
-		}
+		detailStr = waitingReason
 	case anyAgent && allIdle && !sess.LastOutputTime().IsZero():
-		idleStr := fmt.Sprintf("idle %dm", int(time.Since(sess.LastOutputTime()).Minutes()))
-		if branch != "" {
-			bottomLeftText = branch + " · " + idleStr
-		} else {
-			bottomLeftText = idleStr
+		detailStr = fmt.Sprintf("idle %dm", int(time.Since(sess.LastOutputTime()).Minutes()))
+	}
+
+	// Build the left part of line 4 using a branch chip when a branch is set.
+	chip := renderBranchChip(branch)
+	var bottomLeft string
+	if chip != "" {
+		chipWidth := lipgloss.Width(chip)
+		// Reserve space: stripe(1) + indent(3) + chip + space + detail + some room for elapsed.
+		detailBudget := width - stripeIndentWidth - chipWidth - 13
+		if detailBudget < 0 {
+			detailBudget = 0
 		}
+		var detailRendered string
+		if detailStr != "" && detailBudget > 1 {
+			detailRendered = " " + StyleSubtle.Render(truncateVisible(detailStr, detailBudget))
+		}
+		bottomLeft = stripe + indent + chip + detailRendered
+	} else {
+		// No branch: fall back to plain subtle text (waiting reason or idle).
+		bottomLeftText := detailStr
+		bottomBudget := width - 12
+		if bottomBudget < 1 {
+			bottomBudget = 1
+		}
+		bottomLeft = stripe + indent + StyleSubtle.Render(truncateVisible(bottomLeftText, bottomBudget))
 	}
-	bottomBudget := width - 12
-	if bottomBudget < 1 {
-		bottomBudget = 1
-	}
-	bottomLeftText = truncateVisible(bottomLeftText, bottomBudget)
-	bottomLeft := stripe + indent + StyleSubtle.Render(bottomLeftText)
 
 	totalMins := int(sess.Elapsed().Minutes())
 	var elapsedStr string
@@ -775,9 +786,24 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	} else {
 		elapsedStr = fmt.Sprintf("%dm", totalMins)
 	}
-	line4 := rightAlign(bottomLeft, StyleSubtle.Render(elapsedStr), width)
+	line4 := rightAlign(bottomLeft, StyleSubtle.Render("⏱ "+elapsedStr), width)
 
 	return []string{line1, line2, line3, line4}
+}
+
+// renderBranchChip returns a visually-tinted chip string for a branch name,
+// prefixed with 🌿. The chip has a 1-cell horizontal padding on each side and
+// a dark background (#1F2937, matching the status bar). Returns "" for an
+// empty branch so callers can omit it cleanly.
+func renderBranchChip(branch string) string {
+	if branch == "" {
+		return ""
+	}
+	return lipgloss.NewStyle().
+		Foreground(ColorText).
+		Background(lipgloss.Color("#1F2937")).
+		Padding(0, 1).
+		Render("🌿 " + branch)
 }
 
 // planningStatusBadge renders the right-aligned status badge for a Planning

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -413,6 +413,40 @@ func (d dashboardModel) buildingSessions() []listItem {
 	return result
 }
 
+// renderCardProgressBar returns a progress bar + muted "done/total" suffix
+// right-padded to exactly width display cells. Returns "" when total == 0.
+// At 100% the bar is colored ColorSuccess; otherwise it uses primary.
+func renderCardProgressBar(done, total, width int, primary lipgloss.Color) string {
+	if total == 0 {
+		return ""
+	}
+	pct := float64(done) / float64(total)
+	suffix := StyleSubtle.Render(fmt.Sprintf("%d/%d", done, total))
+	suffixWidth := ansi.StringWidth(suffix)
+	// Reserve at least 1 cell for the bar (plus a separating space).
+	barWidth := width - suffixWidth - 1
+	if barWidth < 1 {
+		barWidth = 1
+	}
+	bar := progress.New(
+		progress.WithoutPercentage(),
+		progress.WithColorFunc(func(_, _ float64) color.Color {
+			if done == total && total > 0 {
+				return ColorSuccess
+			}
+			return primary
+		}),
+	)
+	bar.SetWidth(barWidth)
+	rendered := bar.ViewAs(pct) + " " + suffix
+	// Pad or trim to exactly width cells so callers can right-align predictably.
+	got := ansi.StringWidth(rendered)
+	if got < width {
+		rendered += strings.Repeat(" ", width-got)
+	}
+	return rendered
+}
+
 // sessionFocusStatus returns a styled inline status badge for a session row in
 // the unified SESSIONS list. Priority: Error > Waiting > May Need Input >
 // idle-but-reviewable > finished (DoneAt set) > normal (N active, M idle).

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -942,7 +942,6 @@ func secondUncompletedTask(plan string) string {
 	return ""
 }
 
-
 // focusTaskDescription chooses the description lines for a session card in
 // focus mode and reports whether they should render in pending (italic) style.
 // For Building-phase sessions, line1 is the active task text (raw, no "▸ " prefix

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -585,13 +585,53 @@ func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Co
 	}
 }
 
+// sessionStatusGlyph returns a single-rune glyph and color that mirrors the
+// dominant session state. Used on line 1 of the card, between the stripe and
+// the session name, so the reader can identify state at a glance even when ANSI
+// colors are unavailable. planningPhase callers pass true to suppress the glyph
+// when the right-side badge already begins with one.
+func (d dashboardModel) sessionStatusGlyph(sess *agent.Session) (glyph string, col lipgloss.Color) {
+	var hasError, hasWaiting, hasIdleAsking, hasActive bool
+	for _, item := range d.items {
+		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
+			continue
+		}
+		switch item.agent.Status() {
+		case agent.StatusError:
+			hasError = true
+		case agent.StatusWaiting:
+			hasWaiting = true
+		case agent.StatusActive:
+			hasActive = true
+		case agent.StatusIdle:
+			if item.agent.AskingQuestion() {
+				hasIdleAsking = true
+			}
+		}
+	}
+	switch {
+	case hasError:
+		return "✗", ColorError
+	case hasWaiting:
+		return "⏸", ColorWaiting
+	case hasIdleAsking:
+		return "?", ColorWarning
+	case sess.IsReviewable() || !sess.DoneAt().IsZero():
+		return "✓", ColorSuccess
+	case hasActive:
+		return "⚡", ColorSecondary
+	default:
+		return "○", ColorMuted
+	}
+}
+
 // renderFocusSessionCard returns 4 lines for a session card in focus mode, or
 // 5 lines when a Building session has unfinished plan tasks. Each line begins
 // with a colored vertical stripe (▎) whose color encodes the dominant session
 // state via sessionFocusStripeColor; the selected card brightens the stripe to
 // ColorSecondary.
 //
-// Line 1: <stripe> <name (bold, ColorText)>     ... right-aligned <status badge>
+// Line 1: <stripe> <glyph> <name (bold, ColorText)>   ... right-aligned <status badge>
 // Line 2: <stripe>   <description line 1 (muted; italic if pending)>
 // Line 3: <stripe>   <description line 2 or empty>  (always reserved)
 // Line 4: <stripe>   ▸ <first open task> [· next: <second open>]  (plan-backed building only)
@@ -627,6 +667,13 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 		badge = planningStatusBadge(sess)
 	} else {
 		badge = d.sessionFocusStatus(sess)
+	}
+	// Status glyph: prepend between stripe and name for non-planning cards.
+	// Planning cards suppress the glyph because the badge already leads with ✎/✗/○.
+	if !planningPhase {
+		glyph, glyphColor := d.sessionStatusGlyph(sess)
+		glyphStyled := lipgloss.NewStyle().Foreground(glyphColor).Render(glyph)
+		nameStyled = glyphStyled + " " + nameStyled
 	}
 	line1 := rightAlign(stripe+" "+nameStyled, badge, width)
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -496,11 +496,9 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 	}
 	if sess.LifecyclePhase() == agent.LifecycleInProgress {
 		const barWidth = 20
-		if plan, present := sess.CachedPlan(); present {
-			if total, done := planTaskCounts(plan); total > 0 {
-				return renderCardProgressBar(done, total, barWidth, ColorPrimary)
-			}
-		}
+		// Check todos first to stay in sync with focusTaskDescription's priority:
+		// when both todos and a plan exist, the badge and the task text on lines
+		// 2–3 should count the same source.
 		if ag := sess.PrimaryAgent(); ag != nil {
 			todos := ag.Todos()
 			if len(todos) > 0 {
@@ -511,6 +509,11 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 						done++
 					}
 				}
+				return renderCardProgressBar(done, total, barWidth, ColorPrimary)
+			}
+		}
+		if plan, present := sess.CachedPlan(); present {
+			if total, done := planTaskCounts(plan); total > 0 {
 				return renderCardProgressBar(done, total, barWidth, ColorPrimary)
 			}
 		}
@@ -625,17 +628,15 @@ func (d dashboardModel) sessionStatusGlyph(sess *agent.Session) (glyph string, c
 	}
 }
 
-// renderFocusSessionCard returns 4 lines for a session card in focus mode, or
-// 5 lines when a Building session has unfinished plan tasks. Each line begins
-// with a colored vertical stripe (▎) whose color encodes the dominant session
-// state via sessionFocusStripeColor; the selected card brightens the stripe to
-// ColorSecondary.
+// renderFocusSessionCard returns exactly 4 lines for a session card in focus mode.
+// Each line begins with a colored vertical stripe (▎) whose color encodes the
+// dominant session state via sessionFocusStripeColor; the selected card
+// brightens the stripe to ColorSecondary.
 //
-// Line 1: <stripe> <glyph> <name (bold, ColorText)>   ... right-aligned <status badge>
-// Line 2: <stripe>   <description line 1 (muted; italic if pending)>
-// Line 3: <stripe>   <description line 2 or empty>  (always reserved)
-// Line 4: <stripe>   ▸ <first open task> [· next: <second open>]  (plan-backed building only)
-// Line 4/5: <stripe>   <branch [· detail]>      ... right-aligned <elapsed>
+// Line 1: <stripe> <glyph> <name (bold, ColorText)>   ... right-aligned <status badge/progress bar>
+// Line 2: <stripe>   ▸ <active task (bold)>   (building) | <description (muted/italic)> (planning/other)
+// Line 3: <stripe>   ↳ next: <next task (muted-italic)>   (building) | <description line 2 or empty>
+// Line 4: <stripe>   [🌿 branch chip] [detail]      ... right-aligned ⏱ <elapsed>
 func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName string, selected bool, width int) []string {
 	stripeColor := d.sessionFocusStripeColor(sess)
 	if selected {
@@ -704,17 +705,26 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 			line3 = stripe + indent + descStyle.Render(descLine2)
 		}
 	} else if buildingPhase {
-		// Active task: ▸ <bold text>
+		// Active task: ▸ <bold text>. Subtract 2 cells for the "▸ " prefix so
+		// the total line stays within descBudget.
 		activeLine := ""
 		if descLine1 != "" {
-			activeLine = lipgloss.NewStyle().Bold(true).Render("▸ " + descLine1)
+			activeBudget := descBudget - 2
+			if activeBudget < 0 {
+				activeBudget = 0
+			}
+			activeLine = lipgloss.NewStyle().Bold(true).Render("▸ " + truncateVisible(descLine1, activeBudget))
 		}
 		line2 = stripe + indent + activeLine
-		// Next task: ↳ next: <muted-italic text>
+		// Next task: ↳ next: <muted-italic text>. Subtract 8 cells for "↳ next: ".
 		line3 = stripe + indent
 		if descLine2 != "" {
+			nextBudget := descBudget - 8
+			if nextBudget < 0 {
+				nextBudget = 0
+			}
 			nextStyle := lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
-			line3 = stripe + indent + nextStyle.Render("↳ next: "+descLine2)
+			line3 = stripe + indent + nextStyle.Render("↳ next: "+truncateVisible(descLine2, nextBudget))
 		}
 	} else {
 		line2 = stripe + indent + StyleSubtle.Render(descLine1)

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -691,14 +691,37 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	} else {
 		descLine1, descLine2, descPending = focusTaskDescription(sess, descBudget)
 	}
-	descStyle := StyleSubtle
-	if descPending {
-		descStyle = lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
-	}
-	line2 := stripe + indent + descStyle.Render(descLine1)
-	line3 := stripe + indent
-	if descLine2 != "" {
-		line3 = stripe + indent + descStyle.Render(descLine2)
+	var line2, line3 string
+	buildingPhase := phase == agent.LifecycleInProgress && !sess.IsReviewable()
+	if planningPhase {
+		descStyle := StyleSubtle
+		if descPending {
+			descStyle = lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
+		}
+		line2 = stripe + indent + descStyle.Render(descLine1)
+		line3 = stripe + indent
+		if descLine2 != "" {
+			line3 = stripe + indent + descStyle.Render(descLine2)
+		}
+	} else if buildingPhase {
+		// Active task: ▸ <bold text>
+		activeLine := ""
+		if descLine1 != "" {
+			activeLine = lipgloss.NewStyle().Bold(true).Render("▸ " + descLine1)
+		}
+		line2 = stripe + indent + activeLine
+		// Next task: ↳ next: <muted-italic text>
+		line3 = stripe + indent
+		if descLine2 != "" {
+			nextStyle := lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
+			line3 = stripe + indent + nextStyle.Render("↳ next: "+descLine2)
+		}
+	} else {
+		line2 = stripe + indent + StyleSubtle.Render(descLine1)
+		line3 = stripe + indent
+		if descLine2 != "" {
+			line3 = stripe + indent + StyleSubtle.Render(descLine2)
+		}
 	}
 
 	// --- Line 4: branch [· detail], right-aligned elapsed ---
@@ -754,10 +777,6 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	}
 	line4 := rightAlign(bottomLeft, StyleSubtle.Render(elapsedStr), width)
 
-	if progress := planProgressLine(sess, descBudget); progress != "" {
-		progressLine := stripe + indent + StyleSubtle.Render(progress)
-		return []string{line1, line2, line3, progressLine, line4}
-	}
 	return []string{line1, line2, line3, line4}
 }
 
@@ -930,9 +949,9 @@ func planProgressLine(sess *agent.Session, budget int) string {
 
 // focusTaskDescription chooses the description lines for a session card in
 // focus mode and reports whether they should render in pending (italic) style.
-// For Building-phase sessions that have received ≥1 TodoWrite, line1 shows the
-// active task's activeForm and line2 shows the next pending task. Otherwise
-// the text is word-wrapped into two lines by wrapTwoLines.
+// For Building-phase sessions, line1 is the active task text (raw, no "▸ " prefix
+// — the render layer adds that) and line2 is the next task text (raw, no "↳ next: "
+// prefix). Priority: in_progress TodoItem > plan firstUncompletedTask > fallback.
 func focusTaskDescription(sess *agent.Session, budget int) (line1, line2 string, pending bool) {
 	if sess.LifecyclePhase() == agent.LifecycleInProgress && !sess.IsReviewable() {
 		if ag := sess.PrimaryAgent(); ag != nil {
@@ -959,13 +978,18 @@ func focusTaskDescription(sess *agent.Session, budget int) (line1, line2 string,
 					nextPending = ""
 				}
 				if activeText != "" {
-					l1 := truncateVisible("▸ "+activeText, budget)
-					var l2 string
-					if nextPending != "" {
-						l2 = truncateVisible("next: "+nextPending, budget)
-					}
+					l1 := truncateVisible(activeText, budget)
+					l2 := truncateVisible(nextPending, budget)
 					return l1, l2, false
 				}
+			}
+		}
+		// No todos: fall back to plan checkboxes.
+		if plan, present := sess.CachedPlan(); present {
+			first := firstUncompletedTask(plan)
+			if first != "" {
+				second := secondUncompletedTask(plan)
+				return truncateVisible(first, budget), truncateVisible(second, budget), false
 			}
 		}
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -495,18 +495,23 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ finished — awaiting prompt")
 	}
 	if sess.LifecyclePhase() == agent.LifecycleInProgress {
+		const barWidth = 20
 		if plan, present := sess.CachedPlan(); present {
 			if total, done := planTaskCounts(plan); total > 0 {
-				badge := fmt.Sprintf("▸ %d/%d", done, total)
-				if activeCount > 0 {
-					badge += fmt.Sprintf(" · %d active", activeCount)
-				}
-				return StyleSubtle.Render(badge)
+				return renderCardProgressBar(done, total, barWidth, ColorPrimary)
 			}
 		}
 		if ag := sess.PrimaryAgent(); ag != nil {
-			if badge := buildingProgressBadge(ag.Todos(), activeCount); badge != "" {
-				return badge
+			todos := ag.Todos()
+			if len(todos) > 0 {
+				total := len(todos)
+				done := 0
+				for _, t := range todos {
+					if t.Status == "completed" {
+						done++
+					}
+				}
+				return renderCardProgressBar(done, total, barWidth, ColorPrimary)
 			}
 		}
 	}
@@ -875,28 +880,6 @@ func planProgressLine(sess *agent.Session, budget int) string {
 	return truncateVisible(text, budget)
 }
 
-// buildingProgressBadge returns a styled "▸ done/total · N active" badge for
-// a Building-phase session that has received ≥1 TodoWrite. Returns "" when
-// todos is empty so the caller can fall back to the normal "N active, M idle"
-// string. Status conditions (error/waiting/asking) must preempt this badge —
-// the caller is responsible for that guard.
-func buildingProgressBadge(todos []agent.TodoItem, activeCount int) string {
-	if len(todos) == 0 {
-		return ""
-	}
-	total := len(todos)
-	done := 0
-	for _, t := range todos {
-		if t.Status == "completed" {
-			done++
-		}
-	}
-	badge := fmt.Sprintf("▸ %d/%d", done, total)
-	if activeCount > 0 {
-		badge += fmt.Sprintf(" · %d active", activeCount)
-	}
-	return StyleSubtle.Render(badge)
-}
 
 // focusTaskDescription chooses the description lines for a session card in
 // focus mode and reports whether they should render in pending (italic) style.

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -639,3 +639,47 @@ func TestSessionFocusStatus_BuildingWithPlanAllDoneReviewablePrefersReviewBadge(
 		t.Errorf("plan progress badge must not appear when reviewable, got %q", badge)
 	}
 }
+
+// TestRenderCardProgressBar_DoneTotalAndColor verifies the renderCardProgressBar
+// helper contract:
+//
+//	(a) returns "" when total == 0
+//	(b) rendered string contains the "done/total" count suffix
+//	(c) ansi.StringWidth of the output equals the requested width
+//	(d) at 100% the rendered output uses ColorSuccess's hex
+//	(e) at <100% it uses the passed primary color's hex
+func TestRenderCardProgressBar_DoneTotalAndColor(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	// (a) total==0 → empty string
+	if got := renderCardProgressBar(0, 0, 20, ColorPrimary); got != "" {
+		t.Errorf("total==0: want \"\", got %q", got)
+	}
+
+	const width = 24
+	// (b) contains "2/7" count suffix
+	out := renderCardProgressBar(2, 7, width, ColorPrimary)
+	if !strings.Contains(ansi.Strip(out), "2/7") {
+		t.Errorf("expected \"2/7\" in output, got %q", ansi.Strip(out))
+	}
+
+	// (c) display width equals requested width
+	if w := ansi.StringWidth(out); w != width {
+		t.Errorf("display width = %d, want %d; raw=%q", w, width, out)
+	}
+
+	// (d) at 100% uses ColorSuccess (#10B981 → decimal 16;185;129 in ANSI).
+	full := renderCardProgressBar(7, 7, width, ColorPrimary)
+	// ColorSuccess = #10B981 → R=16, G=185, B=129.
+	if !strings.Contains(full, "16;185;129") {
+		t.Errorf("100%%: expected ColorSuccess (16;185;129) in output, got %q", full)
+	}
+
+	// (e) at <100% uses the passed primary color (#7C3AED → 124;58;237).
+	// ColorPrimary = #7C3AED → R=124, G=58, B=237.
+	if !strings.Contains(out, "124;58;237") {
+		t.Errorf("<100%%: expected ColorPrimary (124;58;237) in output, got %q", out)
+	}
+}

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -822,3 +822,65 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 		})
 	}
 }
+
+// TestRenderFocusSessionCard_BranchChipAndElapsedGlyph verifies that line 4
+// contains a 🌿 chip before the branch name (with a background tint), ⏱ before
+// the elapsed token, and no chip when the branch is empty.
+func TestRenderFocusSessionCard_BranchChipAndElapsedGlyph(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	sess.UpdateBranch("baton/add-dark-mode")
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 120)
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card, got %d", len(card))
+	}
+
+	line4Raw := card[3]
+	line4 := ansi.Strip(line4Raw)
+
+	// 🌿 immediately before branch name.
+	if !strings.Contains(line4, "🌿") {
+		t.Errorf("line 4 should contain 🌿 glyph, got %q", line4)
+	}
+	if !strings.Contains(line4, "add-dark-mode") {
+		t.Errorf("line 4 should contain branch name, got %q", line4)
+	}
+
+	// ⏱ before the elapsed token.
+	if !strings.Contains(line4, "⏱") {
+		t.Errorf("line 4 should contain ⏱ glyph, got %q", line4)
+	}
+
+	// Branch chip carries a background color escape (48;2; = background TrueColor).
+	if !strings.Contains(line4Raw, "48;2;") {
+		t.Errorf("line 4 raw should contain background ANSI sequence (48;2;) for chip tint, got %q", line4Raw)
+	}
+
+	// No branch → no chip.
+	sessNoBranch := agent.NewSessionForTest("s2", "no-branch-session")
+	sessNoBranch.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag2 := sessNoBranch.AddTestAgent("a-2", false, agent.StatusActive)
+	d2 := newDashboardModel()
+	d2.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sessNoBranch},
+		{kind: listItemAgent, repoPath: "/r", session: sessNoBranch, agent: ag2},
+	}
+	card2 := d2.renderFocusSessionCard(sessNoBranch, "", false, 120)
+	line4b := ansi.Strip(card2[3])
+	if strings.Contains(line4b, "🌿") {
+		t.Errorf("no-branch session should not render 🌿 chip, got %q", line4b)
+	}
+}

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -418,10 +418,8 @@ func TestRenderQueueRow_RepoPrefix(t *testing.T) {
 }
 
 // TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine verifies
-// that a Building session with a plan and open tasks produces a 5-line card
-// where the description (lines 2–3) is preserved and the new line 4 shows
-// "▸ first open · next: second open", with the branch/elapsed row moved to
-// line 5.
+// that a Building session with a plan and open tasks produces a 4-line card
+// where line 2 shows "▸ first open task" (bold) and line 3 shows "↳ next: second open".
 func TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
@@ -439,24 +437,63 @@ func TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine(t *testing
 	}
 
 	card := d.renderFocusSessionCard(sess, "", false, 100)
-	if len(card) != 5 {
-		t.Fatalf("expected 5-line card for plan-backed building session, got %d lines: %v", len(card), card)
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card for plan-backed building session, got %d lines: %v", len(card), card)
 	}
-	if !strings.Contains(ansi.Strip(card[1]), "implement oauth flow") {
-		t.Errorf("line 2 should show description (task summary), got %q", ansi.Strip(card[1]))
+	line2 := ansi.Strip(card[1])
+	if !strings.Contains(line2, "▸") {
+		t.Errorf("line 2 should contain ▸ prefix, got %q", line2)
 	}
-	line4 := ansi.Strip(card[3])
-	if !strings.Contains(line4, "write tests") {
-		t.Errorf("line 4 should contain first open task, got %q", line4)
+	if !strings.Contains(line2, "write tests") {
+		t.Errorf("line 2 should contain first open task, got %q", line2)
 	}
-	if !strings.Contains(line4, "next: open PR") {
-		t.Errorf("line 4 should contain 'next: open PR', got %q", line4)
+	line3 := ansi.Strip(card[2])
+	if !strings.Contains(line3, "↳ next:") {
+		t.Errorf("line 3 should contain ↳ next: prefix, got %q", line3)
+	}
+	if !strings.Contains(line3, "open PR") {
+		t.Errorf("line 3 should contain second open task, got %q", line3)
+	}
+}
+
+// TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan verifies that
+// when the session's primary agent has an in_progress TodoItem, that item's
+// content wins on line 2 over the plan's first uncompleted task.
+func TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	if err := sess.WritePlan("- [ ] plan task one\n- [ ] plan task two\n"); err != nil {
+		t.Fatal(err)
+	}
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+	ag.SetTodos([]agent.TodoItem{
+		{Content: "todo task from agent", ActiveForm: "Running todo task", Status: "in_progress"},
+		{Content: "next pending todo", Status: "pending"},
+	})
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 100)
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card, got %d", len(card))
+	}
+	line2 := ansi.Strip(card[1])
+	if !strings.Contains(line2, "Running todo task") {
+		t.Errorf("line 2 should show in_progress todo's ActiveForm, got %q", line2)
+	}
+	if strings.Contains(line2, "plan task") {
+		t.Errorf("line 2 must not show plan task when todo overrides it, got %q", line2)
 	}
 }
 
 // TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix verifies
-// that when only one open task remains, the task-progress line shows "▸ task"
-// without a "next:" suffix.
+// that when only one open task remains, line 2 shows "▸ last task" and line 3
+// is blank (no "↳ next:" suffix), card is exactly 4 lines.
 func TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
@@ -473,15 +510,16 @@ func TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix(t *testing
 	}
 
 	card := d.renderFocusSessionCard(sess, "", false, 100)
-	if len(card) != 5 {
-		t.Fatalf("expected 5-line card with single open task, got %d lines", len(card))
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card with single open task, got %d lines", len(card))
 	}
-	line4 := ansi.Strip(card[3])
-	if !strings.Contains(line4, "last task") {
-		t.Errorf("line 4 should contain open task name, got %q", line4)
+	line2 := ansi.Strip(card[1])
+	if !strings.Contains(line2, "last task") {
+		t.Errorf("line 2 should contain open task name, got %q", line2)
 	}
-	if strings.Contains(line4, "next:") {
-		t.Errorf("line 4 must not have 'next:' with single open task, got %q", line4)
+	line3 := ansi.Strip(card[2])
+	if strings.Contains(line3, "next:") {
+		t.Errorf("line 3 must not have 'next:' with single open task, got %q", line3)
 	}
 }
 

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -253,19 +253,6 @@ func TestBuildingProgressBadge(t *testing.T) {
 	}
 }
 
-// makeTodos builds a slice of n TodoItems with done of them marked completed.
-func makeTodos(n, done int) []agent.TodoItem {
-	items := make([]agent.TodoItem, n)
-	for i := range items {
-		if i < done {
-			items[i] = agent.TodoItem{Content: "task", Status: "completed"}
-		} else {
-			items[i] = agent.TodoItem{Content: "task", Status: "pending"}
-		}
-	}
-	return items
-}
-
 // TestSessionFocusStatus_BuildingWithTodosShowsProgressBadge verifies that
 // sessionFocusStatus shows a "▸ done/total" progress badge for a Building
 // session that has received ≥1 TodoWrite, instead of the plain "N active, M idle".

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -693,3 +693,94 @@ func TestRenderCardProgressBar_DoneTotalAndColor(t *testing.T) {
 		t.Errorf("<100%%: expected ColorPrimary (124;58;237) in output, got %q", out)
 	}
 }
+
+// TestRenderFocusSessionCard_StatusGlyphMapping verifies that line 1 of each
+// card carries the correct status glyph for each lifecycle/agent-state combination.
+func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	tests := []struct {
+		name      string
+		setup     func() (*agent.Session, []listItem)
+		wantGlyph string
+	}{
+		{
+			name: "error → ✗",
+			setup: func() (*agent.Session, []listItem) {
+				sess := agent.NewSessionForTest("s", "my-session")
+				sess.SetLifecyclePhase(agent.LifecycleInProgress)
+				ag := sess.AddTestAgent("a-1", false, agent.StatusError)
+				return sess, []listItem{
+					{kind: listItemSession, repoPath: "/r", session: sess},
+					{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+				}
+			},
+			wantGlyph: "✗",
+		},
+		{
+			name: "waiting → ⏸",
+			setup: func() (*agent.Session, []listItem) {
+				sess := agent.NewSessionForTest("s", "my-session")
+				sess.SetLifecyclePhase(agent.LifecycleInProgress)
+				ag := sess.AddTestAgent("a-1", false, agent.StatusWaiting)
+				return sess, []listItem{
+					{kind: listItemSession, repoPath: "/r", session: sess},
+					{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+				}
+			},
+			wantGlyph: "⏸",
+		},
+		{
+			name: "active → ⚡",
+			setup: func() (*agent.Session, []listItem) {
+				sess := agent.NewSessionForTest("s", "my-session")
+				sess.SetLifecyclePhase(agent.LifecycleInProgress)
+				ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+				return sess, []listItem{
+					{kind: listItemSession, repoPath: "/r", session: sess},
+					{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+				}
+			},
+			wantGlyph: "⚡",
+		},
+		{
+			name: "reviewable → ✓",
+			setup: func() (*agent.Session, []listItem) {
+				sess := agent.NewSessionForTest("s", "my-session")
+				sess.SetLifecyclePhase(agent.LifecycleInProgress)
+				ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
+				return sess, []listItem{
+					{kind: listItemSession, repoPath: "/r", session: sess},
+					{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+				}
+			},
+			wantGlyph: "✓",
+		},
+		{
+			name: "idle, no agents → ○",
+			setup: func() (*agent.Session, []listItem) {
+				sess := agent.NewSessionForTest("s", "my-session")
+				sess.SetLifecyclePhase(agent.LifecycleInProgress)
+				return sess, []listItem{
+					{kind: listItemSession, repoPath: "/r", session: sess},
+				}
+			},
+			wantGlyph: "○",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sess, items := tc.setup()
+			d := newDashboardModel()
+			d.items = items
+			card := d.renderFocusSessionCard(sess, "", false, 100)
+			line1 := ansi.Strip(card[0])
+			if !strings.Contains(line1, tc.wantGlyph) {
+				t.Errorf("line 1 should contain glyph %q, got %q", tc.wantGlyph, line1)
+			}
+		})
+	}
+}

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -208,42 +208,37 @@ func TestRenderFocusSessionCard_RepoPrefix(t *testing.T) {
 	}
 }
 
-// TestBuildingProgressBadge verifies the badge string for various todo states.
+// TestBuildingProgressBadge verifies renderCardProgressBar for various todo-count states.
 func TestBuildingProgressBadge(t *testing.T) {
 	tests := []struct {
-		name        string
-		todos       []agent.TodoItem
-		activeCount int
-		wantEmpty   bool
-		wantSubstr  string
+		name      string
+		done      int
+		total     int
+		wantEmpty bool
+		wantStr   string
 	}{
 		{
 			name:      "no todos returns empty",
-			todos:     nil,
+			done:      0,
+			total:     0,
 			wantEmpty: true,
 		},
 		{
-			name:        "2/5 with 1 active",
-			todos:       makeTodos(5, 2),
-			activeCount: 1,
-			wantSubstr:  "2/5",
+			name:    "2/5 shows correct counts",
+			done:    2,
+			total:   5,
+			wantStr: "2/5",
 		},
 		{
-			name:        "active count included",
-			todos:       makeTodos(3, 0),
-			activeCount: 2,
-			wantSubstr:  "2 active",
-		},
-		{
-			name:        "no active count omitted when zero",
-			todos:       makeTodos(3, 1),
-			activeCount: 0,
-			wantSubstr:  "1/3",
+			name:    "1/3 shows correct counts",
+			done:    1,
+			total:   3,
+			wantStr: "1/3",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildingProgressBadge(tc.todos, tc.activeCount)
+			got := renderCardProgressBar(tc.done, tc.total, 20, ColorPrimary)
 			if tc.wantEmpty {
 				if got != "" {
 					t.Errorf("expected empty badge, got %q", got)
@@ -251,8 +246,8 @@ func TestBuildingProgressBadge(t *testing.T) {
 				return
 			}
 			plain := ansi.Strip(got)
-			if !strings.Contains(plain, tc.wantSubstr) {
-				t.Errorf("expected badge to contain %q, got %q", tc.wantSubstr, plain)
+			if !strings.Contains(plain, tc.wantStr) {
+				t.Errorf("expected badge to contain %q, got %q", tc.wantStr, plain)
 			}
 		})
 	}
@@ -533,9 +528,13 @@ func TestRenderFocusSessionCard_NoPlanStaysFourLines(t *testing.T) {
 }
 
 // TestSessionFocusStatus_BuildingWithPlanShowsProgressBadge verifies that a
-// Building session backed by a plan file shows "▸ done/total · N active" on
-// the badge, not the plain "N active, M idle" fallback.
+// Building session backed by a plan file shows a progress bar with done/total,
+// not the plain "N active, M idle" fallback.
 func TestSessionFocusStatus_BuildingWithPlanShowsProgressBadge(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
 	sess.SetLifecyclePhase(agent.LifecycleInProgress)
@@ -550,12 +549,23 @@ func TestSessionFocusStatus_BuildingWithPlanShowsProgressBadge(t *testing.T) {
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := ansi.Strip(d.sessionFocusStatus(sess))
-	if !strings.Contains(badge, "1/3") {
-		t.Errorf("expected plan progress badge '1/3', got %q", badge)
+	badge := d.sessionFocusStatus(sess)
+	stripped := ansi.Strip(badge)
+	// Must contain the "1/3" count.
+	if !strings.Contains(stripped, "1/3") {
+		t.Errorf("expected plan progress badge '1/3', got %q", stripped)
 	}
-	if !strings.Contains(badge, "1 active") {
-		t.Errorf("expected '1 active' in plan badge, got %q", badge)
+	// Must contain a progress bar block rune (▌ or █ or ░).
+	if !strings.ContainsAny(badge, "▌█░") {
+		t.Errorf("expected progress bar glyph (▌/█/░) in badge, got %q", badge)
+	}
+	// Must NOT contain the legacy "▸ " prefix.
+	if strings.Contains(stripped, "▸ ") {
+		t.Errorf("legacy ▸ prefix must not appear in new badge, got %q", stripped)
+	}
+	// Must NOT contain "· N active" suffix.
+	if strings.Contains(stripped, "active") {
+		t.Errorf("legacy '· N active' suffix must not appear in new badge, got %q", stripped)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Fix: plan-cache mtime invalidation** — `CachedPlan` now keys the cache on the file's mtime via `os.Stat` on every call. If mtime is unchanged, no read occurs; if the build agent toggled checkboxes via Claude's Edit tool (bypassing `WritePlan`), the file re-reads within one 100ms tick. `WritePlan` records mtime alongside content so the next tick never does a redundant read.
- **New: real progress bar on the status badge** — line 1's right side shows a `charm.land/bubbles/v2/progress` bar (`ColorSuccess` at 100%, `ColorPrimary` otherwise) with a muted `done/total` count, replacing the plain `▸ N/M` text.
- **New: status glyph on line 1** — `✗` error, `⏸` waiting, `?` idle-asking, `✓` reviewable/finished, `⚡` active, `○` otherwise; suppressed for Planning/Drafting cards whose badge already leads with an icon.
- **New: active/next task lines 2–3** — line 2 shows `▸` + bold active task (in-progress TodoItem, falling back to first uncompleted plan checkbox); line 3 shows `↳ next:` + muted-italic next task.
- **New: branch chip + clock glyph on line 4** — branch renders as a dark-background (`#1F2937`) chip with `🌿` prefix; elapsed is prefixed with `⏱`.
- **Removed: 5-line card variant** — all cards are now a uniform 4 lines; `planProgressLine` helper deleted along with its call site in `app.go`'s scroll height calculation.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` (pre-existing failures in `internal/config` and `internal/hook` are environment-specific unix-socket/path issues present on main before this branch)
- [ ] Manual TUI: build against a repo with a Building session whose plan has 3 tasks; observe progress bar advance from `0/3` → `1/3` → `2/3` → reviewable badge as the build agent toggles checkboxes in `.claude/plan.md`; confirm active task on line 2 updates and next task on line 3 shifts.
- [ ] Manual TUI: launch baton, create one session per lifecycle phase and confirm each card has the right glyph, progress bar appears only on Building cards with tasks, and every card occupies exactly 4 lines.
- [ ] Manual TUI: test at ≥120 cols and ~60 cols; confirm progress bar truncates gracefully and chip doesn't wrap.

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — fragment added to `changelog.d/building-card-progress-refresh.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description