### PR TITLE
Refresh session card design for improved clarity

### DIFF
--- a/changelog.d/refresh-session-card-design.md
+++ b/changelog.d/refresh-session-card-design.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Building session cards: branch is now rendered as a muted `⎇ branch` inline label (no background chip), placing it in the same muted-metadata tier as elapsed and idle tokens; branch and detail join with ` · ` when both are present
+- Progress bar suffix now reads `N/M tasks` instead of `N/M`, matching the Planning badge's wording
+- Active task line no longer has a leading `▸ ` glyph; next-task line changes from `↳ next: …` to `next: …`; typographic hierarchy (bold vs muted italic) carries the visual distinction
+- Active-state status glyph changes from `⚡` to `●` (calm filled circle); attention-demanding glyphs (`⏸`, `?`, `✗`) are now reserved for states that require action

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -945,9 +945,9 @@ func secondUncompletedTask(plan string) string {
 
 // focusTaskDescription chooses the description lines for a session card in
 // focus mode and reports whether they should render in pending (italic) style.
-// For Building-phase sessions, line1 is the active task text (raw, no "▸ " prefix
-// — the render layer adds that) and line2 is the next task text (raw, no "↳ next: "
-// prefix). Priority: in_progress TodoItem > plan firstUncompletedTask > fallback.
+// For Building-phase sessions, line1 is the active task text and line2 is
+// the next task text (both raw). Priority: in_progress TodoItem > plan
+// firstUncompletedTask > fallback.
 func focusTaskDescription(sess *agent.Session, budget int) (line1, line2 string, pending bool) {
 	if sess.LifecyclePhase() == agent.LifecycleInProgress && !sess.IsReviewable() {
 		if ag := sess.PrimaryAgent(); ag != nil {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -634,8 +634,8 @@ func (d dashboardModel) sessionStatusGlyph(sess *agent.Session) (glyph string, c
 // brightens the stripe to ColorSecondary.
 //
 // Line 1: <stripe> <glyph> <name (bold, ColorText)>   ... right-aligned <status badge/progress bar>
-// Line 2: <stripe>   ▸ <active task (bold)>   (building) | <description (muted/italic)> (planning/other)
-// Line 3: <stripe>   ↳ next: <next task (muted-italic)>   (building) | <description line 2 or empty>
+// Line 2: <stripe>   <active task (bold)>   (building) | <description (muted/italic)> (planning/other)
+// Line 3: <stripe>   next: <next task (muted-italic)>   (building) | <description line 2 or empty>
 // Line 4: <stripe>   [⎇ branch] [· detail]      ... right-aligned ⏱ <elapsed>
 func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName string, selected bool, width int) []string {
 	stripeColor := d.sessionFocusStripeColor(sess)
@@ -705,26 +705,21 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 			line3 = stripe + indent + descStyle.Render(descLine2)
 		}
 	} else if buildingPhase {
-		// Active task: ▸ <bold text>. Subtract 2 cells for the "▸ " prefix so
-		// the total line stays within descBudget.
+		// Active task: bold text, no leading glyph.
 		activeLine := ""
 		if descLine1 != "" {
-			activeBudget := descBudget - 2
-			if activeBudget < 0 {
-				activeBudget = 0
-			}
-			activeLine = lipgloss.NewStyle().Bold(true).Render("▸ " + truncateVisible(descLine1, activeBudget))
+			activeLine = lipgloss.NewStyle().Bold(true).Render(truncateVisible(descLine1, descBudget))
 		}
 		line2 = stripe + indent + activeLine
-		// Next task: ↳ next: <muted-italic text>. Subtract 8 cells for "↳ next: ".
+		// Next task: "next: <muted-italic text>". Subtract 6 cells for "next: ".
 		line3 = stripe + indent
 		if descLine2 != "" {
-			nextBudget := descBudget - 8
+			nextBudget := descBudget - 6
 			if nextBudget < 0 {
 				nextBudget = 0
 			}
 			nextStyle := lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
-			line3 = stripe + indent + nextStyle.Render("↳ next: "+truncateVisible(descLine2, nextBudget))
+			line3 = stripe + indent + nextStyle.Render("next: "+truncateVisible(descLine2, nextBudget))
 		}
 	} else {
 		line2 = stripe + indent + StyleSubtle.Render(descLine1)

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -421,7 +421,7 @@ func renderCardProgressBar(done, total, width int, primary lipgloss.Color) strin
 		return ""
 	}
 	pct := float64(done) / float64(total)
-	suffix := StyleSubtle.Render(fmt.Sprintf("%d/%d", done, total))
+	suffix := StyleSubtle.Render(fmt.Sprintf("%d/%d tasks", done, total))
 	suffixWidth := ansi.StringWidth(suffix)
 	// Reserve at least 1 cell for the bar (plus a separating space).
 	barWidth := width - suffixWidth - 1

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -622,7 +622,7 @@ func (d dashboardModel) sessionStatusGlyph(sess *agent.Session) (glyph string, c
 	case sess.IsReviewable() || !sess.DoneAt().IsZero():
 		return "✓", ColorSuccess
 	case hasActive:
-		return "⚡", ColorSecondary
+		return "●", ColorSecondary
 	default:
 		return "○", ColorMuted
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -636,7 +636,7 @@ func (d dashboardModel) sessionStatusGlyph(sess *agent.Session) (glyph string, c
 // Line 1: <stripe> <glyph> <name (bold, ColorText)>   ... right-aligned <status badge/progress bar>
 // Line 2: <stripe>   ▸ <active task (bold)>   (building) | <description (muted/italic)> (planning/other)
 // Line 3: <stripe>   ↳ next: <next task (muted-italic)>   (building) | <description line 2 or empty>
-// Line 4: <stripe>   [🌿 branch chip] [detail]      ... right-aligned ⏱ <elapsed>
+// Line 4: <stripe>   [⎇ branch] [· detail]      ... right-aligned ⏱ <elapsed>
 func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName string, selected bool, width int) []string {
 	stripeColor := d.sessionFocusStripeColor(sess)
 	if selected {
@@ -764,31 +764,6 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 		detailStr = fmt.Sprintf("idle %dm", int(time.Since(sess.LastOutputTime()).Minutes()))
 	}
 
-	// Build the left part of line 4 using a branch chip when a branch is set.
-	chip := renderBranchChip(branch)
-	var bottomLeft string
-	if chip != "" {
-		chipWidth := lipgloss.Width(chip)
-		// Reserve space: stripe(1) + indent(3) + chip + space + detail + some room for elapsed.
-		detailBudget := width - stripeIndentWidth - chipWidth - 13
-		if detailBudget < 0 {
-			detailBudget = 0
-		}
-		var detailRendered string
-		if detailStr != "" && detailBudget > 1 {
-			detailRendered = " " + StyleSubtle.Render(truncateVisible(detailStr, detailBudget))
-		}
-		bottomLeft = stripe + indent + chip + detailRendered
-	} else {
-		// No branch: fall back to plain subtle text (waiting reason or idle).
-		bottomLeftText := detailStr
-		bottomBudget := width - 12
-		if bottomBudget < 1 {
-			bottomBudget = 1
-		}
-		bottomLeft = stripe + indent + StyleSubtle.Render(truncateVisible(bottomLeftText, bottomBudget))
-	}
-
 	totalMins := int(sess.Elapsed().Minutes())
 	var elapsedStr string
 	if totalMins >= 60 {
@@ -796,24 +771,45 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	} else {
 		elapsedStr = fmt.Sprintf("%dm", totalMins)
 	}
+
+	// Build the left part of line 4: ⎇ branch [ · detail], right side ⏱ elapsed.
+	elapsedBudget := lipgloss.Width("⏱ "+elapsedStr) + 1
+	leftBudget := width - stripeIndentWidth - elapsedBudget
+	if leftBudget < 0 {
+		leftBudget = 0
+	}
+	var bottomLeft string
+	branchLabel := renderBranchLabel(branch)
+	if branchLabel != "" {
+		branchWidth := lipgloss.Width(branchLabel)
+		var detailRendered string
+		if detailStr != "" {
+			remaining := leftBudget - branchWidth - 3 // 3 = " · "
+			if remaining > 0 {
+				detailRendered = StyleSubtle.Render(" · " + truncateVisible(detailStr, remaining))
+			}
+		}
+		bottomLeft = stripe + indent + branchLabel + detailRendered
+	} else {
+		var detailRendered string
+		if detailStr != "" {
+			detailRendered = StyleSubtle.Render(truncateVisible(detailStr, leftBudget))
+		}
+		bottomLeft = stripe + indent + detailRendered
+	}
+
 	line4 := rightAlign(bottomLeft, StyleSubtle.Render("⏱ "+elapsedStr), width)
 
 	return []string{line1, line2, line3, line4}
 }
 
-// renderBranchChip returns a visually-tinted chip string for a branch name,
-// prefixed with 🌿. The chip has a 1-cell horizontal padding on each side and
-// a dark background (#1F2937, matching the status bar). Returns "" for an
-// empty branch so callers can omit it cleanly.
-func renderBranchChip(branch string) string {
+// renderBranchLabel returns a muted "⎇ <branch>" label with no background fill.
+// Returns "" for an empty branch so callers can omit it cleanly.
+func renderBranchLabel(branch string) string {
 	if branch == "" {
 		return ""
 	}
-	return lipgloss.NewStyle().
-		Foreground(ColorText).
-		Background(lipgloss.Color("#1F2937")).
-		Padding(0, 1).
-		Render("🌿 " + branch)
+	return StyleSubtle.Render("⎇ " + branch)
 }
 
 // planningStatusBadge renders the right-aligned status badge for a Planning

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1567,7 +1567,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 			rs := repoStats[path]
 			var sym string
 			if rs.active > 0 {
-				sym = fmt.Sprintf("%d⚡", rs.active)
+				sym = fmt.Sprintf("%d●", rs.active)
 			} else if rs.waiting > 0 {
 				sym = fmt.Sprintf("%d⏸", rs.waiting)
 			} else {

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -406,7 +406,8 @@ func TestRenderQueueRow_RepoPrefix(t *testing.T) {
 
 // TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine verifies
 // that a Building session with a plan and open tasks produces a 4-line card
-// where line 2 shows "▸ first open task" (bold) and line 3 shows "↳ next: second open".
+// where line 2 shows the first open task (bold, no leading ▸) and line 3
+// shows "next: second open" (no leading ↳).
 func TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
@@ -428,15 +429,18 @@ func TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine(t *testing
 		t.Fatalf("expected 4-line card for plan-backed building session, got %d lines: %v", len(card), card)
 	}
 	line2 := ansi.Strip(card[1])
-	if !strings.Contains(line2, "▸") {
-		t.Errorf("line 2 should contain ▸ prefix, got %q", line2)
+	if strings.Contains(line2, "▸") {
+		t.Errorf("line 2 must not contain ▸ prefix, got %q", line2)
 	}
 	if !strings.Contains(line2, "write tests") {
 		t.Errorf("line 2 should contain first open task, got %q", line2)
 	}
 	line3 := ansi.Strip(card[2])
-	if !strings.Contains(line3, "↳ next:") {
-		t.Errorf("line 3 should contain ↳ next: prefix, got %q", line3)
+	if strings.Contains(line3, "↳") {
+		t.Errorf("line 3 must not contain ↳ glyph, got %q", line3)
+	}
+	if !strings.Contains(line3, "next:") {
+		t.Errorf("line 3 should contain \"next:\" prefix, got %q", line3)
 	}
 	if !strings.Contains(line3, "open PR") {
 		t.Errorf("line 3 should contain second open task, got %q", line3)
@@ -479,8 +483,8 @@ func TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan(t *testing.
 }
 
 // TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix verifies
-// that when only one open task remains, line 2 shows "▸ last task" and line 3
-// is blank (no "↳ next:" suffix), card is exactly 4 lines.
+// that when only one open task remains, line 2 shows the last task (bold, no ▸)
+// and line 3 is blank (no "next:" suffix), card is exactly 4 lines.
 func TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -227,13 +227,13 @@ func TestBuildingProgressBadge(t *testing.T) {
 			name:    "2/5 shows correct counts",
 			done:    2,
 			total:   5,
-			wantStr: "2/5",
+			wantStr: "2/5 tasks",
 		},
 		{
 			name:    "1/3 shows correct counts",
 			done:    1,
 			total:   3,
-			wantStr: "1/3",
+			wantStr: "1/3 tasks",
 		},
 	}
 	for _, tc := range tests {
@@ -694,10 +694,10 @@ func TestRenderCardProgressBar_DoneTotalAndColor(t *testing.T) {
 	}
 
 	const width = 24
-	// (b) contains "2/7" count suffix
+	// (b) contains "2/7 tasks" count suffix
 	out := renderCardProgressBar(2, 7, width, ColorPrimary)
-	if !strings.Contains(ansi.Strip(out), "2/7") {
-		t.Errorf("expected \"2/7\" in output, got %q", ansi.Strip(out))
+	if !strings.Contains(ansi.Strip(out), "2/7 tasks") {
+		t.Errorf("expected \"2/7 tasks\" in output, got %q", ansi.Strip(out))
 	}
 
 	// (c) display width equals requested width

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -254,7 +254,7 @@ func TestBuildingProgressBadge(t *testing.T) {
 }
 
 // TestSessionFocusStatus_BuildingWithTodosShowsProgressBadge verifies that
-// sessionFocusStatus shows a "▸ done/total" progress badge for a Building
+// sessionFocusStatus shows a "done/total tasks" progress badge for a Building
 // session that has received ≥1 TodoWrite, instead of the plain "N active, M idle".
 func TestSessionFocusStatus_BuildingWithTodosShowsProgressBadge(t *testing.T) {
 	sess := agent.NewSessionForTest("s", "my-session")

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -762,7 +762,7 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 			wantGlyph: "⏸",
 		},
 		{
-			name: "active → ⚡",
+			name: "active → ●",
 			setup: func() (*agent.Session, []listItem) {
 				sess := agent.NewSessionForTest("s", "my-session")
 				sess.SetLifecyclePhase(agent.LifecycleInProgress)
@@ -772,7 +772,7 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 					{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 				}
 			},
-			wantGlyph: "⚡",
+			wantGlyph: "●",
 		},
 		{
 			name: "reviewable → ✓",

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -811,8 +811,8 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 }
 
 // TestRenderFocusSessionCard_BranchChipAndElapsedGlyph verifies that line 4
-// contains a 🌿 chip before the branch name (with a background tint), ⏱ before
-// the elapsed token, and no chip when the branch is empty.
+// contains a ⎇ label before the branch name (no background tint), ⏱ before
+// the elapsed token, and no label when the branch is empty.
 func TestRenderFocusSessionCard_BranchChipAndElapsedGlyph(t *testing.T) {
 	prev := lipgloss.ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)
@@ -838,9 +838,9 @@ func TestRenderFocusSessionCard_BranchChipAndElapsedGlyph(t *testing.T) {
 	line4Raw := card[3]
 	line4 := ansi.Strip(line4Raw)
 
-	// 🌿 immediately before branch name.
-	if !strings.Contains(line4, "🌿") {
-		t.Errorf("line 4 should contain 🌿 glyph, got %q", line4)
+	// ⎇ immediately before branch name (no background fill).
+	if !strings.Contains(line4, "⎇") {
+		t.Errorf("line 4 should contain ⎇ glyph, got %q", line4)
 	}
 	if !strings.Contains(line4, "add-dark-mode") {
 		t.Errorf("line 4 should contain branch name, got %q", line4)
@@ -851,12 +851,12 @@ func TestRenderFocusSessionCard_BranchChipAndElapsedGlyph(t *testing.T) {
 		t.Errorf("line 4 should contain ⏱ glyph, got %q", line4)
 	}
 
-	// Branch chip carries a background color escape (48;2; = background TrueColor).
-	if !strings.Contains(line4Raw, "48;2;") {
-		t.Errorf("line 4 raw should contain background ANSI sequence (48;2;) for chip tint, got %q", line4Raw)
+	// Branch label must NOT carry a background color escape (48;2; = background TrueColor).
+	if strings.Contains(line4Raw, "48;2;") {
+		t.Errorf("line 4 raw must NOT contain background ANSI sequence (48;2;) — branch is now a plain label, got %q", line4Raw)
 	}
 
-	// No branch → no chip.
+	// No branch → no label.
 	sessNoBranch := agent.NewSessionForTest("s2", "no-branch-session")
 	sessNoBranch.SetLifecyclePhase(agent.LifecycleInProgress)
 	ag2 := sessNoBranch.AddTestAgent("a-2", false, agent.StatusActive)
@@ -867,7 +867,7 @@ func TestRenderFocusSessionCard_BranchChipAndElapsedGlyph(t *testing.T) {
 	}
 	card2 := d2.renderFocusSessionCard(sessNoBranch, "", false, 120)
 	line4b := ansi.Strip(card2[3])
-	if strings.Contains(line4b, "🌿") {
-		t.Errorf("no-branch session should not render 🌿 chip, got %q", line4b)
+	if strings.Contains(line4b, "⎇") {
+		t.Errorf("no-branch session should not render ⎇ label, got %q", line4b)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace branch chip with muted `⎇` label to reduce visual noise and improve line-4 budget calculations
- Append "tasks" label to progress bar suffix (`%d/%d tasks`) for consistency with Planning badge wording
- Remove `▸` and `↳` glyph prefixes from active and next task lines; typographic hierarchy (bold vs muted-italic) now carries visual distinction
- Replace loud `⚡` lightning bolt with calm `●` filled circle for active agent state—attention-demanding glyphs reserved for states requiring user action
- Update stale glyph/chip references in comments and test documentation
- Add changelog fragment documenting the design refresh

This redesign honors TUI philosophy by reducing competing visual elements, clarifying typographic hierarchy, and reserving prominent glyphs for states that demand user attention.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI: Verify session cards render with correct branch label, progress bar suffix, task line formatting, and active-state glyph; confirm line-4 layout with combined branch and detail context

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] UI changes are documented as manual-test-only (no new automated test coverage needed for typographic/glyph changes)
- [x] No new public API surface