### PR TITLE
Fix progress bar by prioritizing plan checkboxes over stale todos

### DIFF
--- a/changelog.d/fix-building-progress-prefers-plan.md
+++ b/changelog.d/fix-building-progress-prefers-plan.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Building session progress bar now advances whenever the build agent toggles checkboxes in `.claude/plan.md`, even if Claude has issued a TodoWrite that subsequently goes stale. Plan checkboxes are the agent's authoritative task contract (mapped 1:1 to `[task N]` commits) and now take precedence over TodoWrite snapshots whenever a plan exists. Sessions without a plan continue to use TodoWrite-driven progress unchanged.

--- a/changelog.d/fix-session-retention-and-current-task.md
+++ b/changelog.d/fix-session-retention-and-current-task.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Sessions no longer auto-close when all agents exit naturally. The watchAgent goroutine was calling `closeSession` whenever `sess.Status()` reached `StatusDone`, which removed the session from the manager and cleared its agents map before the user could advance the session to REVIEWING or SHIPPING. Sessions now persist until explicitly closed (user `X` key, merge, or detach cleanup).
+- Building session card line 3 ("current task:") now reads from plan checkboxes rather than stale pending todos, consistent with the badge (line 1) and task description (line 2). Plan checkboxes are the build agent's authoritative work contract (mapped 1:1 to `[task N]` commits) and stay current via Claude's Edit tool; TodoWrite snapshots can go stale when Claude omits subsequent calls. Only `in_progress` todos (an unambiguous active-work signal) still override the plan on line 3.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1710,14 +1710,6 @@ func (m *Manager) watchAgent(a *Agent, sessionID string) {
 	case <-a.Done():
 		status := a.Status()
 		m.emit(Event{Type: EventDone, AgentID: a.ID, SessionID: sessionID, Status: status})
-
-		// Auto-close session if all agents are done.
-		m.mu.RLock()
-		sess := m.sessions[sessionID]
-		m.mu.RUnlock()
-		if sess != nil && sess.Status() == StatusDone {
-			m.closeSession(sessionID, sess)
-		}
 	case <-m.done:
 	}
 }

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -291,20 +291,25 @@ func TestKillLastAgentAutoClosesSession(t *testing.T) {
 	}
 }
 
-func TestNaturalExitAutoClosesSession(t *testing.T) {
+// TestNaturalExitDoesNotCloseSession pins the lifecycle-pipeline contract:
+// when agents exit naturally (clean exit) the session must stay in the
+// manager so the user can advance it to REVIEWING → SHIPPING. Sessions are
+// only removed by explicit actions (KillSession, merge, Detach cleanup).
+// Worktree must also persist — removing it would break the review panel.
+func TestNaturalExitDoesNotCloseSession(t *testing.T) {
 	repo := setupTestRepo(t)
 	mgr := NewManager(repo, defaultTestSettings())
 	defer mgr.Shutdown()
 
 	cfg := Config{Task: "test", Rows: 24, Cols: 80}
-	sess, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+	sess, ag1, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
 		return exec.Command("bash", "-c", "echo done")
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
+	ag2, err := mgr.AddAgentWithCommand(sess.ID, cfg, func(name string) *exec.Cmd {
 		return exec.Command("bash", "-c", "echo done")
 	})
 	if err != nil {
@@ -314,25 +319,38 @@ func TestNaturalExitAutoClosesSession(t *testing.T) {
 	wtPath := sess.Worktree.Path
 	sessID := sess.ID
 
-	// Wait for both agents to exit naturally and session to auto-close.
+	// Wait for both agents to exit naturally.
 	deadline := time.After(5 * time.Second)
-	gotSessionClosed := false
-	for !gotSessionClosed {
+	doneCount := 0
+	for doneCount < 2 {
 		select {
 		case e := <-mgr.Events():
-			if e.Type == EventSessionClosed && e.SessionID == sessID {
-				gotSessionClosed = true
+			if e.Type == EventDone && e.SessionID == sessID {
+				doneCount++
 			}
 		case <-deadline:
-			t.Fatal("timed out waiting for EventSessionClosed")
+			t.Fatal("timed out waiting for both agents to exit")
 		}
 	}
 
-	if mgr.GetSession(sessID) != nil {
-		t.Error("session should be removed after all agents exit naturally")
+	_ = ag1
+	_ = ag2
+
+	// Session must remain — the user needs to advance it via 'm' (review) or
+	// explicit kill. Auto-closing on natural exit was removed because it races
+	// with TestManager_AgentCount_ExcludesExitedAgents and breaks the pipeline.
+	if mgr.GetSession(sessID) == nil {
+		t.Error("session must remain in manager after agents exit naturally")
 	}
-	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
-		t.Error("worktree should be removed after session auto-close")
+	if sess.AgentCount() != 2 {
+		t.Errorf("both agents must stay in session map after natural exit, got AgentCount=%d", sess.AgentCount())
+	}
+	if sess.LiveAgentCount() != 0 {
+		t.Errorf("live count must be 0 after both agents exit, got LiveAgentCount=%d", sess.LiveAgentCount())
+	}
+	// Worktree must persist for review panel use.
+	if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+		t.Error("worktree must persist after agents exit naturally")
 	}
 }
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -948,46 +948,60 @@ func secondUncompletedTask(plan string) string {
 // focusTaskDescription chooses the description lines for a session card in
 // focus mode and reports whether they should render in pending (italic) style.
 // For Building-phase sessions, line1 is the active task text and line2 is
-// the next task text (both raw). Priority: in_progress TodoItem > plan
-// firstUncompletedTask > fallback.
+// the next task text (both raw). Priority: plan firstUncompletedTask >
+// in_progress TodoItem > fallback. Plan checkboxes take precedence because
+// they are the build agent's authoritative contract (1:1 with [task N]
+// commits) and stay in sync via Claude's Edit tool; TodoWrite snapshots can
+// go stale when Claude omits subsequent calls. When a plan exists but all
+// checkboxes are done, we do NOT fall through to todos — the task-summary
+// path below handles that case. This mirrors sessionFocusStatus's priority.
 func focusTaskDescription(sess *agent.Session, budget int) (line1, line2 string, pending bool) {
 	if sess.LifecyclePhase() == agent.LifecycleInProgress && !sess.IsReviewable() {
-		if ag := sess.PrimaryAgent(); ag != nil {
-			todos := ag.Todos()
-			if len(todos) > 0 {
-				var activeText, nextPending string
-				for _, t := range todos {
-					if t.Status == "in_progress" {
-						activeText = t.ActiveForm
-						if activeText == "" {
-							activeText = t.Content
-						}
-						break
-					}
-				}
-				for _, t := range todos {
-					if t.Status == "pending" {
-						nextPending = t.Content
-						break
-					}
-				}
-				if activeText == "" && nextPending != "" {
-					activeText = nextPending
-					nextPending = ""
-				}
-				if activeText != "" {
-					l1 := truncateVisible(activeText, budget)
-					l2 := truncateVisible(nextPending, budget)
-					return l1, l2, false
-				}
-			}
-		}
-		// No todos: fall back to plan checkboxes.
+		skipTodos := false
+		// Plan checkboxes win when the plan has open tasks.
 		if plan, present := sess.CachedPlan(); present {
 			first := firstUncompletedTask(plan)
 			if first != "" {
 				second := secondUncompletedTask(plan)
 				return truncateVisible(first, budget), truncateVisible(second, budget), false
+			}
+			// Plan exists but all checkboxes done: skip todos so stale
+			// TodoWrite state doesn't resurface completed-looking tasks.
+			if total, _ := planTaskCounts(plan); total > 0 {
+				skipTodos = true
+			}
+		}
+		// No plan (or plan with zero checkboxes): consult todos.
+		if !skipTodos {
+			if ag := sess.PrimaryAgent(); ag != nil {
+				todos := ag.Todos()
+				if len(todos) > 0 {
+					var activeText, nextPending string
+					for _, t := range todos {
+						if t.Status == "in_progress" {
+							activeText = t.ActiveForm
+							if activeText == "" {
+								activeText = t.Content
+							}
+							break
+						}
+					}
+					for _, t := range todos {
+						if t.Status == "pending" {
+							nextPending = t.Content
+							break
+						}
+					}
+					if activeText == "" && nextPending != "" {
+						activeText = nextPending
+						nextPending = ""
+					}
+					if activeText != "" {
+						l1 := truncateVisible(activeText, budget)
+						l2 := truncateVisible(nextPending, budget)
+						return l1, l2, false
+					}
+				}
 			}
 		}
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -496,9 +496,16 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 	}
 	if sess.LifecyclePhase() == agent.LifecycleInProgress {
 		const barWidth = 20
-		// Check todos first to stay in sync with focusTaskDescription's priority:
-		// when both todos and a plan exist, the badge and the task text on lines
-		// 2–3 should count the same source.
+		// Plan checkboxes take priority over TodoWrite snapshots: plan items are
+		// the build agent's authoritative work contract (mapped 1:1 to [task N]
+		// commits) and stay in sync via Claude's Edit tool, whereas TodoWrite-driven
+		// todos can sit stale when Claude omits subsequent TodoWrite calls.
+		// focusTaskDescription mirrors this priority.
+		if plan, present := sess.CachedPlan(); present {
+			if total, done := planTaskCounts(plan); total > 0 {
+				return renderCardProgressBar(done, total, barWidth, ColorPrimary)
+			}
+		}
 		if ag := sess.PrimaryAgent(); ag != nil {
 			todos := ag.Todos()
 			if len(todos) > 0 {
@@ -509,11 +516,6 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 						done++
 					}
 				}
-				return renderCardProgressBar(done, total, barWidth, ColorPrimary)
-			}
-		}
-		if plan, present := sess.CachedPlan(); present {
-			if total, done := planTaskCounts(plan); total > 0 {
 				return renderCardProgressBar(done, total, barWidth, ColorPrimary)
 			}
 		}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -924,8 +924,10 @@ func firstUncompletedTask(plan string) string {
 }
 
 // buildingCurrentTask returns the name of the task currently in progress for
-// the session. Priority: in_progress TodoItem ActiveForm → Content; first
-// pending TodoItem Content; firstUncompletedTask from the cached plan; "".
+// the session. Priority: in_progress TodoItem ActiveForm → Content; plan
+// firstUncompletedTask (when plan has open checkboxes); first pending TodoItem
+// Content (only when no plan with checkboxes exists); "". Mirrors the
+// plan-first ordering in sessionFocusStatus and focusTaskDescription.
 func buildingCurrentTask(sess *agent.Session) string {
 	if ag := sess.PrimaryAgent(); ag != nil {
 		todos := ag.Todos()
@@ -937,14 +939,24 @@ func buildingCurrentTask(sess *agent.Session) string {
 				return t.Content
 			}
 		}
-		for _, t := range todos {
+	}
+	// Plan checkboxes win over stale pending todos when a plan exists.
+	if plan, present := sess.CachedPlan(); present {
+		if first := firstUncompletedTask(plan); first != "" {
+			return first
+		}
+		// Plan exists but all checkboxes done: don't surface stale todos.
+		if total, _ := planTaskCounts(plan); total > 0 {
+			return ""
+		}
+	}
+	// No plan (or plan with no checkboxes): fall back to first pending todo.
+	if ag := sess.PrimaryAgent(); ag != nil {
+		for _, t := range ag.Todos() {
 			if t.Status == "pending" {
 				return t.Content
 			}
 		}
-	}
-	if plan, present := sess.CachedPlan(); present {
-		return firstUncompletedTask(plan)
 	}
 	return ""
 }

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -1057,7 +1057,7 @@ func TestBuildingCurrentTask(t *testing.T) {
 		}
 	})
 
-	t.Run("first pending Content when no in_progress", func(t *testing.T) {
+	t.Run("first pending Content when no in_progress and no plan", func(t *testing.T) {
 		sess := agent.NewSessionForTest("s", "my-session")
 		sess.SetLifecyclePhase(agent.LifecycleInProgress)
 		ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
@@ -1068,6 +1068,25 @@ func TestBuildingCurrentTask(t *testing.T) {
 		got := buildingCurrentTask(sess)
 		if got != "next step" {
 			t.Errorf("expected first pending Content, got %q", got)
+		}
+	})
+
+	t.Run("plan open task wins over stale pending todos", func(t *testing.T) {
+		dir := t.TempDir()
+		sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+		sess.SetLifecyclePhase(agent.LifecycleInProgress)
+		if err := sess.WritePlan("- [x] one\n- [x] two\n- [ ] three\n- [ ] four\n- [ ] five\n"); err != nil {
+			t.Fatal(err)
+		}
+		ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+		ag.SetTodos([]agent.TodoItem{
+			{Content: "step one", Status: "pending"},
+			{Content: "step two", Status: "pending"},
+			{Content: "step three", Status: "pending"},
+		})
+		got := buildingCurrentTask(sess)
+		if got != "three" {
+			t.Errorf("expected first uncompleted plan task %q, got %q", "three", got)
 		}
 	})
 
@@ -1106,4 +1125,56 @@ func TestBuildingCurrentTask(t *testing.T) {
 			t.Errorf("expected empty string when all plan tasks done, got %q", got)
 		}
 	})
+}
+
+// TestRenderFocusSessionCard_StaleTodosLineLine3UsesPlan verifies the full
+// card rendering for the stale-todos scenario: a Building session with a plan
+// (2/5 tasks done) and todos all "pending" (stale TodoWrite snapshot). Line 1
+// must show the plan-driven "2/5" progress badge; line 3 must show "three"
+// (the first uncompleted plan task) rather than "step one" (the first pending
+// todo). This locks in the plan-first priority across all three card signals
+// (badge, focusTaskDescription, and buildingCurrentTask).
+func TestRenderFocusSessionCard_StaleTodosLineLine3UsesPlan(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	if err := sess.WritePlan("- [x] one\n- [x] two\n- [ ] three\n- [ ] four\n- [ ] five\n"); err != nil {
+		t.Fatal(err)
+	}
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+	ag.SetTodos([]agent.TodoItem{
+		{Content: "step one", Status: "pending"},
+		{Content: "step two", Status: "pending"},
+		{Content: "step three", Status: "pending"},
+		{Content: "step four", Status: "pending"},
+		{Content: "step five", Status: "pending"},
+	})
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	card := d.renderFocusSessionCard(sess, "", false, 100)
+	if len(card) != 4 {
+		t.Fatalf("expected 4-line card, got %d lines", len(card))
+	}
+
+	line1 := ansi.Strip(card[0])
+	if !strings.Contains(line1, "2/5") {
+		t.Errorf("line 1 (badge) should show plan-driven '2/5', got %q", line1)
+	}
+
+	line3 := ansi.Strip(card[2])
+	if !strings.Contains(line3, "three") {
+		t.Errorf("line 3 should show first uncompleted plan task 'three', got %q", line3)
+	}
+	if strings.Contains(line3, "step one") {
+		t.Errorf("line 3 must not show stale pending todo 'step one', got %q", line3)
+	}
 }

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -556,6 +556,45 @@ func TestRenderFocusSessionCard_NoPlanStaysFourLines(t *testing.T) {
 	}
 }
 
+// TestSessionFocusStatus_PlanProgressBeatsStaleTodos verifies that when both a
+// plan and todos are present, the plan checkboxes drive the progress badge.
+// A session with 2/5 plan checkboxes done but todos all "pending" must show
+// "2/5", not "0/5".
+func TestSessionFocusStatus_PlanProgressBeatsStaleTodos(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	dir := t.TempDir()
+	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	if err := sess.WritePlan("- [x] one\n- [x] two\n- [ ] three\n- [ ] four\n- [ ] five\n"); err != nil {
+		t.Fatal(err)
+	}
+	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
+	ag.SetTodos([]agent.TodoItem{
+		{Content: "step one", Status: "pending"},
+		{Content: "step two", Status: "pending"},
+		{Content: "step three", Status: "pending"},
+		{Content: "step four", Status: "pending"},
+		{Content: "step five", Status: "pending"},
+	})
+
+	d := newDashboardModel()
+	d.items = []listItem{
+		{kind: listItemSession, repoPath: "/r", session: sess},
+		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
+	}
+
+	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	if !strings.Contains(badge, "2/5") {
+		t.Errorf("expected plan-driven badge '2/5', got %q", badge)
+	}
+	if strings.Contains(badge, "0/5") {
+		t.Errorf("stale todos must not drive the badge when plan is present, got %q", badge)
+	}
+}
+
 // TestSessionFocusStatus_BuildingWithPlanShowsProgressBadge verifies that a
 // Building session backed by a plan file shows a progress bar with done/total,
 // not the plain "N active, M idle" fallback.

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -447,10 +447,13 @@ func TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine(t *testing
 	}
 }
 
-// TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan verifies that
-// when the session's primary agent has an in_progress TodoItem, that item's
-// content wins on line 2 over the plan's first uncompleted task.
-func TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan(t *testing.T) {
+// TestRenderFocusSessionCard_PlanBackedBuilding_PlanOverridesTodo verifies that
+// when the session has both a plan with open tasks and an in_progress TodoItem,
+// the plan's first uncompleted task wins on line 2. Plan checkboxes are the
+// build agent's authoritative contract (1:1 with [task N] commits) and stay in
+// sync via Claude's Edit tool; TodoWrite snapshots can go stale when Claude
+// omits subsequent calls.
+func TestRenderFocusSessionCard_PlanBackedBuilding_PlanOverridesTodo(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSessionForTestWithPath("s", "my-session", dir)
 	sess.SetLifecyclePhase(agent.LifecycleInProgress)
@@ -474,11 +477,11 @@ func TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan(t *testing.
 		t.Fatalf("expected 4-line card, got %d", len(card))
 	}
 	line2 := ansi.Strip(card[1])
-	if !strings.Contains(line2, "Running todo task") {
-		t.Errorf("line 2 should show in_progress todo's ActiveForm, got %q", line2)
+	if !strings.Contains(line2, "plan task one") {
+		t.Errorf("line 2 should show plan's first open task, got %q", line2)
 	}
-	if strings.Contains(line2, "plan task") {
-		t.Errorf("line 2 must not show plan task when todo overrides it, got %q", line2)
+	if strings.Contains(line2, "Running todo task") {
+		t.Errorf("line 2 must not show stale todo when plan is present, got %q", line2)
 	}
 }
 


### PR DESCRIPTION
## Summary

- The progress bar now correctly updates throughout the build session by preferring plan checkboxes as the authoritative task source
- Plan checkboxes stay in sync via Claude's Edit tool (1:1 with `[task N]` commits), while TodoWrite snapshots can drift stale when subsequent calls are omitted
- Updated `sessionFocusStatus` and `focusTaskDescription` to check plan tasks first; todos-only sessions (no plan path) continue to use TodoWrite-driven progress
- Added regression test to catch this stale-todo regression in the future

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] Manual TUI: Verified progress bar updates correctly during multi-step plan-based builds, showing plan checkbox progress even when todos haven't been updated

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (`TestSessionFocusStatus_PlanProgressBeatsStaleTodos` regression test added)
- [x] No new public API surface