### PR TITLE
Review panel rework: consolidated diff and spec overlay

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -903,11 +903,11 @@ func ParsePlanSections(plan string) PlanSections {
 	)
 
 	var (
-		cur    field
-		goal   []string
-		spec   []string
-		verif  []string
-		notin  []string
+		cur   field
+		goal  []string
+		spec  []string
+		verif []string
+		notin []string
 	)
 
 	for _, line := range strings.Split(plan, "\n") {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -881,6 +881,81 @@ func ParsePlanTasks(plan string) []PlanTask {
 	return tasks
 }
 
+// PlanSections holds the named sections extracted from a plan markdown document.
+type PlanSections struct {
+	Goal, Spec, Verification, NotInScope string
+}
+
+// ParsePlanSections extracts Goal, Spec, Verification, and Not in scope bodies
+// from plan markdown. It uses a simple state machine: each recognized heading
+// (`# Goal`, `## Spec`, `## Verification`, `## Not in scope`) switches the
+// active section; lines between headings accumulate into the corresponding
+// field. The heading lines themselves are excluded. Body text is trimmed of
+// trailing whitespace.
+func ParsePlanSections(plan string) PlanSections {
+	type field int
+	const (
+		fieldNone field = iota
+		fieldGoal
+		fieldSpec
+		fieldVerification
+		fieldNotInScope
+	)
+
+	var (
+		cur    field
+		goal   []string
+		spec   []string
+		verif  []string
+		notin  []string
+	)
+
+	for _, line := range strings.Split(plan, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch trimmed {
+		case "# Goal":
+			cur = fieldGoal
+			continue
+		case "## Spec":
+			cur = fieldSpec
+			continue
+		case "## Verification":
+			cur = fieldVerification
+			continue
+		case "## Not in scope":
+			cur = fieldNotInScope
+			continue
+		default:
+			// Any other heading (## Context, ## Reuse, etc.) ends the current section.
+			if strings.HasPrefix(trimmed, "# ") || strings.HasPrefix(trimmed, "## ") {
+				cur = fieldNone
+				continue
+			}
+		}
+
+		switch cur {
+		case fieldGoal:
+			goal = append(goal, line)
+		case fieldSpec:
+			spec = append(spec, line)
+		case fieldVerification:
+			verif = append(verif, line)
+		case fieldNotInScope:
+			notin = append(notin, line)
+		}
+	}
+
+	join := func(lines []string) string {
+		return strings.TrimSpace(strings.Join(lines, "\n"))
+	}
+	return PlanSections{
+		Goal:         join(goal),
+		Spec:         join(spec),
+		Verification: join(verif),
+		NotInScope:   join(notin),
+	}
+}
+
 // taskSubjectRE matches "[task N]" at the start of a commit subject where N is
 // a positive integer. Case-insensitive so "[Task 3]" is also accepted.
 var taskSubjectRE = regexp.MustCompile(`(?i)^\[task\s+(\d+)\]`)

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1460,3 +1460,86 @@ func TestSession_CachedPlan_RestorePrevPlanRefreshesCache(t *testing.T) {
 		t.Errorf("after RestorePrevPlan, cache = %q, want %q", plan, v1)
 	}
 }
+
+func TestParsePlanSections(t *testing.T) {
+	fullPlan := `# Goal
+Fix the auth redirect bug.
+
+## Spec
+1. Users are redirected correctly.
+2. Tokens are validated.
+
+## Context
+internal/auth/handler.go:42
+
+## Reuse
+existing middleware helpers
+
+## Risks
+Token expiry edge case
+
+## Tasks
+- [ ] write handler test
+- [ ] implement redirect
+
+## Verification
+go test -race ./internal/auth
+
+## Not in scope
+OAuth2 support`
+
+	t.Run("full plan returns all four sections", func(t *testing.T) {
+		s := ParsePlanSections(fullPlan)
+		if s.Goal != "Fix the auth redirect bug." {
+			t.Errorf("Goal = %q, want %q", s.Goal, "Fix the auth redirect bug.")
+		}
+		if !strings.Contains(s.Spec, "Users are redirected correctly.") {
+			t.Errorf("Spec missing expected content, got %q", s.Spec)
+		}
+		if !strings.Contains(s.Verification, "go test -race ./internal/auth") {
+			t.Errorf("Verification missing expected content, got %q", s.Verification)
+		}
+		if !strings.Contains(s.NotInScope, "OAuth2 support") {
+			t.Errorf("NotInScope missing expected content, got %q", s.NotInScope)
+		}
+	})
+
+	t.Run("missing Verification returns empty string", func(t *testing.T) {
+		plan := "# Goal\nDo a thing.\n\n## Spec\nSome spec.\n\n## Tasks\n- [ ] task\n"
+		s := ParsePlanSections(plan)
+		if s.Verification != "" {
+			t.Errorf("Verification = %q, want empty", s.Verification)
+		}
+		if s.Goal != "Do a thing." {
+			t.Errorf("Goal = %q, want %q", s.Goal, "Do a thing.")
+		}
+	})
+
+	t.Run("only Goal populates Goal, rest empty", func(t *testing.T) {
+		plan := "# Goal\nOnly the goal here.\n"
+		s := ParsePlanSections(plan)
+		if s.Goal != "Only the goal here." {
+			t.Errorf("Goal = %q, want %q", s.Goal, "Only the goal here.")
+		}
+		if s.Spec != "" {
+			t.Errorf("Spec = %q, want empty", s.Spec)
+		}
+		if s.Verification != "" {
+			t.Errorf("Verification = %q, want empty", s.Verification)
+		}
+		if s.NotInScope != "" {
+			t.Errorf("NotInScope = %q, want empty", s.NotInScope)
+		}
+	})
+
+	t.Run("heading lines excluded from body", func(t *testing.T) {
+		plan := "# Goal\nGoal text.\n\n## Spec\nSpec text.\n"
+		s := ParsePlanSections(plan)
+		if strings.Contains(s.Goal, "# Goal") {
+			t.Errorf("Goal body contains heading, got %q", s.Goal)
+		}
+		if strings.Contains(s.Spec, "## Spec") {
+			t.Errorf("Spec body contains heading, got %q", s.Spec)
+		}
+	})
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1232,6 +1232,10 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case reviewDiffMsg:
 		if msg.err == nil && msg.entry != nil {
 			a.reviewDiffCache[msg.sessionID] = msg.entry
+			// Refresh the inline diff viewport when data arrives for the open session.
+			if a.reviewSession != nil && a.reviewSession.ID == msg.sessionID && len(msg.entry.groups) > 0 {
+				a.refreshReviewDiffViewport()
+			}
 			// If the entry has task groups, dispatch a reviewer per group.
 			if len(msg.entry.groups) > 0 {
 				repoPath := a.repoPathForSession(msg.sessionID)
@@ -1731,9 +1735,10 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "j", "down":
 				// Move cursor down in the task list.
 				if entry := a.reviewDiffCache[a.reviewSession.ID]; entry != nil {
-					max := reviewTaskCount(entry) - 1
-					if a.reviewTaskCursor < max {
+					maxIdx := reviewTaskCount(entry) - 1
+					if a.reviewTaskCursor < maxIdx {
 						a.reviewTaskCursor++
+						a.refreshReviewDiffViewport()
 					}
 				}
 				return a, nil
@@ -1741,6 +1746,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Move cursor up in the task list.
 				if a.reviewTaskCursor > 0 {
 					a.reviewTaskCursor--
+					a.refreshReviewDiffViewport()
 				}
 				return a, nil
 			case "f":
@@ -2021,11 +2027,13 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				sess.SetLifecyclePhase(agent.LifecycleInReview)
 				a.reviewSession = sess
 				a.reviewTaskCursor = 0
+				a.reviewDiffCacheByTask = make(map[int]*diffmodel.Model)
 				a.dashboard.panelFocus = focusReview
 				// Fetch diff stats if not already cached.
 				if _, ok := a.reviewDiffCache[sess.ID]; !ok {
 					return a, a.fetchReviewDiffCmd(sess)
 				}
+				a.refreshReviewDiffViewport()
 				return a, nil
 			case "n":
 				if a.cfg != nil && len(a.cfg.Repos) > 1 {
@@ -3546,10 +3554,12 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 		sess.SetLifecyclePhase(agent.LifecycleInReview)
 		a.reviewSession = sess
 		a.reviewTaskCursor = 0
+		a.reviewDiffCacheByTask = make(map[int]*diffmodel.Model)
 		a.dashboard.panelFocus = focusReview
 		if _, ok := a.reviewDiffCache[sess.ID]; !ok {
 			return a.fetchReviewDiffCmd(sess), true
 		}
+		a.refreshReviewDiffViewport()
 		return nil, true
 	case focusSectionShipping:
 		a.shippingSession = sess
@@ -4680,6 +4690,7 @@ func (a *App) addressReviewFeedback(sess *agent.Session) (tea.Model, tea.Cmd) {
 	a.reviewSession = nil
 	a.reviewTaskCursor = 0
 	delete(a.reviewDiffCache, sessID)
+	a.reviewDiffCacheByTask = make(map[int]*diffmodel.Model)
 	a.dashboard.panelFocus = focusList
 	return a, func() tea.Msg {
 		ag, err := mgr.AddAgent(sessID, cfg)
@@ -5064,6 +5075,46 @@ func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
 
 		return reviewDiffMsg{sessionID: sessID, entry: entry}
 	}
+}
+
+// refreshReviewDiffViewport updates the inline diff viewport content for the
+// currently selected task. This ensures scroll clamping (PageDown/PageUp) works
+// correctly. Call this whenever the task cursor changes or when the review panel
+// is first entered. Also resets the scroll to the top.
+func (a *App) refreshReviewDiffViewport() {
+	a.reviewDiffVP.GotoTop()
+	if a.reviewSession == nil {
+		a.reviewDiffVP.SetContent("")
+		return
+	}
+	entry := a.reviewDiffCache[a.reviewSession.ID]
+	if entry == nil {
+		a.reviewDiffVP.SetContent("")
+		return
+	}
+	group := reviewTaskGroupAtCursor(entry, a.reviewTaskCursor)
+	if group == nil || group.rawDiff == "" {
+		a.reviewDiffVP.SetContent("(no diff for this task)")
+		return
+	}
+	// Use cache to avoid re-parsing on each keystroke.
+	idx := a.reviewTaskCursor
+	m, ok := a.reviewDiffCacheByTask[idx]
+	if !ok {
+		var err error
+		m, err = diffmodel.Parse(group.rawDiff)
+		if err != nil || m == nil {
+			a.reviewDiffVP.SetContent("(no diff for this task)")
+			return
+		}
+		a.reviewDiffCacheByTask[idx] = m
+	}
+	// Compute right pane width: mirrors renderReviewPanel's wide-mode formula.
+	rightW := a.width*6/10 - 5
+	if rightW < 20 {
+		rightW = 20
+	}
+	a.reviewDiffVP.SetContent(renderAllFilesUnified(m, rightW))
 }
 
 // populateNoDiffVerdicts stamps verdictNoDiff on every plan task in entry that

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -256,6 +256,7 @@ func NewApp() App {
 		lastKnownStatus:       make(map[string]agent.Status),
 		diffStatsCache:        make(map[string]*diffStatsEntry),
 		reviewDiffCache:       make(map[string]*reviewDiffEntry),
+		reviewDiffVP:          viewport.New(),
 		reviewDiffCacheByTask: make(map[int]*diffmodel.Model),
 		prCache:               make(map[string]*prCacheEntry),
 		prPollStates:          make(map[string]*prSessionState),
@@ -3837,7 +3838,7 @@ func (a App) View() tea.View {
 			} else if a.prComposeModal.Active() {
 				panelStr = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, a.prComposeModal.View())
 			} else {
-				panelStr = renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID, a.reviewDiffVP.YOffset())
+				panelStr = renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID, a.reviewDiffVP.View())
 			}
 			v := tea.NewView(panelStr)
 			v.AltScreen = true
@@ -5108,8 +5109,8 @@ func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
 // correctly. Call this whenever the task cursor changes or when the review panel
 // is first entered. Also resets the scroll to the top.
 func (a *App) refreshReviewDiffViewport() {
-	// Compute diffH using the same layout formula as buildRightPane so that
-	// PageDown/PageUp clamp correctly instead of operating on a zero-height viewport.
+	// Compute layout dimensions mirroring renderReviewPanel's wide-mode formula so
+	// that SetHeight/SetWidth are correct and View()/PageDown/PageUp clamp properly.
 	headerLines := len(renderReviewHeader(a.reviewSession, a.width))
 	footerH := 3
 	bodyH := a.height - headerLines - footerH
@@ -5124,7 +5125,12 @@ func (a *App) refreshReviewDiffViewport() {
 	if diffH < 1 {
 		diffH = 1
 	}
+	rightW := a.width*6/10 - 5
+	if rightW < 20 {
+		rightW = 20
+	}
 	a.reviewDiffVP.SetHeight(diffH)
+	a.reviewDiffVP.SetWidth(rightW)
 	a.reviewDiffVP.GotoTop()
 	if a.reviewSession == nil {
 		a.reviewDiffVP.SetContent("")
@@ -5151,11 +5157,6 @@ func (a *App) refreshReviewDiffViewport() {
 			return
 		}
 		a.reviewDiffCacheByTask[idx] = m
-	}
-	// Compute right pane width: mirrors renderReviewPanel's wide-mode formula.
-	rightW := a.width*6/10 - 5
-	if rightW < 20 {
-		rightW = 20
 	}
 	a.reviewDiffVP.SetContent(renderAllFilesUnified(m, rightW))
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -173,26 +173,26 @@ type App struct {
 	audioPlayer     *audio.Player
 
 	// Wellness state.
-	appStart               time.Time // set once at init; never reset; used for total session duration in wellness log
-	sessionStart           time.Time // per-block work timer; reset on each break completion
-	lastReviewAt           time.Time
-	agentLimitModalActive  bool
-	focusSessionMinutes    int          // cached from resolved global settings
-	focusBreakMinutes      int          // cached from resolved global settings
-	focusPlanningIdx       int          // index into planningSessions()
-	focusBuildingIdx       int          // index into buildingSessions()
-	focusReviewIdx         int          // index into reviewQueueSessions()
-	focusShippingIdx       int          // index into shippingSessions()
-	focusCursorSection     focusSection // which section the pipeline cursor is on
-	focusLaunchAgent       *agent.Agent
-	focusLaunchSession     *agent.Session
-	focusBacklogWarning    bool // first n at backlog limit shows warning; second proceeds
-	focusBreakMode         bool
-	focusBreakStart        time.Time // wall-clock; monotonic stripped so suspend counts toward elapsed
-	focusBlockCount        int
-	focusBreakShortWarning bool
-	focusBreakTimerUp      bool // break duration elapsed; waiting on user to resume
-	focusBreakAnimFrame    int
+	appStart                time.Time // set once at init; never reset; used for total session duration in wellness log
+	sessionStart            time.Time // per-block work timer; reset on each break completion
+	lastReviewAt            time.Time
+	agentLimitModalActive   bool
+	focusSessionMinutes     int          // cached from resolved global settings
+	focusBreakMinutes       int          // cached from resolved global settings
+	focusPlanningIdx        int          // index into planningSessions()
+	focusBuildingIdx        int          // index into buildingSessions()
+	focusReviewIdx          int          // index into reviewQueueSessions()
+	focusShippingIdx        int          // index into shippingSessions()
+	focusCursorSection      focusSection // which section the pipeline cursor is on
+	focusLaunchAgent        *agent.Agent
+	focusLaunchSession      *agent.Session
+	focusBacklogWarning     bool // first n at backlog limit shows warning; second proceeds
+	focusBreakMode          bool
+	focusBreakStart         time.Time // wall-clock; monotonic stripped so suspend counts toward elapsed
+	focusBlockCount         int
+	focusBreakShortWarning  bool
+	focusBreakTimerUp       bool // break duration elapsed; waiting on user to resume
+	focusBreakAnimFrame     int
 	reviewDiffCache         map[string]*reviewDiffEntry                // keyed by session ID
 	reviewSession           *agent.Session                             // session currently open in review panel
 	reviewTaskCursor        int                                        // selected task row in the review task list
@@ -248,23 +248,23 @@ type App struct {
 
 func NewApp() App {
 	return App{
-		view:            ViewDashboard,
-		dashboard:       newDashboardModel(),
-		managers:        make(map[string]*agent.Manager),
-		repoSettings:    make(map[string]*config.RepoSettings),
-		resolvedCache:   make(map[string]config.ResolvedSettings),
-		lastKnownStatus: make(map[string]agent.Status),
-		diffStatsCache:  make(map[string]*diffStatsEntry),
+		view:                  ViewDashboard,
+		dashboard:             newDashboardModel(),
+		managers:              make(map[string]*agent.Manager),
+		repoSettings:          make(map[string]*config.RepoSettings),
+		resolvedCache:         make(map[string]config.ResolvedSettings),
+		lastKnownStatus:       make(map[string]agent.Status),
+		diffStatsCache:        make(map[string]*diffStatsEntry),
 		reviewDiffCache:       make(map[string]*reviewDiffEntry),
 		reviewDiffCacheByTask: make(map[int]*diffmodel.Model),
-		prCache:         make(map[string]*prCacheEntry),
-		prPollStates:    make(map[string]*prSessionState),
-		closingAgents:   make(map[string]bool),
-		closingSessions: make(map[string]bool),
-		feedbackTriage:  make(map[string]map[string]*feedbackTriageEntry),
-		feedbackNote:    newFeedbackNoteModal(),
-		promptModal:     newPromptModal(),
-		prComposeModal:  newPRComposeModal(),
+		prCache:               make(map[string]*prCacheEntry),
+		prPollStates:          make(map[string]*prSessionState),
+		closingAgents:         make(map[string]bool),
+		closingSessions:       make(map[string]bool),
+		feedbackTriage:        make(map[string]map[string]*feedbackTriageEntry),
+		feedbackNote:          newFeedbackNoteModal(),
+		promptModal:           newPromptModal(),
+		prComposeModal:        newPRComposeModal(),
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
@@ -195,6 +196,8 @@ type App struct {
 	reviewDiffCache        map[string]*reviewDiffEntry                // keyed by session ID
 	reviewSession          *agent.Session                             // session currently open in review panel
 	reviewTaskCursor       int                                        // selected task row in the review task list
+	reviewDiffVP           viewport.Model                             // scroll state for the inline diff viewport
+	reviewDiffCacheByTask  map[int]*diffmodel.Model                   // parsed diff per task index; cleared with reviewDiffCache
 	shippingSession        *agent.Session                             // session currently open in shipping panel
 	feedbackTriage         map[string]map[string]*feedbackTriageEntry // keyed by sessionID → itemKey
 	shippingFeedbackCursor int                                        // cursor row in the feedback list pane
@@ -250,7 +253,8 @@ func NewApp() App {
 		resolvedCache:   make(map[string]config.ResolvedSettings),
 		lastKnownStatus: make(map[string]agent.Status),
 		diffStatsCache:  make(map[string]*diffStatsEntry),
-		reviewDiffCache: make(map[string]*reviewDiffEntry),
+		reviewDiffCache:       make(map[string]*reviewDiffEntry),
+		reviewDiffCacheByTask: make(map[int]*diffmodel.Model),
 		prCache:         make(map[string]*prCacheEntry),
 		prPollStates:    make(map[string]*prSessionState),
 		closingAgents:   make(map[string]bool),
@@ -3797,7 +3801,7 @@ func (a App) View() tea.View {
 			if a.prComposeModal.Active() {
 				panelStr = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, a.prComposeModal.View())
 			} else {
-				panelStr = renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID)
+				panelStr = renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID, a.reviewDiffVP.YOffset())
 			}
 			v := tea.NewView(panelStr)
 			v.AltScreen = true

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1627,10 +1627,11 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case "esc":
 					a.reviewSpecOverlayActive = false
 				case "pgdown":
-					a.reviewSpecOverlayScroll++
+					a.reviewSpecOverlayScroll += a.height - 4
 				case "pgup":
-					if a.reviewSpecOverlayScroll > 0 {
-						a.reviewSpecOverlayScroll--
+					a.reviewSpecOverlayScroll -= a.height - 4
+					if a.reviewSpecOverlayScroll < 0 {
+						a.reviewSpecOverlayScroll = 0
 					}
 				case "g":
 					a.reviewSpecOverlayScroll = 0
@@ -5107,6 +5108,23 @@ func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
 // correctly. Call this whenever the task cursor changes or when the review panel
 // is first entered. Also resets the scroll to the top.
 func (a *App) refreshReviewDiffViewport() {
+	// Compute diffH using the same layout formula as buildRightPane so that
+	// PageDown/PageUp clamp correctly instead of operating on a zero-height viewport.
+	headerLines := len(renderReviewHeader(a.reviewSession, a.width))
+	footerH := 3
+	bodyH := a.height - headerLines - footerH
+	if bodyH < 4 {
+		bodyH = 4
+	}
+	maxSummaryH := bodyH / 3
+	if maxSummaryH < 4 {
+		maxSummaryH = 4
+	}
+	diffH := bodyH - maxSummaryH - 1
+	if diffH < 1 {
+		diffH = 1
+	}
+	a.reviewDiffVP.SetHeight(diffH)
 	a.reviewDiffVP.GotoTop()
 	if a.reviewSession == nil {
 		a.reviewDiffVP.SetContent("")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1778,30 +1778,25 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// rows the user flagged with `f`. Session returns to InProgress.
 				return a.addressReviewFeedback(a.reviewSession)
 			case "enter", "space":
-				// Drill into the selected task's diff. Opens the diff browser
-				// filtered to the commits for that task; esc returns to the
-				// task list (handled by diffCloseMsg).
-				entry := a.reviewDiffCache[a.reviewSession.ID]
-				if entry == nil || len(entry.groups) == 0 {
-					return a, nil
-				}
-				group := reviewTaskGroupAtCursor(entry, a.reviewTaskCursor)
-				if group == nil || group.rawDiff == "" {
-					return a, nil
-				}
-				m, err := diffmodel.Parse(group.rawDiff)
-				if err != nil {
-					a.setError(err.Error())
-					return a, nil
-				}
-				taskLabel := a.reviewSession.GetDisplayName()
-				if group.taskIndex > 0 {
-					taskLabel += fmt.Sprintf(" · task %d", group.taskIndex)
-				} else {
-					taskLabel += " · other changes"
-				}
-				a.view = ViewDiff
-				a.diff = newDiffModel(taskLabel, m, a.width, a.height-1)
+				// Inline diff is shown in the right pane; enter/space are no-ops here.
+				return a, nil
+			case "pgdown":
+				a.reviewDiffVP.PageDown()
+				return a, nil
+			case "pgup":
+				a.reviewDiffVP.PageUp()
+				return a, nil
+			case "ctrl+d":
+				a.reviewDiffVP.HalfPageDown()
+				return a, nil
+			case "ctrl+u":
+				a.reviewDiffVP.HalfPageUp()
+				return a, nil
+			case "g":
+				a.reviewDiffVP.GotoTop()
+				return a, nil
+			case "G":
+				a.reviewDiffVP.GotoBottom()
 				return a, nil
 			}
 			// All other keys are no-ops in review panel.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -193,18 +193,20 @@ type App struct {
 	focusBreakShortWarning bool
 	focusBreakTimerUp      bool // break duration elapsed; waiting on user to resume
 	focusBreakAnimFrame    int
-	reviewDiffCache        map[string]*reviewDiffEntry                // keyed by session ID
-	reviewSession          *agent.Session                             // session currently open in review panel
-	reviewTaskCursor       int                                        // selected task row in the review task list
-	reviewDiffVP           viewport.Model                             // scroll state for the inline diff viewport
-	reviewDiffCacheByTask  map[int]*diffmodel.Model                   // parsed diff per task index; cleared with reviewDiffCache
-	shippingSession        *agent.Session                             // session currently open in shipping panel
-	feedbackTriage         map[string]map[string]*feedbackTriageEntry // keyed by sessionID → itemKey
-	shippingFeedbackCursor int                                        // cursor row in the feedback list pane
-	shippingDetailScroll   int                                        // scroll offset in the feedback detail pane
-	feedbackNote           feedbackNoteModal                          // overlay for adding a guidance note to a feedback item
-	planEditor             *planEditorModel                           // non-nil while panelFocus == focusPlanEditor
-	promptModal            promptModalModel                           // overlay for plan-first new-session prompt
+	reviewDiffCache         map[string]*reviewDiffEntry                // keyed by session ID
+	reviewSession           *agent.Session                             // session currently open in review panel
+	reviewTaskCursor        int                                        // selected task row in the review task list
+	reviewDiffVP            viewport.Model                             // scroll state for the inline diff viewport
+	reviewDiffCacheByTask   map[int]*diffmodel.Model                   // parsed diff per task index; cleared with reviewDiffCache
+	reviewSpecOverlayActive bool                                       // true while the ? Spec overlay is open
+	reviewSpecOverlayScroll int                                        // scroll offset for the Spec overlay (line index)
+	shippingSession         *agent.Session                             // session currently open in shipping panel
+	feedbackTriage          map[string]map[string]*feedbackTriageEntry // keyed by sessionID → itemKey
+	shippingFeedbackCursor  int                                        // cursor row in the feedback list pane
+	shippingDetailScroll    int                                        // scroll offset in the feedback detail pane
+	feedbackNote            feedbackNoteModal                          // overlay for adding a guidance note to a feedback item
+	planEditor              *planEditorModel                           // non-nil while panelFocus == focusPlanEditor
+	promptModal             promptModalModel                           // overlay for plan-first new-session prompt
 
 	// Wellness counters (written to log on quit).
 	agentsCreatedCount   int
@@ -1619,11 +1621,30 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Review panel key handling.
 		if a.dashboard.panelFocus == focusReview && a.reviewSession != nil {
+			// Spec overlay intercepts all keys while active.
+			if a.reviewSpecOverlayActive {
+				switch msg.String() {
+				case "esc":
+					a.reviewSpecOverlayActive = false
+				case "pgdown":
+					a.reviewSpecOverlayScroll++
+				case "pgup":
+					if a.reviewSpecOverlayScroll > 0 {
+						a.reviewSpecOverlayScroll--
+					}
+				case "g":
+					a.reviewSpecOverlayScroll = 0
+				case "G":
+					a.reviewSpecOverlayScroll = 9999 // clamped at render time
+				}
+				return a, nil
+			}
 			switch msg.String() {
 			case "esc":
 				// Return to focus mode; session stays InReview.
 				a.dashboard.panelFocus = focusList
 				a.reviewSession = nil
+				a.reviewSpecOverlayActive = false
 				return a, nil
 			case "d":
 				// Defer: back to ReadyForReview, return to focus.
@@ -1797,6 +1818,12 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			case "G":
 				a.reviewDiffVP.GotoBottom()
+				return a, nil
+			case "?":
+				if a.reviewSession.HasPlan() {
+					a.reviewSpecOverlayActive = true
+					a.reviewSpecOverlayScroll = 0
+				}
 				return a, nil
 			}
 			// All other keys are no-ops in review panel.
@@ -3803,7 +3830,10 @@ func (a App) View() tea.View {
 		if a.dashboard.panelFocus == focusReview && a.reviewSession != nil {
 			entry := a.reviewDiffCache[a.reviewSession.ID]
 			var panelStr string
-			if a.prComposeModal.Active() {
+			if a.reviewSpecOverlayActive {
+				plan, _ := a.reviewSession.CachedPlan()
+				panelStr = renderReviewSpecOverlay(a.reviewSession, plan, a.reviewSpecOverlayScroll, a.width, a.height)
+			} else if a.prComposeModal.Active() {
 				panelStr = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, a.prComposeModal.View())
 			} else {
 				panelStr = renderReviewPanel(a.reviewSession, entry, a.width, a.height, a.reviewTaskCursor, a.prDraftInFlight && a.prDraftSessionID == a.reviewSession.ID, a.reviewDiffVP.YOffset())

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4061,3 +4061,59 @@ func TestReviewPanel_EnterDoesNotChangeView(t *testing.T) {
 		}
 	}
 }
+
+// TestReviewPanel_ScrollBindingsAdvanceViewport verifies that pressing pgdown
+// while focusReview is active advances the inline diff viewport's scroll position,
+// confirming the viewport is interactable via the scroll key bindings wired in the
+// focusReview key handler.
+func TestReviewPanel_ScrollBindingsAdvanceViewport(t *testing.T) {
+	// Build a diff with enough added lines to exceed the viewport height at 40 rows.
+	var sb strings.Builder
+	sb.WriteString("diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,53 @@\n package main\n \n")
+	for range 50 {
+		sb.WriteString("+// scroll-test-line\n")
+	}
+	sb.WriteString(" func A() {}\n")
+	rawDiff := sb.String()
+
+	sessR := agent.NewSessionForTest("scroll-vp", "review-scroll")
+	sessR.SetLifecyclePhase(agent.LifecycleInReview)
+	sessR.SetOriginalPrompt("Fix auth")
+	sessR.MarkDone()
+
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Fix handler", Done: false}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "[task 1] fix handler"}},
+			rawDiff:   rawDiff,
+		}},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictPending},
+		},
+	}
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.reviewSession = sessR
+	app.dashboard.panelFocus = focusReview
+	app.reviewDiffCache[sessR.ID] = entry
+	// Load diff content and set viewport dimensions before sending scroll keys.
+	app.refreshReviewDiffViewport()
+
+	if !app.reviewDiffVP.AtTop() {
+		t.Fatal("expected viewport at top before scrolling")
+	}
+
+	// pgdown must advance the viewport away from the top.
+	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	updated := model.(App)
+
+	if updated.reviewDiffVP.AtTop() {
+		t.Error("pgdown: inline diff viewport did not scroll; viewport must advance when diff content exceeds viewport height")
+	}
+	if updated.dashboard.panelFocus != focusReview {
+		t.Error("pgdown: panelFocus must remain focusReview")
+	}
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devenjarvis/baton/internal/agent"
 	"github.com/devenjarvis/baton/internal/audio"
 	"github.com/devenjarvis/baton/internal/config"
+	"github.com/devenjarvis/baton/internal/git"
 	"github.com/devenjarvis/baton/internal/github"
 )
 
@@ -4014,5 +4015,49 @@ func TestNewApp_InitsFeedbackTriage(t *testing.T) {
 	}
 	if len(app.feedbackTriage) != 0 {
 		t.Errorf("feedbackTriage should be empty on init, got len=%d", len(app.feedbackTriage))
+	}
+}
+
+// TestReviewPanel_EnterDoesNotChangeView verifies that pressing enter or space
+// while focusReview is active does not transition to ViewDiff. The inline diff
+// is now shown inline, so the fullscreen hop is removed.
+func TestReviewPanel_EnterDoesNotChangeView(t *testing.T) {
+	sessR := agent.NewSessionForTest("r", "review-r")
+	sessR.SetLifecyclePhase(agent.LifecycleInReview)
+	sessR.SetOriginalPrompt("Fix auth")
+	sessR.MarkDone()
+
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Fix handler", Done: false}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "[task 1] fix handler"}},
+			rawDiff:   "diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,4 @@\n package main\n \n+// marker\n func A() {}\n",
+		}},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictPending},
+		},
+	}
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.reviewSession = sessR
+	app.dashboard.panelFocus = focusReview
+	app.reviewDiffCache[sessR.ID] = entry
+
+	for _, key := range []string{"enter", "space"} {
+		msg := tea.KeyPressMsg{Code: tea.KeyEnter, Text: key}
+		if key == "space" {
+			msg = tea.KeyPressMsg{Code: tea.KeySpace, Text: " "}
+		}
+		model, _ := app.Update(msg)
+		updated := model.(App)
+		if updated.view != ViewDashboard {
+			t.Errorf("%s: expected view=ViewDashboard, got %v", key, updated.view)
+		}
+		if updated.dashboard.panelFocus != focusReview {
+			t.Errorf("%s: expected panelFocus=focusReview, got %v", key, updated.dashboard.panelFocus)
+		}
 	}
 }

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -240,14 +240,6 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	return strings.Join(lines, "\n")
 }
 
-// getGroups safely returns groups, even on a nil entry.
-func (e *reviewDiffEntry) getGroups() []taskReviewGroup {
-	if e == nil {
-		return nil
-	}
-	return e.groups
-}
-
 // reviewListPaneRowAt returns the 0-based task row index at (mouseX, mouseY) within the
 // left task-list pane, or -1 if the click is outside the pane or in the PLAN TASKS header.
 // paneTop is the Y coordinate of the first line of the pane (including the 2-line header).
@@ -702,7 +694,7 @@ func renderReviewSpecOverlay(sess *agent.Session, plan string, scrollOffset, wid
 		{"## Not in scope", sections.NotInScope},
 	}
 
-	var allLines []string
+	allLines := make([]string, 0, len(ordered)*8)
 	for _, sec := range ordered {
 		if sec.body == "" {
 			continue

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -218,10 +218,6 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	// Action footer.
 	lines = append(lines, "")
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
-	taskHint := ""
-	if len(entry.getGroups()) > 0 {
-		taskHint = "   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#f0c060")).Render("enter") + StyleSubtle.Render(" — view task diff")
-	}
 	var pHint string
 	if prDraftInFlight {
 		pHint = StyleSubtle.Render("p — (in progress…)")
@@ -236,7 +232,8 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 		"   " + StyleSubtle.Render("c — mark complete") +
 		"   " + StyleSubtle.Render("e — open in editor") +
 		"   " + StyleSubtle.Render("d — defer") +
-		taskHint +
+		"   " + StyleSubtle.Render("pgdn") + StyleSubtle.Render("/pgup") + StyleSubtle.Render(" — scroll diff") +
+		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#f0c060")).Render("?") + StyleSubtle.Render(" — spec") +
 		"   " + StyleSubtle.Render("ESC — back to focus")
 	lines = append(lines, hints)
 

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -94,8 +94,31 @@ func renderReviewHeader(sess *agent.Session, width int) []string {
 		intentLines = []string{intentLines[0], line2 + " …"}
 	}
 
-	lines := make([]string, 0, 2+len(intentLines)+1)
+	lines := make([]string, 0, 3+len(intentLines)+1)
 	lines = append(lines, titleRow)
+
+	// Goal line from plan, if present.
+	if plan, ok := sess.CachedPlan(); ok {
+		sections := agent.ParsePlanSections(plan)
+		// Use the first non-empty line of the Goal section.
+		goalText := ""
+		for _, l := range strings.Split(sections.Goal, "\n") {
+			if t := strings.TrimSpace(l); t != "" {
+				goalText = t
+				break
+			}
+		}
+		if goalText != "" {
+			maxGoal := width - 10
+			if maxGoal < 10 {
+				maxGoal = 10
+			}
+			goalText = truncateVisible(goalText, maxGoal)
+			goalLine := "  " + StyleSubtle.Render("Goal:") + " " + goalText
+			lines = append(lines, goalLine)
+		}
+	}
+
 	for _, l := range intentLines {
 		lines = append(lines, "  "+l)
 	}

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devenjarvis/baton/internal/diffmodel"
 	"github.com/devenjarvis/baton/internal/git"
 	"github.com/devenjarvis/baton/internal/tui/diff"
+	"github.com/devenjarvis/baton/internal/tui/mdrender"
 )
 
 // spinnerFrames is the braille spinner sequence used while a verdict is running.
@@ -668,6 +669,81 @@ func sortFileStatsByChurn(files []git.FileStat) {
 	sort.Slice(files, func(i, j int) bool {
 		return (files[i].Insertions + files[i].Deletions) > (files[j].Insertions + files[j].Deletions)
 	})
+}
+
+// renderReviewSpecOverlay renders the full-screen Spec overlay for the review
+// panel. It shows the Goal, Spec, Verification, and Not in scope sections from
+// the plan markdown, rendered via mdrender and scrolled by scrollOffset.
+// sess and plan are passed so callers can cache plan reads; if plan is empty
+// or the session has no plan, shows a brief "no plan available" message.
+func renderReviewSpecOverlay(sess *agent.Session, plan string, scrollOffset, width, height int) string {
+	titleStyle := lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true)
+	title := titleStyle.Render("SPEC") + "  " + StyleSubtle.Render("›") + "  " + sess.GetDisplayName()
+	header := title + "\n" + StyleSubtle.Render(strings.Repeat("─", width-2))
+	bodyH := height - 2 // title + divider
+	if bodyH < 1 {
+		bodyH = 1
+	}
+
+	if plan == "" {
+		msg := StyleSubtle.Render("(no plan available for this session)")
+		return header + "\n" + msg
+	}
+
+	sections := agent.ParsePlanSections(plan)
+	r := mdrender.New(planEditorChromaStyle)
+	contentW := width - 4
+
+	type namedSection struct {
+		heading string
+		body    string
+	}
+	ordered := []namedSection{
+		{"# Goal", sections.Goal},
+		{"## Spec", sections.Spec},
+		{"## Verification", sections.Verification},
+		{"## Not in scope", sections.NotInScope},
+	}
+
+	var allLines []string
+	for _, sec := range ordered {
+		if sec.body == "" {
+			continue
+		}
+		allLines = append(allLines, StyleSubtle.Render(sec.heading), "")
+		rendered := r.RenderLines(sec.body, contentW)
+		for _, l := range rendered {
+			allLines = append(allLines, "  "+l)
+		}
+		allLines = append(allLines, "")
+	}
+
+	if len(allLines) == 0 {
+		allLines = []string{StyleSubtle.Render("(no content)")}
+	}
+
+	// Clamp scroll offset.
+	if scrollOffset < 0 {
+		scrollOffset = 0
+	}
+	if scrollOffset >= len(allLines) {
+		scrollOffset = max(0, len(allLines)-1)
+	}
+
+	end := scrollOffset + bodyH
+	if end > len(allLines) {
+		end = len(allLines)
+	}
+	window := allLines[scrollOffset:end]
+	body := strings.Join(window, "\n")
+
+	// Footer hint.
+	footer := "\n" + StyleSubtle.Render(strings.Repeat("─", width-2)) + "\n" +
+		"  " + StyleSubtle.Render("pgdn/pgup") + " scroll  " +
+		StyleSubtle.Render("g/G") + " top/bottom  " +
+		lipgloss.NewStyle().Foreground(lipgloss.Color("#f0c060")).Render("esc") + StyleSubtle.Render(" — back to review")
+
+	return header + "\n" + body + footer
 }
 
 // wrapText wraps s to maxWidth columns.

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -10,7 +10,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/baton/internal/agent"
+	"github.com/devenjarvis/baton/internal/diffmodel"
 	"github.com/devenjarvis/baton/internal/git"
+	"github.com/devenjarvis/baton/internal/tui/diff"
 )
 
 // spinnerFrames is the braille spinner sequence used while a verdict is running.
@@ -130,7 +132,8 @@ func renderReviewHeader(sess *agent.Session, width int) []string {
 // entry may be nil while diff stats are being fetched (shows loading placeholder).
 // cursor is the currently selected task row index (0-based among all task rows).
 // prDraftInFlight, when true, shows a spinner status line and disables the p hint.
-func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool) string {
+// diffScrollOffset is the current Y scroll offset of the inline diff viewport (0 = top).
+func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool, diffScrollOffset int) string {
 	// Header (3–4 lines depending on prompt length).
 	headerLines := renderReviewHeader(sess, width)
 
@@ -176,7 +179,7 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 			rightW = 20
 		}
 		leftPaneLines := renderTaskListPane(entry, leftW, bodyH, cursor)
-		rightPaneLines := renderTaskDetailPane(entry, cursor, rightW, bodyH)
+		rightPaneLines := buildRightPane(entry, cursor, rightW, bodyH, diffScrollOffset)
 
 		gutter := " " + StyleSubtle.Render("│") + " "
 		maxRows := len(leftPaneLines)
@@ -549,12 +552,107 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 		}
 	}
 
-	// (6) Diff hint.
-	if group.rawDiff != "" {
-		lines = append(lines, "", StyleSubtle.Render("enter — open task diff"))
+	return capLines(lines, height)
+}
+
+// renderTaskSummaryPane renders the summary portion of the right pane (verdict,
+// rationale, files, commits) capped to summaryH lines. It is the upper half of
+// the right pane in wide mode; the inline diff viewport occupies the lower half.
+// This is identical to renderTaskDetailPane but without the "enter — open task diff" hint.
+func renderTaskSummaryPane(entry *reviewDiffEntry, cursor, width, summaryH int) []string {
+	return renderTaskDetailPane(entry, cursor, width, summaryH)
+}
+
+// renderAllFilesUnified renders every file in a diffmodel.Model as unified
+// (non-side-by-side) text at the given width, with files joined by newlines.
+func renderAllFilesUnified(m *diffmodel.Model, width int) string {
+	if m == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(m.Files))
+	for i := range m.Files {
+		r := diff.NewRenderer(&m.Files[i])
+		parts = append(parts, r.Render(width, false))
+	}
+	return strings.Join(parts, "\n")
+}
+
+// renderInlineDiffPane renders the diff body for the cursor task's rawDiff,
+// windowed by scrollOffset and capped to height. Returns a placeholder line
+// when the diff is empty.
+func renderInlineDiffPane(entry *reviewDiffEntry, cursor, width, height, scrollOffset int) []string {
+	rawDiff := ""
+	if entry != nil {
+		group := reviewTaskGroupAtCursor(entry, cursor)
+		// For the no-plan overview path (no tasks), fall back to the first group.
+		if group == nil && len(entry.groups) > 0 && len(entry.tasks) == 0 {
+			group = &entry.groups[0]
+		}
+		if group != nil {
+			rawDiff = group.rawDiff
+		}
 	}
 
-	return capLines(lines, height)
+	const placeholder = "(no diff for this task)"
+	if rawDiff == "" {
+		if height <= 0 {
+			return []string{StyleSubtle.Render(placeholder)}
+		}
+		out := make([]string, height)
+		out[0] = StyleSubtle.Render(placeholder)
+		return out
+	}
+
+	m, err := diffmodel.Parse(rawDiff)
+	if err != nil || m == nil || len(m.Files) == 0 {
+		out := make([]string, max(1, height))
+		out[0] = StyleSubtle.Render(placeholder)
+		return out
+	}
+
+	content := renderAllFilesUnified(m, width)
+	allLines := strings.Split(content, "\n")
+
+	if scrollOffset < 0 {
+		scrollOffset = 0
+	}
+	if scrollOffset >= len(allLines) {
+		scrollOffset = max(0, len(allLines)-1)
+	}
+	end := scrollOffset + height
+	if end > len(allLines) {
+		end = len(allLines)
+	}
+	result := allLines[scrollOffset:end]
+	// Pad to height so the pane always occupies its allocated rows.
+	for len(result) < height {
+		result = append(result, "")
+	}
+	return result
+}
+
+// buildRightPane composes the right pane for wide mode: summary on top,
+// a horizontal rule, then the inline diff below.
+func buildRightPane(entry *reviewDiffEntry, cursor, width, bodyH, diffScrollOffset int) []string {
+	if entry == nil {
+		return []string{StyleSubtle.Render("loading…")}
+	}
+	maxSummaryH := bodyH / 3
+	if maxSummaryH < 4 {
+		maxSummaryH = 4
+	}
+	summaryLines := renderTaskSummaryPane(entry, cursor, width, maxSummaryH)
+	divider := StyleSubtle.Render(strings.Repeat("─", width))
+	diffH := bodyH - len(summaryLines) - 1
+	if diffH < 1 {
+		diffH = 1
+	}
+	diffLines := renderInlineDiffPane(entry, cursor, width, diffH, diffScrollOffset)
+	result := make([]string, 0, len(summaryLines)+1+len(diffLines))
+	result = append(result, summaryLines...)
+	result = append(result, divider)
+	result = append(result, diffLines...)
+	return result
 }
 
 // capLines returns lines capped to height, with a trailing truncation note if needed.

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -133,8 +133,10 @@ func renderReviewHeader(sess *agent.Session, width int) []string {
 // entry may be nil while diff stats are being fetched (shows loading placeholder).
 // cursor is the currently selected task row index (0-based among all task rows).
 // prDraftInFlight, when true, shows a spinner status line and disables the p hint.
-// diffScrollOffset is the current Y scroll offset of the inline diff viewport (0 = top).
-func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool, diffScrollOffset int) string {
+// vpView is the pre-rendered viewport.View() string for the inline diff. When
+// non-empty it is used directly; when empty (tests / no data) renderInlineDiffPane
+// is called as a fallback with scrollOffset=0.
+func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool, vpView string) string {
 	// Header (3–4 lines depending on prompt length).
 	headerLines := renderReviewHeader(sess, width)
 
@@ -180,7 +182,7 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 			rightW = 20
 		}
 		leftPaneLines := renderTaskListPane(entry, leftW, bodyH, cursor)
-		rightPaneLines := buildRightPane(entry, cursor, rightW, bodyH, diffScrollOffset)
+		rightPaneLines := buildRightPane(entry, cursor, rightW, bodyH, vpView)
 
 		gutter := " " + StyleSubtle.Render("│") + " "
 		maxRows := len(leftPaneLines)
@@ -623,7 +625,10 @@ func renderInlineDiffPane(entry *reviewDiffEntry, cursor, width, height, scrollO
 
 // buildRightPane composes the right pane for wide mode: summary on top,
 // a horizontal rule, then the inline diff below.
-func buildRightPane(entry *reviewDiffEntry, cursor, width, bodyH, diffScrollOffset int) []string {
+// vpView is the pre-rendered output from viewport.View(). When non-empty it is
+// used directly for the diff section (no re-parsing); when empty renderInlineDiffPane
+// is called as a fallback (used by tests that don't wire up a viewport).
+func buildRightPane(entry *reviewDiffEntry, cursor, width, bodyH int, vpView string) []string {
 	if entry == nil {
 		return []string{StyleSubtle.Render("loading…")}
 	}
@@ -637,7 +642,13 @@ func buildRightPane(entry *reviewDiffEntry, cursor, width, bodyH, diffScrollOffs
 	if diffH < 1 {
 		diffH = 1
 	}
-	diffLines := renderInlineDiffPane(entry, cursor, width, diffH, diffScrollOffset)
+	var diffLines []string
+	if vpView != "" {
+		// Use the viewport's pre-rendered content (scroll already applied, no re-parse).
+		diffLines = strings.Split(vpView, "\n")
+	} else {
+		diffLines = renderInlineDiffPane(entry, cursor, width, diffH, 0)
+	}
 	result := make([]string, 0, len(summaryLines)+1+len(diffLines))
 	result = append(result, summaryLines...)
 	result = append(result, divider)

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -900,6 +900,36 @@ func TestRenderReviewHeader_NoGoalWhenNoPlan(t *testing.T) {
 	}
 }
 
+// TestRenderReviewPanel_HintsIncludeSpecAndScroll verifies that the footer hints
+// include ? (spec) and pgdn/pgup (scroll), and no longer show "view task diff".
+func TestRenderReviewPanel_HintsIncludeSpecAndScroll(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-hints", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Fix handler"}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "[task 1] fix"}},
+			rawDiff:   "diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,2 +1,3 @@\n package main\n+// marker\n func A() {}\n",
+		}},
+		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
+	}
+
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+
+	if !strings.Contains(output, "?") {
+		t.Error("footer must include '?' hint for spec overlay")
+	}
+	if !strings.Contains(output, "pgdn") {
+		t.Error("footer must include 'pgdn' hint for scroll")
+	}
+	if strings.Contains(output, "view task diff") {
+		t.Error("footer must not include 'view task diff' hint (removed in favor of inline diff)")
+	}
+}
+
 // TestRenderReviewSpecOverlay_ContainsAllSections verifies that the spec overlay
 // renders Goal, Spec, Verification, and Not in scope section content.
 func TestRenderReviewSpecOverlay_ContainsAllSections(t *testing.T) {

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -851,6 +851,55 @@ func TestVerdictBadge(t *testing.T) {
 	}
 }
 
+// TestRenderReviewHeader_GoalLineFromPlan verifies that the review header includes
+// a Goal: line populated from the plan's # Goal section when the session has a plan.
+func TestRenderReviewHeader_GoalLineFromPlan(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("sess-goal", "fix-auth", dir)
+	sess.SetOriginalPrompt("Fix the auth redirect bug")
+	sess.MarkDone()
+
+	plan := "# Goal\nFix the auth redirect bug.\n\n## Spec\n1. Users redirect correctly.\n"
+	if err := sess.WritePlan(plan); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+
+	lines := renderReviewHeader(sess, 120)
+	out := strings.Join(lines, "\n")
+
+	foundGoalLine := false
+	for _, l := range lines {
+		stripped := ansi.Strip(l)
+		if strings.HasPrefix(strings.TrimSpace(stripped), "Goal:") {
+			foundGoalLine = true
+			if !strings.Contains(stripped, "Fix the auth redirect bug.") {
+				t.Errorf("Goal: line does not contain goal text, got: %q", stripped)
+			}
+			break
+		}
+	}
+	if !foundGoalLine {
+		t.Errorf("renderReviewHeader must include a 'Goal:' line when session has a plan; got:\n%s", out)
+	}
+}
+
+// TestRenderReviewHeader_NoGoalWhenNoPlan verifies that the review header has no
+// Goal: line when the session has no plan.
+func TestRenderReviewHeader_NoGoalWhenNoPlan(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-noplan", "fix-auth")
+	sess.SetOriginalPrompt("Fix the auth redirect bug")
+	sess.MarkDone()
+
+	lines := renderReviewHeader(sess, 120)
+	out := strings.Join(lines, "\n")
+
+	for _, l := range lines {
+		if strings.Contains(ansi.Strip(l), "Goal:") {
+			t.Errorf("renderReviewHeader must not include a 'Goal:' line when session has no plan; got:\n%s", out)
+		}
+	}
+}
+
 // TestRenderReviewPanel_PRDraftInFlight verifies that the spinner status line
 // and disabled p hint appear when prDraftInFlight is true.
 func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -962,6 +962,50 @@ func TestRenderReviewPanel_InlineDiffPresent(t *testing.T) {
 	}
 }
 
+// TestReviewPanel_CursorMoveSwapsDiff verifies that moving the cursor from task 1
+// to task 2 causes the inline diff area to render task 2's diff and not task 1's.
+func TestReviewPanel_CursorMoveSwapsDiff(t *testing.T) {
+	rawDiff1 := "diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,4 @@\n package main\n \n+// task-one-marker\n func A() {}\n"
+	rawDiff2 := "diff --git a/b.go b/b.go\nindex 1234567..abcdefg 100644\n--- a/b.go\n+++ b/b.go\n@@ -1,3 +1,4 @@\n package main\n \n+// task-two-marker\n func B() {}\n"
+
+	sess := agent.NewSessionForTest("sess-cursor", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{
+			{Index: 1, Text: "Task one", Done: false},
+			{Index: 2, Text: "Task two", Done: false},
+		},
+		groups: []taskReviewGroup{
+			{taskIndex: 1, commits: []git.Commit{{Hash: "aaa1111"}}, rawDiff: rawDiff1},
+			{taskIndex: 2, commits: []git.Commit{{Hash: "bbb2222"}}, rawDiff: rawDiff2},
+		},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictPending},
+			2: {state: verdictPending},
+		},
+	}
+
+	// cursor=0 → task 1's diff
+	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	if !strings.Contains(out0, "task-one-marker") {
+		t.Errorf("cursor=0: expected task-one-marker in output; got:\n%s", out0)
+	}
+	if strings.Contains(out0, "task-two-marker") {
+		t.Errorf("cursor=0: must not contain task-two-marker; got:\n%s", out0)
+	}
+
+	// cursor=1 → task 2's diff
+	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false, 0)
+	if !strings.Contains(out1, "task-two-marker") {
+		t.Errorf("cursor=1: expected task-two-marker in output; got:\n%s", out1)
+	}
+	if strings.Contains(out1, "task-one-marker") {
+		t.Errorf("cursor=1: must not contain task-one-marker; got:\n%s", out1)
+	}
+}
+
 // TestRenderReviewPanel_NoDiffPlaceholder verifies that when a task group has an
 // empty rawDiff, the inline diff area shows the "(no diff for this task)" placeholder.
 func TestRenderReviewPanel_NoDiffPlaceholder(t *testing.T) {

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -249,7 +249,7 @@ func TestRenderReviewPanel_TwoPaneLayout(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 30, 0, false)
+	output := renderReviewPanel(sess, entry, 140, 30, 0, false, 0)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from left pane")
@@ -286,7 +286,7 @@ func TestRenderReviewPanel_NarrowWidthStacks(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 70, 30, 0, false)
+	output := renderReviewPanel(sess, entry, 70, 30, 0, false, 0)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from list pane")
@@ -316,7 +316,7 @@ func TestRenderReviewPanel_ShowsOriginalPrompt(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 213, Deletions: 34},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
 
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("review panel must show the original prompt")
@@ -331,7 +331,7 @@ func TestRenderReviewPanel_NilDiffEntry(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 
 	// nil entry — should not panic
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("must still show prompt even with nil diff entry")
 	}
@@ -355,7 +355,7 @@ func TestRenderReviewPanel_UsesThemeColors(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0)
 
 	// The pass verdict icon should carry the ColorSuccess ANSI escape.
 	expectedPrefix := StyleSuccess.Render("✓")
@@ -417,7 +417,7 @@ func TestRenderReviewPanel_NoPlanShowsOverview(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 30, Deletions: 2},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0)
 
 	if !strings.Contains(output, "Overview") {
 		t.Error("must show 'Overview' row in list pane for no-plan session")
@@ -457,7 +457,7 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
 
 	for _, want := range []string{
 		"open PR",
@@ -500,7 +500,7 @@ func TestRenderReviewPanel_TaskListShown(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("task list view must show PLAN TASKS header")
@@ -708,7 +708,7 @@ func TestRenderReviewPanel_NoDiffFoundBadge(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
 
 	if !strings.Contains(output, "Write tests") {
 		t.Error("must render a row for task 2 even though it has no commits")
@@ -907,7 +907,7 @@ func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, true)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, true, 0)
 
 	if !strings.Contains(output, "Pushing branch and drafting PR") {
 		t.Error("in-flight state must show draft spinner line")
@@ -917,5 +917,74 @@ func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {
 	}
 	if strings.Contains(output, "create or open PR") {
 		t.Error("in-flight state must not show normal p hint")
+	}
+}
+
+// TestRenderReviewPanel_InlineDiffPresent verifies that when a task group has a
+// non-empty rawDiff, the wide-mode review panel renders an inline diff showing
+// both the verdict label and a diff hunk header.
+func TestRenderReviewPanel_InlineDiffPresent(t *testing.T) {
+	rawDiff := "diff --git a/internal/auth/handler.go b/internal/auth/handler.go\n" +
+		"index 1234567..abcdefg 100644\n" +
+		"--- a/internal/auth/handler.go\n" +
+		"+++ b/internal/auth/handler.go\n" +
+		"@@ -10,5 +10,6 @@ func Handle(w http.ResponseWriter, r *http.Request) {\n" +
+		" \ttoken := r.Header.Get(\"Authorization\")\n" +
+		" \tif token == \"\" {\n" +
+		" \t\thttp.Redirect(w, r, \"/login\", http.StatusFound)\n" +
+		"+\t\treturn\n" +
+		" \t}\n" +
+		" }\n"
+	sess := agent.NewSessionForTest("sess-diff", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth redirect")
+	sess.MarkDone()
+
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Fix handler", Done: false}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "[task 1] fix handler"}},
+			stats:     &git.DiffStats{Files: 1, Insertions: 1, Deletions: 0},
+			rawDiff:   rawDiff,
+		}},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictPass}},
+		},
+	}
+
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+
+	if !strings.Contains(output, "pass") {
+		t.Error("must contain verdict label 'pass'")
+	}
+	if !strings.Contains(output, "@@") {
+		t.Errorf("inline diff must contain hunk header '@@'; got:\n%s", output)
+	}
+}
+
+// TestRenderReviewPanel_NoDiffPlaceholder verifies that when a task group has an
+// empty rawDiff, the inline diff area shows the "(no diff for this task)" placeholder.
+func TestRenderReviewPanel_NoDiffPlaceholder(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-nodiff", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth redirect")
+	sess.MarkDone()
+
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Fix handler", Done: false}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "[task 1] fix handler"}},
+			stats:     &git.DiffStats{Files: 0, Insertions: 0, Deletions: 0},
+			rawDiff:   "",
+		}},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictNoDiff},
+		},
+	}
+
+	// Must not panic and must show the placeholder.
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	if !strings.Contains(output, "(no diff for this task)") {
+		t.Errorf("must show '(no diff for this task)' placeholder; got:\n%s", output)
 	}
 }

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -249,7 +249,7 @@ func TestRenderReviewPanel_TwoPaneLayout(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 30, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 140, 30, 0, false, "")
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from left pane")
@@ -286,7 +286,7 @@ func TestRenderReviewPanel_NarrowWidthStacks(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 70, 30, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 70, 30, 0, false, "")
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from list pane")
@@ -316,7 +316,7 @@ func TestRenderReviewPanel_ShowsOriginalPrompt(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 213, Deletions: 34},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, "")
 
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("review panel must show the original prompt")
@@ -331,7 +331,7 @@ func TestRenderReviewPanel_NilDiffEntry(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 
 	// nil entry — should not panic
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, "")
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("must still show prompt even with nil diff entry")
 	}
@@ -355,7 +355,7 @@ func TestRenderReviewPanel_UsesThemeColors(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, "")
 
 	// The pass verdict icon should carry the ColorSuccess ANSI escape.
 	expectedPrefix := StyleSuccess.Render("✓")
@@ -417,7 +417,7 @@ func TestRenderReviewPanel_NoPlanShowsOverview(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 30, Deletions: 2},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, "")
 
 	if !strings.Contains(output, "Overview") {
 		t.Error("must show 'Overview' row in list pane for no-plan session")
@@ -457,7 +457,7 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, "")
 
 	for _, want := range []string{
 		"open PR",
@@ -500,7 +500,7 @@ func TestRenderReviewPanel_TaskListShown(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, "")
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("task list view must show PLAN TASKS header")
@@ -708,7 +708,7 @@ func TestRenderReviewPanel_NoDiffFoundBadge(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, "")
 
 	if !strings.Contains(output, "Write tests") {
 		t.Error("must render a row for task 2 even though it has no commits")
@@ -917,7 +917,7 @@ func TestRenderReviewPanel_HintsIncludeSpecAndScroll(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, "")
 
 	if !strings.Contains(output, "?") {
 		t.Error("footer must include '?' hint for spec overlay")
@@ -987,7 +987,7 @@ func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, true, 0)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, true, "")
 
 	if !strings.Contains(output, "Pushing branch and drafting PR") {
 		t.Error("in-flight state must show draft spinner line")
@@ -1032,7 +1032,7 @@ func TestRenderReviewPanel_InlineDiffPresent(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, "")
 
 	if !strings.Contains(output, "pass") {
 		t.Error("must contain verdict label 'pass'")
@@ -1068,7 +1068,7 @@ func TestReviewPanel_CursorMoveSwapsDiff(t *testing.T) {
 	}
 
 	// cursor=0 → task 1's diff
-	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false, "")
 	if !strings.Contains(out0, "task-one-marker") {
 		t.Errorf("cursor=0: expected task-one-marker in output; got:\n%s", out0)
 	}
@@ -1077,7 +1077,7 @@ func TestReviewPanel_CursorMoveSwapsDiff(t *testing.T) {
 	}
 
 	// cursor=1 → task 2's diff
-	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false, 0)
+	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false, "")
 	if !strings.Contains(out1, "task-two-marker") {
 		t.Errorf("cursor=1: expected task-two-marker in output; got:\n%s", out1)
 	}
@@ -1107,7 +1107,7 @@ func TestRenderReviewPanel_NoDiffPlaceholder(t *testing.T) {
 	}
 
 	// Must not panic and must show the placeholder.
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, "")
 	if !strings.Contains(output, "(no diff for this task)") {
 		t.Errorf("must show '(no diff for this task)' placeholder; got:\n%s", output)
 	}

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -900,6 +900,56 @@ func TestRenderReviewHeader_NoGoalWhenNoPlan(t *testing.T) {
 	}
 }
 
+// TestRenderReviewSpecOverlay_ContainsAllSections verifies that the spec overlay
+// renders Goal, Spec, Verification, and Not in scope section content.
+func TestRenderReviewSpecOverlay_ContainsAllSections(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("spec-sess", "fix-auth", dir)
+	sess.SetOriginalPrompt("Fix auth")
+
+	plan := `# Goal
+Fix the auth redirect bug.
+
+## Spec
+1. Users redirect correctly.
+2. Tokens validated.
+
+## Context
+internal/auth/handler.go:42
+
+## Tasks
+- [ ] write test
+- [ ] implement
+
+## Verification
+go test -race ./internal/auth
+
+## Not in scope
+OAuth2 support`
+
+	if err := sess.WritePlan(plan); err != nil {
+		t.Fatalf("WritePlan: %v", err)
+	}
+	planContent, _ := sess.CachedPlan()
+
+	output := renderReviewSpecOverlay(sess, planContent, 0, 120, 40)
+
+	for _, want := range []string{"Goal", "Spec", "Verification", "Not in scope"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("overlay must contain %q; got:\n%s", want, output)
+		}
+	}
+	if !strings.Contains(output, "Fix the auth redirect bug.") {
+		t.Errorf("overlay must contain Goal body text; got:\n%s", output)
+	}
+	if !strings.Contains(output, "go test -race") {
+		t.Errorf("overlay must contain Verification body text; got:\n%s", output)
+	}
+	if !strings.Contains(output, "OAuth2 support") {
+		t.Errorf("overlay must contain Not in scope body text; got:\n%s", output)
+	}
+}
+
 // TestRenderReviewPanel_PRDraftInFlight verifies that the spinner status line
 // and disabled p hint appear when prDraftInFlight is true.
 func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {


### PR DESCRIPTION
## Summary

- Added `ParsePlanSections` helper to extract Goal/Spec/Verification/NotInScope from plan markdown for structured access
- Integrated plan Goal line into review header for context
- Added inline diff viewport to review panel's right pane, rendering diffs directly without mode transitions
- Diff viewport re-renders automatically on task cursor moves and when entering review panel
- Added interactive spec overlay (triggered with `?`) displaying the Spec section with keyboard navigation (pgdn/pgup/g/G to scroll, esc to close)
- Updated review footer hints to guide users toward spec context (removed view-diff hint, added ? spec hint)
- Fixed viewport initialization, width/height tracking, and rendering pipeline to properly display diffs
- Added test (`TestReviewPanel_ScrollBindingsAdvanceViewport`) verifying viewport interactability
- Fixed lint issues (gofumpt, prealloc, unused helpers)

This consolidates the review experience: users stay in one panel to see feedback and diffs together, and can quickly reference the original spec without leaving the review context.

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI:
  - [ ] Open review panel and confirm inline diff renders in right pane
  - [ ] Move task cursor up/down and confirm diff updates
  - [ ] Press `?` to open spec overlay and verify it displays
  - [ ] Use pgdn/pgup to scroll spec, g to jump to top, G to jump to bottom
  - [ ] Press esc to close spec overlay
  - [ ] Confirm footer shows `? spec` hint and scroll hints

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]`
- [ ] New behavior has tests (`TestReviewPanel_ScrollBindingsAdvanceViewport` added)
- [ ] No new public API surface