### PR TITLE
Auto-complete and remove Shipping sessions when PR merges

### DIFF
--- a/changelog.d/fix-shipping-auto-complete-on-external-merge.md
+++ b/changelog.d/fix-shipping-auto-complete-on-external-merge.md
@@ -1,0 +1,3 @@
+### Fixed
+
+Sessions in the SHIPPING column now auto-complete and clear from the dashboard when their PR is merged or closed externally (e.g. via the GitHub UI or `gh pr merge`). Previously the open-only PR poll filtered merged PRs out, leaving the session stuck in Shipping until the next refrain restart.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -518,10 +518,13 @@ func (c *Client) GetReviewThreads(ctx context.Context, owner, repo string, numbe
 }
 
 // RefreshPR fetches the latest PR state by number, including mergeable_state
-// (always populated by the singular PR endpoint, unlike List/Create). Used to
-// re-validate a PR is still mergeable immediately before MergePR — the
-// pr-poller's cached state can be seconds stale, and CI/conflicts can change
-// in that window. Returns (nil, nil) if the PR no longer exists.
+// (always populated by the singular PR endpoint, unlike List/Create). Used in
+// two contexts: (1) re-validating a PR is still mergeable immediately before
+// MergePR — the pr-poller's cached state can be seconds stale; (2) the
+// pr-poller's merged-fallback path for Shipping sessions — when GetPRBySHA and
+// GetPR both return nil (open-only filters), RefreshPR is called with the
+// cached PR number to detect external merge or close so the session can
+// transition to LifecycleComplete. Returns (nil, nil) if the PR no longer exists.
 func (c *Client) RefreshPR(ctx context.Context, owner, repo string, number int) (*PRState, error) {
 	pr, err := c.getPRDetail(ctx, owner, repo, number)
 	if err != nil {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4421,7 +4421,7 @@ outer:
 			ps.inFlight = true
 			a.prPollsInFlight++
 			fetchThreads := sess.LifecyclePhase() == agent.LifecycleShipping
-			cmds = append(cmds, a.refreshPRStatusForSession(sess.ID, sess.Branch(), repo.Path, sess.Worktree.Path, fetchThreads))
+			cmds = append(cmds, a.refreshPRStatusForSession(sess.ID, sess.Branch(), repo.Path, sess.Worktree.Path, fetchThreads, 0))
 		}
 	}
 	return cmds
@@ -4493,7 +4493,9 @@ func getLocalHeadSHA(worktreePath string) string {
 
 // refreshPRStatusForSession returns a Cmd that polls PR, check, and review status for a single session.
 // worktreePath is used as a fallback SHA source when the branch hasn't been pushed under its current name.
-func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePath string, fetchThreads bool) tea.Cmd {
+// cachedPRNumber, when > 0 and the session is in LifecycleShipping, enables a merged-fallback lookup
+// via resolveMergedFallback so externally-merged/closed PRs are detected and the session is cleaned up.
+func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePath string, fetchThreads bool, cachedPRNumber int) tea.Cmd {
 	// Guard: ensure the caller passed the repo that actually owns this session.
 	// This catches programming errors (e.g. passing cfg.Repos[0].Path for a
 	// session that belongs to a different repo) before the poll fires.
@@ -4538,6 +4540,11 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 			if err != nil {
 				return prPollMsg{sessionID: sessionID, err: err}
 			}
+		}
+		// Shipping sessions: if the open-only lookups all returned nil, check
+		// whether the cached PR was merged or closed externally.
+		if pr == nil && cachedPRNumber > 0 {
+			pr = resolveMergedFallback(ctx, owner, repo, cachedPRNumber, ghClient.RefreshPR)
 		}
 		var checks *github.CheckStatus
 		var reviews *github.ReviewStatus

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -4421,10 +4421,26 @@ outer:
 			ps.inFlight = true
 			a.prPollsInFlight++
 			fetchThreads := sess.LifecyclePhase() == agent.LifecycleShipping
-			cmds = append(cmds, a.refreshPRStatusForSession(sess.ID, sess.Branch(), repo.Path, sess.Worktree.Path, fetchThreads, 0))
+			cachedPRNumber := a.cachedPRNumberForFallback(sess)
+			cmds = append(cmds, a.refreshPRStatusForSession(sess.ID, sess.Branch(), repo.Path, sess.Worktree.Path, fetchThreads, cachedPRNumber))
 		}
 	}
 	return cmds
+}
+
+// cachedPRNumberForFallback returns the cached PR number for a Shipping session
+// so the poll cmd can call resolveMergedFallback when the open-only lookup
+// returns nil. Returns 0 for non-Shipping sessions, preserving today's
+// 2-consecutive-nil eviction behaviour for Building/Reviewing sessions.
+func (a *App) cachedPRNumberForFallback(sess *agent.Session) int {
+	if sess.LifecyclePhase() != agent.LifecycleShipping {
+		return 0
+	}
+	entry := a.prCache[sess.ID]
+	if entry == nil || entry.pr == nil {
+		return 0
+	}
+	return entry.pr.Number
 }
 
 // prPollInterval returns the adaptive polling interval for a session.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4282,7 +4282,7 @@ func TestRefreshPRStatus_WrongRepoReturnsError(t *testing.T) {
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
 	wrongRepoPath := "/nonexistent/wrong-repo"
-	cmd := app.refreshPRStatusForSession(sess.ID, sess.Branch(), wrongRepoPath, "", false)
+	cmd := app.refreshPRStatusForSession(sess.ID, sess.Branch(), wrongRepoPath, "", false, 0)
 	if cmd == nil {
 		t.Fatal("expected non-nil Cmd from refreshPRStatusForSession with wrong repo")
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4892,3 +4892,34 @@ func TestAgentEvent_IdleLeavesShippingPhaseAlone(t *testing.T) {
 		t.Errorf("phase: got %v, want LifecycleShipping (idle event must not demote Shipping session)", sess.LifecyclePhase())
 	}
 }
+
+// TestPollAllSessions_PassesCachedPRNumberForShippingOnly verifies that
+// cachedPRNumberForFallback returns the cached PR number only for Shipping
+// sessions, and 0 for all other lifecycle phases.
+func TestPollAllSessions_PassesCachedPRNumberForShippingOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	shipping := agent.NewSessionForTest("ship-sess", "ship-branch")
+	shipping.SetLifecyclePhase(agent.LifecycleShipping)
+
+	building := agent.NewSessionForTest("build-sess", "build-branch")
+	building.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
+	defer mgr.Shutdown()
+	mgr.AddSessionForTest(shipping)
+	mgr.AddSessionForTest(building)
+
+	app := NewApp()
+	app.managers[dir] = mgr
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+	app.prCache[shipping.ID] = &prCacheEntry{pr: &github.PRState{Number: 42}}
+	app.prCache[building.ID] = &prCacheEntry{pr: &github.PRState{Number: 99}}
+
+	if got := app.cachedPRNumberForFallback(shipping); got != 42 {
+		t.Errorf("Shipping session: got %d, want 42", got)
+	}
+	if got := app.cachedPRNumberForFallback(building); got != 0 {
+		t.Errorf("InProgress session: got %d, want 0", got)
+	}
+}

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -193,6 +194,24 @@ func statePhraseStyle(phrase string) lipgloss.Style {
 	default: // "CI N/M failing"
 		return lipgloss.NewStyle().Foreground(ColorError)
 	}
+}
+
+// resolveMergedFallback fetches the authoritative PR state for a cached PR when
+// the open-only poll returns nil. It is only called for Shipping sessions so that
+// Building/Reviewing sessions retain today's 2-nil eviction behaviour.
+// Returns the PR if State is "merged" or "closed"; otherwise returns nil.
+func resolveMergedFallback(ctx context.Context, owner, repo string, cachedPRNumber int, refresh func(context.Context, string, string, int) (*github.PRState, error)) *github.PRState {
+	if cachedPRNumber <= 0 {
+		return nil
+	}
+	pr, err := refresh(ctx, owner, repo, cachedPRNumber)
+	if err != nil || pr == nil {
+		return nil
+	}
+	if pr.State == "merged" || pr.State == "closed" {
+		return pr
+	}
+	return nil
 }
 
 // prIndicatorWidth returns the approximate visible width of prIndicator output

--- a/internal/tui/pr_test.go
+++ b/internal/tui/pr_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -118,6 +119,82 @@ func TestPrPollMsg_NilGracePeriod(t *testing.T) {
 	}
 	if got2.prPollStates["sess-1"].consecutiveNilPolls != 0 {
 		t.Errorf("consecutiveNilPolls should reset to 0 after eviction, got %d", got2.prPollStates["sess-1"].consecutiveNilPolls)
+	}
+}
+
+// TestResolveMergedFallback verifies the six cases of the merged-fallback helper.
+func TestResolveMergedFallback(t *testing.T) {
+	ctx := context.Background()
+	mergedPR := &github.PRState{State: "merged", Number: 42}
+	closedPR := &github.PRState{State: "closed", Number: 43}
+	openPR := &github.PRState{State: "open", Number: 44}
+
+	tests := []struct {
+		name           string
+		cachedPRNumber int
+		refreshReturn  *github.PRState
+		refreshErr     error
+		want           *github.PRState
+		wantCalled     bool
+	}{
+		{
+			name:           "zero cachedPRNumber skips refresh",
+			cachedPRNumber: 0,
+			wantCalled:     false,
+			want:           nil,
+		},
+		{
+			name:           "refresh error returns nil",
+			cachedPRNumber: 42,
+			refreshErr:     errors.New("network error"),
+			wantCalled:     true,
+			want:           nil,
+		},
+		{
+			name:           "refresh returns nil PR returns nil",
+			cachedPRNumber: 42,
+			refreshReturn:  nil,
+			wantCalled:     true,
+			want:           nil,
+		},
+		{
+			name:           "open PR returns nil",
+			cachedPRNumber: 44,
+			refreshReturn:  openPR,
+			wantCalled:     true,
+			want:           nil,
+		},
+		{
+			name:           "merged PR is returned",
+			cachedPRNumber: 42,
+			refreshReturn:  mergedPR,
+			wantCalled:     true,
+			want:           mergedPR,
+		},
+		{
+			name:           "closed PR is returned",
+			cachedPRNumber: 43,
+			refreshReturn:  closedPR,
+			wantCalled:     true,
+			want:           closedPR,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			refresh := func(_ context.Context, _, _ string, _ int) (*github.PRState, error) {
+				called = true
+				return tc.refreshReturn, tc.refreshErr
+			}
+			got := resolveMergedFallback(ctx, "owner", "repo", tc.cachedPRNumber, refresh)
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+			if called != tc.wantCalled {
+				t.Errorf("refresh called = %v, want %v", called, tc.wantCalled)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- When a Shipping session's PR merges, automatically resolve the session and remove it from the dashboard
- Added `resolveMergedFallback` helper to detect merged PRs and complete sessions
- Thread cached PR number through `pollAllSessions` → `refreshPRStatusForSession` to enable lookup without additional API calls
- Feature gated on Shipping mode; no impact to other session types
- Includes unit tests for the new helper

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] Manual TUI: Start a Shipping session, merge the PR externally, verify the session auto-completes and is removed from the dashboard

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (unit tests for `resolveMergedFallback`)
- [x] No new public API surface without a note