### PR TITLE
Add collapsible plan sections with focused navigation

### DIFF
--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -350,8 +350,9 @@ func (m *planEditorModel) reload() {
 	m.rebuildSections()
 }
 
-// rebuildSections parses the current plan into sections and seeds folds,
-// preserving any existing fold state for headings that still exist.
+// rebuildSections parses the current plan into sections and applies the
+// default fold policy to every heading. It does NOT preserve existing fold
+// state — callers that need preservation (see Reload) must do so explicitly.
 //
 // Fold state is keyed by heading text, not by position. If two H2s share the
 // same name (non-canonical but user-editable), they collapse/expand together —
@@ -363,11 +364,7 @@ func (m *planEditorModel) rebuildSections() {
 	newSections := parsePlanSections(srcLines, ctxs)
 	newFolds := make(map[string]bool, len(newSections))
 	for _, s := range newSections {
-		if existing, ok := m.folds[s.heading]; ok {
-			newFolds[s.heading] = existing
-		} else {
-			newFolds[s.heading] = defaultSectionFolded(s.heading, s.level)
-		}
+		newFolds[s.heading] = defaultSectionFolded(s.heading, s.level)
 	}
 	m.sections = newSections
 	m.folds = newFolds
@@ -381,9 +378,24 @@ func splitPlanLines(plan string) []string {
 	return strings.Split(plan, "\n")
 }
 
-// Reload is the exported version called by the App when a draft completes
-// or a revise lands.
-func (m *planEditorModel) Reload() { m.reload() }
+// Reload is called by the App when a draft completes or a revise lands. It
+// re-reads the plan from disk and preserves fold state for every heading name
+// that still exists in the new content. New headings receive the default fold
+// policy (spec item 2); vanished headings are dropped silently.
+func (m *planEditorModel) Reload() {
+	// Snapshot current fold state before reload resets it to defaults.
+	savedFolds := make(map[string]bool, len(m.folds))
+	for heading, folded := range m.folds {
+		savedFolds[heading] = folded
+	}
+	m.reload()
+	// Overwrite default folds with saved state for any heading that survived.
+	for _, s := range m.sections {
+		if saved, ok := savedFolds[s.heading]; ok {
+			m.folds[s.heading] = saved
+		}
+	}
+}
 
 // Update routes a key event. The caller should already have dispatched
 // other tea.Msg types (resize, ticks).

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -418,6 +418,25 @@ func (m *planEditorModel) Update(msg tea.Msg) tea.Cmd {
 	}
 }
 
+// activeSectionIndex returns the index into m.sections of the section that
+// contains the current viewport top (m.scrollOff). Returns -1 if there are no
+// sections or if scrollOff is in the preamble before any section heading.
+func (m *planEditorModel) activeSectionIndex() int {
+	// Ensure sectionDisplayStart is populated.
+	m.displayLines()
+	if len(m.sectionDisplayStart) == 0 {
+		return -1
+	}
+	// Walk backward to find the last section whose display start <= scrollOff.
+	result := -1
+	for i, start := range m.sectionDisplayStart {
+		if start <= m.scrollOff {
+			result = i
+		}
+	}
+	return result
+}
+
 func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
 	if m.drafting {
 		// Only esc/q work during drafting; everything else is a no-op so the
@@ -461,6 +480,15 @@ func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
 	case "G", "end":
 		m.scrollOff = len(m.displayLines())
 		m.clampScroll()
+		return nil
+	case "tab":
+		idx := m.activeSectionIndex()
+		if idx >= 0 {
+			heading := m.sections[idx].heading
+			m.folds[heading] = !m.folds[heading]
+			m.invalidateDisplayCache()
+			m.clampScroll()
+		}
 		return nil
 	case "i":
 		if m.revising {

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -130,9 +130,9 @@ type planEditorModel struct {
 	//
 	// sectionDisplayStart[i] is the display-line index where sections[i]'s
 	// heading line appears. Recomputed with displayCache.
-	displayCache         []string
-	displayCacheKey      displayCacheKey
-	sectionDisplayStart  []int
+	displayCache        []string
+	displayCacheKey     displayCacheKey
+	sectionDisplayStart []int
 
 	// Planner question state. When questionAnswerCh is non-nil, the editor is
 	// in planEditorModeQuestion and mirrors the question text + a single-line

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"crypto/sha256"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -126,8 +127,12 @@ type planEditorModel struct {
 	// foldsHash is included in the key because a fold toggle changes the
 	// displayed lines without changing the plan content; missing this would
 	// return stale lines from cache after a toggle.
-	displayCache    []string
-	displayCacheKey displayCacheKey
+	//
+	// sectionDisplayStart[i] is the display-line index where sections[i]'s
+	// heading line appears. Recomputed with displayCache.
+	displayCache         []string
+	displayCacheKey      displayCacheKey
+	sectionDisplayStart  []int
 
 	// Planner question state. When questionAnswerCh is non-nil, the editor is
 	// in planEditorModeQuestion and mirrors the question text + a single-line
@@ -614,23 +619,133 @@ func (m *planEditorModel) emitClose() tea.Cmd {
 	return func() tea.Msg { return planEditorCloseMsg{sessionID: sessID} }
 }
 
-// displayLines returns the post-wrap, post-style ANSI display lines for the
-// current textarea content at the current width. Result is cached on the
-// model keyed by (width, valueHash); the renderer itself caches at a coarser
-// grain so cross-frame reuse is cheap even when the editor is reconstructed.
+// foldsHashFor computes a stable hash over the current fold state so it can be
+// included in displayCacheKey. The hash is built from "heading|folded\n" pairs
+// in section order so that reordering is detectable (though the canonical plan
+// format has unique names, reordering is still a content change).
+func (m *planEditorModel) foldsHashFor() [32]byte {
+	var sb strings.Builder
+	for _, s := range m.sections {
+		folded := m.folds[s.heading]
+		if folded {
+			fmt.Fprintf(&sb, "%s|1\n", s.heading)
+		} else {
+			fmt.Fprintf(&sb, "%s|0\n", s.heading)
+		}
+	}
+	return sha256.Sum256([]byte(sb.String()))
+}
+
+// invalidateDisplayCache zeroes the display cache key so the next displayLines
+// call rebuilds from scratch.
+func (m *planEditorModel) invalidateDisplayCache() {
+	m.displayCacheKey = displayCacheKey{}
+	m.displayCache = nil
+	m.sectionDisplayStart = nil
+}
+
+// displayLines returns the fold-aware, post-wrap, post-style ANSI display lines
+// for the current textarea content at the current width. Collapsed sections
+// appear as a single line with ▶ glyph, heading text, and hidden-line count.
+// Expanded sections prepend ▼ to the heading line. Preamble lines (before the
+// first H1/H2) are always shown.
+//
+// Result is cached on (width, valueHash, foldsHash); the renderer itself caches
+// at a coarser grain so cross-frame reuse is cheap.
+//
+// sectionDisplayStart is populated as a side-effect of building the cache so
+// navigation ([ and ]) and tab-fold detection can look up section positions
+// without re-scanning.
 func (m *planEditorModel) displayLines() []string {
 	v := m.textarea.Value()
 	if v == "" {
 		return nil
 	}
 	w := m.contentWidth()
-	key := displayCacheKey{width: w, valueHash: sha256.Sum256([]byte(v))}
+	key := displayCacheKey{
+		width:     w,
+		valueHash: sha256.Sum256([]byte(v)),
+		foldsHash: m.foldsHashFor(),
+	}
 	if m.displayCache != nil && m.displayCacheKey == key {
 		return m.displayCache
 	}
-	out := m.renderer.RenderLines(v, w)
+
+	// If there are no sections at all, fall back to the plain renderer path.
+	if len(m.sections) == 0 {
+		out := m.renderer.RenderLines(v, w)
+		m.displayCache = out
+		m.displayCacheKey = key
+		m.sectionDisplayStart = nil
+		return out
+	}
+
+	srcLines := splitPlanLines(v)
+	ctxs := m.renderer.LineContexts(v)
+	sectionStarts := make([]int, len(m.sections))
+
+	var out []string
+
+	// Preamble: source lines before the first section heading.
+	preambleEnd := m.sections[0].headingLine
+	for i := 0; i < preambleEnd && i < len(srcLines); i++ {
+		var ctx mdrender.LineCtx
+		if i < len(ctxs) {
+			ctx = ctxs[i]
+		}
+		out = append(out, m.renderer.StyleLine(srcLines[i], ctx, w)...)
+	}
+
+	// Sections.
+	for si, s := range m.sections {
+		sectionStarts[si] = len(out)
+		folded := m.folds[s.heading]
+
+		// Render the heading line with ▼/▶ glyph.
+		var headingCtx mdrender.LineCtx
+		if s.headingLine < len(ctxs) {
+			headingCtx = ctxs[s.headingLine]
+		}
+		headingSegs := m.renderer.StyleLine(srcLines[s.headingLine], headingCtx, w)
+		if len(headingSegs) == 0 {
+			headingSegs = []string{""}
+		}
+		glyph := StyleSubtle.Render("▼ ")
+		if folded {
+			glyph = StyleSubtle.Render("▶ ")
+		}
+		headingLine := glyph + headingSegs[0]
+		if folded {
+			// Count hidden source lines, excluding a trailing empty line that is
+			// an artifact of the final \n in well-formed plan files.
+			hiddenSlice := srcLines[s.headingLine+1 : s.nextLine]
+			hiddenCount := len(hiddenSlice)
+			if hiddenCount > 0 && hiddenSlice[hiddenCount-1] == "" {
+				hiddenCount--
+			}
+			headingLine += StyleSubtle.Render(fmt.Sprintf("  · %d lines", hiddenCount))
+		}
+		out = append(out, headingLine)
+		// Additional wrapped heading segments (rare but possible on narrow terminals).
+		out = append(out, headingSegs[1:]...)
+
+		if folded {
+			continue
+		}
+
+		// Expanded: emit all content lines within this section.
+		for i := s.headingLine + 1; i < s.nextLine && i < len(srcLines); i++ {
+			var ctx mdrender.LineCtx
+			if i < len(ctxs) {
+				ctx = ctxs[i]
+			}
+			out = append(out, m.renderer.StyleLine(srcLines[i], ctx, w)...)
+		}
+	}
+
 	m.displayCache = out
 	m.displayCacheKey = key
+	m.sectionDisplayStart = sectionStarts
 	return out
 }
 

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -352,6 +352,10 @@ func (m *planEditorModel) reload() {
 
 // rebuildSections parses the current plan into sections and seeds folds,
 // preserving any existing fold state for headings that still exist.
+//
+// Fold state is keyed by heading text, not by position. If two H2s share the
+// same name (non-canonical but user-editable), they collapse/expand together —
+// accepted rather than introducing a positional disambiguator.
 func (m *planEditorModel) rebuildSections() {
 	v := m.textarea.Value()
 	srcLines := splitPlanLines(v)
@@ -782,11 +786,13 @@ func (m *planEditorModel) displayLines() []string {
 		}
 		headingLine := glyph + headingSegs[0]
 		if folded {
-			// Count hidden source lines, excluding a trailing empty line that is
-			// an artifact of the final \n in well-formed plan files.
+			// Count hidden source lines. Only strip a trailing "" for the last
+			// section (where strings.Split produces a spurious empty entry from
+			// the final \n). For mid-plan sections the final "" is a real blank
+			// line the user typed before the next heading and should be counted.
 			hiddenSlice := srcLines[s.headingLine+1 : s.nextLine]
 			hiddenCount := len(hiddenSlice)
-			if hiddenCount > 0 && hiddenSlice[hiddenCount-1] == "" {
+			if s.nextLine == len(srcLines) && hiddenCount > 0 && hiddenSlice[hiddenCount-1] == "" {
 				hiddenCount--
 			}
 			headingLine += StyleSubtle.Render(fmt.Sprintf("  · %d lines", hiddenCount))

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -370,6 +370,22 @@ func (m *planEditorModel) rebuildSections() {
 	m.folds = newFolds
 }
 
+// rebuildSectionsPreservingFolds rebuilds section boundaries from the current
+// textarea value, restoring fold state for any heading that survives the edit.
+// New headings receive the default fold policy; vanished headings are dropped.
+func (m *planEditorModel) rebuildSectionsPreservingFolds() {
+	savedFolds := make(map[string]bool, len(m.folds))
+	for heading, folded := range m.folds {
+		savedFolds[heading] = folded
+	}
+	m.rebuildSections()
+	for _, s := range m.sections {
+		if saved, ok := savedFolds[s.heading]; ok {
+			m.folds[s.heading] = saved
+		}
+	}
+}
+
 // splitPlanLines splits plan content on "\n", matching mdrender's convention.
 func splitPlanLines(plan string) []string {
 	if plan == "" {
@@ -509,6 +525,9 @@ func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
 	case "]":
 		m.displayLines() // ensure sectionDisplayStart is populated
 		for _, start := range m.sectionDisplayStart {
+			// Strict > so that pressing ] from exactly on a heading advances
+			// to the *next* heading. Two presses from the same heading are a
+			// no-op on the second press, which is intentional.
 			if start > m.scrollOff {
 				m.scrollOff = start
 				m.clampScroll()
@@ -603,6 +622,7 @@ func (m *planEditorModel) updateEdit(msg tea.KeyPressMsg) tea.Cmd {
 		// the user can scroll and approve without losing typed content. The
 		// dirty indicator stays visible until ctrl+s or `a` writes to disk.
 		m.textarea.Blur()
+		m.rebuildSectionsPreservingFolds()
 		m.mode = planEditorModeScroll
 		return nil
 	case "ctrl+s":
@@ -618,6 +638,7 @@ func (m *planEditorModel) updateEdit(msg tea.KeyPressMsg) tea.Cmd {
 		m.dirty = false
 		m.saveNote = "saved"
 		m.saveAt = time.Now()
+		m.rebuildSectionsPreservingFolds()
 		sessID := m.sess.ID
 		return func() tea.Msg { return planEditorSavedMsg{sessionID: sessID} }
 	}
@@ -766,7 +787,7 @@ func (m *planEditorModel) displayLines() []string {
 	ctxs := m.renderer.LineContexts(v)
 	sectionStarts := make([]int, len(m.sections))
 
-	var out []string
+	out := make([]string, 0, len(srcLines))
 
 	// Preamble: source lines before the first section heading.
 	preambleEnd := m.sections[0].headingLine

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -988,7 +988,10 @@ func (m *planEditorModel) renderFooter() string {
 		hints = StyleActive.Render("enter") + StyleSubtle.Render(" answer  ") +
 			StyleActive.Render("esc") + StyleSubtle.Render(" skip")
 	default:
-		hints = StyleActive.Render("i") + StyleSubtle.Render(" edit  ") +
+		hints = StyleActive.Render("tab") + StyleSubtle.Render(" fold  ") +
+			StyleActive.Render("[ ]") + StyleSubtle.Render(" sections  ") +
+			StyleActive.Render("Z") + StyleSubtle.Render(" toggle all  ") +
+			StyleActive.Render("i") + StyleSubtle.Render(" edit  ") +
 			StyleActive.Render("r") + StyleSubtle.Render(" revise  ")
 		if m.sess != nil && m.sess.HasPrevPlan() {
 			hints += StyleActive.Render("u") + StyleSubtle.Render(" undo  ")

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -19,6 +19,56 @@ import (
 // Hardcoded for now — a follow-up will plumb this through config.Settings.
 const planEditorChromaStyle = "monokai"
 
+// planSection represents one H1 or H2 ATX section in the plan. headingLine is
+// the 0-based source-line index of the `#`/`##` line; nextLine is the index of
+// the next sibling-or-ancestor heading (or end-of-lines). level is 1 or 2.
+// heading is the trimmed text after the `#` characters.
+type planSection struct {
+	headingLine int
+	nextLine    int
+	level       int
+	heading     string
+}
+
+// parsePlanSections walks LineContexts and builds the ordered section list.
+// preamble lines before the first H1/H2 are not represented here; callers
+// handle them as source lines [0, sections[0].headingLine).
+func parsePlanSections(srcLines []string, ctxs []mdrender.LineCtx) []planSection {
+	var sections []planSection
+	for i, ctx := range ctxs {
+		if ctx.Kind == mdrender.LineHeading && ctx.HeadingLevel <= 2 {
+			heading := strings.TrimSpace(strings.TrimLeft(srcLines[i], "#\t "))
+			sections = append(sections, planSection{
+				headingLine: i,
+				level:       ctx.HeadingLevel,
+				heading:     heading,
+			})
+		}
+	}
+	// Fill nextLine: each section ends where the next one begins (or at len(srcLines)).
+	for i := range sections {
+		if i+1 < len(sections) {
+			sections[i].nextLine = sections[i+1].headingLine
+		} else {
+			sections[i].nextLine = len(srcLines)
+		}
+	}
+	return sections
+}
+
+// defaultSectionFolded returns the initial fold state for a section.
+// H1 sections and H2 Spec/Tasks/Goal are expanded; every other H2 is collapsed.
+func defaultSectionFolded(heading string, level int) bool {
+	if level == 1 {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(heading)) {
+	case "spec", "tasks", "goal":
+		return false
+	}
+	return true
+}
+
 // planEditorMode is the editor's current input mode. The default is
 // scroll-mode (read-only navigation); `i` enters edit-mode and `r` enters
 // revise-input-mode. planEditorModeQuestion is entered automatically when
@@ -60,11 +110,22 @@ type planEditorModel struct {
 
 	renderer *mdrender.Renderer
 
+	// sections is the ordered list of H1/H2 sections parsed from the current
+	// plan. folds maps section heading name to its current fold state (true =
+	// collapsed). Both are repopulated by reload() and preserved across Reload()
+	// for headings that survive the edit.
+	sections []planSection
+	folds    map[string]bool
+
 	// displayCache memoises the post-wrap, post-style display lines for the
 	// current textarea value at the current width. Invalidated by content
 	// hash so edits always re-derive. The renderer itself caches at a coarser
 	// grain (sha256(plan), styleName, width) — this avoids the per-frame map
 	// lookup when nothing changed between renders.
+	//
+	// foldsHash is included in the key because a fold toggle changes the
+	// displayed lines without changing the plan content; missing this would
+	// return stale lines from cache after a toggle.
 	displayCache    []string
 	displayCacheKey displayCacheKey
 
@@ -81,11 +142,12 @@ type planEditorModel struct {
 
 // displayCacheKey gates the editor-local cache of display lines. width matters
 // because re-wrap depends on it; valueHash matters because edits change the
-// content. styleName isn't part of the key — the renderer is reused per
-// editor and the style is fixed at construction.
+// content; foldsHash captures the current fold state so toggling a fold
+// invalidates the cache even when the plan content is unchanged.
 type displayCacheKey struct {
 	width     int
 	valueHash [32]byte
+	foldsHash [32]byte
 }
 
 // planEditorApproveMsg is emitted when the user approves the plan (`a`).
@@ -265,6 +327,8 @@ func (m *planEditorModel) resolveQuestion(answer string) {
 }
 
 // reload rereads the plan file from disk and resets dirty/scroll state.
+// It repopulates sections and seeds folds with default values; existing fold
+// state for unchanged heading names is preserved in Reload() by the caller.
 func (m *planEditorModel) reload() {
 	if m.sess == nil {
 		return
@@ -278,6 +342,34 @@ func (m *planEditorModel) reload() {
 	m.textarea.SetValue(plan)
 	m.dirty = false
 	m.scrollOff = 0
+	m.rebuildSections()
+}
+
+// rebuildSections parses the current plan into sections and seeds folds,
+// preserving any existing fold state for headings that still exist.
+func (m *planEditorModel) rebuildSections() {
+	v := m.textarea.Value()
+	srcLines := splitPlanLines(v)
+	ctxs := m.renderer.LineContexts(v)
+	newSections := parsePlanSections(srcLines, ctxs)
+	newFolds := make(map[string]bool, len(newSections))
+	for _, s := range newSections {
+		if existing, ok := m.folds[s.heading]; ok {
+			newFolds[s.heading] = existing
+		} else {
+			newFolds[s.heading] = defaultSectionFolded(s.heading, s.level)
+		}
+	}
+	m.sections = newSections
+	m.folds = newFolds
+}
+
+// splitPlanLines splits plan content on "\n", matching mdrender's convention.
+func splitPlanLines(plan string) []string {
+	if plan == "" {
+		return nil
+	}
+	return strings.Split(plan, "\n")
 }
 
 // Reload is the exported version called by the App when a draft completes

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -513,6 +513,21 @@ func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
 			m.clampScroll()
 		}
 		return nil
+	case "Z":
+		// If any section is expanded, collapse all; otherwise expand all.
+		anyExpanded := false
+		for _, s := range m.sections {
+			if !m.folds[s.heading] {
+				anyExpanded = true
+				break
+			}
+		}
+		for _, s := range m.sections {
+			m.folds[s.heading] = anyExpanded
+		}
+		m.invalidateDisplayCache()
+		m.clampScroll()
+		return nil
 	case "i":
 		if m.revising {
 			return nil

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -490,6 +490,29 @@ func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
 			m.clampScroll()
 		}
 		return nil
+	case "]":
+		m.displayLines() // ensure sectionDisplayStart is populated
+		for _, start := range m.sectionDisplayStart {
+			if start > m.scrollOff {
+				m.scrollOff = start
+				m.clampScroll()
+				return nil
+			}
+		}
+		return nil
+	case "[":
+		m.displayLines() // ensure sectionDisplayStart is populated
+		best := -1
+		for _, start := range m.sectionDisplayStart {
+			if start < m.scrollOff {
+				best = start
+			}
+		}
+		if best >= 0 {
+			m.scrollOff = best
+			m.clampScroll()
+		}
+		return nil
 	case "i":
 		if m.revising {
 			return nil

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -381,6 +381,28 @@ func TestPlanEditor_FoldedSectionsCollapseToMarker(t *testing.T) {
 	}
 }
 
+// TestPlanEditor_FoldedSectionMidPlanCountsBlankLine verifies that a blank line
+// before the next heading is counted as a hidden line (it's real content, not a
+// strings.Split artifact). The trailing-blank strip applies only to the last
+// section whose nextLine == len(srcLines).
+func TestPlanEditor_FoldedSectionMidPlanCountsBlankLine(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	sess, _ := newEditorTestSession(t)
+	// Context has 2 content lines + 1 blank before Tasks — should show 3 lines.
+	const plan = "# Goal\n\n## Context\nctx 1\nctx 2\n\n## Tasks\ntask\n"
+	if err := sess.WritePlan(plan); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	editor := newPlanEditor(sess, "", 80, 30)
+	rendered := testutil.StripANSI(strings.Join(editor.displayLines(), "\n"))
+	if !strings.Contains(rendered, "3 lines") {
+		t.Errorf("mid-plan collapsed section should show '3 lines' (including blank before next heading):\n%s", rendered)
+	}
+}
+
 // TestPlanEditor_TabTogglesFoldAtViewportTop verifies that pressing tab in
 // scroll mode toggles the fold of whichever section contains the viewport top.
 func TestPlanEditor_TabTogglesFoldAtViewportTop(t *testing.T) {

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -374,6 +374,53 @@ func TestPlanEditor_FoldedSectionsCollapseToMarker(t *testing.T) {
 	}
 }
 
+// TestPlanEditor_TabTogglesFoldAtViewportTop verifies that pressing tab in
+// scroll mode toggles the fold of whichever section contains the viewport top.
+func TestPlanEditor_TabTogglesFoldAtViewportTop(t *testing.T) {
+	sess, _ := newEditorTestSession(t)
+	const plan = "# Goal\nGoal body\n\n## Spec\nspec body\n\n## Context\nctx body\n"
+	if err := sess.WritePlan(plan); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	editor := newPlanEditor(sess, "", 80, 30)
+
+	// Initially: Goal expanded, Spec expanded, Context collapsed.
+	if editor.folds["Goal"] {
+		t.Fatal("Goal should be expanded by default")
+	}
+	if editor.folds["Spec"] {
+		t.Fatal("Spec should be expanded by default")
+	}
+	if !editor.folds["Context"] {
+		t.Fatal("Context should be collapsed by default")
+	}
+
+	// Viewport top is at scrollOff=0 → Goal section; pressing tab collapses it.
+	editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if !editor.folds["Goal"] {
+		t.Errorf("after tab at Goal, folds[Goal] = false, want true (collapsed)")
+	}
+
+	// Move viewport to Spec's heading display line, then tab toggles Spec.
+	lines := editor.displayLines()
+	specDisplayLine := -1
+	for i, l := range lines {
+		stripped := testutil.StripANSI(l)
+		if strings.Contains(stripped, "Spec") && strings.Contains(stripped, "##") {
+			specDisplayLine = i
+			break
+		}
+	}
+	if specDisplayLine < 0 {
+		t.Fatal("could not find Spec heading in displayLines")
+	}
+	editor.scrollOff = specDisplayLine
+	editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if !editor.folds["Spec"] {
+		t.Errorf("after tab at Spec, folds[Spec] = false, want true (collapsed)")
+	}
+}
+
 // TestPlanEditor_ScrollModeStylesHeadings asserts that scroll-mode rendering
 // actually emits ANSI styling for known markdown constructs. Without this,
 // a regression that silently nil-checks the renderer or short-circuits

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -297,6 +297,43 @@ func TestPlanEditor_DisplayLineCountAgreesWithRenderer(t *testing.T) {
 	}
 }
 
+// TestPlanEditor_ParsesCanonicalSectionsAndAppliesDefaults verifies that
+// parsePlanSections finds all eight canonical H1/H2 headings and that
+// defaultSectionFolded gives the right initial fold state: Goal (H1), Spec, and
+// Tasks are expanded; every other H2 is collapsed.
+func TestPlanEditor_ParsesCanonicalSectionsAndAppliesDefaults(t *testing.T) {
+	sess, _ := newEditorTestSession(t)
+	const plan = "# Goal\nGoal body\n\n## Spec\nspec\n\n## Context\nctx\n\n## Reuse\nreuse\n\n## Risks\nrisks\n\n## Tasks\n- [ ] t1\n\n## Verification\nverify\n\n## Not in scope\nnot\n"
+	if err := sess.WritePlan(plan); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	editor := newPlanEditor(sess, "", 80, 30)
+	if len(editor.sections) != 8 {
+		t.Fatalf("sections count = %d, want 8", len(editor.sections))
+	}
+	if editor.sections[0].heading != "Goal" || editor.sections[0].level != 1 {
+		t.Errorf("sections[0] = {%q, level %d}, want Goal level 1", editor.sections[0].heading, editor.sections[0].level)
+	}
+	if editor.sections[1].heading != "Spec" {
+		t.Errorf("sections[1].heading = %q, want Spec", editor.sections[1].heading)
+	}
+	if editor.sections[0].headingLine != 0 {
+		t.Errorf("sections[0].headingLine = %d, want 0", editor.sections[0].headingLine)
+	}
+	expanded := []string{"Goal", "Spec", "Tasks"}
+	for _, name := range expanded {
+		if editor.folds[name] {
+			t.Errorf("folds[%q] = true, want false (expanded by default)", name)
+		}
+	}
+	collapsed := []string{"Context", "Reuse", "Risks", "Verification", "Not in scope"}
+	for _, name := range collapsed {
+		if !editor.folds[name] {
+			t.Errorf("folds[%q] = false, want true (collapsed by default)", name)
+		}
+	}
+}
+
 // TestPlanEditor_ScrollModeStylesHeadings asserts that scroll-mode rendering
 // actually emits ANSI styling for known markdown constructs. Without this,
 // a regression that silently nil-checks the renderer or short-circuits

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -269,9 +269,9 @@ func TestPlanEditor_ScrollAndEditModeUseSameWidth(t *testing.T) {
 
 // TestPlanEditor_DisplayLineCountAgreesWithRenderer asserts that the editor's
 // scroll-mode display lines exactly match a direct mdrender call on the same
-// content+width. If this drifts apart the i/esc toggle no longer guarantees
-// "scroll position preserved" — the post-wrap row count would change between
-// modes, scrolling the user past content unexpectedly.
+// content+width when no sections are folded. Folding intentionally elides
+// content lines; this test pins the wrap-parity invariant for the fully-
+// expanded case so the i/esc mode toggle guarantees "scroll position preserved".
 func TestPlanEditor_DisplayLineCountAgreesWithRenderer(t *testing.T) {
 	prev := lipgloss.ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)
@@ -288,6 +288,13 @@ func TestPlanEditor_DisplayLineCountAgreesWithRenderer(t *testing.T) {
 		t.Fatal(err)
 	}
 	editor := newPlanEditor(sess, "", 60, 30)
+
+	// Expand all folds before comparing: folding intentionally elides content
+	// lines, so the line-count invariant only holds when nothing is folded.
+	for k := range editor.folds {
+		editor.folds[k] = false
+	}
+	editor.invalidateDisplayCache()
 
 	scrollLines := editor.displayLines()
 	directLines := mdrender.New("monokai").RenderLines(editor.textarea.Value(), editor.contentWidth())

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -435,7 +435,7 @@ func TestPlanEditor_TabTogglesFoldAtViewportTop(t *testing.T) {
 	specDisplayLine := -1
 	for i, l := range lines {
 		stripped := testutil.StripANSI(l)
-		if strings.Contains(stripped, "Spec") && strings.Contains(stripped, "##") {
+		if strings.Contains(stripped, "Spec") && !strings.Contains(stripped, "Goal") {
 			specDisplayLine = i
 			break
 		}

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -421,6 +421,75 @@ func TestPlanEditor_TabTogglesFoldAtViewportTop(t *testing.T) {
 	}
 }
 
+// TestPlanEditor_BracketsJumpBetweenSections verifies that ] and [ step the
+// viewport to the next and previous section headings respectively, clamping at
+// the ends.
+func TestPlanEditor_BracketsJumpBetweenSections(t *testing.T) {
+	sess, _ := newEditorTestSession(t)
+	// Use non-default folds: all expanded so we get display lines between sections.
+	const plan = "# Goal\nGoal body\n\n## Spec\nspec body\n\n## Tasks\ntask body\n"
+	if err := sess.WritePlan(plan); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	// height=8 gives bodyHeight=3, so clampScroll allows scrolling (content > viewport).
+	editor := newPlanEditor(sess, "", 80, 8)
+	// Expand all sections so navigation has multiple display lines to cross.
+	for k := range editor.folds {
+		editor.folds[k] = false
+	}
+	editor.invalidateDisplayCache()
+	editor.scrollOff = 0
+
+	lines := editor.displayLines()
+	if len(lines) == 0 {
+		t.Fatal("no display lines")
+	}
+
+	// Find display-line indices for ## Spec and ## Tasks headings.
+	specLine, tasksLine := -1, -1
+	for i, l := range lines {
+		stripped := testutil.StripANSI(l)
+		if strings.Contains(stripped, "## Spec") && specLine < 0 {
+			specLine = i
+		}
+		if strings.Contains(stripped, "## Tasks") && tasksLine < 0 {
+			tasksLine = i
+		}
+	}
+	if specLine < 0 || tasksLine < 0 {
+		t.Fatalf("couldn't find section headings; specLine=%d tasksLine=%d\nlines:\n%s",
+			specLine, tasksLine, strings.Join(lines, "\n"))
+	}
+
+	// ] from top → Spec heading.
+	editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
+	if editor.scrollOff != specLine {
+		t.Errorf("] from 0: scrollOff = %d, want %d (Spec)", editor.scrollOff, specLine)
+	}
+
+	// ] again → Tasks heading.
+	editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
+	if editor.scrollOff != tasksLine {
+		t.Errorf("] from Spec: scrollOff = %d, want %d (Tasks)", editor.scrollOff, tasksLine)
+	}
+
+	// ] at last section → no change.
+	editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
+	if editor.scrollOff != tasksLine {
+		t.Errorf("] at last section: scrollOff = %d, want %d (clamp)", editor.scrollOff, tasksLine)
+	}
+
+	// [ twice → back to top (Goal heading).
+	editor.Update(tea.KeyPressMsg{Code: '[', Text: "["})
+	if editor.scrollOff != specLine {
+		t.Errorf("[ from Tasks: scrollOff = %d, want %d (Spec)", editor.scrollOff, specLine)
+	}
+	editor.Update(tea.KeyPressMsg{Code: '[', Text: "["})
+	if editor.scrollOff != 0 {
+		t.Errorf("[ from Spec: scrollOff = %d, want 0 (Goal)", editor.scrollOff)
+	}
+}
+
 // TestPlanEditor_ScrollModeStylesHeadings asserts that scroll-mode rendering
 // actually emits ANSI styling for known markdown constructs. Without this,
 // a regression that silently nil-checks the renderer or short-circuits

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -490,6 +490,34 @@ func TestPlanEditor_BracketsJumpBetweenSections(t *testing.T) {
 	}
 }
 
+// TestPlanEditor_ShiftZTogglesAllFolds verifies that pressing Z collapses every
+// section when any is expanded, and expands every section when all are
+// collapsed.
+func TestPlanEditor_ShiftZTogglesAllFolds(t *testing.T) {
+	sess, _ := newEditorTestSession(t)
+	const plan = "# Goal\nGoal body\n\n## Spec\nspec\n\n## Context\nctx\n\n## Reuse\nreuse\n\n## Risks\nrisks\n\n## Tasks\n- [ ] t1\n\n## Verification\nverify\n\n## Not in scope\nnot\n"
+	if err := sess.WritePlan(plan); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	editor := newPlanEditor(sess, "", 80, 30)
+
+	// Default: Goal/Spec/Tasks expanded, others collapsed. Press Z → all collapsed.
+	editor.Update(tea.KeyPressMsg{Code: 'Z', Text: "Z"})
+	for _, s := range editor.sections {
+		if !editor.folds[s.heading] {
+			t.Errorf("after first Z, folds[%q] = false, want true (all collapsed)", s.heading)
+		}
+	}
+
+	// All collapsed. Press Z again → all expanded.
+	editor.Update(tea.KeyPressMsg{Code: 'Z', Text: "Z"})
+	for _, s := range editor.sections {
+		if editor.folds[s.heading] {
+			t.Errorf("after second Z, folds[%q] = true, want false (all expanded)", s.heading)
+		}
+	}
+}
+
 // TestPlanEditor_ScrollModeStylesHeadings asserts that scroll-mode rendering
 // actually emits ANSI styling for known markdown constructs. Without this,
 // a regression that silently nil-checks the renderer or short-circuits

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -518,6 +518,57 @@ func TestPlanEditor_ShiftZTogglesAllFolds(t *testing.T) {
 	}
 }
 
+// TestPlanEditor_ReloadPreservesFoldsByHeading verifies that after Reload(),
+// existing fold state is preserved for headings that survive the edit, and
+// new headings get their default fold policy.
+func TestPlanEditor_ReloadPreservesFoldsByHeading(t *testing.T) {
+	sess, _ := newEditorTestSession(t)
+	const plan1 = "# Goal\n## Spec\n## Tasks\n"
+	if err := sess.WritePlan(plan1); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	editor := newPlanEditor(sess, "", 80, 30)
+
+	// Manually collapse Spec (user action).
+	editor.folds["Spec"] = true
+
+	// Write a new plan with an extra section.
+	const plan2 = "# Goal\n## Spec\n## Tasks\n## Extra\n"
+	if err := sess.WritePlan(plan2); err != nil {
+		t.Fatalf("WritePlan plan2: %v", err)
+	}
+	editor.Reload()
+
+	if !editor.folds["Spec"] {
+		t.Error("folds[Spec] should remain true after Reload (user-collapsed)")
+	}
+	if editor.folds["Goal"] {
+		t.Error("folds[Goal] should remain false after Reload (H1 default)")
+	}
+	if editor.folds["Tasks"] {
+		t.Error("folds[Tasks] should remain false after Reload (default expanded)")
+	}
+	if !editor.folds["Extra"] {
+		t.Error("folds[Extra] should be true after Reload (new H2 default-collapsed)")
+	}
+}
+
+// TestPlanEditor_ScrollFooterIncludesFoldHints verifies that the footer row in
+// scroll mode mentions the fold-navigation key bindings.
+func TestPlanEditor_ScrollFooterIncludesFoldHints(t *testing.T) {
+	sess, _ := newEditorTestSession(t)
+	if err := sess.WritePlan("# Goal\nsome content\n"); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	editor := newPlanEditor(sess, "", 80, 30)
+	view := testutil.StripANSI(editor.View())
+	for _, want := range []string{"tab", "fold", "[", "]", "Z", "toggle all"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("footer hint %q missing from view:\n%s", want, view)
+		}
+	}
+}
+
 // TestPlanEditor_ScrollModeStylesHeadings asserts that scroll-mode rendering
 // actually emits ANSI styling for known markdown constructs. Without this,
 // a regression that silently nil-checks the renderer or short-circuits

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -334,6 +334,46 @@ func TestPlanEditor_ParsesCanonicalSectionsAndAppliesDefaults(t *testing.T) {
 	}
 }
 
+// TestPlanEditor_FoldedSectionsCollapseToMarker verifies that a collapsed
+// section renders as a single line containing the ▶ glyph, the heading, and a
+// "N lines" suffix, while its content is hidden; expanded sections show their
+// content and use the ▼ glyph.
+func TestPlanEditor_FoldedSectionsCollapseToMarker(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	sess, _ := newEditorTestSession(t)
+	const plan = "# Goal\nGoal body\n\n## Context\nctx line 1\nctx line 2\nctx line 3\n"
+	if err := sess.WritePlan(plan); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	editor := newPlanEditor(sess, "", 80, 30)
+
+	rendered := testutil.StripANSI(strings.Join(editor.displayLines(), "\n"))
+
+	// Goal (H1) is expanded — body should be visible and ▼ present.
+	if !strings.Contains(rendered, "Goal body") {
+		t.Errorf("Goal body missing from rendered output:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "▼") {
+		t.Errorf("expand glyph ▼ missing from rendered output:\n%s", rendered)
+	}
+	// Context (H2) is collapsed by default — heading + lines count visible, content hidden.
+	if !strings.Contains(rendered, "▶") {
+		t.Errorf("collapse glyph ▶ missing from rendered output:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "Context") {
+		t.Errorf("Context heading missing from rendered output:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "3 lines") {
+		t.Errorf("line-count suffix '3 lines' missing:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "ctx line 1") {
+		t.Errorf("collapsed section content 'ctx line 1' should be hidden:\n%s", rendered)
+	}
+}
+
 // TestPlanEditor_ScrollModeStylesHeadings asserts that scroll-mode rendering
 // actually emits ANSI styling for known markdown constructs. Without this,
 // a regression that silently nil-checks the renderer or short-circuits


### PR DESCRIPTION
## Summary

- Implement section folding for plan editor to highlight critical details while collapsing supporting information
- Parse plan sections (H2 headings) and apply default fold policy: Goal, Spec, and Tasks expand; all other sections collapse
- Render collapsed sections as single-line markers showing hidden-line count with ▼/▶ glyphs
- Add keyboard navigation: **Tab** toggles the active section fold, **[**/**]** jump to previous/next section heading, **Z** toggles all folds at once
- Preserve fold state across Reload operations: snapshot current folds before reset, apply defaults to new headings, restore saved state for unchanged headings
- Fix line-counting accuracy for mid-plan sections and trailing blank artifacts

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI:
  - [ ] Open plan editor and verify Goal/Spec/Tasks sections are expanded by default
  - [ ] Verify other H2 sections appear as collapsed one-liners with line counts
  - [ ] Press Tab to toggle collapse on active section; verify scroll repositions appropriately
  - [ ] Press **]** to jump forward through section headings; press **[** to jump backward
  - [ ] Press **Z** to collapse all sections; press **Z** again to expand all
  - [ ] Edit plan (add/remove/rename sections) and Reload; verify fold state persists for unchanged headings
  - [ ] Verify display line count matches renderer when all sections expanded

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]`
- [ ] New behavior has tests (wrap-parity test updated; regression test added for mid-plan line counting)
- [ ] No new public API surface