### PR TITLE
Restore session description and show current task in Building card

### DIFF
--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -690,7 +690,7 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 		descText, descPending = planningDescription(sess)
 		descLine1, descLine2 = wrapTwoLines(descText, descBudget)
 	} else {
-		descLine1, descLine2, descPending = focusTaskDescription(sess, descBudget)
+		descLine1, descLine2, descPending = focusSessionDescription(sess, descBudget)
 	}
 	var line2, line3 string
 	buildingPhase := phase == agent.LifecycleInProgress && !sess.IsReviewable()
@@ -943,53 +943,12 @@ func secondUncompletedTask(plan string) string {
 	return ""
 }
 
-// focusTaskDescription chooses the description lines for a session card in
+// focusSessionDescription chooses the description lines for a session card in
 // focus mode and reports whether they should render in pending (italic) style.
-// For Building-phase sessions, line1 is the active task text and line2 is
-// the next task text (both raw). Priority: in_progress TodoItem > plan
-// firstUncompletedTask > fallback.
-func focusTaskDescription(sess *agent.Session, budget int) (line1, line2 string, pending bool) {
-	if sess.LifecyclePhase() == agent.LifecycleInProgress && !sess.IsReviewable() {
-		if ag := sess.PrimaryAgent(); ag != nil {
-			todos := ag.Todos()
-			if len(todos) > 0 {
-				var activeText, nextPending string
-				for _, t := range todos {
-					if t.Status == "in_progress" {
-						activeText = t.ActiveForm
-						if activeText == "" {
-							activeText = t.Content
-						}
-						break
-					}
-				}
-				for _, t := range todos {
-					if t.Status == "pending" {
-						nextPending = t.Content
-						break
-					}
-				}
-				if activeText == "" && nextPending != "" {
-					activeText = nextPending
-					nextPending = ""
-				}
-				if activeText != "" {
-					l1 := truncateVisible(activeText, budget)
-					l2 := truncateVisible(nextPending, budget)
-					return l1, l2, false
-				}
-			}
-		}
-		// No todos: fall back to plan checkboxes.
-		if plan, present := sess.CachedPlan(); present {
-			first := firstUncompletedTask(plan)
-			if first != "" {
-				second := secondUncompletedTask(plan)
-				return truncateVisible(first, budget), truncateVisible(second, budget), false
-			}
-		}
-	}
-
+// Priority: TaskSummary → OriginalPrompt → "…". Building-phase todo/plan task
+// text is intentionally excluded — current-task signal belongs on line 3 via
+// buildingCurrentTask, not here.
+func focusSessionDescription(sess *agent.Session, budget int) (line1, line2 string, pending bool) {
 	origPrompt := sess.OriginalPrompt()
 	var text string
 	var pend bool

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -715,7 +715,7 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 		task := buildingCurrentTask(sess)
 		line3 = stripe + indent
 		if task != "" {
-			taskBudget := descBudget - 14 // subtract len("current task: ")
+			taskBudget := descBudget - lipgloss.Width("current task: ")
 			if taskBudget < 0 {
 				taskBudget = 0
 			}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -705,21 +705,25 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 			line3 = stripe + indent + descStyle.Render(descLine2)
 		}
 	} else if buildingPhase {
-		// Active task: bold text, no leading glyph.
-		activeLine := ""
-		if descLine1 != "" {
-			activeLine = lipgloss.NewStyle().Bold(true).Render(truncateVisible(descLine1, descBudget))
+		// Line 2: session description — StyleSubtle or muted-italic when pending.
+		descStyle := StyleSubtle
+		if descPending {
+			descStyle = lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
 		}
-		line2 = stripe + indent + activeLine
-		// Next task: "next: <muted-italic text>". Subtract 6 cells for "next: ".
+		line2 = stripe + indent + descStyle.Render(descLine1)
+		// Line 3: current task (label muted, name bold) or description overflow.
+		task := buildingCurrentTask(sess)
 		line3 = stripe + indent
-		if descLine2 != "" {
-			nextBudget := descBudget - 6
-			if nextBudget < 0 {
-				nextBudget = 0
+		if task != "" {
+			taskBudget := descBudget - 14 // subtract len("current task: ")
+			if taskBudget < 0 {
+				taskBudget = 0
 			}
-			nextStyle := lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
-			line3 = stripe + indent + nextStyle.Render("next: "+truncateVisible(descLine2, nextBudget))
+			taskLabel := StyleSubtle.Render("current task: ")
+			taskName := lipgloss.NewStyle().Bold(true).Render(truncateVisible(task, taskBudget))
+			line3 = stripe + indent + taskLabel + taskName
+		} else if descLine2 != "" {
+			line3 = stripe + indent + descStyle.Render(descLine2)
 		}
 	} else {
 		line2 = stripe + indent + StyleSubtle.Render(descLine1)

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -948,31 +948,6 @@ func buildingCurrentTask(sess *agent.Session) string {
 	return ""
 }
 
-// secondUncompletedTask returns the text of the second "- [ ]" line in plan,
-// or "" if fewer than two open tasks exist. Uses the same whitespace-trimming
-// and blank-body-skipping rules as firstUncompletedTask so both helpers agree
-// on what constitutes a valid open task. The "second open task" approximation
-// is intentional — deriving the truly-in-flight task from git commits would
-// require per-tick git I/O that the plan cache exists to avoid.
-func secondUncompletedTask(plan string) string {
-	count := 0
-	for _, raw := range strings.Split(plan, "\n") {
-		line := strings.TrimLeft(raw, " \t")
-		if !strings.HasPrefix(line, "- [ ]") {
-			continue
-		}
-		text := strings.TrimSpace(strings.TrimPrefix(line, "- [ ]"))
-		if text == "" {
-			continue
-		}
-		count++
-		if count == 2 {
-			return text
-		}
-	}
-	return ""
-}
-
 // focusSessionDescription chooses the description lines for a session card in
 // focus mode and reports whether they should render in pending (italic) style.
 // Priority: TaskSummary → OriginalPrompt → "…". Building-phase todo/plan task

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -918,6 +918,32 @@ func firstUncompletedTask(plan string) string {
 	return ""
 }
 
+// buildingCurrentTask returns the name of the task currently in progress for
+// the session. Priority: in_progress TodoItem ActiveForm → Content; first
+// pending TodoItem Content; firstUncompletedTask from the cached plan; "".
+func buildingCurrentTask(sess *agent.Session) string {
+	if ag := sess.PrimaryAgent(); ag != nil {
+		todos := ag.Todos()
+		for _, t := range todos {
+			if t.Status == "in_progress" {
+				if t.ActiveForm != "" {
+					return t.ActiveForm
+				}
+				return t.Content
+			}
+		}
+		for _, t := range todos {
+			if t.Status == "pending" {
+				return t.Content
+			}
+		}
+	}
+	if plan, present := sess.CachedPlan(); present {
+		return firstUncompletedTask(plan)
+	}
+	return ""
+}
+
 // secondUncompletedTask returns the text of the second "- [ ]" line in plan,
 // or "" if fewer than two open tasks exist. Uses the same whitespace-trimming
 // and blank-body-skipping rules as firstUncompletedTask so both helpers agree

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -578,7 +578,6 @@ func TestFirstUncompletedTask(t *testing.T) {
 	}
 }
 
-
 func TestPlanningStatusBadge_PhaseTransitions(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("id", "name", dir)

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -578,28 +578,6 @@ func TestFirstUncompletedTask(t *testing.T) {
 	}
 }
 
-func TestSecondUncompletedTask(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		plan string
-		want string
-	}{
-		{"empty", "", ""},
-		{"no tasks", "# just a header\n", ""},
-		{"one open task only", "- [ ] only task\n", ""},
-		{"all done", "- [x] one\n- [X] two\n", ""},
-		{"two open tasks", "- [ ] first\n- [ ] second\n", "second"},
-		{"closed between two open", "- [ ] first\n- [x] done\n- [ ] second\n", "second"},
-		{"trims surrounding whitespace", "- [ ] first\n  - [ ]   trim me  \n", "trim me"},
-		{"skips blank task body", "- [ ] first\n- [ ]   \n- [ ] real second\n", "real second"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := secondUncompletedTask(tc.plan); got != tc.want {
-				t.Errorf("secondUncompletedTask(%q) = %q, want %q", tc.plan, got, tc.want)
-			}
-		})
-	}
-}
 
 func TestPlanningStatusBadge_PhaseTransitions(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -543,7 +543,9 @@ func TestRenderFocusSessionCard_BuildingNoTasksShortDescription(t *testing.T) {
 
 // TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan verifies that
 // when the session's primary agent has an in_progress TodoItem, that item's
-// content wins on line 2 over the plan's first uncompleted task.
+// ActiveForm wins on line 3 ("current task: Running todo task") over the
+// plan's first uncompleted task. Line 2 shows the description; line 1 still
+// shows the progress bar.
 func TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
@@ -567,18 +569,29 @@ func TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan(t *testing.
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card, got %d", len(card))
 	}
-	line2 := ansi.Strip(card[1])
-	if !strings.Contains(line2, "Running todo task") {
-		t.Errorf("line 2 should show in_progress todo's ActiveForm, got %q", line2)
+	line1 := ansi.Strip(card[0])
+	if !strings.Contains(line1, "tasks") {
+		t.Errorf("line 1 should still contain progress bar, got %q", line1)
 	}
-	if strings.Contains(line2, "plan task") {
-		t.Errorf("line 2 must not show plan task when todo overrides it, got %q", line2)
+	line3 := ansi.Strip(card[2])
+	if !strings.Contains(line3, "current task:") {
+		t.Errorf("line 3 should contain 'current task:' prefix, got %q", line3)
+	}
+	if !strings.Contains(line3, "Running todo task") {
+		t.Errorf("line 3 should show in_progress todo's ActiveForm, got %q", line3)
+	}
+	if strings.Contains(line3, "next:") {
+		t.Errorf("line 3 must not contain 'next:', got %q", line3)
+	}
+	if strings.Contains(line3, "plan task") {
+		t.Errorf("line 3 must not show plan task text when todo overrides it, got %q", line3)
 	}
 }
 
 // TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix verifies
-// that when only one open task remains, line 2 shows the last task (bold, no ▸)
-// and line 3 is blank (no "next:" suffix), card is exactly 4 lines.
+// that when only one open task remains, line 3 shows "current task: last task"
+// and contains no "next:" suffix. Line 1 still holds the progress bar.
+// Card is exactly 4 lines.
 func TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
@@ -598,13 +611,19 @@ func TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix(t *testing
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card with single open task, got %d lines", len(card))
 	}
-	line2 := ansi.Strip(card[1])
-	if !strings.Contains(line2, "last task") {
-		t.Errorf("line 2 should contain open task name, got %q", line2)
+	line1 := ansi.Strip(card[0])
+	if !strings.Contains(line1, "tasks") {
+		t.Errorf("line 1 should still contain progress bar, got %q", line1)
 	}
 	line3 := ansi.Strip(card[2])
+	if !strings.Contains(line3, "current task:") {
+		t.Errorf("line 3 should contain 'current task:' prefix, got %q", line3)
+	}
+	if !strings.Contains(line3, "last task") {
+		t.Errorf("line 3 should contain the open task name, got %q", line3)
+	}
 	if strings.Contains(line3, "next:") {
-		t.Errorf("line 3 must not have 'next:' with single open task, got %q", line3)
+		t.Errorf("line 3 must not contain 'next:', got %q", line3)
 	}
 }
 

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -303,9 +303,10 @@ func TestSessionFocusStatus_BuildingWithTodosErrorPreempts(t *testing.T) {
 	}
 }
 
-// TestFocusTaskDescription_WithTodos verifies that focusTaskDescription returns
-// the in_progress todo's activeForm on line1 and the first pending todo on line2.
-func TestFocusTaskDescription_WithTodos(t *testing.T) {
+// TestFocusSessionDescription_PrefersSummaryOverTodos verifies that
+// focusSessionDescription ignores todo items and returns the description
+// (TaskSummary → OriginalPrompt → "…") regardless of Building phase.
+func TestFocusSessionDescription_PrefersSummaryOverTodos(t *testing.T) {
 	sess := agent.NewSessionForTest("s", "my-session")
 	sess.SetLifecyclePhase(agent.LifecycleInProgress)
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
@@ -313,39 +314,34 @@ func TestFocusTaskDescription_WithTodos(t *testing.T) {
 		{Content: "write unit tests", Status: "in_progress", ActiveForm: "Writing unit tests"},
 		{Content: "open PR", Status: "pending", ActiveForm: ""},
 	})
-	// PrimaryAgent() reads from session's agents map.
 	_ = ag
 
-	line1, line2, pending := focusTaskDescription(sess, 80)
-	if !strings.Contains(line1, "Writing unit tests") {
-		t.Errorf("line1 should contain active todo activeForm, got %q", line1)
+	line1, _, _ := focusSessionDescription(sess, 80)
+	if strings.Contains(line1, "Writing unit tests") {
+		t.Errorf("line1 should not contain active todo activeForm, got %q", line1)
 	}
-	if !strings.Contains(line2, "open PR") {
-		t.Errorf("line2 should contain next pending todo, got %q", line2)
-	}
-	if pending {
-		t.Error("expected pending=false for todo-driven description")
+	// No TaskSummary or OriginalPrompt set → falls back to "…"
+	if !strings.Contains(line1, "…") {
+		t.Errorf("line1 should contain task summary fallback, got %q", line1)
 	}
 }
 
-// TestFocusTaskDescription_WithoutTodos verifies that focusTaskDescription
+// TestFocusSessionDescription_WithoutTodos verifies that focusSessionDescription
 // falls back to the task summary / original prompt when no todos are present.
-func TestFocusTaskDescription_WithoutTodos(t *testing.T) {
+func TestFocusSessionDescription_WithoutTodos(t *testing.T) {
 	sess := agent.NewSessionForTest("s", "my-session")
 	sess.SetLifecyclePhase(agent.LifecycleInProgress)
 	sess.SetTaskSummary("implement oauth flow")
 
-	line1, _, _ := focusTaskDescription(sess, 80)
+	line1, _, _ := focusSessionDescription(sess, 80)
 	if !strings.Contains(line1, "implement oauth flow") {
 		t.Errorf("expected task summary fallback, got %q", line1)
 	}
 }
 
-// TestFocusTaskDescription_ReviewableFallsThrough verifies that stale todos
+// TestFocusSessionDescription_ReviewableFallsThrough verifies that stale todos
 // do not surface on lines 2-3 when the session IsReviewable (all agents Idle).
-// The badge on line 1 already shows "✓ idle — press m to review" in that state,
-// so todo lines would be contradictory.
-func TestFocusTaskDescription_ReviewableFallsThrough(t *testing.T) {
+func TestFocusSessionDescription_ReviewableFallsThrough(t *testing.T) {
 	sess := agent.NewSessionForTest("s", "my-session")
 	sess.SetLifecyclePhase(agent.LifecycleInProgress)
 	sess.SetTaskSummary("implement oauth flow")
@@ -355,7 +351,7 @@ func TestFocusTaskDescription_ReviewableFallsThrough(t *testing.T) {
 		{Content: "stale task", Status: "in_progress", ActiveForm: "Stale active work"},
 	})
 
-	line1, line2, _ := focusTaskDescription(sess, 80)
+	line1, line2, _ := focusSessionDescription(sess, 80)
 	// Must NOT show the in_progress todo text.
 	if strings.Contains(line1, "Stale active work") || strings.Contains(line2, "Stale active work") {
 		t.Errorf("expected todo description suppressed for reviewable session, got line1=%q line2=%q", line1, line2)

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -871,3 +871,83 @@ func TestRenderFocusSessionCard_BranchChipAndElapsedGlyph(t *testing.T) {
 		t.Errorf("no-branch session should not render ⎇ label, got %q", line4b)
 	}
 }
+
+// TestBuildingCurrentTask covers the priority chain in buildingCurrentTask.
+func TestBuildingCurrentTask(t *testing.T) {
+	t.Run("in_progress todo ActiveForm wins", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s", "my-session")
+		sess.SetLifecyclePhase(agent.LifecycleInProgress)
+		ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+		ag.SetTodos([]agent.TodoItem{
+			{Content: "write tests", Status: "in_progress", ActiveForm: "Writing unit tests"},
+			{Content: "open PR", Status: "pending", ActiveForm: ""},
+		})
+		got := buildingCurrentTask(sess)
+		if got != "Writing unit tests" {
+			t.Errorf("expected ActiveForm, got %q", got)
+		}
+	})
+
+	t.Run("in_progress todo falls back to Content when ActiveForm empty", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s", "my-session")
+		sess.SetLifecyclePhase(agent.LifecycleInProgress)
+		ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+		ag.SetTodos([]agent.TodoItem{
+			{Content: "write tests", Status: "in_progress", ActiveForm: ""},
+		})
+		got := buildingCurrentTask(sess)
+		if got != "write tests" {
+			t.Errorf("expected Content fallback, got %q", got)
+		}
+	})
+
+	t.Run("first pending Content when no in_progress", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s", "my-session")
+		sess.SetLifecyclePhase(agent.LifecycleInProgress)
+		ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+		ag.SetTodos([]agent.TodoItem{
+			{Content: "done step", Status: "completed", ActiveForm: ""},
+			{Content: "next step", Status: "pending", ActiveForm: ""},
+		})
+		got := buildingCurrentTask(sess)
+		if got != "next step" {
+			t.Errorf("expected first pending Content, got %q", got)
+		}
+	})
+
+	t.Run("falls back to firstUncompletedTask from plan", func(t *testing.T) {
+		dir := t.TempDir()
+		sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+		sess.SetLifecyclePhase(agent.LifecycleInProgress)
+		if err := sess.WritePlan("- [x] done\n- [ ] implement auth\n- [ ] write docs\n"); err != nil {
+			t.Fatal(err)
+		}
+		// No agent / no todos.
+		got := buildingCurrentTask(sess)
+		if got != "implement auth" {
+			t.Errorf("expected first uncompleted plan task, got %q", got)
+		}
+	})
+
+	t.Run("returns empty when no todos and no plan", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s", "my-session")
+		sess.SetLifecyclePhase(agent.LifecycleInProgress)
+		got := buildingCurrentTask(sess)
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("returns empty when all plan tasks are checked", func(t *testing.T) {
+		dir := t.TempDir()
+		sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+		sess.SetLifecyclePhase(agent.LifecycleInProgress)
+		if err := sess.WritePlan("- [x] one\n- [x] two\n"); err != nil {
+			t.Fatal(err)
+		}
+		got := buildingCurrentTask(sess)
+		if got != "" {
+			t.Errorf("expected empty string when all plan tasks done, got %q", got)
+		}
+	})
+}

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -401,9 +401,9 @@ func TestRenderQueueRow_RepoPrefix(t *testing.T) {
 }
 
 // TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine verifies
-// that a Building session with a plan and open tasks produces a 4-line card
-// where line 2 shows the first open task (bold, no leading ▸) and line 3
-// shows "next: second open" (no leading ↳).
+// that a Building session with a plan shows the session description on line 2
+// and "current task: <first open task>" on line 3. The line-1 progress bar
+// and the 4-line card height are unchanged.
 func TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
@@ -424,22 +424,120 @@ func TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine(t *testing
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card for plan-backed building session, got %d lines: %v", len(card), card)
 	}
-	line2 := ansi.Strip(card[1])
-	if strings.Contains(line2, "▸") {
-		t.Errorf("line 2 must not contain ▸ prefix, got %q", line2)
+	line1 := ansi.Strip(card[0])
+	if !strings.Contains(line1, "1/3") {
+		t.Errorf("line 1 should still contain progress bar '1/3', got %q", line1)
 	}
-	if !strings.Contains(line2, "write tests") {
-		t.Errorf("line 2 should contain first open task, got %q", line2)
+	line2 := ansi.Strip(card[1])
+	if !strings.Contains(line2, "implement oauth flow") {
+		t.Errorf("line 2 should contain session description (TaskSummary), got %q", line2)
 	}
 	line3 := ansi.Strip(card[2])
-	if strings.Contains(line3, "↳") {
-		t.Errorf("line 3 must not contain ↳ glyph, got %q", line3)
+	if !strings.Contains(line3, "current task:") {
+		t.Errorf("line 3 should contain \"current task:\" prefix, got %q", line3)
 	}
-	if !strings.Contains(line3, "next:") {
-		t.Errorf("line 3 should contain \"next:\" prefix, got %q", line3)
+	if !strings.Contains(line3, "write tests") {
+		t.Errorf("line 3 should contain first open task name, got %q", line3)
 	}
-	if !strings.Contains(line3, "open PR") {
-		t.Errorf("line 3 should contain second open task, got %q", line3)
+	if strings.Contains(line3, "next:") {
+		t.Errorf("line 3 must not contain 'next:', got %q", line3)
+	}
+	if strings.Contains(line3, "open PR") {
+		t.Errorf("line 3 must not contain the second open task, got %q", line3)
+	}
+}
+
+// TestRenderFocusSessionCard_BuildingDescriptionFallsBackToOriginalPrompt
+// verifies that when no TaskSummary is set, line 2 shows the OriginalPrompt
+// in muted-italic style (pending=true branch).
+func TestRenderFocusSessionCard_BuildingDescriptionFallsBackToOriginalPrompt(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	sess := agent.NewSessionForTest("s", "my-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	sess.SetOriginalPrompt("add dark mode")
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 100)
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card, got %d", len(card))
+	}
+	if !strings.Contains(ansi.Strip(card[1]), "add dark mode") {
+		t.Errorf("line 2 should contain OriginalPrompt, got %q", ansi.Strip(card[1]))
+	}
+	// Pending style → italic SGR (\x1b[...;3m or \x1b[3m).
+	if !strings.Contains(card[1], "\x1b[") {
+		t.Errorf("line 2 raw should contain ANSI escape (italic), got %q", card[1])
+	}
+}
+
+// TestRenderFocusSessionCard_BuildingNoTasksFallsBackToDescriptionOverflow
+// verifies that when there are no todos and no plan, a long OriginalPrompt
+// wraps onto lines 2 and 3 with no "current task:" present.
+func TestRenderFocusSessionCard_BuildingNoTasksFallsBackToDescriptionOverflow(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "my-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	sess.SetOriginalPrompt("implement the entire authentication subsystem with OAuth2 PKCE flow")
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 60)
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card, got %d", len(card))
+	}
+	line2 := ansi.Strip(card[1])
+	line3 := ansi.Strip(card[2])
+	if !strings.Contains(line2, "implement") {
+		t.Errorf("line 2 should contain first wrapped chunk, got %q", line2)
+	}
+	if !strings.Contains(line3, "OAuth2") && !strings.Contains(line3, "authentication") {
+		t.Errorf("line 3 should contain description overflow, got %q", line3)
+	}
+	if strings.Contains(line2, "current task:") || strings.Contains(line3, "current task:") {
+		t.Errorf("no current task should appear when no todos/plan, got line2=%q line3=%q", line2, line3)
+	}
+}
+
+// TestRenderFocusSessionCard_BuildingNoTasksShortDescription verifies that
+// when there are no todos, no plan, and the description fits in one line,
+// line 3 is blank (no "current task:", no overflow).
+func TestRenderFocusSessionCard_BuildingNoTasksShortDescription(t *testing.T) {
+	sess := agent.NewSessionForTest("s", "my-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	sess.SetOriginalPrompt("add dark mode")
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 100)
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card, got %d", len(card))
+	}
+	line3 := ansi.Strip(card[2])
+	if strings.Contains(line3, "current task:") {
+		t.Errorf("line 3 must not contain 'current task:' when no todos/plan, got %q", line3)
+	}
+	// "Blank" in card context = stripe glyph + indent spaces, no content.
+	contentAfterStripe := strings.TrimLeft(strings.TrimPrefix(line3, "▎"), " ")
+	if contentAfterStripe != "" {
+		t.Errorf("line 3 should be blank (stripe+indent only) when description fits one line, got %q", line3)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Restored session description display in the Building card (renamed `focusTaskDescription` to `focusSessionDescription`)
- Replaced next-task display with current-task display for more immediate visibility of active work
- Added `buildingCurrentTask` helper with fallback chain: active todo → active plan → fallback value
- Reworked Building card layout to show session description on line 2 and current task on line 3
- Removed `secondUncompletedTask` helper and its associated tests (no longer needed)
- Adjusted progress bar positioning for improved visual hierarchy

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI: Verify Building card displays session description and current task; confirm progress bar positioning

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description