### PR TITLE
Gate Planning-advance 'b' on !focusBreakMode to fix break-exit

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2039,7 +2039,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// to advance is a deliberate action, while taking a break is
 				// the catch-all everywhere else — so the cursor location is
 				// the disambiguator the user already has at hand.
-				if a.focusCursorSection == focusSectionPlanning {
+				if !a.focusBreakMode && a.focusCursorSection == focusSectionPlanning {
 					planning := a.dashboard.planningSessions()
 					if len(planning) > 0 {
 						idx := a.focusPlanningIdx

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2532,6 +2532,29 @@ func TestBKey_OutsidePlanning_FallsThroughToBreak(t *testing.T) {
 	}
 }
 
+// TestBKey_InBreakMode_FromPlanningCursor_ExitsBreak verifies that pressing 'b'
+// while the break overlay is active exits the break regardless of which pipeline
+// section the cursor is on. The Planning-advance branch must not intercept the
+// press when focusBreakMode is true.
+func TestBKey_InBreakMode_FromPlanningCursor_ExitsBreak(t *testing.T) {
+	app, sessP, _, _, _ := makeFourPhaseApp(t)
+	app.focusBreakMode = true
+	app.focusBreakTimerUp = true // single-press clean exit
+	// makeFourPhaseApp already sets focusCursorSection = focusSectionPlanning
+	app.focusPlanningIdx = 0
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
+	app = model.(App)
+
+	if app.focusBreakMode {
+		t.Fatal("expected 'b' in break mode to exit the break overlay; focusBreakMode is still true")
+	}
+	if sessP.LifecyclePhase() != agent.LifecyclePlanning {
+		t.Errorf("Planning session phase changed unexpectedly: got %v, want %v",
+			sessP.LifecyclePhase(), agent.LifecyclePlanning)
+	}
+}
+
 // TestTick_BreakDoesNotEnterWhilePanelOpen pins M1: the auto-break entry must
 // only fire when the user is on the pipeline (focusList). If the user is in
 // the shipping panel mid-merge, the review panel, the plan editor, or


### PR DESCRIPTION
## Summary

- Fix bug where pressing 'b' was silently swallowed while the break overlay was active with the cursor on the Planning card
- When focusBreakMode is true, the Planning-advance branch now falls through to the global break-exit state machine regardless of cursor position
- Users can now always exit break mode by pressing 'b', even when the Planning card has focus

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] Manual TUI: Enter break mode, move cursor to Planning card, verify 'b' exits break mode

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description