### PR TITLE
Enhance PR feedback review with expanded comments, human approval, and agent handoff

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -480,6 +480,7 @@ func (c *Client) GetReviewThreads(ctx context.Context, owner, repo string, numbe
 	for _, comment := range allComments {
 		login := comment.GetUser().GetLogin()
 		rc := ReviewComment{
+			ID:   comment.GetID(),
 			Path: comment.GetPath(),
 			Body: comment.GetBody(),
 			Line: comment.GetLine(),

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -462,6 +462,9 @@ func TestGetReviewThreads_GroupsByReviewer(t *testing.T) {
 	if len(threads[0].Comments) != 1 || threads[0].Comments[0].Path != "utils.go" {
 		t.Errorf("thread[0] comments = %+v, want 1 comment on utils.go", threads[0].Comments)
 	}
+	if threads[0].Comments[0].ID != 2 {
+		t.Errorf("thread[0].Comments[0].ID = %d, want 2", threads[0].Comments[0].ID)
+	}
 	if threads[1].Reviewer != "bob" {
 		t.Errorf("thread[1] reviewer = %q, want bob", threads[1].Reviewer)
 	}
@@ -470,6 +473,44 @@ func TestGetReviewThreads_GroupsByReviewer(t *testing.T) {
 	}
 	if len(threads[1].Comments) != 1 || threads[1].Comments[0].Path != "main.go" {
 		t.Errorf("thread[1] comments = %+v, want 1 comment on main.go", threads[1].Comments)
+	}
+	if threads[1].Comments[0].ID != 1 {
+		t.Errorf("thread[1].Comments[0].ID = %d, want 1", threads[1].Comments[0].ID)
+	}
+}
+
+func TestGetReviewThreads_CommentIDsStable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/o/r/pulls/3/reviews":
+			_, _ = fmt.Fprintln(w, `[]`)
+		case "/repos/o/r/pulls/3/comments":
+			_, _ = fmt.Fprintln(w, `[
+				{"id":1001,"user":{"login":"dave"},"path":"a.go","body":"first","line":1},
+				{"id":1002,"user":{"login":"dave"},"path":"b.go","body":"second","line":2}
+			]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	threads, err := c.GetReviewThreads(context.Background(), "o", "r", 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(threads) != 1 {
+		t.Fatalf("expected 1 thread, got %d", len(threads))
+	}
+	if len(threads[0].Comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(threads[0].Comments))
+	}
+	if threads[0].Comments[0].ID != 1001 {
+		t.Errorf("comment[0].ID = %d, want 1001", threads[0].Comments[0].ID)
+	}
+	if threads[0].Comments[1].ID != 1002 {
+		t.Errorf("comment[1].ID = %d, want 1002", threads[0].Comments[1].ID)
 	}
 }
 
@@ -498,6 +539,9 @@ func TestGetReviewThreads_CommentOnlyReviewer(t *testing.T) {
 	}
 	if threads[0].Reviewer != "charlie" || threads[0].State != "COMMENTED" {
 		t.Errorf("unexpected thread: %+v", threads[0])
+	}
+	if len(threads[0].Comments) != 1 || threads[0].Comments[0].ID != 1 {
+		t.Errorf("expected comment with ID=1, got: %+v", threads[0].Comments)
 	}
 }
 

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -44,6 +44,7 @@ type ReviewStatus struct {
 
 // ReviewComment is a single inline comment on a pull request.
 type ReviewComment struct {
+	ID   int64
 	Path string
 	Body string
 	Line int

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -196,6 +196,10 @@ type App struct {
 	reviewSession          *agent.Session              // session currently open in review panel
 	reviewTaskCursor       int                         // selected task row in the review task list
 	shippingSession        *agent.Session              // session currently open in shipping panel
+	feedbackTriage         map[string]map[string]*feedbackTriageEntry // keyed by sessionID → itemKey
+	shippingFeedbackCursor int                         // cursor row in the feedback list pane
+	shippingDetailScroll   int                         // scroll offset in the feedback detail pane
+	feedbackNote           feedbackNoteModal           // overlay for adding a guidance note to a feedback item
 	planEditor             *planEditorModel            // non-nil while panelFocus == focusPlanEditor
 	promptModal            promptModalModel            // overlay for plan-first new-session prompt
 
@@ -251,6 +255,8 @@ func NewApp() App {
 		prPollStates:    make(map[string]*prSessionState),
 		closingAgents:   make(map[string]bool),
 		closingSessions: make(map[string]bool),
+		feedbackTriage:  make(map[string]map[string]*feedbackTriageEntry),
+		feedbackNote:    newFeedbackNoteModal(),
 		promptModal:     newPromptModal(),
 		prComposeModal:  newPRComposeModal(),
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -192,16 +192,16 @@ type App struct {
 	focusBreakShortWarning bool
 	focusBreakTimerUp      bool // break duration elapsed; waiting on user to resume
 	focusBreakAnimFrame    int
-	reviewDiffCache        map[string]*reviewDiffEntry // keyed by session ID
-	reviewSession          *agent.Session              // session currently open in review panel
-	reviewTaskCursor       int                         // selected task row in the review task list
-	shippingSession        *agent.Session              // session currently open in shipping panel
+	reviewDiffCache        map[string]*reviewDiffEntry                // keyed by session ID
+	reviewSession          *agent.Session                             // session currently open in review panel
+	reviewTaskCursor       int                                        // selected task row in the review task list
+	shippingSession        *agent.Session                             // session currently open in shipping panel
 	feedbackTriage         map[string]map[string]*feedbackTriageEntry // keyed by sessionID → itemKey
-	shippingFeedbackCursor int                         // cursor row in the feedback list pane
-	shippingDetailScroll   int                         // scroll offset in the feedback detail pane
-	feedbackNote           feedbackNoteModal           // overlay for adding a guidance note to a feedback item
-	planEditor             *planEditorModel            // non-nil while panelFocus == focusPlanEditor
-	promptModal            promptModalModel            // overlay for plan-first new-session prompt
+	shippingFeedbackCursor int                                        // cursor row in the feedback list pane
+	shippingDetailScroll   int                                        // scroll offset in the feedback detail pane
+	feedbackNote           feedbackNoteModal                          // overlay for adding a guidance note to a feedback item
+	planEditor             *planEditorModel                           // non-nil while panelFocus == focusPlanEditor
+	promptModal            promptModalModel                           // overlay for plan-first new-session prompt
 
 	// Wellness counters (written to log on quit).
 	agentsCreatedCount   int

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4492,6 +4492,7 @@ func (a *App) addressFeedback(sess *agent.Session) (tea.Model, tea.Cmd) {
 	sessID := sess.ID
 	a.shippingSession = nil
 	a.dashboard.panelFocus = focusList
+	delete(a.feedbackTriage, sessID)
 	return a, func() tea.Msg {
 		ag, err := mgr.AddAgent(sessID, cfg)
 		if err != nil {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1831,6 +1831,9 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.shippingDetailScroll = 0
 			case "pgdown", "ctrl+d":
 				a.shippingDetailScroll += halfPane
+				if a.shippingDetailScroll < 0 { // overflow guard only; render clamps to real max
+					a.shippingDetailScroll = 0
+				}
 			case "pgup", "ctrl+u":
 				a.shippingDetailScroll -= halfPane
 				if a.shippingDetailScroll < 0 {
@@ -4558,7 +4561,7 @@ func buildFeedbackPrompt(entry *prCacheEntry, triage map[string]*feedbackTriageE
 
 	for _, item := range items {
 		// Apply actionability filter.
-		if !item.IsInline && !actionableThreads[item.Reviewer] {
+		if !actionableThreads[item.Reviewer] {
 			continue
 		}
 		key := feedbackItemKey(item)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1799,7 +1799,69 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Shipping panel key handling.
 		if a.dashboard.panelFocus == focusShipping && a.shippingSession != nil {
+			// Modal intercepts all keys first.
+			if a.feedbackNote.Active() {
+				cmd, submitted, note := a.feedbackNote.Update(msg)
+				if submitted {
+					a.setFeedbackNote(a.shippingSession.ID, a.feedbackNote.itemKey, note)
+				}
+				return a, cmd
+			}
+			entry := a.prCache[a.shippingSession.ID]
+			items := feedbackItems(entryThreads(entry))
+			halfPane := a.height / 4
+			if halfPane < 1 {
+				halfPane = 1
+			}
 			switch msg.String() {
+			case "j", "down":
+				max := len(items) - 1
+				if max < 0 {
+					max = 0
+				}
+				if a.shippingFeedbackCursor < max {
+					a.shippingFeedbackCursor++
+				}
+				a.shippingDetailScroll = 0
+			case "k", "up":
+				if a.shippingFeedbackCursor > 0 {
+					a.shippingFeedbackCursor--
+				}
+				a.shippingDetailScroll = 0
+			case "pgdown", "ctrl+d":
+				a.shippingDetailScroll += halfPane
+			case "pgup", "ctrl+u":
+				a.shippingDetailScroll -= halfPane
+				if a.shippingDetailScroll < 0 {
+					a.shippingDetailScroll = 0
+				}
+			case "a":
+				if len(items) > 0 && a.shippingFeedbackCursor < len(items) {
+					key := feedbackItemKey(items[a.shippingFeedbackCursor])
+					a.setFeedbackVerdict(a.shippingSession.ID, key, feedbackApproved)
+				}
+			case "x":
+				if len(items) > 0 && a.shippingFeedbackCursor < len(items) {
+					key := feedbackItemKey(items[a.shippingFeedbackCursor])
+					a.setFeedbackVerdict(a.shippingSession.ID, key, feedbackDisagreed)
+				}
+			case "u":
+				if len(items) > 0 && a.shippingFeedbackCursor < len(items) {
+					key := feedbackItemKey(items[a.shippingFeedbackCursor])
+					a.setFeedbackVerdict(a.shippingSession.ID, key, feedbackNeutral)
+				}
+			case "n":
+				if len(items) > 0 && a.shippingFeedbackCursor < len(items) {
+					item := items[a.shippingFeedbackCursor]
+					key := feedbackItemKey(item)
+					existing := ""
+					if m := a.feedbackTriage[a.shippingSession.ID]; m != nil {
+						if e := m[key]; e != nil {
+							existing = e.Note
+						}
+					}
+					return a, a.feedbackNote.Open(key, existing)
+				}
 			case "esc":
 				a.dashboard.panelFocus = focusList
 				a.shippingSession = nil
@@ -1811,7 +1873,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.setError("session has no agents to open")
 				}
 			case "p":
-				if entry := a.prCache[a.shippingSession.ID]; entry != nil && entry.pr != nil && entry.pr.URL != "" {
+				if entry != nil && entry.pr != nil && entry.pr.URL != "" {
 					if err := openURL(entry.pr.URL); err != nil {
 						a.setError(err.Error())
 					}
@@ -1820,7 +1882,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case "m":
 				// Merge: gated on isMergeReady.
-				entry := a.prCache[a.shippingSession.ID]
 				if !isMergeReady(entry) {
 					a.setError("not ready to merge — use M to force")
 					return a, nil
@@ -1828,7 +1889,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, a.mergePRCmd(a.shippingSession.ID)
 			case "M":
 				// Force merge: bypasses isMergeReady check.
-				entry := a.prCache[a.shippingSession.ID]
 				if entry == nil || entry.pr == nil {
 					a.setError("no PR found")
 					return a, nil
@@ -3485,6 +3545,8 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 		return nil, true
 	case focusSectionShipping:
 		a.shippingSession = sess
+		a.shippingFeedbackCursor = 0
+		a.shippingDetailScroll = 0
 		a.dashboard.panelFocus = focusShipping
 		return nil, true
 	}
@@ -4329,6 +4391,55 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 			threads:   threads,
 			stack:     stack,
 		}
+	}
+}
+
+// entryThreads safely returns threads from a prCacheEntry (nil-safe).
+func entryThreads(entry *prCacheEntry) []github.ReviewThread {
+	if entry == nil {
+		return nil
+	}
+	return entry.threads
+}
+
+// setFeedbackVerdict lazily allocates the per-session triage map and sets the
+// verdict on the item with the given key. For feedbackNeutral with an empty
+// note, the entry is deleted to keep the map clean.
+func (a *App) setFeedbackVerdict(sessID, itemKey string, v feedbackVerdict) {
+	if a.feedbackTriage[sessID] == nil {
+		a.feedbackTriage[sessID] = make(map[string]*feedbackTriageEntry)
+	}
+	m := a.feedbackTriage[sessID]
+	if v == feedbackNeutral {
+		if e := m[itemKey]; e == nil || strings.TrimSpace(e.Note) == "" {
+			delete(m, itemKey)
+			return
+		}
+	}
+	if m[itemKey] == nil {
+		m[itemKey] = &feedbackTriageEntry{}
+	}
+	m[itemKey].Verdict = v
+}
+
+// setFeedbackNote lazily allocates the per-session triage map and sets the
+// note on the item. If the resulting entry is neutral with an empty note, it
+// is deleted.
+func (a *App) setFeedbackNote(sessID, itemKey, note string) {
+	if a.feedbackTriage[sessID] == nil {
+		a.feedbackTriage[sessID] = make(map[string]*feedbackTriageEntry)
+	}
+	m := a.feedbackTriage[sessID]
+	if m[itemKey] == nil {
+		if note == "" {
+			return
+		}
+		m[itemKey] = &feedbackTriageEntry{}
+	}
+	m[itemKey].Note = note
+	// Clean up neutral entries with no note.
+	if m[itemKey].Verdict == feedbackNeutral && strings.TrimSpace(m[itemKey].Note) == "" {
+		delete(m, itemKey)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4467,7 +4467,7 @@ func (a *App) addressFeedback(sess *agent.Session) (tea.Model, tea.Cmd) {
 	}
 
 	entry := a.prCache[sess.ID]
-	prompt := buildFeedbackPrompt(entry)
+	prompt := buildFeedbackPrompt(entry, a.feedbackTriage[sess.ID])
 	if prompt == "" {
 		prompt = "Address the CI failures and review feedback on this PR."
 	}
@@ -4503,14 +4503,17 @@ func (a *App) addressFeedback(sess *agent.Session) (tea.Model, tea.Cmd) {
 }
 
 // buildFeedbackPrompt synthesizes an agent prompt from the failing CI checks
-// and unresolved review comments in entry. Returns "" when nothing is actionable.
-func buildFeedbackPrompt(entry *prCacheEntry) string {
+// and review feedback, bucketed by user triage verdicts. Returns "" when
+// nothing is actionable (all disagreed with no notes, and no failing CI).
+// triage may be nil (treats all items as neutral).
+func buildFeedbackPrompt(entry *prCacheEntry, triage map[string]*feedbackTriageEntry) string {
 	if entry == nil {
 		return ""
 	}
 	var b strings.Builder
 	wrote := false
 
+	// ── Failing CI checks (unchanged) ────────────────────────────────────────
 	if entry.checks != nil {
 		var failingRuns []github.CheckRun
 		for _, run := range entry.checks.Runs {
@@ -4538,42 +4541,79 @@ func buildFeedbackPrompt(entry *prCacheEntry) string {
 		}
 	}
 
-	hasActionableThreads := false
+	// ── Review feedback, bucketed by triage ──────────────────────────────────
+	// Pre-compute actionable threads using the same filter as the original code:
+	// CHANGES_REQUESTED always actionable; COMMENTED only when it has inline comments.
+	actionableThreads := make(map[string]bool, len(entry.threads))
 	for _, thread := range entry.threads {
 		if thread.State == "CHANGES_REQUESTED" || (thread.State == "COMMENTED" && len(thread.Comments) > 0) {
-			hasActionableThreads = true
-			break
+			actionableThreads[thread.Reviewer] = true
 		}
 	}
-	if hasActionableThreads {
-		b.WriteString("## Review Feedback\n\n")
-		for _, thread := range entry.threads {
-			if thread.State != "CHANGES_REQUESTED" && (thread.State != "COMMENTED" || len(thread.Comments) == 0) {
+
+	items := feedbackItems(entry.threads)
+	var addressItems, disputedItems []feedbackItem
+	var disputedNotes []string
+
+	for _, item := range items {
+		// Apply actionability filter.
+		if !item.IsInline && !actionableThreads[item.Reviewer] {
+			continue
+		}
+		key := feedbackItemKey(item)
+		var e *feedbackTriageEntry
+		if triage != nil {
+			e = triage[key]
+		}
+		if e != nil && e.Verdict == feedbackDisagreed {
+			if strings.TrimSpace(e.Note) == "" {
+				// Disagreed with no note: skip entirely.
 				continue
 			}
-			b.WriteString("**")
-			b.WriteString(thread.Reviewer)
-			b.WriteString("**")
-			if thread.State == "CHANGES_REQUESTED" {
-				b.WriteString(" (changes requested)")
-			}
-			b.WriteString(":\n")
-			if thread.Body != "" {
-				b.WriteString(thread.Body)
-				b.WriteByte('\n')
-			}
-			for _, c := range thread.Comments {
-				b.WriteString("- ")
-				b.WriteString(c.Path)
-				if c.Line > 0 {
-					b.WriteString(fmt.Sprintf(":%d", c.Line))
-				}
-				b.WriteString(": ")
-				b.WriteString(c.Body)
-				b.WriteByte('\n')
-			}
-			b.WriteByte('\n')
+			disputedItems = append(disputedItems, item)
+			disputedNotes = append(disputedNotes, strings.TrimSpace(e.Note))
+		} else {
+			addressItems = append(addressItems, item)
 		}
+	}
+
+	writeFeedbackItem := func(item feedbackItem) {
+		b.WriteString("- ")
+		if item.IsInline {
+			b.WriteString(item.Reviewer)
+			b.WriteString(" (")
+			b.WriteString(item.Path)
+			if item.Line > 0 {
+				b.WriteString(fmt.Sprintf(":%d", item.Line))
+			}
+			b.WriteString("): ")
+		} else {
+			b.WriteString("**")
+			b.WriteString(item.Reviewer)
+			b.WriteString("**: ")
+		}
+		b.WriteString(item.Body)
+		b.WriteByte('\n')
+	}
+
+	if len(addressItems) > 0 {
+		b.WriteString("## Feedback to address\n\n")
+		for _, item := range addressItems {
+			writeFeedbackItem(item)
+		}
+		b.WriteByte('\n')
+		wrote = true
+	}
+
+	if len(disputedItems) > 0 {
+		b.WriteString("## Disputed feedback (advisory — do not change unless you find a strong reason)\n\n")
+		for i, item := range disputedItems {
+			writeFeedbackItem(item)
+			if i < len(disputedNotes) && disputedNotes[i] != "" {
+				b.WriteString(fmt.Sprintf("  > I disagree because: %s\n", disputedNotes[i]))
+			}
+		}
+		b.WriteByte('\n')
 		wrote = true
 	}
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3739,7 +3739,8 @@ func (a App) View() tea.View {
 		}
 		if a.dashboard.panelFocus == focusShipping && a.shippingSession != nil {
 			entry := a.prCache[a.shippingSession.ID]
-			v := tea.NewView(renderShippingPanel(a.shippingSession, entry, a.width, a.height))
+			sessID := a.shippingSession.ID
+			v := tea.NewView(renderShippingPanel(a.shippingSession, entry, a.width, a.height, a.shippingFeedbackCursor, a.shippingDetailScroll, a.feedbackTriage[sessID]))
 			v.AltScreen = true
 			return v
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -350,6 +350,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			a.promptModal.SetSize(msg.Width, msg.Height-1)
 			a.prComposeModal.SetSize(msg.Width, msg.Height-1)
+			a.feedbackNote.SetSize(msg.Width, msg.Height)
 		}
 
 	case initAppMsg:
@@ -3802,7 +3803,11 @@ func (a App) View() tea.View {
 		if a.dashboard.panelFocus == focusShipping && a.shippingSession != nil {
 			entry := a.prCache[a.shippingSession.ID]
 			sessID := a.shippingSession.ID
-			v := tea.NewView(renderShippingPanel(a.shippingSession, entry, a.width, a.height, a.shippingFeedbackCursor, a.shippingDetailScroll, a.feedbackTriage[sessID]))
+			panel := renderShippingPanel(a.shippingSession, entry, a.width, a.height, a.shippingFeedbackCursor, a.shippingDetailScroll, a.feedbackTriage[sessID])
+			if a.feedbackNote.Active() {
+				panel = lipgloss.Place(a.width, a.height, lipgloss.Center, lipgloss.Center, a.feedbackNote.View())
+			}
+			v := tea.NewView(panel)
 			v.AltScreen = true
 			return v
 		}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3960,6 +3960,53 @@ func TestShippingPanel_VerdictKeys(t *testing.T) {
 	}
 }
 
+func TestAddressFeedback_ClearsTriage(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTest("addr-t", "ship")
+	sess.SetLifecyclePhase(agent.LifecycleShipping)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(sess)
+
+	app := NewApp()
+	app.shippingSession = sess
+	app.dashboard.panelFocus = focusShipping
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.prCache[sess.ID] = &prCacheEntry{
+		pr: &github.PRState{Number: 5, MergeableState: "clean"},
+		threads: []github.ReviewThread{
+			{Reviewer: "alice", State: "CHANGES_REQUESTED", Body: "fix it"},
+		},
+	}
+	// Seed triage.
+	app.feedbackTriage[sess.ID] = map[string]*feedbackTriageEntry{
+		"thread:alice": {Verdict: feedbackDisagreed, Note: "n/a"},
+	}
+
+	// Press 'r' → dispatches addressFeedback, which should clear triage.
+	// addressFeedback uses pointer receiver so may return *App — handle both.
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	var gotApp App
+	switch v := model.(type) {
+	case App:
+		gotApp = v
+	case *App:
+		gotApp = *v
+	default:
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	if m := gotApp.feedbackTriage[sess.ID]; len(m) != 0 {
+		t.Errorf("expected feedbackTriage[%s] cleared after r, got: %v", sess.ID, m)
+	}
+}
+
 func TestNewApp_InitsFeedbackTriage(t *testing.T) {
 	app := NewApp()
 	if app.feedbackTriage == nil {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3801,3 +3801,13 @@ func TestRefreshPRStatus_WrongRepoReturnsError(t *testing.T) {
 		t.Errorf("expected error to contain %q, got: %s", "internal", poll.err.Error())
 	}
 }
+
+func TestNewApp_InitsFeedbackTriage(t *testing.T) {
+	app := NewApp()
+	if app.feedbackTriage == nil {
+		t.Error("feedbackTriage should be initialized, got nil")
+	}
+	if len(app.feedbackTriage) != 0 {
+		t.Errorf("feedbackTriage should be empty on init, got len=%d", len(app.feedbackTriage))
+	}
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3866,6 +3866,51 @@ func TestShippingPanel_CursorAndScrollKeys(t *testing.T) {
 	}
 }
 
+func TestShippingPanel_VerdictKeys(t *testing.T) {
+	sess := agent.NewSessionForTest("ship-v", "ship")
+	sess.SetLifecyclePhase(agent.LifecycleShipping)
+	app := NewApp()
+	app.shippingSession = sess
+	app.dashboard.panelFocus = focusShipping
+	app.width = 120
+	app.height = 40
+	// One inline comment with ID=42.
+	app.prCache[sess.ID] = &prCacheEntry{
+		pr: &github.PRState{Number: 2, MergeableState: "clean"},
+		threads: []github.ReviewThread{
+			{
+				Reviewer: "alice",
+				State:    "CHANGES_REQUESTED",
+				Comments: []github.ReviewComment{
+					{ID: 42, Path: "foo.go", Body: "fix this", Line: 1},
+				},
+			},
+		},
+	}
+	// cursor=0 → the inline comment (no body → only inline item)
+
+	// Press 'a' — approve.
+	m, _ := app.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	got := m.(App)
+	if e := got.feedbackTriage[sess.ID]["comment:42"]; e == nil || e.Verdict != feedbackApproved {
+		t.Errorf("after a: want feedbackApproved, got %+v", e)
+	}
+
+	// Press 'x' — disagree.
+	m, _ = got.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	got = m.(App)
+	if e := got.feedbackTriage[sess.ID]["comment:42"]; e == nil || e.Verdict != feedbackDisagreed {
+		t.Errorf("after x: want feedbackDisagreed, got %+v", e)
+	}
+
+	// Press 'u' — neutral (should remove the entry since no note).
+	m, _ = got.Update(tea.KeyPressMsg{Code: 'u', Text: "u"})
+	got = m.(App)
+	if e := got.feedbackTriage[sess.ID]["comment:42"]; e != nil {
+		t.Errorf("after u: expected entry removed (neutral+empty note), got %+v", e)
+	}
+}
+
 func TestNewApp_InitsFeedbackTriage(t *testing.T) {
 	app := NewApp()
 	if app.feedbackTriage == nil {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3802,6 +3802,70 @@ func TestRefreshPRStatus_WrongRepoReturnsError(t *testing.T) {
 	}
 }
 
+func TestShippingPanel_CursorAndScrollKeys(t *testing.T) {
+	sess := agent.NewSessionForTest("ship-cs", "ship")
+	sess.SetLifecyclePhase(agent.LifecycleShipping)
+	app := NewApp()
+	app.shippingSession = sess
+	app.dashboard.panelFocus = focusShipping
+	app.width = 120
+	app.height = 40
+	app.prCache[sess.ID] = &prCacheEntry{
+		pr: &github.PRState{Number: 1, MergeableState: "clean"},
+		threads: []github.ReviewThread{
+			{Reviewer: "alice", State: "CHANGES_REQUESTED", Body: "fix a"},
+			{Reviewer: "bob", State: "CHANGES_REQUESTED", Body: "fix b"},
+			{Reviewer: "carol", State: "APPROVED", Body: "lgtm"},
+		},
+	}
+
+	// j moves cursor down.
+	m, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	got := m.(App)
+	if got.shippingFeedbackCursor != 1 {
+		t.Errorf("after j: cursor = %d, want 1", got.shippingFeedbackCursor)
+	}
+	if got.shippingDetailScroll != 0 {
+		t.Errorf("after j: scroll should reset to 0, got %d", got.shippingDetailScroll)
+	}
+
+	// j again.
+	m, _ = got.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	got = m.(App)
+	if got.shippingFeedbackCursor != 2 {
+		t.Errorf("after j×2: cursor = %d, want 2", got.shippingFeedbackCursor)
+	}
+
+	// j past end clamps.
+	m, _ = got.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	got = m.(App)
+	if got.shippingFeedbackCursor != 2 {
+		t.Errorf("j past end: cursor = %d, want 2 (clamped)", got.shippingFeedbackCursor)
+	}
+
+	// k moves cursor up.
+	m, _ = got.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	got = m.(App)
+	if got.shippingFeedbackCursor != 1 {
+		t.Errorf("after k: cursor = %d, want 1", got.shippingFeedbackCursor)
+	}
+
+	// pgdn increments detail scroll.
+	got.shippingDetailScroll = 0
+	m, _ = got.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	got = m.(App)
+	if got.shippingDetailScroll <= 0 {
+		t.Errorf("pgdn: scroll = %d, want >0", got.shippingDetailScroll)
+	}
+
+	// j resets detail scroll to 0.
+	m, _ = got.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	got = m.(App)
+	if got.shippingDetailScroll != 0 {
+		t.Errorf("j after scroll: scroll should reset to 0, got %d", got.shippingDetailScroll)
+	}
+}
+
 func TestNewApp_InitsFeedbackTriage(t *testing.T) {
 	app := NewApp()
 	if app.feedbackTriage == nil {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2990,7 +2990,7 @@ func TestBuildFeedbackPrompt_FailingChecksAndComments(t *testing.T) {
 			},
 		},
 	}
-	prompt := buildFeedbackPrompt(entry)
+	prompt := buildFeedbackPrompt(entry, nil)
 
 	if !strings.Contains(prompt, "lint") {
 		t.Errorf("prompt missing failing check name: %q", prompt)
@@ -3011,7 +3011,7 @@ func TestBuildFeedbackPrompt_FailingChecksAndComments(t *testing.T) {
 
 // TestBuildFeedbackPrompt_NilEntry verifies that a nil entry returns "".
 func TestBuildFeedbackPrompt_NilEntry(t *testing.T) {
-	if got := buildFeedbackPrompt(nil); got != "" {
+	if got := buildFeedbackPrompt(nil, nil); got != "" {
 		t.Errorf("expected empty prompt for nil entry, got: %q", got)
 	}
 }
@@ -3025,7 +3025,7 @@ func TestBuildFeedbackPrompt_ApprovedOnly(t *testing.T) {
 			{Reviewer: "bob", State: "APPROVED", Body: "LGTM"},
 		},
 	}
-	if got := buildFeedbackPrompt(entry); got != "" {
+	if got := buildFeedbackPrompt(entry, nil); got != "" {
 		t.Errorf("expected empty prompt when no actionable feedback, got: %q", got)
 	}
 }
@@ -3045,7 +3045,7 @@ func TestBuildFeedbackPrompt_CommentedOnlyWithInlineComments(t *testing.T) {
 			},
 		},
 	}
-	prompt := buildFeedbackPrompt(entry)
+	prompt := buildFeedbackPrompt(entry, nil)
 	if prompt == "" {
 		t.Error("expected non-empty prompt for COMMENTED thread with inline comments")
 	}
@@ -3070,12 +3070,61 @@ func TestBuildFeedbackPrompt_CommentedOnlyWithoutInlineComments(t *testing.T) {
 			},
 		},
 	}
-	if got := buildFeedbackPrompt(entry); got != "" {
+	if got := buildFeedbackPrompt(entry, nil); got != "" {
 		t.Errorf("expected empty prompt for COMMENTED thread with no inline comments, got: %q", got)
 	}
 }
 
 // TestBuildReviewReworkPrompt_NilEntry verifies a nil entry returns "".
+func TestBuildFeedbackPrompt_TriagedApprovedAndDisagreed(t *testing.T) {
+	entry := &prCacheEntry{
+		threads: []github.ReviewThread{
+			{Reviewer: "alice", State: "CHANGES_REQUESTED", Body: "fix X"},
+			{Reviewer: "bob", State: "CHANGES_REQUESTED", Body: "rename Y"},
+		},
+	}
+	triage := map[string]*feedbackTriageEntry{
+		"thread:alice": {Verdict: feedbackApproved},
+		"thread:bob":   {Verdict: feedbackDisagreed, Note: "API contract"},
+	}
+	prompt := buildFeedbackPrompt(entry, triage)
+
+	if !strings.Contains(prompt, "## Feedback to address") {
+		t.Errorf("prompt missing approved section: %q", prompt)
+	}
+	if !strings.Contains(prompt, "fix X") {
+		t.Errorf("prompt missing approved body: %q", prompt)
+	}
+	if !strings.Contains(prompt, "## Disputed feedback") {
+		t.Errorf("prompt missing disputed section: %q", prompt)
+	}
+	if !strings.Contains(prompt, "bob") {
+		t.Errorf("prompt missing disputed reviewer: %q", prompt)
+	}
+	if !strings.Contains(prompt, "rename Y") {
+		t.Errorf("prompt missing disputed body: %q", prompt)
+	}
+	if !strings.Contains(prompt, "API contract") {
+		t.Errorf("prompt missing disagreement note: %q", prompt)
+	}
+}
+
+func TestBuildFeedbackPrompt_AllDisagreedNoNoteReturnsEmpty(t *testing.T) {
+	entry := &prCacheEntry{
+		threads: []github.ReviewThread{
+			{Reviewer: "alice", State: "CHANGES_REQUESTED", Body: "fix X"},
+		},
+	}
+	triage := map[string]*feedbackTriageEntry{
+		"thread:alice": {Verdict: feedbackDisagreed}, // no note
+	}
+	// All items disagreed with no note → nothing to act on, return "".
+	got := buildFeedbackPrompt(entry, triage)
+	if got != "" {
+		t.Errorf("expected empty prompt when all items disagreed with no note, got: %q", got)
+	}
+}
+
 func TestBuildReviewReworkPrompt_NilEntry(t *testing.T) {
 	if got := buildReviewReworkPrompt(nil); got != "" {
 		t.Errorf("expected empty prompt for nil entry, got: %q", got)

--- a/internal/tui/feedbacknotemodal.go
+++ b/internal/tui/feedbacknotemodal.go
@@ -1,0 +1,120 @@
+package tui
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	xlipgloss "charm.land/lipgloss/v2"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// feedbackNoteModal is a centered textarea overlay for attaching a guidance
+// note to a feedback item (approve/disagree verdict). It mirrors the
+// promptModalModel pattern: border + chip footer, enter to save, esc to cancel.
+type feedbackNoteModal struct {
+	active  bool
+	itemKey string
+	ta      textarea.Model
+	width   int
+	height  int
+}
+
+func newFeedbackNoteModal() feedbackNoteModal {
+	ta := textarea.New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.CharLimit = 2000
+	ta.SetHeight(4)
+	styles := ta.Styles()
+	styles.Focused.CursorLine = xlipgloss.NewStyle()
+	styles.Cursor.Color = ColorPrimary
+	ta.SetStyles(styles)
+	ta.KeyMap.InsertNewline.SetKeys("enter", "ctrl+m", "shift+enter")
+	return feedbackNoteModal{ta: ta}
+}
+
+// SetSize updates the modal's understanding of the surrounding viewport.
+func (m *feedbackNoteModal) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+	m.ta.SetWidth(modalWidth(w) - 4)
+}
+
+// Open shows the modal, pre-populating the textarea with an existing note.
+func (m *feedbackNoteModal) Open(itemKey, existing string) tea.Cmd {
+	m.active = true
+	m.itemKey = itemKey
+	m.ta.SetValue(existing)
+	m.ta.SetWidth(modalWidth(m.width) - 4)
+	return m.ta.Focus()
+}
+
+// Close hides the modal and blurs the textarea.
+func (m *feedbackNoteModal) Close() {
+	m.active = false
+	m.ta.Blur()
+}
+
+// Active reports whether the modal is currently visible.
+func (m *feedbackNoteModal) Active() bool { return m.active }
+
+// Update routes a tea.Msg to the modal.
+// Returns (cmd, submitted, note). submitted is true when the user pressed enter.
+func (m *feedbackNoteModal) Update(msg tea.Msg) (tea.Cmd, bool, string) {
+	if !m.active {
+		return nil, false, ""
+	}
+	if key, ok := msg.(tea.KeyPressMsg); ok {
+		switch key.String() {
+		case "esc":
+			m.Close()
+			return nil, false, ""
+		case "enter":
+			val := strings.TrimSpace(m.ta.Value())
+			m.Close()
+			return nil, true, val
+		}
+	}
+	var cmd tea.Cmd
+	m.ta, cmd = m.ta.Update(msg)
+	return cmd, false, ""
+}
+
+// View renders the modal box. Caller should overlay this when Active().
+func (m *feedbackNoteModal) View() string {
+	w := modalWidth(m.width)
+	innerW := w - 4
+
+	// Header: "FEEDBACK NOTE" left, truncated itemKey right.
+	left := StyleSubtle.Render("FEEDBACK NOTE")
+	right := StyleSubtle.Render(truncateVisible(m.itemKey, innerW-lipgloss.Width(left)-2))
+	gap := innerW - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+	header := left + strings.Repeat(" ", gap) + right
+
+	// Footer chips.
+	enter := StyleTitle.Render("enter")
+	shiftEnter := StyleTitle.Render("shift+enter")
+	esc := StyleTitle.Render("esc")
+	footer := enter + StyleSubtle.Render(" — save") +
+		"   " + shiftEnter + StyleSubtle.Render(" — newline") +
+		"   " + esc + StyleSubtle.Render(" — cancel")
+
+	body := lipgloss.JoinVertical(
+		lipgloss.Left,
+		header,
+		"",
+		m.ta.View(),
+		"",
+		footer,
+	)
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorPrimary).
+		Padding(0, 1).
+		Width(w).
+		Render(body)
+}

--- a/internal/tui/feedbacknotemodal_test.go
+++ b/internal/tui/feedbacknotemodal_test.go
@@ -1,0 +1,59 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestFeedbackNoteModal_SubmitReturnsNote(t *testing.T) {
+	m := newFeedbackNoteModal()
+	m.SetSize(100, 40)
+	_ = m.Open("comment:42", "old note")
+
+	if !m.Active() {
+		t.Fatal("expected modal to be active after Open")
+	}
+	if m.ta.Value() != "old note" {
+		t.Errorf("textarea value = %q, want %q", m.ta.Value(), "old note")
+	}
+
+	// Pressing enter should submit.
+	cmd, submitted, note := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !submitted {
+		t.Error("expected submitted=true on enter")
+	}
+	if note != "old note" {
+		t.Errorf("note = %q, want %q", note, "old note")
+	}
+	if m.Active() {
+		t.Error("expected modal inactive after submit")
+	}
+	_ = cmd
+}
+
+func TestFeedbackNoteModal_EscCancels(t *testing.T) {
+	m := newFeedbackNoteModal()
+	m.SetSize(100, 40)
+	_ = m.Open("comment:42", "existing")
+
+	cmd, submitted, note := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if submitted {
+		t.Error("expected submitted=false on esc")
+	}
+	if note != "" {
+		t.Errorf("note = %q, want empty on cancel", note)
+	}
+	if m.Active() {
+		t.Error("expected modal inactive after esc")
+	}
+	_ = cmd
+}
+
+func TestFeedbackNoteModal_InactiveNoop(t *testing.T) {
+	m := newFeedbackNoteModal()
+	cmd, submitted, note := m.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	if submitted || note != "" || cmd != nil {
+		t.Errorf("inactive modal should be a noop; got submitted=%v note=%q cmd=%v", submitted, note, cmd)
+	}
+}

--- a/internal/tui/shippingpanel.go
+++ b/internal/tui/shippingpanel.go
@@ -474,11 +474,17 @@ func shippingHints(mergeReady bool) string {
 	if !mergeReady {
 		mKey = StyleSubtle.Render("m")
 	}
+	blue := lipgloss.Color("#7ec8e3")
+	key := func(s string) string { return lipgloss.NewStyle().Foreground(blue).Render(s) }
 	return "  " +
 		mKey + mDesc +
 		"   " + StyleSubtle.Render("M — force merge") +
-		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#7ec8e3")).Render("r") + StyleSubtle.Render(" — address feedback") +
-		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#7ec8e3")).Render("p") + StyleSubtle.Render(" — open PR") +
-		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#7ec8e3")).Render("t") + StyleSubtle.Render(" — terminal") +
+		"   " + key("a") + StyleSubtle.Render(" — approve") +
+		"   " + key("x") + StyleSubtle.Render(" — disagree") +
+		"   " + key("u") + StyleSubtle.Render(" — clear") +
+		"   " + key("n") + StyleSubtle.Render(" — note") +
+		"   " + key("r") + StyleSubtle.Render(" — address feedback") +
+		"   " + key("p") + StyleSubtle.Render(" — open PR") +
+		"   " + key("t") + StyleSubtle.Render(" — terminal") +
 		"   " + StyleSubtle.Render("ESC — back")
 }

--- a/internal/tui/shippingpanel.go
+++ b/internal/tui/shippingpanel.go
@@ -232,8 +232,6 @@ func renderFeedbackList(items []feedbackItem, cursor int, triage map[string]*fee
 		if maxLabelW < 4 {
 			maxLabelW = 4
 		}
-		// One-line body preview.
-		previewBody := strings.ReplaceAll(item.Body, "\n", " ")
 		// Truncate label; show body preview inline after a colon.
 		labelStr := truncateVisible(label, maxLabelW)
 		rowText := glyph + " " + labelStr + noteGlyph
@@ -243,7 +241,6 @@ func renderFeedbackList(items []feedbackItem, cursor int, triage map[string]*fee
 			if rw := ansi.StringWidth(rowText); rw < contentW {
 				rowText += strings.Repeat(" ", contentW-rw)
 			}
-			_ = previewBody
 			lines = append(lines, " "+cursorBar+rowText+cursorBar+" ")
 		} else {
 			lines = append(lines, "  "+rowText)
@@ -425,6 +422,8 @@ func feedbackItems(threads []github.ReviewThread) []feedbackItem {
 
 // feedbackItemKey returns the stable triage map key for an item.
 // Inline comments use "comment:<id>"; thread bodies use "thread:<reviewer>".
+// The reviewer key is unique because GetReviewThreads produces at most one
+// ReviewThread per reviewer (latest-review dedup + seen guard).
 func feedbackItemKey(item feedbackItem) string {
 	if item.IsInline {
 		return fmt.Sprintf("comment:%d", item.CommentID)

--- a/internal/tui/shippingpanel.go
+++ b/internal/tui/shippingpanel.go
@@ -13,7 +13,8 @@ import (
 
 // renderShippingPanel renders the fullscreen shipping panel for a session.
 // entry may be nil while the first PR poll is in flight (shows loading state).
-func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height int) string {
+// cursor and scroll control the feedback two-pane UI; triage holds user verdicts.
+func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height, cursor, scroll int, triage map[string]*feedbackTriageEntry) string {
 	var lines []string
 
 	// ── Header ────────────────────────────────────────────────────────────────
@@ -78,18 +79,69 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 	lines = append(lines, "")
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
 
-	// ── Review threads ────────────────────────────────────────────────────────
-	lines = append(lines, StyleSubtle.Render("REVIEW THREADS"))
-	if len(entry.threads) == 0 {
+	// ── Review feedback (two-pane) ────────────────────────────────────────────
+	lines = append(lines, StyleSubtle.Render("REVIEW FEEDBACK"))
+	items := feedbackItems(entry.threads)
+	if len(items) == 0 {
 		lines = append(lines, StyleSubtle.Render("  no review feedback"))
+		lines = append(lines, "")
 	} else {
-		for _, thread := range entry.threads {
-			lines = append(lines, renderReviewThread(thread, width)...)
+		// Reserve height for header+PR+CI+dividers already rendered (+ footer).
+		usedAbove := len(lines) + 3 // +3 for footer sep + hints + blank before footer
+		bodyH := height - usedAbove
+		if bodyH < 4 {
+			bodyH = 4
+		}
+
+		if width < 80 {
+			// Narrow: stack list above detail.
+			listH := bodyH / 2
+			detailH := bodyH - listH - 1
+			if listH < 2 {
+				listH = 2
+			}
+			if detailH < 2 {
+				detailH = 2
+			}
+			w := width - 2
+			lines = append(lines, renderFeedbackList(items, cursor, triage, w, listH)...)
+			lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+			lines = append(lines, renderFeedbackDetail(items, cursor, triage, scroll, w, detailH)...)
+		} else {
+			// Wide: side-by-side panes.
+			leftW := width * 4 / 10
+			if leftW < 30 {
+				leftW = 30
+			}
+			rightW := width - leftW - 5
+			if rightW < 20 {
+				rightW = 20
+			}
+			leftLines := renderFeedbackList(items, cursor, triage, leftW, bodyH)
+			rightLines := renderFeedbackDetail(items, cursor, triage, scroll, rightW, bodyH)
+			gutter := " " + StyleSubtle.Render("│") + " "
+			maxRows := len(leftLines)
+			if len(rightLines) > maxRows {
+				maxRows = len(rightLines)
+			}
+			for i := 0; i < maxRows; i++ {
+				l, r := "", ""
+				if i < len(leftLines) {
+					l = leftLines[i]
+				}
+				if i < len(rightLines) {
+					r = rightLines[i]
+				}
+				padW := leftW - ansi.StringWidth(l)
+				if padW < 0 {
+					padW = 0
+				}
+				lines = append(lines, l+strings.Repeat(" ", padW)+gutter+r)
+			}
 		}
 	}
 
 	// ── Footer ────────────────────────────────────────────────────────────────
-	// Pad remaining height so the footer always sits at the bottom.
 	used := len(lines) + 2 // +2 for separator + hints
 	if remaining := height - used; remaining > 0 {
 		lines = append(lines, strings.Repeat("\n", remaining-1))
@@ -98,6 +150,187 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 	lines = append(lines, shippingHints(isMergeReady(entry)))
 
 	return strings.Join(lines, "\n")
+}
+
+// verdictGlyph returns the colored one-character glyph for a verdict.
+func verdictGlyph(v feedbackVerdict) string {
+	switch v {
+	case feedbackApproved:
+		return StyleSuccess.Render("✓")
+	case feedbackDisagreed:
+		return StyleError.Render("✗")
+	default:
+		return StyleSubtle.Render("·")
+	}
+}
+
+// renderFeedbackList renders the left-pane list of feedback items.
+func renderFeedbackList(items []feedbackItem, cursor int, triage map[string]*feedbackTriageEntry, w, h int) []string {
+	header := []string{StyleSubtle.Render("FEEDBACK"), ""}
+	const headerLines = 2
+
+	rowsH := h - headerLines
+	if rowsH < 1 {
+		rowsH = 1
+	}
+	offset := cursor - rowsH/2
+	if offset < 0 {
+		offset = 0
+	}
+	if offset+rowsH > len(items) {
+		offset = len(items) - rowsH
+		if offset < 0 {
+			offset = 0
+		}
+	}
+
+	cursorBar := lipgloss.NewStyle().Foreground(ColorPrimary).Render("│")
+
+	end := offset + rowsH
+	if end > len(items) {
+		end = len(items)
+	}
+	lines := make([]string, 0, h)
+	lines = append(lines, header...)
+
+	for i := offset; i < end; i++ {
+		item := items[i]
+		selected := i == cursor
+		key := feedbackItemKey(item)
+
+		var verdict feedbackVerdict
+		if triage != nil {
+			if e := triage[key]; e != nil {
+				verdict = e.Verdict
+			}
+		}
+		glyph := verdictGlyph(verdict)
+
+		// Note indicator.
+		noteGlyph := "  "
+		if triage != nil {
+			if e := triage[key]; e != nil && strings.TrimSpace(e.Note) != "" {
+				noteGlyph = " " + StyleSubtle.Render("✎")
+			}
+		}
+
+		// Label: reviewer (for body items) or path:line (for inline).
+		var label string
+		if item.IsInline {
+			if item.Line > 0 {
+				label = fmt.Sprintf("%s:%d", item.Path, item.Line)
+			} else {
+				label = item.Path
+			}
+		} else {
+			label = item.Reviewer
+		}
+
+		// Overhead: glyph(1) + space(1) + border×2(4) + note(2) + sep(2)
+		overhead := 1 + 1 + 4 + 2 + 2
+		maxLabelW := w - overhead - 1
+		if maxLabelW < 4 {
+			maxLabelW = 4
+		}
+		// One-line body preview.
+		previewBody := strings.ReplaceAll(item.Body, "\n", " ")
+		// Truncate label; show body preview inline after a colon.
+		labelStr := truncateVisible(label, maxLabelW)
+		rowText := glyph + " " + labelStr + noteGlyph
+
+		if selected {
+			contentW := w - 4
+			if rw := ansi.StringWidth(rowText); rw < contentW {
+				rowText += strings.Repeat(" ", contentW-rw)
+			}
+			_ = previewBody
+			lines = append(lines, " "+cursorBar+rowText+cursorBar+" ")
+		} else {
+			lines = append(lines, "  "+rowText)
+		}
+	}
+	return lines
+}
+
+// renderFeedbackDetail renders the right-pane detail for the cursor-selected item.
+func renderFeedbackDetail(items []feedbackItem, cursor int, triage map[string]*feedbackTriageEntry, scroll, w, h int) []string {
+	if len(items) == 0 || cursor >= len(items) {
+		return []string{StyleSubtle.Render("no feedback")}
+	}
+	item := items[cursor]
+	key := feedbackItemKey(item)
+
+	var lines []string
+
+	// Heading: reviewer + state (or path:line for inline).
+	var heading string
+	stateStyle := StyleSubtle
+	switch item.State {
+	case "APPROVED":
+		stateStyle = StyleSuccess
+	case "CHANGES_REQUESTED":
+		stateStyle = StyleError
+	}
+	if item.IsInline {
+		loc := item.Path
+		if item.Line > 0 {
+			loc = fmt.Sprintf("%s:%d", item.Path, item.Line)
+		}
+		heading = StyleSubtle.Render(loc) + "  " + stateStyle.Render(strings.ToLower(strings.ReplaceAll(item.State, "_", " ")))
+	} else {
+		heading = lipgloss.NewStyle().Bold(true).Render(item.Reviewer) + "  " + stateStyle.Render(strings.ToLower(strings.ReplaceAll(item.State, "_", " ")))
+	}
+	lines = append(lines, heading, "")
+
+	// Wrapped body.
+	wrapped := wrapText(item.Body, w-2)
+	// Scroll offset into wrapped lines.
+	bodyH := h - 4 // leave room for heading + note section
+	if bodyH < 2 {
+		bodyH = 2
+	}
+	maxScroll := len(wrapped) - bodyH
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if scroll > maxScroll {
+		scroll = maxScroll
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+
+	// Scroll affordance above.
+	if scroll > 0 {
+		lines = append(lines, StyleSubtle.Render(fmt.Sprintf("↑ %d lines above", scroll)))
+	}
+
+	end := scroll + bodyH
+	if end > len(wrapped) {
+		end = len(wrapped)
+	}
+	for _, l := range wrapped[scroll:end] {
+		lines = append(lines, l)
+	}
+
+	// Scroll affordance below.
+	remaining := len(wrapped) - end
+	if remaining > 0 {
+		lines = append(lines, StyleSubtle.Render(fmt.Sprintf("↓ %d below", remaining)))
+	}
+
+	// Note section.
+	if triage != nil {
+		if e := triage[key]; e != nil && strings.TrimSpace(e.Note) != "" {
+			lines = append(lines, "")
+			lines = append(lines, StyleSubtle.Render("Your note:"))
+			for _, noteLine := range wrapText(e.Note, w-2) {
+				lines = append(lines, "  "+noteLine)
+			}
+		}
+	}
+
+	return lines
 }
 
 // renderCheckRow renders one check-run line: status icon + name + duration.

--- a/internal/tui/shippingpanel.go
+++ b/internal/tui/shippingpanel.go
@@ -260,7 +260,7 @@ func renderFeedbackDetail(items []feedbackItem, cursor int, triage map[string]*f
 	item := items[cursor]
 	key := feedbackItemKey(item)
 
-	var lines []string
+	lines := make([]string, 0, h)
 
 	// Heading: reviewer + state (or path:line for inline).
 	var heading string
@@ -309,9 +309,7 @@ func renderFeedbackDetail(items []feedbackItem, cursor int, triage map[string]*f
 	if end > len(wrapped) {
 		end = len(wrapped)
 	}
-	for _, l := range wrapped[scroll:end] {
-		lines = append(lines, l)
-	}
+	lines = append(lines, wrapped[scroll:end]...)
 
 	// Scroll affordance below.
 	remaining := len(wrapped) - end
@@ -369,39 +367,6 @@ func renderCheckRow(run github.CheckRun, width int) string {
 		row += strings.Repeat(" ", padW) + StyleSubtle.Render(dur)
 	}
 	return row
-}
-
-// renderReviewThread renders one reviewer block (state + body + inline comments).
-func renderReviewThread(thread github.ReviewThread, width int) []string {
-	lines := make([]string, 0, 2+len(thread.Comments)*2)
-
-	stateStyle := StyleSubtle
-	switch thread.State {
-	case "APPROVED":
-		stateStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
-	case "CHANGES_REQUESTED":
-		stateStyle = lipgloss.NewStyle().Foreground(ColorError)
-	}
-	header := "  " + lipgloss.NewStyle().Bold(true).Render(thread.Reviewer) +
-		"  " + stateStyle.Render(strings.ToLower(strings.ReplaceAll(thread.State, "_", " ")))
-	lines = append(lines, header)
-
-	if thread.Body != "" {
-		body := truncateVisible(thread.Body, width-6)
-		lines = append(lines, "    "+StyleSubtle.Render(body))
-	}
-
-	for _, c := range thread.Comments {
-		fileLabel := StyleSubtle.Render(c.Path)
-		if c.Line > 0 {
-			fileLabel += StyleSubtle.Render(fmt.Sprintf(":%d", c.Line))
-		}
-		lines = append(lines, "    "+fileLabel)
-		commentBody := truncateVisible(c.Body, width-8)
-		lines = append(lines, "      "+commentBody)
-	}
-	lines = append(lines, "")
-	return lines
 }
 
 // feedbackVerdict is the user's disposition on a single feedback item.

--- a/internal/tui/shippingpanel.go
+++ b/internal/tui/shippingpanel.go
@@ -171,6 +171,69 @@ func renderReviewThread(thread github.ReviewThread, width int) []string {
 	return lines
 }
 
+// feedbackVerdict is the user's disposition on a single feedback item.
+type feedbackVerdict int
+
+const (
+	feedbackNeutral   feedbackVerdict = iota
+	feedbackApproved                  // user agreed; item will be addressed
+	feedbackDisagreed                 // user disputes; item framed as advisory
+)
+
+// feedbackTriageEntry holds the verdict and optional guidance note for one item.
+type feedbackTriageEntry struct {
+	Verdict feedbackVerdict
+	Note    string
+}
+
+// feedbackItem is a flattened view of a single piece of review feedback.
+type feedbackItem struct {
+	Reviewer  string
+	State     string
+	Path      string
+	Line      int
+	Body      string
+	CommentID int64
+	IsInline  bool
+}
+
+// feedbackItems flattens review threads into an ordered slice of feedback items.
+// For each thread: one body item (when non-empty), then one item per inline comment.
+func feedbackItems(threads []github.ReviewThread) []feedbackItem {
+	var items []feedbackItem
+	for _, t := range threads {
+		if strings.TrimSpace(t.Body) != "" {
+			items = append(items, feedbackItem{
+				Reviewer: t.Reviewer,
+				State:    t.State,
+				Body:     t.Body,
+				IsInline: false,
+			})
+		}
+		for _, c := range t.Comments {
+			items = append(items, feedbackItem{
+				Reviewer:  t.Reviewer,
+				State:     t.State,
+				Path:      c.Path,
+				Line:      c.Line,
+				Body:      c.Body,
+				CommentID: c.ID,
+				IsInline:  true,
+			})
+		}
+	}
+	return items
+}
+
+// feedbackItemKey returns the stable triage map key for an item.
+// Inline comments use "comment:<id>"; thread bodies use "thread:<reviewer>".
+func feedbackItemKey(item feedbackItem) string {
+	if item.IsInline {
+		return fmt.Sprintf("comment:%d", item.CommentID)
+	}
+	return "thread:" + item.Reviewer
+}
+
 // shippingHints returns the action hint line for the shipping panel footer.
 func shippingHints(mergeReady bool) string {
 	mKey := lipgloss.NewStyle().Foreground(lipgloss.Color("#5ab58a")).Render("m")

--- a/internal/tui/shippingpanel_test.go
+++ b/internal/tui/shippingpanel_test.go
@@ -115,6 +115,66 @@ func TestRenderShippingPanel_UnknownMergeable(t *testing.T) {
 	}
 }
 
+func TestFeedbackItems_FlattensThreadsAndComments(t *testing.T) {
+	threads := []github.ReviewThread{
+		{
+			Reviewer: "alice",
+			State:    "CHANGES_REQUESTED",
+			Body:     "please fix",
+			Comments: []github.ReviewComment{
+				{ID: 101, Path: "a.go", Body: "nit one", Line: 5},
+				{ID: 202, Path: "b.go", Body: "nit two", Line: 10},
+			},
+		},
+	}
+	items := feedbackItems(threads)
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d: %+v", len(items), items)
+	}
+	// First: thread body item.
+	if items[0].Body != "please fix" || items[0].IsInline || items[0].Reviewer != "alice" {
+		t.Errorf("item[0] unexpected: %+v", items[0])
+	}
+	if k := feedbackItemKey(items[0]); k != "thread:alice" {
+		t.Errorf("item[0] key = %q, want thread:alice", k)
+	}
+	// Second: inline comment 101.
+	if !items[1].IsInline || items[1].CommentID != 101 {
+		t.Errorf("item[1] unexpected: %+v", items[1])
+	}
+	if k := feedbackItemKey(items[1]); k != "comment:101" {
+		t.Errorf("item[1] key = %q, want comment:101", k)
+	}
+	// Third: inline comment 202.
+	if !items[2].IsInline || items[2].CommentID != 202 {
+		t.Errorf("item[2] unexpected: %+v", items[2])
+	}
+	if k := feedbackItemKey(items[2]); k != "comment:202" {
+		t.Errorf("item[2] key = %q, want comment:202", k)
+	}
+}
+
+func TestFeedbackItems_SkipsEmptyThreadBody(t *testing.T) {
+	threads := []github.ReviewThread{
+		{
+			Reviewer: "bob",
+			State:    "APPROVED",
+			Body:     "  ",
+			Comments: []github.ReviewComment{
+				{ID: 5, Path: "x.go", Body: "nice", Line: 1},
+			},
+		},
+	}
+	items := feedbackItems(threads)
+	// Only the inline comment, not the whitespace-only body.
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (body skipped), got %d", len(items))
+	}
+	if items[0].CommentID != 5 {
+		t.Errorf("expected inline comment ID 5, got %+v", items[0])
+	}
+}
+
 func TestRenderCheckRow_DurationFormat(t *testing.T) {
 	run := github.CheckRun{
 		Name:       "my-check",

--- a/internal/tui/shippingpanel_test.go
+++ b/internal/tui/shippingpanel_test.go
@@ -115,6 +115,29 @@ func TestRenderShippingPanel_UnknownMergeable(t *testing.T) {
 	}
 }
 
+func TestRenderShippingPanel_HintsListsTriageKeys(t *testing.T) {
+	sess := agent.NewSessionForTest("s-hints", "ship-it")
+	entry := &prCacheEntry{
+		pr: &github.PRState{
+			Number:         1,
+			Title:          "T",
+			BaseBranch:     "main",
+			MergeableState: "clean",
+		},
+	}
+	out := renderShippingPanel(sess, entry, 120, 30, 0, 0, nil)
+	stripped := ansi.Strip(out)
+	if !strings.Contains(stripped, "a — approve") {
+		t.Errorf("hint 'a — approve' missing: %q", stripped)
+	}
+	if !strings.Contains(stripped, "x — disagree") {
+		t.Errorf("hint 'x — disagree' missing: %q", stripped)
+	}
+	if !strings.Contains(stripped, "n — note") {
+		t.Errorf("hint 'n — note' missing: %q", stripped)
+	}
+}
+
 func TestRenderShippingPanel_TwoPaneFullBody(t *testing.T) {
 	sess := agent.NewSessionForTest("s5", "ship-it")
 	// 400-char body with no newlines — old truncateVisible would clip it.

--- a/internal/tui/shippingpanel_test.go
+++ b/internal/tui/shippingpanel_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRenderShippingPanel_NilEntry(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship-it")
-	out := renderShippingPanel(sess, nil, 100, 30)
+	out := renderShippingPanel(sess, nil, 100, 30, 0, 0, nil)
 	if !strings.Contains(out, "SHIPPING") {
 		t.Errorf("header missing: %q", out)
 	}
@@ -52,7 +52,7 @@ func TestRenderShippingPanel_WithEntry(t *testing.T) {
 		},
 	}
 
-	out := renderShippingPanel(sess, entry, 100, 40)
+	out := renderShippingPanel(sess, entry, 100, 40, 0, 0, nil)
 	stripped := ansi.Strip(out)
 
 	if !strings.Contains(out, "#42") {
@@ -88,7 +88,7 @@ func TestRenderShippingPanel_MergeReady(t *testing.T) {
 		checks:  &github.CheckStatus{State: "success", Total: 2, Passed: 2},
 		reviews: &github.ReviewStatus{State: "approved", Approved: 1},
 	}
-	out := renderShippingPanel(sess, entry, 100, 30)
+	out := renderShippingPanel(sess, entry, 100, 30, 0, 0, nil)
 	stripped := ansi.Strip(out)
 	if !strings.Contains(stripped, "Ready") {
 		t.Errorf("Ready phrase missing: %q", stripped)
@@ -105,13 +105,50 @@ func TestRenderShippingPanel_UnknownMergeable(t *testing.T) {
 			MergeableState: "unknown",
 		},
 	}
-	out := renderShippingPanel(sess, entry, 100, 30)
+	out := renderShippingPanel(sess, entry, 100, 30, 0, 0, nil)
 	stripped := ansi.Strip(out)
 	if !strings.Contains(stripped, "checking") {
 		t.Errorf("expected 'checking' for unknown mergeable state: %q", stripped)
 	}
 	if strings.Contains(stripped, "conflicts") {
 		t.Errorf("unexpected 'conflicts' for unknown mergeable state: %q", stripped)
+	}
+}
+
+func TestRenderShippingPanel_TwoPaneFullBody(t *testing.T) {
+	sess := agent.NewSessionForTest("s5", "ship-it")
+	// 400-char body with no newlines — old truncateVisible would clip it.
+	longBody := strings.Repeat("x", 50) + " " + strings.Repeat("y", 50) + " " +
+		strings.Repeat("z", 50) + " " + strings.Repeat("a", 50) + " " +
+		strings.Repeat("b", 50) + " " + strings.Repeat("c", 50) + " " +
+		strings.Repeat("d", 50) + " " + strings.Repeat("e", 7)
+	entry := &prCacheEntry{
+		pr: &github.PRState{
+			Number:         99,
+			Title:          "Long body PR",
+			BaseBranch:     "main",
+			MergeableState: "clean",
+		},
+		threads: []github.ReviewThread{
+			{
+				Reviewer: "reviewer1",
+				State:    "CHANGES_REQUESTED",
+				Body:     longBody,
+			},
+		},
+	}
+	out := renderShippingPanel(sess, entry, 120, 40, 0, 0, nil)
+	stripped := ansi.Strip(out)
+
+	// Reviewer name appears in left pane.
+	if !strings.Contains(stripped, "reviewer1") {
+		t.Errorf("reviewer name missing from left pane: %q", stripped)
+	}
+	// A substring from the *end* of the body that truncateVisible would have dropped.
+	// The old width-8 truncateVisible on a 100-wide panel would cut at ~92 chars.
+	// We look for content from the last word (8 e's).
+	if !strings.Contains(stripped, "eeeeeee") {
+		t.Errorf("full body not shown — late content missing: %q", stripped)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR implements a comprehensive feedback triage system for the shipping panel, enabling human operators to review, approve, disagree with, and add context notes to agent feedback before agent handoff. Key changes:

- **Stable feedback identity**: Added ID field to ReviewComment, persisting across PR poll cycles
- **Feedback triage types**: Introduced feedbackVerdict and feedbackTriageEntry types with item-flattening helpers
- **Two-pane review UI**: Refactored renderShippingPanel into cursor-driven list (verdict glyph, reviewer, path) and scrollable detail (full word-wrapped body). Automatically stacks vertically on narrow terminals (<80 cols)
- **Keyboard navigation**: j/k/up/down for list cursor, pgdn/pgup/ctrl+d/ctrl+u for detail scroll; auto-resets on panel open
- **Human verdict actions**: a/approve, x/disagree, u/clear, with optional modal (alt+n) for adding disagreement context
- **Agent handoff integration**: Rewrote buildFeedbackPrompt to consume triage—approved and neutral items go to "Feedback to address", disagreed-with-notes go to "Disputed feedback", disagreed-no-note items are skipped. Clears session triage after spawning agent for clean rework round
- **Footer affordances**: Added verdict key chips for discoverability

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI:
  - Navigate feedback list with j/k, verify cursor and pane sync
  - Scroll detail with pgdn/pgup, verify word wrapping and viewport
  - Press a/x/u, verify verdict glyph updates
  - Press alt+n on disagreement, add note, submit, verify in "Disputed feedback" section
  - Press r to spawn agent, verify triage clears and next rework starts neutral
  - Verify narrow terminal stacks panes vertically

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]`
- [ ] Feedback triage and modal interactions covered by tests
- [ ] No new public API surface