### PR TITLE
Add review→build rework loop with bordered cursor affordance

### DIFF
--- a/changelog.d/review-rework-loop.md
+++ b/changelog.d/review-rework-loop.md
@@ -1,0 +1,8 @@
+### Added
+
+- Press `b` in the review panel to send tasks marked concerns/fail by the AI reviewer (plus any rows flagged with `f`) back to a new building agent in the same worktree. The session returns to BUILDING with a prompt that names the failing tasks and instructs the agent to keep using `[task N]` commit prefixes so the next review groups round-2 commits under the same task index.
+- Press `f` in the review panel to toggle a flag on the cursor task. Flagged tasks are included in the `b` rework prompt regardless of the AI verdict, and display an orange `⚑` badge.
+
+### Changed
+
+- Review panel: the selected task row is now wrapped in a primary-color vertical-bar border instead of a barely-visible background tint, making the cursor obvious at a glance.

--- a/changelog.d/review-rework-loop.md
+++ b/changelog.d/review-rework-loop.md
@@ -1,7 +1,7 @@
 ### Added
 
 - Press `b` in the review panel to send tasks marked concerns/fail by the AI reviewer (plus any rows flagged with `f`) back to a new building agent in the same worktree. The session returns to BUILDING with a prompt that names the failing tasks and instructs the agent to keep using `[task N]` commit prefixes so the next review groups round-2 commits under the same task index.
-- Press `f` in the review panel to toggle a flag on the cursor task. Flagged tasks are included in the `b` rework prompt regardless of the AI verdict, and display an orange `⚑` badge.
+- Press `f` in the review panel to toggle a flag on the cursor task. Flagged tasks are included in the `b` rework prompt regardless of the AI verdict (including plan tasks the agent never touched, which previously couldn't be flagged), and display an orange `⚑` badge.
 
 ### Changed
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1732,6 +1732,35 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.reviewTaskCursor--
 				}
 				return a, nil
+			case "f":
+				// Toggle the user-flag on the cursor row. The flag survives
+				// panel close/re-open and is folded into the `b` rework prompt
+				// alongside any AI concerns/fails.
+				entry := a.reviewDiffCache[a.reviewSession.ID]
+				if entry == nil {
+					return a, nil
+				}
+				group := reviewTaskGroupAtCursor(entry, a.reviewTaskCursor)
+				if group == nil {
+					// Synthetic Overview row (no plan, no commits): nothing to flag.
+					return a, nil
+				}
+				idx := group.taskIndex
+				if entry.verdicts == nil {
+					entry.verdicts = make(map[int]*taskVerdictRecord)
+				}
+				rec := entry.verdicts[idx]
+				if rec == nil {
+					rec = &taskVerdictRecord{state: verdictPending}
+					entry.verdicts[idx] = rec
+				}
+				rec.userFlagged = !rec.userFlagged
+				return a, nil
+			case "b":
+				// Back to build: spawn a new agent in the existing worktree with
+				// a prompt built from the AI reviewer's concerns/fails plus any
+				// rows the user flagged with `f`. Session returns to InProgress.
+				return a.addressReviewFeedback(a.reviewSession)
 			case "enter", "space":
 				// Drill into the selected task's diff. Opens the diff browser
 				// filtered to the commits for that task; esc returns to the
@@ -4408,6 +4437,155 @@ func buildFeedbackPrompt(entry *prCacheEntry) string {
 	return "The following issues need to be addressed on this PR:\n\n" + b.String() + "Please fix each issue, commit your changes, and push."
 }
 
+// addressReviewFeedback spawns a new agent in the session's existing worktree
+// with a prompt synthesized from the review panel's AI verdicts and user flags,
+// then transitions the session back to LifecycleInProgress. The reviewDiffCache
+// entry is cleared so the next entry into review re-runs the AI reviewer on the
+// new commit history. Mirrors addressFeedback (the shipping→build path) but
+// draws from in-panel verdicts rather than PR state.
+func (a *App) addressReviewFeedback(sess *agent.Session) (tea.Model, tea.Cmd) {
+	if sess == nil {
+		return a, nil
+	}
+	entry := a.reviewDiffCache[sess.ID]
+	prompt := buildReviewReworkPrompt(entry)
+	if prompt == "" {
+		a.setError("no tasks flagged or marked concerns/fail")
+		return a, nil
+	}
+	repoPath := a.repoPathForSession(sess.ID)
+	if repoPath == "" {
+		a.setError("no repo found for session")
+		return a, nil
+	}
+	mgr := a.managers[repoPath]
+	if mgr == nil {
+		a.setError("session manager not found")
+		return a, nil
+	}
+	resolved := a.resolvedCache[repoPath]
+	fixedW := a.dashboard.fixedTermWidth()
+	fixedH := a.dashboard.fixedTermHeight()
+	if fixedW <= 0 || fixedH <= 0 {
+		a.setError("terminal size not yet known; try again")
+		return a, nil
+	}
+	cfg := agent.Config{
+		Rows:              fixedH,
+		Cols:              fixedW,
+		BypassPermissions: resolved.BypassPermissions,
+		AgentProgram:      resolved.AgentProgram,
+		AgentModel:        resolved.AgentModel,
+		BuildSystemPrompt: resolved.BuildSystemPrompt,
+		Task:              prompt,
+	}
+	sessID := sess.ID
+	// Drop the panel and the cached diff/verdicts: when the user returns to
+	// review after the rework round, fetchReviewDiffCmd will re-parse the plan
+	// and re-run verdicts over the augmented commit history.
+	a.reviewSession = nil
+	a.reviewTaskCursor = 0
+	delete(a.reviewDiffCache, sessID)
+	a.dashboard.panelFocus = focusList
+	return a, func() tea.Msg {
+		ag, err := mgr.AddAgent(sessID, cfg)
+		if err != nil {
+			return createResultMsg{err: err}
+		}
+		sess.SetLifecyclePhase(agent.LifecycleInProgress)
+		return createResultMsg{sessionID: sessID, agentID: ag.ID}
+	}
+}
+
+// buildReviewReworkPrompt synthesizes a builder-agent prompt from the per-task
+// verdicts and user flags in entry. Returns "" when no task qualifies (no flag
+// set and no AI verdict of concerns/fail), so the caller can surface an error.
+//
+// The prompt instructs the agent to use `[task N]` commit prefixes so a
+// subsequent review groups round-2 commits under the same task index — this is
+// what keeps the build↔review round-trip coherent.
+func buildReviewReworkPrompt(entry *reviewDiffEntry) string {
+	if entry == nil || entry.verdicts == nil {
+		return ""
+	}
+	// Build a taskIndex → text lookup, including the special index 0 used for
+	// commits without a `[task N]` prefix.
+	taskText := map[int]string{0: "Other changes"}
+	for _, t := range entry.tasks {
+		taskText[t.Index] = t.Text
+	}
+
+	type entryRow struct {
+		idx        int
+		text       string
+		flagged    bool
+		hasVerdict bool
+		kind       agent.VerdictKind
+		rationale  string
+	}
+	rows := make([]entryRow, 0, len(entry.verdicts))
+	for idx, rec := range entry.verdicts {
+		if rec == nil {
+			continue
+		}
+		hasVerdict := rec.state == verdictDone &&
+			(rec.verdict.Kind == agent.VerdictConcerns || rec.verdict.Kind == agent.VerdictFail)
+		if !rec.userFlagged && !hasVerdict {
+			continue
+		}
+		text, ok := taskText[idx]
+		if !ok {
+			text = fmt.Sprintf("(task %d)", idx)
+		}
+		rows = append(rows, entryRow{
+			idx:        idx,
+			text:       text,
+			flagged:    rec.userFlagged,
+			hasVerdict: hasVerdict,
+			kind:       rec.verdict.Kind,
+			rationale:  strings.TrimSpace(rec.verdict.Rationale),
+		})
+	}
+	if len(rows) == 0 {
+		return ""
+	}
+	// Stable ordering: by task index ascending, with "Other changes" (index 0)
+	// last so it doesn't lead the list when present.
+	sort.SliceStable(rows, func(i, j int) bool {
+		a, b := rows[i].idx, rows[j].idx
+		if a == 0 {
+			return false
+		}
+		if b == 0 {
+			return true
+		}
+		return a < b
+	})
+
+	var b strings.Builder
+	b.WriteString("The following tasks need rework based on the review:\n\n")
+	for _, r := range rows {
+		if r.idx > 0 {
+			fmt.Fprintf(&b, "## Task %d: %s\n", r.idx, r.text)
+		} else {
+			b.WriteString("## Other changes\n")
+		}
+		if r.hasVerdict {
+			fmt.Fprintf(&b, "AI reviewer verdict: %s\n", r.kind)
+			if r.rationale != "" {
+				fmt.Fprintf(&b, "Rationale: %s\n", r.rationale)
+			}
+		}
+		if r.flagged {
+			b.WriteString("Flagged by you: yes\n")
+		}
+		b.WriteByte('\n')
+	}
+	b.WriteString("Please address each task above. Re-read `.claude/plan.md` for full context.\n")
+	b.WriteString("When you commit fixes, prefix each commit subject with `[task N]` matching the task numbers above so the next review groups commits correctly. For \"Other changes\", commit without a `[task N]` prefix.\n")
+	return b.String()
+}
+
 // mergePRCmd returns a Cmd that merges the PR for the given session using the
 // repo-configured merge method (default squash). The caller is responsible for
 // any merge-readiness gating before invoking this.
@@ -4584,6 +4762,10 @@ type taskVerdictRecord struct {
 	state   verdictState
 	verdict agent.ReviewVerdict
 	err     error
+	// userFlagged is set when the human reviewer presses `f` on this row to
+	// override the AI verdict — the task gets included in the next
+	// review→build feedback prompt regardless of what the AI returned.
+	userFlagged bool
 }
 
 // taskReviewGroup holds one plan task's commits and their resolved diff stats.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1740,12 +1740,11 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if entry == nil {
 					return a, nil
 				}
-				group := reviewTaskGroupAtCursor(entry, a.reviewTaskCursor)
-				if group == nil {
-					// Synthetic Overview row (no plan, no commits): nothing to flag.
+				idx, ok := reviewTaskIndexAtCursor(entry, a.reviewTaskCursor)
+				if !ok {
+					// Synthetic Overview row (no-plan session): nothing to flag.
 					return a, nil
 				}
-				idx := group.taskIndex
 				if entry.verdicts == nil {
 					entry.verdicts = make(map[int]*taskVerdictRecord)
 				}
@@ -3984,6 +3983,30 @@ func reviewTaskGroupAtCursor(entry *reviewDiffEntry, cursor int) *taskReviewGrou
 	return nil
 }
 
+// reviewTaskIndexAtCursor returns the task index at cursor following the same
+// row ordering as reviewTaskGroupAtCursor (plan tasks first, then the "Other
+// changes" row when present). Unlike reviewTaskGroupAtCursor, this resolves
+// even when the plan task has no associated commit group — so the user can
+// flag a never-touched task for rework. Returns (0, false) for the synthetic
+// Overview row used in no-plan sessions.
+func reviewTaskIndexAtCursor(entry *reviewDiffEntry, cursor int) (int, bool) {
+	if entry == nil || cursor < 0 {
+		return 0, false
+	}
+	if cursor < len(entry.tasks) {
+		return entry.tasks[cursor].Index, true
+	}
+	// "Other changes" row, only present when some commit has no [task N] prefix.
+	if cursor == len(entry.tasks) {
+		for i := range entry.groups {
+			if entry.groups[i].taskIndex == 0 {
+				return 0, true
+			}
+		}
+	}
+	return 0, false
+}
+
 // reviewTaskCount returns the number of task rows in a review entry (plan tasks
 // plus the "other" group if present). For no-plan sessions with aggregate data,
 // returns 1 for the synthetic "Overview" row.
@@ -4520,6 +4543,7 @@ func buildReviewReworkPrompt(entry *reviewDiffEntry) string {
 		text       string
 		flagged    bool
 		hasVerdict bool
+		noCommits  bool
 		kind       agent.VerdictKind
 		rationale  string
 	}
@@ -4542,6 +4566,7 @@ func buildReviewReworkPrompt(entry *reviewDiffEntry) string {
 			text:       text,
 			flagged:    rec.userFlagged,
 			hasVerdict: hasVerdict,
+			noCommits:  rec.state == verdictNoDiff,
 			kind:       rec.verdict.Kind,
 			rationale:  strings.TrimSpace(rec.verdict.Rationale),
 		})
@@ -4575,6 +4600,8 @@ func buildReviewReworkPrompt(entry *reviewDiffEntry) string {
 			if r.rationale != "" {
 				fmt.Fprintf(&b, "Rationale: %s\n", r.rationale)
 			}
+		} else if r.noCommits {
+			b.WriteString("Status: no commits yet for this task.\n")
 		}
 		if r.flagged {
 			b.WriteString("Flagged by you: yes\n")

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3075,6 +3075,184 @@ func TestBuildFeedbackPrompt_CommentedOnlyWithoutInlineComments(t *testing.T) {
 	}
 }
 
+// TestBuildReviewReworkPrompt_NilEntry verifies a nil entry returns "".
+func TestBuildReviewReworkPrompt_NilEntry(t *testing.T) {
+	if got := buildReviewReworkPrompt(nil); got != "" {
+		t.Errorf("expected empty prompt for nil entry, got: %q", got)
+	}
+}
+
+// TestBuildReviewReworkPrompt_NilVerdicts verifies an entry with nil verdicts
+// returns "" — there's nothing actionable to send back.
+func TestBuildReviewReworkPrompt_NilVerdicts(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks:    []agent.PlanTask{{Index: 1, Text: "Add auth"}},
+		verdicts: nil,
+	}
+	if got := buildReviewReworkPrompt(entry); got != "" {
+		t.Errorf("expected empty prompt for nil verdicts, got: %q", got)
+	}
+}
+
+// TestBuildReviewReworkPrompt_NoActionableTasks verifies that all-pass /
+// pending / unflagged verdicts produce no prompt.
+func TestBuildReviewReworkPrompt_NoActionableTasks(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{
+			{Index: 1, Text: "Add auth"},
+			{Index: 2, Text: "Wire login"},
+		},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictPass, Rationale: "lgtm"}},
+			2: {state: verdictPending},
+		},
+	}
+	if got := buildReviewReworkPrompt(entry); got != "" {
+		t.Errorf("expected empty prompt when no concerns/fails/flags, got: %q", got)
+	}
+}
+
+// TestBuildReviewReworkPrompt_FlaggedOnly verifies a user-flagged task with no
+// AI verdict (pending state) is included in the rework prompt without the
+// "AI reviewer verdict" / "Rationale" lines.
+func TestBuildReviewReworkPrompt_FlaggedOnly(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 3, Text: "Add logout"}},
+		verdicts: map[int]*taskVerdictRecord{
+			3: {state: verdictPending, userFlagged: true},
+		},
+	}
+	prompt := buildReviewReworkPrompt(entry)
+	if !strings.Contains(prompt, "## Task 3: Add logout") {
+		t.Errorf("prompt missing task heading: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Flagged by you: yes") {
+		t.Errorf("prompt missing user-flag note: %q", prompt)
+	}
+	if strings.Contains(prompt, "AI reviewer verdict") {
+		t.Errorf("prompt should not include AI verdict line when state is pending: %q", prompt)
+	}
+}
+
+// TestBuildReviewReworkPrompt_VerdictFail verifies a fail verdict with no
+// user flag is included with the verdict + rationale lines.
+func TestBuildReviewReworkPrompt_VerdictFail(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 2, Text: "Wire login"}},
+		verdicts: map[int]*taskVerdictRecord{
+			2: {
+				state:   verdictDone,
+				verdict: agent.ReviewVerdict{Kind: agent.VerdictFail, Rationale: "login form is missing the password field."},
+			},
+		},
+	}
+	prompt := buildReviewReworkPrompt(entry)
+	if !strings.Contains(prompt, "## Task 2: Wire login") {
+		t.Errorf("prompt missing task heading: %q", prompt)
+	}
+	if !strings.Contains(prompt, "AI reviewer verdict: fail") {
+		t.Errorf("prompt missing AI verdict: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Rationale: login form is missing the password field.") {
+		t.Errorf("prompt missing rationale: %q", prompt)
+	}
+	if strings.Contains(prompt, "Flagged by you") {
+		t.Errorf("prompt should not include flagged-by-you note when not flagged: %q", prompt)
+	}
+}
+
+// TestBuildReviewReworkPrompt_FlaggedAndConcerns verifies a single task with
+// both a user flag and an AI concerns verdict gets a single combined entry.
+func TestBuildReviewReworkPrompt_FlaggedAndConcerns(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Add auth"}},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {
+				state:       verdictDone,
+				verdict:     agent.ReviewVerdict{Kind: agent.VerdictConcerns, Rationale: "rate limit unverified"},
+				userFlagged: true,
+			},
+		},
+	}
+	prompt := buildReviewReworkPrompt(entry)
+	if !strings.Contains(prompt, "AI reviewer verdict: concerns") {
+		t.Errorf("prompt missing AI verdict: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Flagged by you: yes") {
+		t.Errorf("prompt missing user-flag note: %q", prompt)
+	}
+	if c := strings.Count(prompt, "## Task 1:"); c != 1 {
+		t.Errorf("expected exactly one task-1 heading, got %d in: %q", c, prompt)
+	}
+}
+
+// TestBuildReviewReworkPrompt_OtherChanges verifies a flagged or fail record
+// at taskIndex=0 renders as "## Other changes" instead of "## Task 0".
+func TestBuildReviewReworkPrompt_OtherChanges(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks: nil,
+		verdicts: map[int]*taskVerdictRecord{
+			0: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictFail, Rationale: "drive-by typo fix breaks build"}},
+		},
+	}
+	prompt := buildReviewReworkPrompt(entry)
+	if !strings.Contains(prompt, "## Other changes") {
+		t.Errorf("prompt missing 'Other changes' heading: %q", prompt)
+	}
+	if strings.Contains(prompt, "## Task 0") {
+		t.Errorf("prompt should not contain '## Task 0': %q", prompt)
+	}
+}
+
+// TestBuildReviewReworkPrompt_SortOrder verifies tasks render in ascending
+// index order, with index 0 ("Other changes") last regardless of map order.
+func TestBuildReviewReworkPrompt_SortOrder(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{
+			{Index: 2, Text: "second"},
+			{Index: 5, Text: "fifth"},
+		},
+		verdicts: map[int]*taskVerdictRecord{
+			5: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictFail}},
+			0: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictFail}},
+			2: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictConcerns}},
+		},
+	}
+	prompt := buildReviewReworkPrompt(entry)
+	pos2 := strings.Index(prompt, "## Task 2:")
+	pos5 := strings.Index(prompt, "## Task 5:")
+	posOther := strings.Index(prompt, "## Other changes")
+	if pos2 < 0 || pos5 < 0 || posOther < 0 {
+		t.Fatalf("missing one of the headings (2=%d, 5=%d, other=%d): %q", pos2, pos5, posOther, prompt)
+	}
+	if pos2 >= pos5 || pos5 >= posOther {
+		t.Errorf("expected order: task 2 < task 5 < Other changes; got positions 2=%d 5=%d other=%d",
+			pos2, pos5, posOther)
+	}
+}
+
+// TestBuildReviewReworkPrompt_FlaggedNoCommits verifies a task with
+// verdictNoDiff (no commits yet) that the human flagged is included in the
+// prompt with a clear "no commits yet" status note.
+func TestBuildReviewReworkPrompt_FlaggedNoCommits(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 4, Text: "Add metrics"}},
+		verdicts: map[int]*taskVerdictRecord{
+			4: {state: verdictNoDiff, userFlagged: true},
+		},
+	}
+	prompt := buildReviewReworkPrompt(entry)
+	if !strings.Contains(prompt, "## Task 4: Add metrics") {
+		t.Errorf("prompt missing task heading: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Status: no commits yet") {
+		t.Errorf("prompt missing no-commits note: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Flagged by you: yes") {
+		t.Errorf("prompt missing user-flag note: %q", prompt)
+	}
+}
+
 // TestNKeyOpensPromptModal_WhenPlanFirstEnabled verifies the new plan-first
 // gate: with PlanFirstEnabled=true, pressing `n` opens the prompt modal
 // instead of immediately creating a session. With the flag off (today's

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -29,6 +29,11 @@ func verdictBadge(rec *taskVerdictRecord) (icon, label string, style lipgloss.St
 	if rec == nil {
 		return "⋯", "Pending", StyleSubtle
 	}
+	// User flag wins over the AI verdict: the human reviewer is explicitly
+	// asking for rework on this task.
+	if rec.userFlagged {
+		return "⚑", "flagged", lipgloss.NewStyle().Foreground(ColorWarning)
+	}
 	switch rec.state {
 	case verdictPending:
 		return "⋯", "Pending", StyleSubtle
@@ -199,6 +204,8 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	hints := "  " +
 		pHint +
 		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#7ec8e3")).Render("t") + StyleSubtle.Render(" — open agent terminal") +
+		"   " + lipgloss.NewStyle().Foreground(ColorWarning).Render("b") + StyleSubtle.Render(" — back to build") +
+		"   " + StyleSubtle.Render("f — flag task") +
 		"   " + StyleSubtle.Render("c — mark complete") +
 		"   " + StyleSubtle.Render("e — open in editor") +
 		"   " + StyleSubtle.Render("d — defer") +
@@ -285,7 +292,11 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int) []str
 		}
 	}
 
-	cursorStyle := lipgloss.NewStyle().Background(lipgloss.Color("#2a2a3a")).Bold(true)
+	// Selection affordance: a vertical bar in primary color on each side of the
+	// cursor row. We reserve 2 columns globally (one per side) so moving the
+	// cursor never reflows text — both selected and unselected rows have the
+	// same content budget.
+	cursorBar := lipgloss.NewStyle().Foreground(ColorPrimary).Render("│")
 	subtleGreen := StyleSuccess
 	subtleRed := StyleError
 
@@ -339,8 +350,10 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int) []str
 		iconW := ansi.StringWidth(iconStr)
 		labelW := len(label)
 		statW := ansi.StringWidth(statStr)
-		// 2 prefix spaces + icon + space + label + space + ... + 2 sep + stat
-		overhead := 2 + iconW + 1 + labelW + 1 + 2 + statW
+		// 1 outer space + 1 border + icon + space + label + space + ... + 2 sep
+		// + stat + 1 border + 1 outer space. The +4 over the prior layout
+		// reserves columns for the cursor border on both sides.
+		overhead := 4 + iconW + 1 + labelW + 1 + 2 + statW
 		maxTextW := width - overhead
 		if maxTextW < 4 {
 			maxTextW = 4
@@ -351,7 +364,7 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int) []str
 		rowText := iconStr + " " + StyleSubtle.Render(label) + " " + textStr
 		if statStr != "" {
 			usedW := iconW + 1 + labelW + 1 + ansi.StringWidth(textStr)
-			padW := width - 2 - usedW - 2 - statW
+			padW := width - 4 - usedW - 2 - statW
 			if padW < 1 {
 				padW = 1
 			}
@@ -359,13 +372,14 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int) []str
 		}
 
 		if selected {
-			padW := width - 2 - ansi.StringWidth(rowText)
-			if padW < 0 {
-				padW = 0
+			contentW := width - 4
+			if w := ansi.StringWidth(rowText); w < contentW {
+				rowText += strings.Repeat(" ", contentW-w)
 			}
-			rowText = cursorStyle.Render(rowText + strings.Repeat(" ", padW))
+			lines = append(lines, " "+cursorBar+rowText+cursorBar+" ")
+		} else {
+			lines = append(lines, "  "+rowText)
 		}
-		lines = append(lines, "  "+rowText)
 	}
 
 	return lines

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -557,6 +557,56 @@ func TestReviewTaskGroupAtCursor(t *testing.T) {
 	}
 }
 
+// TestReviewTaskIndexAtCursor checks that the index resolves correctly for the
+// f-flag path, including plan tasks that have no commit group (which is the
+// case the cursor helper used to silently skip).
+func TestReviewTaskIndexAtCursor(t *testing.T) {
+	// Plan with two tasks; only task 2 has commits. Task 1 has no group — the
+	// reviewer might want to flag it as "never started".
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{
+			{Index: 1, Text: "Add metrics"},
+			{Index: 2, Text: "Wire dashboard"},
+		},
+		groups: []taskReviewGroup{
+			{taskIndex: 2, commits: []git.Commit{{Hash: "b"}}},
+			{taskIndex: 0, commits: []git.Commit{{Hash: "c"}}},
+		},
+	}
+	tests := []struct {
+		name    string
+		cursor  int
+		wantIdx int
+		wantOk  bool
+	}{
+		{"task 1 with no commits resolves", 0, 1, true},
+		{"task 2 with commits resolves", 1, 2, true},
+		{"other-changes row resolves to 0", 2, 0, true},
+		{"out of range returns false", 3, 0, false},
+		{"negative cursor returns false", -1, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, ok := reviewTaskIndexAtCursor(entry, tt.cursor)
+			if ok != tt.wantOk {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOk)
+			}
+			if idx != tt.wantIdx {
+				t.Errorf("idx = %d, want %d", idx, tt.wantIdx)
+			}
+		})
+	}
+
+	// No-plan synthetic Overview row: no tasks, no groups → never resolves.
+	emptyEntry := &reviewDiffEntry{}
+	if _, ok := reviewTaskIndexAtCursor(emptyEntry, 0); ok {
+		t.Error("expected !ok for no-plan synthetic Overview row")
+	}
+	if _, ok := reviewTaskIndexAtCursor(nil, 0); ok {
+		t.Error("expected !ok for nil entry")
+	}
+}
+
 // TestPopulateNoDiffVerdicts verifies the detection logic that stamps verdictNoDiff
 // on plan tasks with no matching commit group, leaving matched tasks untouched.
 func TestPopulateNoDiffVerdicts(t *testing.T) {
@@ -772,6 +822,20 @@ func TestVerdictBadge(t *testing.T) {
 			rec:       &taskVerdictRecord{state: verdictNoDiff},
 			wantIcon:  func(s string) bool { return s == "⊘" },
 			wantLabel: "no diff found",
+		},
+		{
+			name:      "userFlagged overrides pending",
+			rec:       &taskVerdictRecord{state: verdictPending, userFlagged: true},
+			wantIcon:  func(s string) bool { return s == "⚑" },
+			wantLabel: "flagged",
+		},
+		{
+			// Documents the intentional precedence: a human flag wins over the
+			// AI reviewer's verdict, even a passing one.
+			name:      "userFlagged overrides verdictDone pass",
+			rec:       &taskVerdictRecord{state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictPass}, userFlagged: true},
+			wantIcon:  func(s string) bool { return s == "⚑" },
+			wantLabel: "flagged",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The review panel now has a clear `b` ("back to build") action that spawns
a new building agent in the existing worktree from per-task AI verdicts
(concerns/fail) plus any rows the human reviewer flags with `f`. The
synthesized prompt names each task by its plan index and tells the agent
to keep using `[task N]` commit prefixes so subsequent reviews group
round-2 commits under the same task — sessions can now cycle review↔build
as many times as needed without losing the task→commit mapping.

The selected task row in the review list also gets a primary-color
vertical-bar border instead of the previous near-invisible background
tint, so the cursor is obvious at a glance.

https://claude.ai/code/session_01YJn3WeSgqNLpY92uXkC9sN