### PR TITLE
Fix PR conflict status to reflect actual merge state

### DIFF
--- a/changelog.d/fix-pr-status-conflicts.md
+++ b/changelog.d/fix-pr-status-conflicts.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- PR rows no longer report "Conflicts" for every open PR. The root cause was the GitHub list endpoint always returning null for `mergeable`, which the client coerced to "not mergeable". PR lookups now follow up with the singular `GET /pulls/:number` endpoint, which populates `mergeable_state`. The shipping row shows "Conflicts" only when `mergeable_state` is `"dirty"`. While GitHub is still computing mergeability (state `"unknown"` or absent), the shipping panel header shows "⋯ checking" and the poller arms a 15s burst window so the state resolves promptly.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -142,6 +142,24 @@ func isNotFoundOrUnprocessable(resp *gh.Response) bool {
 		resp.StatusCode == http.StatusUnprocessableEntity
 }
 
+// getPRDetail fetches the singular PR endpoint for the given number, which
+// populates mergeable_state (always null from list endpoints). Falls back to
+// the provided base PR if the detail fetch fails so a transient error doesn't
+// blank the panel.
+func (c *Client) getPRDetail(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
+	var pr *gh.PullRequest
+	err := c.doWithRetry(ctx, func() (*gh.Response, error) {
+		var resp *gh.Response
+		var err error
+		pr, resp, err = c.gh.PullRequests.Get(ctx, owner, repo, number)
+		return resp, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
+}
+
 // GetPR finds an open pull request for the given head branch.
 // Returns nil (not an error) if no open PR exists for the branch.
 func (c *Client) GetPR(ctx context.Context, owner, repo, branch string) (*PRState, error) {
@@ -166,7 +184,11 @@ func (c *Client) GetPR(ctx context.Context, owner, repo, branch string) (*PRStat
 		return nil, nil
 	}
 
-	return prToState(prs[0]), nil
+	detail, err := c.getPRDetail(ctx, owner, repo, prs[0].GetNumber())
+	if err != nil {
+		return prToState(prs[0]), nil
+	}
+	return prToState(detail), nil
 }
 
 // GetPRBySHA finds the open PR associated with a commit SHA. This is invariant
@@ -206,7 +228,11 @@ func (c *Client) GetPRBySHA(ctx context.Context, owner, repo, sha string) (*PRSt
 			continue
 		}
 		if pr.GetState() == "open" {
-			return prToState(pr), nil
+			detail, err := c.getPRDetail(ctx, owner, repo, pr.GetNumber())
+			if err != nil {
+				return prToState(pr), nil
+			}
+			return prToState(detail), nil
 		}
 	}
 	return nil, nil
@@ -387,7 +413,11 @@ func (c *Client) CreatePR(ctx context.Context, owner, repo, head, base, title, b
 	if err != nil {
 		return nil, fmt.Errorf("creating PR: %w", err)
 	}
-	return prToState(pr), nil
+	detail, err := c.getPRDetail(ctx, owner, repo, pr.GetNumber())
+	if err != nil {
+		return prToState(pr), nil
+	}
+	return prToState(detail), nil
 }
 
 // GetReviewThreads returns review threads for a PR grouped by reviewer.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -512,19 +512,14 @@ func prToState(pr *gh.PullRequest) *PRState {
 		state = "merged"
 	}
 
-	mergeable := false
-	if pr.Mergeable != nil {
-		mergeable = *pr.Mergeable
-	}
-
 	return &PRState{
-		Number:     pr.GetNumber(),
-		Title:      pr.GetTitle(),
-		URL:        pr.GetHTMLURL(),
-		State:      state,
-		Mergeable:  mergeable,
-		Draft:      pr.GetDraft(),
-		HeadBranch: pr.GetHead().GetRef(),
-		BaseBranch: pr.GetBase().GetRef(),
+		Number:         pr.GetNumber(),
+		Title:          pr.GetTitle(),
+		URL:            pr.GetHTMLURL(),
+		State:          state,
+		MergeableState: pr.GetMergeableState(),
+		Draft:          pr.GetDraft(),
+		HeadBranch:     pr.GetHead().GetRef(),
+		BaseBranch:     pr.GetBase().GetRef(),
 	}
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -143,8 +143,9 @@ func isNotFoundOrUnprocessable(resp *gh.Response) bool {
 }
 
 // getPRDetail fetches the singular PR endpoint for the given number, which
-// populates mergeable_state (always null from list endpoints). Returns an
-// error if the fetch fails after retries; callers fall back to the list result.
+// populates mergeable_state (always null from list and create endpoints).
+// Returns an error if the fetch fails after retries; callers fall back to
+// their list/create result with MergeableState == "".
 func (c *Client) getPRDetail(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
 	var pr *gh.PullRequest
 	err := c.doWithRetry(ctx, func() (*gh.Response, error) {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -143,9 +143,8 @@ func isNotFoundOrUnprocessable(resp *gh.Response) bool {
 }
 
 // getPRDetail fetches the singular PR endpoint for the given number, which
-// populates mergeable_state (always null from list endpoints). Falls back to
-// the provided base PR if the detail fetch fails so a transient error doesn't
-// blank the panel.
+// populates mergeable_state (always null from list endpoints). Returns an
+// error if the fetch fails after retries; callers fall back to the list result.
 func (c *Client) getPRDetail(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
 	var pr *gh.PullRequest
 	err := c.doWithRetry(ctx, func() (*gh.Response, error) {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -183,11 +183,10 @@ func (c *Client) GetPR(ctx context.Context, owner, repo, branch string) (*PRStat
 		return nil, nil
 	}
 
-	detail, err := c.getPRDetail(ctx, owner, repo, prs[0].GetNumber())
-	if err != nil {
-		return prToState(prs[0]), nil
+	if detail, err := c.getPRDetail(ctx, owner, repo, prs[0].GetNumber()); err == nil {
+		return prToState(detail), nil
 	}
-	return prToState(detail), nil
+	return prToState(prs[0]), nil
 }
 
 // GetPRBySHA finds the open PR associated with a commit SHA. This is invariant
@@ -227,11 +226,10 @@ func (c *Client) GetPRBySHA(ctx context.Context, owner, repo, sha string) (*PRSt
 			continue
 		}
 		if pr.GetState() == "open" {
-			detail, err := c.getPRDetail(ctx, owner, repo, pr.GetNumber())
-			if err != nil {
-				return prToState(pr), nil
+			if detail, err := c.getPRDetail(ctx, owner, repo, pr.GetNumber()); err == nil {
+				return prToState(detail), nil
 			}
-			return prToState(detail), nil
+			return prToState(pr), nil
 		}
 	}
 	return nil, nil
@@ -412,11 +410,10 @@ func (c *Client) CreatePR(ctx context.Context, owner, repo, head, base, title, b
 	if err != nil {
 		return nil, fmt.Errorf("creating PR: %w", err)
 	}
-	detail, err := c.getPRDetail(ctx, owner, repo, pr.GetNumber())
-	if err != nil {
-		return prToState(pr), nil
+	if detail, err := c.getPRDetail(ctx, owner, repo, pr.GetNumber()); err == nil {
+		return prToState(detail), nil
 	}
-	return prToState(detail), nil
+	return prToState(pr), nil
 }
 
 // GetReviewThreads returns review threads for a PR grouped by reviewer.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -36,10 +36,14 @@ func newTestClient(t *testing.T, srv *httptest.Server) *Client {
 
 func TestGetPR_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/o/r/pulls" {
+		switch r.URL.Path {
+		case "/repos/o/r/pulls":
+			_, _ = fmt.Fprintln(w, `[{"number":42,"title":"t","html_url":"u","state":"open","head":{"ref":"feat"},"base":{"ref":"main"}}]`)
+		case "/repos/o/r/pulls/42":
+			_, _ = fmt.Fprintln(w, `{"number":42,"title":"t","html_url":"u","state":"open","head":{"ref":"feat"},"base":{"ref":"main"}}`)
+		default:
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		_, _ = fmt.Fprintln(w, `[{"number":42,"title":"t","html_url":"u","state":"open","head":{"ref":"feat"},"base":{"ref":"main"}}]`)
 	}))
 	defer srv.Close()
 
@@ -70,14 +74,21 @@ func TestGetPR_NoPR(t *testing.T) {
 }
 
 func TestGetPR_Retry503ThenSuccess(t *testing.T) {
-	var calls atomic.Int32
+	var listCalls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := calls.Add(1)
-		if n == 1 {
-			http.Error(w, "down", http.StatusServiceUnavailable)
-			return
+		switch r.URL.Path {
+		case "/repos/o/r/pulls":
+			n := listCalls.Add(1)
+			if n == 1 {
+				http.Error(w, "down", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = fmt.Fprintln(w, `[{"number":1,"title":"","state":"open","head":{"ref":"f"},"base":{"ref":"main"}}]`)
+		case "/repos/o/r/pulls/1":
+			_, _ = fmt.Fprintln(w, `{"number":1,"state":"open","head":{"ref":"f"},"base":{"ref":"main"}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		_, _ = fmt.Fprintln(w, `[{"number":1,"title":"","state":"open","head":{"ref":"f"},"base":{"ref":"main"}}]`)
 	}))
 	defer srv.Close()
 
@@ -89,8 +100,8 @@ func TestGetPR_Retry503ThenSuccess(t *testing.T) {
 	if pr == nil {
 		t.Fatalf("expected PR, got nil")
 	}
-	if got := calls.Load(); got != 2 {
-		t.Fatalf("expected 2 attempts, got %d", got)
+	if got := listCalls.Load(); got != 2 {
+		t.Fatalf("expected 2 list attempts, got %d", got)
 	}
 }
 
@@ -188,10 +199,14 @@ func TestGetPR_CtxCancelledDuringBackoff(t *testing.T) {
 
 func TestGetPRBySHA_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/o/r/commits/deadbeef/pulls" {
+		switch r.URL.Path {
+		case "/repos/o/r/commits/deadbeef/pulls":
+			_, _ = fmt.Fprintln(w, `[{"number":7,"state":"open","head":{"ref":"feat","repo":{"full_name":"o/r"}},"base":{"ref":"main"}}]`)
+		case "/repos/o/r/pulls/7":
+			_, _ = fmt.Fprintln(w, `{"number":7,"state":"open","head":{"ref":"feat"},"base":{"ref":"main"}}`)
+		default:
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		_, _ = fmt.Fprintln(w, `[{"number":7,"state":"open","head":{"ref":"feat","repo":{"full_name":"o/r"}},"base":{"ref":"main"}}]`)
 	}))
 	defer srv.Close()
 
@@ -207,11 +222,18 @@ func TestGetPRBySHA_Success(t *testing.T) {
 
 func TestGetPRBySHA_ForkFilter(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Two PRs for this commit — one from a fork, one from the owner's repo.
-		_, _ = fmt.Fprintln(w, `[
-			{"number":9,"state":"open","head":{"ref":"feat","repo":{"full_name":"fork/r"}}},
-			{"number":7,"state":"open","head":{"ref":"feat","repo":{"full_name":"o/r"}}}
-		]`)
+		switch r.URL.Path {
+		case "/repos/o/r/commits/deadbeef/pulls":
+			// Two PRs for this commit — one from a fork, one from the owner's repo.
+			_, _ = fmt.Fprintln(w, `[
+				{"number":9,"state":"open","head":{"ref":"feat","repo":{"full_name":"fork/r"}}},
+				{"number":7,"state":"open","head":{"ref":"feat","repo":{"full_name":"o/r"}},"base":{"ref":"main"}}
+			]`)
+		case "/repos/o/r/pulls/7":
+			_, _ = fmt.Fprintln(w, `{"number":7,"state":"open","head":{"ref":"feat"},"base":{"ref":"main"}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
 	}))
 	defer srv.Close()
 
@@ -281,11 +303,15 @@ func TestGetPRBySHA_AllClosedReturnsNil(t *testing.T) {
 
 func TestCreatePR_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/repos/o/r/pulls" {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/o/r/pulls":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprintln(w, `{"number":42,"title":"my title","html_url":"https://github.com/o/r/pull/42","state":"open","draft":true,"head":{"ref":"feat","repo":{"full_name":"o/r"}},"base":{"ref":"main"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/42":
+			_, _ = fmt.Fprintln(w, `{"number":42,"title":"my title","html_url":"https://github.com/o/r/pull/42","state":"open","draft":true,"mergeable_state":"unknown","head":{"ref":"feat"},"base":{"ref":"main"}}`)
+		default:
 			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
 		}
-		w.WriteHeader(http.StatusCreated)
-		_, _ = fmt.Fprintln(w, `{"number":42,"title":"my title","html_url":"https://github.com/o/r/pull/42","state":"open","draft":true,"head":{"ref":"feat","repo":{"full_name":"o/r"}},"base":{"ref":"main"}}`)
 	}))
 	defer srv.Close()
 
@@ -472,6 +498,60 @@ func TestGetReviewThreads_CommentOnlyReviewer(t *testing.T) {
 	}
 	if threads[0].Reviewer != "charlie" || threads[0].State != "COMMENTED" {
 		t.Errorf("unexpected thread: %+v", threads[0])
+	}
+}
+
+func TestGetPR_FollowsUpWithGet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/o/r/pulls":
+			_, _ = fmt.Fprintln(w, `[{"number":42,"state":"open","head":{"ref":"feat"},"base":{"ref":"main"}}]`)
+		case "/repos/o/r/pulls/42":
+			_, _ = fmt.Fprintln(w, `{"number":42,"mergeable_state":"clean","state":"open","head":{"ref":"feat"},"base":{"ref":"main"}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPR(context.Background(), "o", "r", "feat")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("expected PR, got nil")
+	}
+	if pr.MergeableState != "clean" {
+		t.Errorf("MergeableState = %q, want \"clean\"", pr.MergeableState)
+	}
+}
+
+func TestGetPRBySHA_FollowsUpWithGet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/o/r/commits/abc123/pulls":
+			_, _ = fmt.Fprintln(w, `[{"number":7,"state":"open","head":{"ref":"feat","repo":{"full_name":"o/r"}},"base":{"ref":"main"}}]`)
+		case "/repos/o/r/pulls/7":
+			_, _ = fmt.Fprintln(w, `{"number":7,"mergeable_state":"clean","state":"open","head":{"ref":"feat"},"base":{"ref":"main"}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPRBySHA(context.Background(), "o", "r", "abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("expected PR, got nil")
+	}
+	if pr.MergeableState != "clean" {
+		t.Errorf("MergeableState = %q, want \"clean\"", pr.MergeableState)
 	}
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -590,13 +590,14 @@ func TestGetPRDetail_RetriesOn5xx(t *testing.T) {
 	}
 }
 
-func TestGetPRDetail_UnknownState(t *testing.T) {
+func TestGetPR_NullMergeableState(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/repos/o/r/pulls":
 			_, _ = fmt.Fprintln(w, `[{"number":1,"state":"open","head":{"ref":"f"},"base":{"ref":"main"}}]`)
 		case "/repos/o/r/pulls/1":
-			// mergeable_state omitted — GitHub still computing
+			// mergeable_state field absent in JSON (null pointer) — distinct from
+			// the string "unknown" GitHub returns while computing.
 			_, _ = fmt.Fprintln(w, `{"number":1,"state":"open","head":{"ref":"f"},"base":{"ref":"main"}}`)
 		default:
 			t.Errorf("unexpected path: %s", r.URL.Path)
@@ -614,6 +615,34 @@ func TestGetPRDetail_UnknownState(t *testing.T) {
 	}
 	if pr.MergeableState != "" {
 		t.Errorf("MergeableState = %q, want \"\"", pr.MergeableState)
+	}
+}
+
+func TestGetPR_DetailExhaustsRetries_FallsBackToListResult(t *testing.T) {
+	var detailCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/o/r/pulls":
+			_, _ = fmt.Fprintln(w, `[{"number":1,"state":"open","head":{"ref":"f"},"base":{"ref":"main"}}]`)
+		case "/repos/o/r/pulls/1":
+			detailCalls.Add(1)
+			http.Error(w, "down", http.StatusServiceUnavailable)
+		}
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv)
+	pr, err := c.GetPR(context.Background(), "o", "r", "f")
+	if err != nil {
+		t.Fatalf("expected fallback success, got error: %v", err)
+	}
+	if pr == nil || pr.Number != 1 {
+		t.Fatalf("expected PR #1 from list fallback, got %+v", pr)
+	}
+	if pr.MergeableState != "" {
+		t.Errorf("MergeableState = %q, want \"\" for list fallback", pr.MergeableState)
+	}
+	if got := detailCalls.Load(); got != 3 {
+		t.Fatalf("expected 3 detail attempts before fallback, got %d", got)
 	}
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -555,6 +555,68 @@ func TestGetPRBySHA_FollowsUpWithGet(t *testing.T) {
 	}
 }
 
+func TestGetPRDetail_RetriesOn5xx(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/o/r/pulls":
+			_, _ = fmt.Fprintln(w, `[{"number":1,"state":"open","head":{"ref":"f"},"base":{"ref":"main"}}]`)
+		case "/repos/o/r/pulls/1":
+			n := calls.Add(1)
+			if n == 1 {
+				http.Error(w, "down", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = fmt.Fprintln(w, `{"number":1,"mergeable_state":"clean","state":"open","head":{"ref":"f"},"base":{"ref":"main"}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPR(context.Background(), "o", "r", "f")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("expected PR, got nil")
+	}
+	if pr.MergeableState != "clean" {
+		t.Errorf("MergeableState = %q, want \"clean\"", pr.MergeableState)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected 2 detail attempts (1 retry), got %d", got)
+	}
+}
+
+func TestGetPRDetail_UnknownState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/o/r/pulls":
+			_, _ = fmt.Fprintln(w, `[{"number":1,"state":"open","head":{"ref":"f"},"base":{"ref":"main"}}]`)
+		case "/repos/o/r/pulls/1":
+			// mergeable_state omitted — GitHub still computing
+			_, _ = fmt.Fprintln(w, `{"number":1,"state":"open","head":{"ref":"f"},"base":{"ref":"main"}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	pr, err := c.GetPR(context.Background(), "o", "r", "f")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pr == nil {
+		t.Fatal("expected PR, got nil")
+	}
+	if pr.MergeableState != "" {
+		t.Errorf("MergeableState = %q, want \"\"", pr.MergeableState)
+	}
+}
+
 func TestPrToState_MergeableState(t *testing.T) {
 	t.Run("dirty state", func(t *testing.T) {
 		pr := &gh.PullRequest{

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -475,6 +475,34 @@ func TestGetReviewThreads_CommentOnlyReviewer(t *testing.T) {
 	}
 }
 
+func TestPrToState_MergeableState(t *testing.T) {
+	t.Run("dirty state", func(t *testing.T) {
+		pr := &gh.PullRequest{
+			Number:         gh.Ptr(42),
+			State:          gh.Ptr("open"),
+			MergeableState: gh.Ptr("dirty"),
+			Head:           &gh.PullRequestBranch{Ref: gh.Ptr("feat")},
+			Base:           &gh.PullRequestBranch{Ref: gh.Ptr("main")},
+		}
+		state := prToState(pr)
+		if state.MergeableState != "dirty" {
+			t.Errorf("MergeableState = %q, want \"dirty\"", state.MergeableState)
+		}
+	})
+	t.Run("nil pointer yields empty string", func(t *testing.T) {
+		pr := &gh.PullRequest{
+			Number: gh.Ptr(1),
+			State:  gh.Ptr("open"),
+			Head:   &gh.PullRequestBranch{Ref: gh.Ptr("feat")},
+			Base:   &gh.PullRequestBranch{Ref: gh.Ptr("main")},
+		}
+		state := prToState(pr)
+		if state.MergeableState != "" {
+			t.Errorf("MergeableState = %q, want \"\"", state.MergeableState)
+		}
+	})
+}
+
 func TestMergePR_DefaultsToSquash(t *testing.T) {
 	var called bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -4,14 +4,14 @@ import "time"
 
 // PRState holds the state of a GitHub pull request.
 type PRState struct {
-	Number     int
-	Title      string
-	URL        string
-	State      string // "open", "closed", "merged"
-	Mergeable  bool
-	Draft      bool
-	HeadBranch string // branch the PR is from
-	BaseBranch string // branch the PR targets
+	Number         int
+	Title          string
+	URL            string
+	State          string // "open", "closed", "merged"
+	MergeableState string // "clean", "dirty", "blocked", "behind", "unstable", "draft", "unknown", or ""
+	Draft          bool
+	HeadBranch     string // branch the PR is from
+	BaseBranch     string // branch the PR targets
 }
 
 // CheckStatus holds the combined check/CI status for a git ref.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1096,6 +1096,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			threads: msg.threads,
 			stack:   msg.stack,
 		}
+		// Arm a short burst so the unknown → known transition resolves promptly.
+		if ps != nil && (msg.pr.MergeableState == "" || msg.pr.MergeableState == "unknown") {
+			ps.burstUntil = time.Now().Add(15 * time.Second)
+		}
 		// Auto-promote to Shipping when an open PR is discovered externally.
 		if msg.pr != nil && msg.pr.State == "open" {
 			if sess := a.sessionByID(msg.sessionID); sess != nil {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1097,8 +1097,11 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			stack:   msg.stack,
 		}
 		// Arm a short burst so the unknown → known transition resolves promptly.
+		// Use max semantics to preserve a longer push burst that may already be active.
 		if ps != nil && (msg.pr.MergeableState == "" || msg.pr.MergeableState == "unknown") {
-			ps.burstUntil = time.Now().Add(15 * time.Second)
+			if newBurst := time.Now().Add(15 * time.Second); newBurst.After(ps.burstUntil) {
+				ps.burstUntil = newBurst
+			}
 		}
 		// Auto-promote to Shipping when an open PR is discovered externally.
 		if msg.pr != nil && msg.pr.State == "open" {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2953,7 +2953,7 @@ func TestShippingPanel_MKeyGatedOnReady(t *testing.T) {
 	app.shippingSession = sess
 	app.dashboard.panelFocus = focusShipping
 	app.prCache = map[string]*prCacheEntry{
-		sess.ID: {pr: &github.PRState{Number: 1, Mergeable: false}},
+		sess.ID: {pr: &github.PRState{Number: 1, MergeableState: "dirty"}},
 	}
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -18,7 +18,7 @@ func rowStatePhrase(entry *prCacheEntry) string {
 	if isMergeReady(entry) {
 		return "Ready"
 	}
-	if !entry.pr.Mergeable {
+	if entry.pr.MergeableState == "dirty" {
 		return "Conflicts"
 	}
 	if entry.reviews != nil && entry.reviews.State == "changes_requested" {
@@ -98,7 +98,7 @@ func isMergeReady(entry *prCacheEntry) bool {
 	// is still initializing (API may briefly return zero check runs).
 	checksOK := entry.checks != nil && entry.checks.State == "success" && entry.checks.Total > 0
 	reviewsOK := entry.reviews != nil && entry.reviews.State == "approved"
-	mergeable := entry.pr.Mergeable
+	mergeable := entry.pr.MergeableState == "clean"
 	return checksOK && reviewsOK && mergeable
 }
 

--- a/internal/tui/pr_test.go
+++ b/internal/tui/pr_test.go
@@ -301,6 +301,57 @@ func TestRowStatePhrase(t *testing.T) {
 	}
 }
 
+// TestPrPollMsg_UnknownArmsBurst verifies that a prPollMsg with MergeableState
+// "unknown" or "" arms the 15s burst window on the poll state.
+func TestPrPollMsg_UnknownArmsBurst(t *testing.T) {
+	cases := []struct {
+		name           string
+		mergeableState string
+	}{
+		{"unknown", "unknown"},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewApp()
+			a.prPollsInFlight = 1
+			a.prPollStates["s1"] = &prSessionState{inFlight: true}
+
+			model, _ := a.Update(prPollMsg{
+				sessionID: "s1",
+				pr:        &github.PRState{Number: 1, MergeableState: tc.mergeableState},
+			})
+			got := model.(App).prPollStates["s1"]
+			if got == nil {
+				t.Fatal("prPollStates missing after update")
+			}
+			if !got.burstUntil.After(time.Now().Add(14 * time.Second)) {
+				t.Errorf("burstUntil should be >14s in the future, got %v", got.burstUntil)
+			}
+		})
+	}
+}
+
+// TestPrPollMsg_KnownDoesNotArmBurst verifies that a prPollMsg with a known
+// mergeable state (e.g. "clean") does not arm the burst window.
+func TestPrPollMsg_KnownDoesNotArmBurst(t *testing.T) {
+	a := NewApp()
+	a.prPollsInFlight = 1
+	a.prPollStates["s1"] = &prSessionState{inFlight: true}
+
+	model, _ := a.Update(prPollMsg{
+		sessionID: "s1",
+		pr:        &github.PRState{Number: 1, MergeableState: "clean"},
+	})
+	got := model.(App).prPollStates["s1"]
+	if got == nil {
+		t.Fatal("prPollStates missing after update")
+	}
+	if got.burstUntil.After(time.Now()) {
+		t.Errorf("burstUntil should not be armed for known state, got %v", got.burstUntil)
+	}
+}
+
 // TestPrIndicator_StatePhrase verifies that prIndicator surfaces the state phrase.
 func TestPrIndicator_StatePhrase(t *testing.T) {
 	entry := &prCacheEntry{

--- a/internal/tui/pr_test.go
+++ b/internal/tui/pr_test.go
@@ -236,7 +236,7 @@ func TestRowStatePhrase(t *testing.T) {
 		{
 			name: "merge ready",
 			entry: &prCacheEntry{
-				pr:      &github.PRState{Mergeable: true},
+				pr:      &github.PRState{MergeableState: "clean"},
 				checks:  &github.CheckStatus{State: "success", Total: 1, Passed: 1},
 				reviews: &github.ReviewStatus{State: "approved", Approved: 1},
 			},
@@ -245,7 +245,7 @@ func TestRowStatePhrase(t *testing.T) {
 		{
 			name: "conflicts",
 			entry: &prCacheEntry{
-				pr:      &github.PRState{Mergeable: false},
+				pr:      &github.PRState{MergeableState: "dirty"},
 				checks:  &github.CheckStatus{State: "success", Total: 1, Passed: 1},
 				reviews: &github.ReviewStatus{State: "approved", Approved: 1},
 			},
@@ -254,7 +254,7 @@ func TestRowStatePhrase(t *testing.T) {
 		{
 			name: "changes requested",
 			entry: &prCacheEntry{
-				pr:      &github.PRState{Mergeable: true},
+				pr:      &github.PRState{MergeableState: "clean"},
 				reviews: &github.ReviewStatus{State: "changes_requested"},
 			},
 			want: "Changes requested",
@@ -262,7 +262,7 @@ func TestRowStatePhrase(t *testing.T) {
 		{
 			name: "ci failing",
 			entry: &prCacheEntry{
-				pr:     &github.PRState{Mergeable: true},
+				pr:     &github.PRState{MergeableState: "clean"},
 				checks: &github.CheckStatus{State: "failure", Failed: 2, Total: 5},
 			},
 			want: "CI 2/5 failing",
@@ -270,10 +270,25 @@ func TestRowStatePhrase(t *testing.T) {
 		{
 			name: "waiting on ci",
 			entry: &prCacheEntry{
-				pr:     &github.PRState{Mergeable: true},
+				pr:     &github.PRState{MergeableState: "clean"},
 				checks: &github.CheckStatus{State: "pending"},
 			},
 			want: "Waiting on CI",
+		},
+		{
+			name: "unknown falls through to CI pending",
+			entry: &prCacheEntry{
+				pr:     &github.PRState{MergeableState: "unknown"},
+				checks: &github.CheckStatus{State: "pending"},
+			},
+			want: "Waiting on CI",
+		},
+		{
+			name: "unknown with no other signal",
+			entry: &prCacheEntry{
+				pr: &github.PRState{MergeableState: "unknown"},
+			},
+			want: "",
 		},
 	}
 	for _, tc := range cases {
@@ -289,7 +304,7 @@ func TestRowStatePhrase(t *testing.T) {
 // TestPrIndicator_StatePhrase verifies that prIndicator surfaces the state phrase.
 func TestPrIndicator_StatePhrase(t *testing.T) {
 	entry := &prCacheEntry{
-		pr:     &github.PRState{Number: 7, Mergeable: true},
+		pr:     &github.PRState{Number: 7, MergeableState: "clean"},
 		checks: &github.CheckStatus{State: "failure", Failed: 1, Total: 3},
 	}
 	ind := prIndicator(entry)

--- a/internal/tui/shippingpanel.go
+++ b/internal/tui/shippingpanel.go
@@ -45,9 +45,14 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 	titleLine := "  " + lipgloss.NewStyle().Bold(true).Render(pr.Title)
 	lines = append(lines, titleLine)
 
-	mergeableLabel := lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ mergeable")
-	if !pr.Mergeable {
+	var mergeableLabel string
+	switch pr.MergeableState {
+	case "clean":
+		mergeableLabel = lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ mergeable")
+	case "dirty":
 		mergeableLabel = lipgloss.NewStyle().Foreground(ColorError).Render("✗ conflicts")
+	default:
+		mergeableLabel = StyleSubtle.Render("⋯ checking")
 	}
 	baseLine := "  " + StyleSubtle.Render("base →") + " " + pr.BaseBranch +
 		"   " + mergeableLabel

--- a/internal/tui/shippingpanel_test.go
+++ b/internal/tui/shippingpanel_test.go
@@ -25,10 +25,10 @@ func TestRenderShippingPanel_WithEntry(t *testing.T) {
 	sess := agent.NewSessionForTest("s2", "ship-it")
 	entry := &prCacheEntry{
 		pr: &github.PRState{
-			Number:     42,
-			Title:      "Add feature X",
-			BaseBranch: "main",
-			Mergeable:  true,
+			Number:         42,
+			Title:          "Add feature X",
+			BaseBranch:     "main",
+			MergeableState: "clean",
 		},
 		checks: &github.CheckStatus{
 			State:  "failure",
@@ -84,7 +84,7 @@ func TestRenderShippingPanel_WithEntry(t *testing.T) {
 func TestRenderShippingPanel_MergeReady(t *testing.T) {
 	sess := agent.NewSessionForTest("s3", "ship-it")
 	entry := &prCacheEntry{
-		pr:      &github.PRState{Number: 7, Mergeable: true},
+		pr:      &github.PRState{Number: 7, MergeableState: "clean"},
 		checks:  &github.CheckStatus{State: "success", Total: 2, Passed: 2},
 		reviews: &github.ReviewStatus{State: "approved", Approved: 1},
 	}
@@ -92,6 +92,26 @@ func TestRenderShippingPanel_MergeReady(t *testing.T) {
 	stripped := ansi.Strip(out)
 	if !strings.Contains(stripped, "Ready") {
 		t.Errorf("Ready phrase missing: %q", stripped)
+	}
+}
+
+func TestRenderShippingPanel_UnknownMergeable(t *testing.T) {
+	sess := agent.NewSessionForTest("s4", "ship-it")
+	entry := &prCacheEntry{
+		pr: &github.PRState{
+			Number:         10,
+			Title:          "WIP",
+			BaseBranch:     "main",
+			MergeableState: "unknown",
+		},
+	}
+	out := renderShippingPanel(sess, entry, 100, 30)
+	stripped := ansi.Strip(out)
+	if !strings.Contains(stripped, "checking") {
+		t.Errorf("expected 'checking' for unknown mergeable state: %q", stripped)
+	}
+	if strings.Contains(stripped, "conflicts") {
+		t.Errorf("unexpected 'conflicts' for unknown mergeable state: %q", stripped)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaced `Mergeable` bool with `MergeableState` string (clean/dirty/unknown) to distinguish actual merge states from unknown during GitHub's computation
- GitHub's list endpoint always returns `mergeable_state: null`, so we now follow up list/create calls with a singular GET to fetch the actual state
- Transient 5xx failures during the GET gracefully degrade to the list result
- Updated row status and shipping panel to show "⋯ checking" when state is unknown, instead of fabricating "Conflicts" during GitHub's async compute window
- Added automatic 15s polling burst when mergeable_state is unknown, using max semantics to preserve longer-lived push bursts (up to 60s)
- Updated all test fixtures and added tests for getPRDetail retry behavior and unknown state handling

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI:
  - Create/update a PR and verify the row briefly shows "⋯ checking" before updating to conflict/ready status
  - Verify shipping panel shows "⋯ checking" during GitHub's merge computation window

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]`
- [ ] New behavior has tests
- [ ] No new public API surface without docs