### PR TITLE
Auto-advance plan approval to dashboard and auto-mark sessions ready for review

### DIFF
--- a/changelog.d/auto-promote-and-quiet-plan-approve.md
+++ b/changelog.d/auto-promote-and-quiet-plan-approve.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Approving a plan no longer drops the user into the agent terminal — focus stays on the dashboard and the pipeline cursor moves to the new BUILDING row, so the developer can keep monitoring all sessions while the build agent runs.
+- Building sessions now auto-advance to REVIEWING when all agents go idle, eliminating the manual `m` press for the common single-turn case. The `m` key remains as a fallback for sessions restored from disk whose agents had already idled before the current process started.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -816,10 +816,15 @@ func (a *Agent) ExitErr() error {
 
 // Kill terminates the agent's process and waits for goroutines to exit.
 // Safe to call multiple times — subsequent calls are no-ops.
+// Also safe on synthetic test agents (nil pty/terminal): nil checks guard both.
 func (a *Agent) Kill() {
-	_ = a.pty.Close()
+	if a.pty != nil {
+		_ = a.pty.Close()
+	}
 	// Close terminal to unblock writeLoop's Read call.
-	a.terminal.Close()
+	if a.terminal != nil {
+		a.terminal.Close()
+	}
 	// Wait for writeLoop to finish before returning.
 	<-a.writeLoopDone
 }

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -662,8 +662,20 @@ func NewSessionForTestWithPath(id, name, worktreePath string) *Session {
 // normal PTY-spawning path so callers don't need a real subprocess to exercise
 // status-dependent session logic (e.g. IsReviewable). The status write is
 // guarded by a.mu to match the pattern of every production writer of status.
+// The done and writeLoopDone channels are pre-closed so Kill() and KillAll()
+// treat the agent as already finished without blocking on a real process.
 func (s *Session) AddTestAgent(id string, isShell bool, status Status) *Agent {
-	a := &Agent{ID: id, IsShell: isShell, CreatedAt: time.Now()}
+	done := make(chan struct{})
+	close(done)
+	writeLoopDone := make(chan struct{})
+	close(writeLoopDone)
+	a := &Agent{
+		ID:            id,
+		IsShell:       isShell,
+		CreatedAt:     time.Now(),
+		done:          done,
+		writeLoopDone: writeLoopDone,
+	}
 	a.mu.Lock()
 	a.status = status
 	a.mu.Unlock()

--- a/internal/e2e/hooks_test.go
+++ b/internal/e2e/hooks_test.go
@@ -100,20 +100,24 @@ func TestHookPipeline(t *testing.T) {
 	if !waitForBadgeText(s, "waiting", 5000) {
 		t.Fatalf("never observed Waiting badge text\nScreen:\n%s", s.Screenshot())
 	}
-	// Idle — stop fires at t≈3.5s. The session card surfaces this as the
-	// "✓ idle — press m to review" cue.
-	if !waitForBadgeText(s, "press m to review", 5000) {
-		t.Fatalf("never observed idle review cue after Stop\nScreen:\n%s", s.Screenshot())
+	// Idle — stop fires at t≈3.5s. Auto-promotion moves the session from
+	// BUILDING to REVIEWING immediately on the idle event, so the session
+	// card now lives in the REVIEWING section of the pipeline.
+	if !waitForBadgeText(s, "REVIEWING", 5000) {
+		t.Fatalf("never observed REVIEWING section after Stop (auto-promotion did not fire)\nScreen:\n%s", s.Screenshot())
 	}
-	// Active again — user-prompt-submit fires at t≈5.5s and re-arms.
+	// Active again — user-prompt-submit fires at t≈5.5s and re-arms the
+	// status indicator. The session remains in REVIEWING (auto-promotion is
+	// idempotent for already-promoted sessions), but the agent badge should
+	// briefly show "active".
 	if !waitForBadgeText(s, "active", 5000) {
 		t.Fatalf("never observed re-armed Active badge after UserPromptSubmit\nScreen:\n%s", s.Screenshot())
 	}
-	// Idle again — stop fires at t≈7.5s. This doubles as a re-arm check:
-	// if UserPromptSubmit hadn't re-armed, there'd be no intermediate Active
-	// and the second Stop would be a no-op status-wise.
-	if !waitForBadgeText(s, "press m to review", 5000) {
-		t.Fatalf("never observed final idle cue after second Stop\nScreen:\n%s", s.Screenshot())
+	// Idle again — stop fires at t≈7.5s. Session stays in REVIEWING (the
+	// phase gate suppresses a second promotion). This doubles as a re-arm
+	// check: no intermediate Active would mean UserPromptSubmit didn't re-arm.
+	if !waitForBadgeText(s, "REVIEWING", 5000) {
+		t.Fatalf("never observed REVIEWING section after second Stop\nScreen:\n%s", s.Screenshot())
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3823,7 +3823,7 @@ func (a *App) approvePlanAndSpawn(msg planEditorApproveMsg) (tea.Model, tea.Cmd)
 		// approved plan is when a session "starts" — submitPromptModal
 		// deliberately doesn't increment on plan creation, since the user
 		// could still abandon it before approving.
-		return createResultMsg{sessionID: sessID, agentID: ag.ID, isNewSession: true}
+		return createResultMsg{sessionID: sessID, agentID: ag.ID, isNewSession: true, skipFocusLaunch: true}
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -51,10 +51,11 @@ type agentEventMsg struct {
 // already created earlier — the heuristic would double-count if we
 // incremented on session creation as well.
 type createResultMsg struct {
-	sessionID    string
-	agentID      string
-	err          error
-	isNewSession bool
+	sessionID       string
+	agentID         string
+	err             error
+	isNewSession    bool
+	skipFocusLaunch bool // when true, don't enter focusLaunch; cursor still moves
 }
 
 // killScope distinguishes an agent-level kill from a session-level kill so the
@@ -800,17 +801,19 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.sessionsCreatedCount++
 		}
 		a.refreshAgentList()
-		// Find the new agent by ID, select it, and auto-focus its terminal in
-		// focusLaunch.
+		// Find the new agent by ID. Cursor always moves to the new session's
+		// row; focusLaunch is only entered when skipFocusLaunch is false.
 		if msg.agentID != "" {
 			for i, item := range a.dashboard.items {
 				if item.kind == listItemAgent && item.agent != nil && item.agent.ID == msg.agentID {
 					a.dashboard.selected = i
-					a.focusLaunchAgent = item.agent
-					a.focusLaunchSession = item.session
-					a.dashboard.panelFocus = focusLaunch
-					a.dashboard.scrollOffset = 0
-					item.agent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+					if !msg.skipFocusLaunch {
+						a.focusLaunchAgent = item.agent
+						a.focusLaunchSession = item.session
+						a.dashboard.panelFocus = focusLaunch
+						a.dashboard.scrollOffset = 0
+						item.agent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+					}
 					// Move the pipeline cursor to the new session so when the
 					// user esc's back to focusList their cursor is on the row
 					// they just spawned. Walk every section because newSession

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -597,6 +597,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, tea.Batch(allCmds...)
 
 	case agentEventMsg:
+		var autoPromoteCmd tea.Cmd
 		// Clean up stale lastKnownStatus entries when a session auto-closes.
 		if msg.event.Type == agent.EventSessionClosed && msg.event.SessionID != "" {
 			prefix := msg.event.SessionID + "-agent-"
@@ -637,18 +638,32 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			a.lastKnownStatus[msg.event.AgentID] = msg.event.Status
-			if msg.event.Status == agent.StatusDone || msg.event.Status == agent.StatusError {
+			// Auto-promote and MarkDone share a single FindAgentAndSession
+			// call, gated on the statuses that can trigger either transition.
+			if msg.event.Status == agent.StatusIdle ||
+				msg.event.Status == agent.StatusDone ||
+				msg.event.Status == agent.StatusError {
 				if mgr := a.managers[msg.repoPath]; mgr != nil {
 					if _, sess := mgr.FindAgentAndSession(msg.event.AgentID); sess != nil {
-						allDone := true
-						for _, ag := range sess.Agents() {
-							if !ag.IsShell && ag.Status() != agent.StatusDone && ag.Status() != agent.StatusError {
-								allDone = false
-								break
-							}
+						// Auto-promote InProgress → ReadyForReview on first
+						// idle/done signal. Only fires once per session (the
+						// phase gate makes it idempotent on subsequent events).
+						if sess.LifecyclePhase() == agent.LifecycleInProgress && sess.IsReviewable() {
+							sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
+							autoPromoteCmd = a.fetchReviewDiffCmd(sess)
 						}
-						if allDone {
-							sess.MarkDone()
+						// Mark session done when all non-shell agents have exited.
+						if msg.event.Status == agent.StatusDone || msg.event.Status == agent.StatusError {
+							allDone := true
+							for _, ag := range sess.Agents() {
+								if !ag.IsShell && ag.Status() != agent.StatusDone && ag.Status() != agent.StatusError {
+									allDone = false
+									break
+								}
+							}
+							if allDone {
+								sess.MarkDone()
+							}
 						}
 					}
 				}
@@ -701,7 +716,13 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Refresh list on any agent event — all repos are visible in the dashboard.
 		a.refreshAgentList()
 		if mgr := a.managers[msg.repoPath]; mgr != nil {
+			if autoPromoteCmd != nil {
+				return a, tea.Batch(autoPromoteCmd, listenEvents(mgr))
+			}
 			return a, listenEvents(mgr)
+		}
+		if autoPromoteCmd != nil {
+			return a, autoPromoteCmd
 		}
 		return a, nil
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4117,3 +4117,51 @@ func TestReviewPanel_ScrollBindingsAdvanceViewport(t *testing.T) {
 		t.Error("pgdown: panelFocus must remain focusReview")
 	}
 }
+
+// TestCreateResult_SkipFocusLaunch_StaysOnDashboard verifies that when
+// skipFocusLaunch is true the createResultMsg handler does not enter
+// focusLaunch, but still moves the pipeline cursor to the new session's row.
+func TestCreateResult_SkipFocusLaunch_StaysOnDashboard(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-skip", "skip-session")
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("agent-skip", false, agent.StatusIdle)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	// Pre-populate items; no manager is set so refreshAgentList returns early
+	// and leaves these items intact.
+	app.dashboard.items = []listItem{
+		{kind: listItemSession, repoPath: "/repo", session: sess},
+		{kind: listItemAgent, repoPath: "/repo", session: sess, agent: ag},
+	}
+
+	model, _ := app.Update(createResultMsg{
+		sessionID:       sess.ID,
+		agentID:         ag.ID,
+		skipFocusLaunch: true,
+	})
+	app = model.(App)
+
+	if app.dashboard.panelFocus == focusLaunch {
+		t.Error("panelFocus: got focusLaunch, want focusList (skipFocusLaunch should suppress terminal open)")
+	}
+	if app.focusLaunchAgent != nil {
+		t.Errorf("focusLaunchAgent: got %v, want nil", app.focusLaunchAgent.ID)
+	}
+	if app.focusCursorSection != focusSectionBuilding {
+		t.Errorf("focusCursorSection: got %v, want focusSectionBuilding", app.focusCursorSection)
+	}
+	building := app.dashboard.buildingSessions()
+	if len(building) == 0 {
+		t.Fatal("building section is empty — cursor-move block must run even when skipFocusLaunch is true")
+	}
+	if app.focusBuildingIdx >= len(building) {
+		t.Fatalf("focusBuildingIdx %d out of range (len=%d)", app.focusBuildingIdx, len(building))
+	}
+	if got := building[app.focusBuildingIdx].session; got == nil || got.ID != sess.ID {
+		t.Errorf("cursor does not point at new session: got %v, want %v", got, sess.ID)
+	}
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4247,3 +4247,139 @@ func TestApprovePlanAndSpawn_StaysOnDashboard(t *testing.T) {
 		t.Errorf("focusLaunchAgent: got %v, want nil", app.focusLaunchAgent.ID)
 	}
 }
+
+// setupAutoPromoteRepo creates a temp git repo and a manager for auto-promote tests.
+func setupAutoPromoteRepo(t *testing.T) (dir string, mgr *agent.Manager) {
+	t.Helper()
+	var err error
+	dir, err = os.MkdirTemp("", "baton-auto-promote-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	for _, args := range [][]string{
+		{"git", "init"},
+		{"git", "config", "commit.gpgsign", "false"},
+		{"git", "commit", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup %v: %v\n%s", args, err, out)
+		}
+	}
+	mgr = agent.NewManager(dir, config.Resolve(nil, nil))
+	t.Cleanup(mgr.Shutdown)
+	return dir, mgr
+}
+
+// TestAgentEvent_IdleAutoPromotesInProgressToReadyForReview verifies that
+// receiving a StatusIdle event for a session in LifecycleInProgress whose
+// agents are all reviewable advances the session to LifecycleReadyForReview.
+func TestAgentEvent_IdleAutoPromotesInProgressToReadyForReview(t *testing.T) {
+	dir, mgr := setupAutoPromoteRepo(t)
+
+	sess, err := mgr.CreateSessionForPlanning(agent.Config{Rows: 24, Cols: 80, AgentProgram: "bash"})
+	if err != nil {
+		t.Fatalf("CreateSessionForPlanning: %v", err)
+	}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("ag-idle-1", false, agent.StatusIdle)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.resolvedCache[dir] = config.Resolve(nil, nil)
+
+	model, cmd := app.Update(agentEventMsg{
+		event: agent.Event{
+			Type:      agent.EventStatusChanged,
+			AgentID:   ag.ID,
+			SessionID: sess.ID,
+			Status:    agent.StatusIdle,
+		},
+		repoPath: dir,
+	})
+	if m, ok := model.(*App); ok {
+		_ = m
+	} else {
+		_ = model.(App)
+	}
+
+	if sess.LifecyclePhase() != agent.LifecycleReadyForReview {
+		t.Errorf("phase: got %v, want LifecycleReadyForReview", sess.LifecyclePhase())
+	}
+	if cmd == nil {
+		t.Error("returned Cmd is nil; expected tea.Batch(fetchReviewDiffCmd, listenEvents)")
+	}
+}
+
+// TestAgentEvent_ActiveDoesNotAutoPromote verifies that an Active-status event
+// does not advance a session from LifecycleInProgress to ReadyForReview.
+func TestAgentEvent_ActiveDoesNotAutoPromote(t *testing.T) {
+	dir, mgr := setupAutoPromoteRepo(t)
+
+	sess, err := mgr.CreateSessionForPlanning(agent.Config{Rows: 24, Cols: 80, AgentProgram: "bash"})
+	if err != nil {
+		t.Fatalf("CreateSessionForPlanning: %v", err)
+	}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("ag-active-1", false, agent.StatusActive)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+
+	app.Update(agentEventMsg{ //nolint:errcheck
+		event: agent.Event{
+			Type:      agent.EventStatusChanged,
+			AgentID:   ag.ID,
+			SessionID: sess.ID,
+			Status:    agent.StatusActive,
+		},
+		repoPath: dir,
+	})
+
+	if sess.LifecyclePhase() != agent.LifecycleInProgress {
+		t.Errorf("phase: got %v, want LifecycleInProgress (Active event must not promote)", sess.LifecyclePhase())
+	}
+}
+
+// TestAgentEvent_IdleLeavesShippingPhaseAlone verifies that a Shipping-phase
+// session is not demoted to ReadyForReview when its agents go idle.
+func TestAgentEvent_IdleLeavesShippingPhaseAlone(t *testing.T) {
+	dir, mgr := setupAutoPromoteRepo(t)
+
+	sess, err := mgr.CreateSessionForPlanning(agent.Config{Rows: 24, Cols: 80, AgentProgram: "bash"})
+	if err != nil {
+		t.Fatalf("CreateSessionForPlanning: %v", err)
+	}
+	sess.SetLifecyclePhase(agent.LifecycleShipping)
+	ag := sess.AddTestAgent("ag-ship-1", false, agent.StatusIdle)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+
+	app.Update(agentEventMsg{ //nolint:errcheck
+		event: agent.Event{
+			Type:      agent.EventStatusChanged,
+			AgentID:   ag.ID,
+			SessionID: sess.ID,
+			Status:    agent.StatusIdle,
+		},
+		repoPath: dir,
+	})
+
+	if sess.LifecyclePhase() != agent.LifecycleShipping {
+		t.Errorf("phase: got %v, want LifecycleShipping (idle event must not demote Shipping session)", sess.LifecyclePhase())
+	}
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4165,3 +4165,85 @@ func TestCreateResult_SkipFocusLaunch_StaysOnDashboard(t *testing.T) {
 		t.Errorf("cursor does not point at new session: got %v, want %v", got, sess.ID)
 	}
 }
+
+// TestApprovePlanAndSpawn_StaysOnDashboard verifies that approving a plan keeps
+// the user on the dashboard (panelFocus == focusList, focusLaunchAgent == nil)
+// instead of dropping into the fullscreen agent terminal.
+func TestApprovePlanAndSpawn_StaysOnDashboard(t *testing.T) {
+	dir, err := os.MkdirTemp("", "baton-approve-spawn-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	for _, args := range [][]string{
+		{"git", "init"},
+		{"git", "config", "commit.gpgsign", "false"},
+		{"git", "commit", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup %v: %v\n%s", args, err, out)
+		}
+	}
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+
+	sess, err := mgr.CreateSessionForPlanning(agent.Config{
+		Rows: 24, Cols: 80, AgentProgram: "bash",
+	})
+	if err != nil {
+		t.Fatalf("CreateSessionForPlanning: %v", err)
+	}
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.resolvedCache[dir] = config.ResolvedSettings{
+		AgentProgram: "bash",
+	}
+
+	model, cmd := app.approvePlanAndSpawn(planEditorApproveMsg{
+		sessionID: sess.ID,
+		repoPath:  dir,
+	})
+	if m, ok := model.(*App); ok {
+		app = *m
+	} else {
+		app = model.(App)
+	}
+	if cmd == nil {
+		t.Fatal("approvePlanAndSpawn returned nil cmd; expected a deferred AddAgent closure")
+	}
+
+	// Execute the cmd synchronously to get the createResultMsg.
+	resultMsg, ok := cmd().(createResultMsg)
+	if !ok {
+		t.Fatalf("cmd() returned %T, want createResultMsg", cmd())
+	}
+	if resultMsg.err != nil {
+		t.Fatalf("createResultMsg.err: %v", resultMsg.err)
+	}
+	if !resultMsg.skipFocusLaunch {
+		t.Error("createResultMsg.skipFocusLaunch: got false, want true (plan-approve path must not open agent terminal)")
+	}
+
+	// Dispatch through Update and verify focus stays on dashboard.
+	model2, _ := app.Update(resultMsg)
+	if m, ok := model2.(*App); ok {
+		app = *m
+	} else {
+		app = model2.(App)
+	}
+	if app.dashboard.panelFocus == focusLaunch {
+		t.Error("panelFocus: got focusLaunch after plan approval, want focusList")
+	}
+	if app.focusLaunchAgent != nil {
+		t.Errorf("focusLaunchAgent: got %v, want nil", app.focusLaunchAgent.ID)
+	}
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1683,10 +1683,16 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName string, sel
 		nameRendered += tag
 	}
 	line1 := prefix + nameRendered
+	prIndSet := false
 	if prEntry := d.prCache[sess.ID]; prEntry != nil {
 		if prInd := prIndicator(prEntry); prInd != "" {
 			line1 = rightAlign(prefix+nameRendered, prInd, width)
+			prIndSet = true
 		}
+	}
+	if !prIndSet && !sess.IsReviewable() {
+		badge := d.sessionFocusStatus(sess)
+		line1 = rightAlign(prefix+nameRendered, badge, width)
 	}
 
 	var taskDisplay string

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -449,7 +449,7 @@ func renderCardProgressBar(done, total, width int, primary lipgloss.Color) strin
 
 // sessionFocusStatus returns a styled inline status badge for a session row in
 // the unified SESSIONS list. Priority: Error > Waiting > May Need Input >
-// idle-but-reviewable > finished (DoneAt set) > normal (N active, M idle).
+// idle-but-reviewable (only when no active agents) > finished (DoneAt set) > normal (N active, M idle).
 func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 	var waitingCount, activeCount, idleCount, idleAskingCount int
 	var firstWaitingReason string
@@ -488,7 +488,7 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 	if idleAskingCount > 0 {
 		return lipgloss.NewStyle().Foreground(ColorWarning).Render(fmt.Sprintf("? %d idle — may need input", idleAskingCount))
 	}
-	if sess.IsReviewable() && sess.DoneAt().IsZero() {
+	if sess.IsReviewable() && sess.DoneAt().IsZero() && activeCount == 0 {
 		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ idle — press m to review")
 	}
 	if !sess.DoneAt().IsZero() {


### PR DESCRIPTION
## Summary

- **Auto-advance plan approval**: When approving a plan via `approvePlanAndSpawn`, the dashboard automatically advances to show the result without stealing focus (gated by `skipFocusLaunch` field)
- **Auto-promote building sessions to review**: Sessions automatically transition from `LifecycleInProgress` → `LifecycleReadyForReview` when agents finish building and go idle, eliminating a manual step
- Updated e2e tests to expect the new `REVIEWING` section behavior instead of manual badge press
- Added changelog entries documenting the quiet plan-approve behavior and auto-promote lifecycle transition

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI:
  - Approve a plan and verify focus stays in the plan view
  - Verify building session auto-transitions to "Ready for Review" when agents idle

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description