### PR TITLE
Fix Detach idempotency and dashboard current-task scoping

### DIFF
--- a/changelog.d/fix-detach-shutdown-and-current-task-scoping.md
+++ b/changelog.d/fix-detach-shutdown-and-current-task-scoping.md
@@ -1,0 +1,5 @@
+### Fixed
+
+`Manager.Detach()` is now idempotent and safe to follow with `Shutdown()` (or vice versa) — previously the second call panicked with "close of closed channel" because `Detach` closed `m.done` outside of `shutdownOnce`. The two teardown methods now share the same once-gate so a deferred `Shutdown()` after an explicit `Detach()` is a no-op rather than a crash.
+
+The dashboard's "current task" indicator now scopes its scan to the `## Tasks` section the same way `planTaskCounts` and `ParsePlanTasks` do. A stray `- [ ]` in `## Spec` or `## Verification` no longer surfaces as the active task while the X/Y count ignores it — the two values are now derived from the same set of checkboxes.

--- a/internal/agent/detach_resume_test.go
+++ b/internal/agent/detach_resume_test.go
@@ -727,3 +727,60 @@ func TestParseSessionNum(t *testing.T) {
 		}
 	}
 }
+
+// TestDetach_CalledTwiceDoesNotPanic pins the idempotency of Detach: calling
+// it twice must not panic on close-of-closed-channel for m.done or m.events.
+// Before the shared shutdownOnce gate, the second call panicked.
+func TestDetach_CalledTwiceDoesNotPanic(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+
+	if got := mgr.Detach(); got != nil {
+		t.Fatalf("first Detach on empty manager: want nil, got %+v", got)
+	}
+	if got := mgr.Detach(); got != nil {
+		t.Errorf("second Detach: want nil (no-op), got %+v", got)
+	}
+}
+
+// TestDetach_ThenShutdownDoesNotPanic pins the production teardown order: the
+// TUI snapshots state via Detach() and then a deferred mgr.Shutdown() fires.
+// The second call must be a no-op rather than panic on close-of-closed-channel.
+func TestDetach_ThenShutdownDoesNotPanic(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+
+	cfg := Config{Task: "test", Rows: 24, Cols: 80}
+	_, _, err := mgr.CreateSessionWithCommand(cfg, func(name string) *exec.Cmd {
+		return exec.Command("bash", "-c", "sleep 60")
+	})
+	if err != nil {
+		t.Fatalf("CreateSessionWithCommand: %v", err)
+	}
+
+	bs := mgr.Detach()
+	if bs == nil {
+		t.Fatal("Detach returned nil; expected snapshot with one session")
+	}
+	if len(bs.Sessions) != 1 {
+		t.Fatalf("Detach snapshot: want 1 session, got %d", len(bs.Sessions))
+	}
+
+	// Must not panic. Shutdown after Detach is the documented production
+	// pattern (defer mgr.Shutdown() paired with an explicit Detach on quit).
+	mgr.Shutdown()
+}
+
+// TestShutdown_ThenDetachReturnsNil pins the reverse order: if Shutdown has
+// already torn down the manager, a subsequent Detach must return nil rather
+// than panic. The shared shutdownOnce gate makes this a no-op.
+func TestShutdown_ThenDetachReturnsNil(t *testing.T) {
+	repo := setupTestRepo(t)
+	mgr := NewManager(repo, defaultTestSettings())
+
+	mgr.Shutdown()
+
+	if got := mgr.Detach(); got != nil {
+		t.Errorf("Detach after Shutdown: want nil, got %+v", got)
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1574,107 +1574,118 @@ func (m *Manager) RepoPath() string {
 
 // Detach snapshots all sessions into a RefrainState, kills all agents but preserves
 // worktrees, and shuts down the manager. Returns the state for persistence.
+//
+// Shares m.shutdownOnce with Shutdown: both close m.done, drain watchers, and
+// close the sends channels exactly once. If Shutdown ran first, Detach returns
+// nil; if Detach ran first, a later Shutdown is a no-op (which is correct —
+// Detach intentionally leaves snapshotted sessions alive for a later resume).
+// Without this gate, a defer mgr.Shutdown() after Detach panics on
+// close-of-closed-channel.
 func (m *Manager) Detach() *state.RefrainState {
-	close(m.done)
+	var result *state.RefrainState
+	m.shutdownOnce.Do(func() {
+		close(m.done)
 
-	// Stop hooks + drain watchers before snapshotting so any in-flight
-	// branch rename has settled and the snapshot captures the final name.
-	m.stopHookServer()
-	m.watchers.Wait()
+		// Stop hooks + drain watchers before snapshotting so any in-flight
+		// branch rename has settled and the snapshot captures the final name.
+		m.stopHookServer()
+		m.watchers.Wait()
 
-	m.mu.RLock()
-	sessions := make([]*Session, 0, len(m.sessions))
-	for _, s := range m.sessions {
-		sessions = append(sessions, s)
-	}
-	m.mu.RUnlock()
-
-	// Partition: complete sessions are cleaned up; others are snapshotted.
-	var toSnapshot, toClean []*Session
-	for _, s := range sessions {
-		if s.LifecyclePhase() == LifecycleComplete {
-			toClean = append(toClean, s)
-		} else {
-			toSnapshot = append(toSnapshot, s)
+		m.mu.RLock()
+		sessions := make([]*Session, 0, len(m.sessions))
+		for _, s := range m.sessions {
+			sessions = append(sessions, s)
 		}
-	}
+		m.mu.RUnlock()
 
-	// Snapshot state before killing agents.
-	sessionStates := make([]state.SessionState, 0, len(toSnapshot))
-	for _, s := range toSnapshot {
-		var doneAt *time.Time
-		if t := s.DoneAt(); !t.IsZero() {
-			doneAt = &t
-		}
-		ss := state.SessionState{
-			ID:             s.ID,
-			Name:           s.CurrentName(),
-			DisplayName:    s.GetDisplayName(),
-			WorktreePath:   s.Worktree.Path,
-			Branch:         s.Branch(),
-			BaseBranch:     s.Worktree.BaseBranch,
-			OwnsBranch:     s.ownsBranch,
-			HasClaudeName:  s.HasClaudeName(),
-			LifecyclePhase: s.LifecyclePhase().String(),
-			OriginalPrompt: s.OriginalPrompt(),
-			DoneAt:         doneAt,
-		}
-		for _, a := range s.Agents() {
-			as := state.AgentState{
-				ID:              a.ID,
-				Name:            a.Name,
-				DisplayName:     a.GetDisplayName(),
-				Task:            a.Task,
-				ClaudeSessionID: a.ClaudeSessionID(),
+		// Partition: complete sessions are cleaned up; others are snapshotted.
+		var toSnapshot, toClean []*Session
+		for _, s := range sessions {
+			if s.LifecyclePhase() == LifecycleComplete {
+				toClean = append(toClean, s)
+			} else {
+				toSnapshot = append(toSnapshot, s)
 			}
-			ss.Agents = append(ss.Agents, as)
 		}
-		sessionStates = append(sessionStates, ss)
-	}
 
-	// Kill complete sessions and remove their worktrees.
-	var cleanWg sync.WaitGroup
-	cleanWg.Add(len(toClean))
-	for _, s := range toClean {
-		go func() {
-			defer cleanWg.Done()
-			s.KillAll()
-			_ = s.Cleanup(m.repoPath)
-		}()
-	}
-	cleanWg.Wait()
+		// Snapshot state before killing agents.
+		sessionStates := make([]state.SessionState, 0, len(toSnapshot))
+		for _, s := range toSnapshot {
+			var doneAt *time.Time
+			if t := s.DoneAt(); !t.IsZero() {
+				doneAt = &t
+			}
+			ss := state.SessionState{
+				ID:             s.ID,
+				Name:           s.CurrentName(),
+				DisplayName:    s.GetDisplayName(),
+				WorktreePath:   s.Worktree.Path,
+				Branch:         s.Branch(),
+				BaseBranch:     s.Worktree.BaseBranch,
+				OwnsBranch:     s.ownsBranch,
+				HasClaudeName:  s.HasClaudeName(),
+				LifecyclePhase: s.LifecyclePhase().String(),
+				OriginalPrompt: s.OriginalPrompt(),
+				DoneAt:         doneAt,
+			}
+			for _, a := range s.Agents() {
+				as := state.AgentState{
+					ID:              a.ID,
+					Name:            a.Name,
+					DisplayName:     a.GetDisplayName(),
+					Task:            a.Task,
+					ClaudeSessionID: a.ClaudeSessionID(),
+				}
+				ss.Agents = append(ss.Agents, as)
+			}
+			sessionStates = append(sessionStates, ss)
+		}
 
-	// Kill agents for snapshotted sessions but do NOT call Cleanup (preserve worktrees).
-	var wg sync.WaitGroup
-	wg.Add(len(toSnapshot))
-	for _, s := range toSnapshot {
-		go func() {
-			defer wg.Done()
-			s.KillAll()
-		}()
-	}
-	wg.Wait()
+		// Kill complete sessions and remove their worktrees.
+		var cleanWg sync.WaitGroup
+		cleanWg.Add(len(toClean))
+		for _, s := range toClean {
+			go func() {
+				defer cleanWg.Done()
+				s.KillAll()
+				_ = s.Cleanup(m.repoPath)
+			}()
+		}
+		cleanWg.Wait()
 
-	m.mu.Lock()
-	m.sessions = make(map[string]*Session)
-	m.mu.Unlock()
+		// Kill agents for snapshotted sessions but do NOT call Cleanup (preserve worktrees).
+		var wg sync.WaitGroup
+		wg.Add(len(toSnapshot))
+		for _, s := range toSnapshot {
+			go func() {
+				defer wg.Done()
+				s.KillAll()
+			}()
+		}
+		wg.Wait()
 
-	// Same gate as Shutdown — see the comment there.
-	m.sendsMu.Lock()
-	m.sendsClosed = true
-	close(m.events)
-	close(m.plannerQuestions)
-	m.sendsMu.Unlock()
+		m.mu.Lock()
+		m.sessions = make(map[string]*Session)
+		m.mu.Unlock()
 
-	if len(sessionStates) == 0 {
-		return nil
-	}
+		// Same gate as Shutdown — see the comment there.
+		m.sendsMu.Lock()
+		m.sendsClosed = true
+		close(m.events)
+		close(m.plannerQuestions)
+		m.sendsMu.Unlock()
 
-	return &state.RefrainState{
-		Version:  1,
-		SavedAt:  time.Now(),
-		Sessions: sessionStates,
-	}
+		if len(sessionStates) == 0 {
+			return
+		}
+
+		result = &state.RefrainState{
+			Version:  1,
+			SavedAt:  time.Now(),
+			Sessions: sessionStates,
+		}
+	})
+	return result
 }
 
 // ResumeSession recreates a session from saved state without creating a new worktree.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -913,8 +913,13 @@ func planTaskCounts(plan string) (total, done int) {
 // "" if every task is done (or the plan has no task lines). Used by the
 // Planning card description so the user sees what's outstanding without
 // opening the editor.
+//
+// Scopes to the "## Tasks" section via agent.ScanTaskLines so a stray "- [ ]"
+// in Spec/Goal/Verification cannot surface as the "current task" while
+// planTaskCounts (which uses the same scope) ignores it — the two would
+// otherwise disagree on which item is outstanding.
 func firstUncompletedTask(plan string) string {
-	for _, raw := range strings.Split(plan, "\n") {
+	for _, raw := range agent.ScanTaskLines(plan) {
 		line := strings.TrimLeft(raw, " \t")
 		if !strings.HasPrefix(line, "- [ ]") {
 			continue

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -569,6 +569,11 @@ func TestPlanTaskCounts(t *testing.T) {
 }
 
 func TestFirstUncompletedTask(t *testing.T) {
+	// Spec/Verification stray-checkbox case mirrors the same scoping rule
+	// planTaskCounts uses (agent.ScanTaskLines): when a "## Tasks" heading
+	// is present, only checkboxes inside that section count — otherwise the
+	// commit-to-task prefix mapping ("[task N]") and the displayed "current
+	// task" disagree on which item is being worked on.
 	for _, tc := range []struct {
 		name string
 		plan string
@@ -579,10 +584,63 @@ func TestFirstUncompletedTask(t *testing.T) {
 		{"first open", "- [x] done\n- [ ] next thing\n- [ ] later\n", "next thing"},
 		{"trims surrounding whitespace", "  - [ ]   trim me  \n", "trim me"},
 		{"skips blank task body", "- [ ]   \n- [ ] real one\n", "real one"},
+		{
+			"ignores spec checkbox when tasks section present",
+			"## Spec\n- [ ] not a task — acceptance criterion\n\n## Tasks\n- [ ] real task\n",
+			"real task",
+		},
+		{
+			"ignores verification checkbox after empty tasks section",
+			"## Tasks\n\n## Verification\n- [ ] run the tests\n",
+			"",
+		},
+		{
+			"no tasks heading falls back to whole-doc scan",
+			"# Goal\nDo a thing.\n- [ ] freeform item\n",
+			"freeform item",
+		},
+		{
+			"tasks section completed with stray spec checkbox returns empty",
+			"## Spec\n- [ ] acceptance criterion not done\n\n## Tasks\n- [x] only task\n",
+			"",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := firstUncompletedTask(tc.plan); got != tc.want {
 				t.Errorf("firstUncompletedTask(%q) = %q, want %q", tc.plan, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFirstUncompletedTask_ConsistentWithPlanTaskCounts pins the structural
+// invariant the scoping bug violated: the planning card cannot display a
+// "current task" that planTaskCounts treats as nonexistent, because the
+// "[task N]" commit prefix the build agent emits is derived from
+// planTaskCounts' scope. If firstUncompletedTask surfaces a Spec checkbox
+// while planTaskCounts counts only Tasks-section items, the UI would show
+// "1/0 tasks · current task: <spec item>" — nonsensical.
+func TestFirstUncompletedTask_ConsistentWithPlanTaskCounts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		plan string
+	}{
+		{"empty", ""},
+		{"freeform only", "- [ ] one\n- [x] two\n"},
+		{"freeform all done", "- [x] one\n- [x] two\n"},
+		{"tasks section with stray spec checkbox", "## Spec\n- [ ] spec\n\n## Tasks\n- [ ] real\n- [x] done\n"},
+		{"tasks section all done with stray verification", "## Tasks\n- [x] done\n\n## Verification\n- [ ] run tests\n"},
+		{"empty tasks section with stray notes", "## Tasks\n\n## Not in scope\n- [ ] later\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			total, done := planTaskCounts(tc.plan)
+			first := firstUncompletedTask(tc.plan)
+			outstanding := total - done
+			if outstanding > 0 && first == "" {
+				t.Errorf("planTaskCounts reports %d outstanding but firstUncompletedTask returned empty for plan:\n%s", outstanding, tc.plan)
+			}
+			if outstanding == 0 && first != "" {
+				t.Errorf("planTaskCounts reports 0 outstanding but firstUncompletedTask returned %q for plan:\n%s", first, tc.plan)
 			}
 		})
 	}


### PR DESCRIPTION
Manager.Detach() now wraps its body in the same shutdownOnce.Do guard
Shutdown() uses, so calling Detach() twice — or pairing it with a
deferred Shutdown() — no longer panics on close-of-closed-channel.
Adds three tests that fail without the fix.

firstUncompletedTask() now uses agent.ScanTaskLines() instead of
strings.Split, matching the section scoping that planTaskCounts and
ParsePlanTasks already enforce. A stray "- [ ]" in ## Spec can no
longer surface as the "current task" while the X/Y count derived from
## Tasks ignores it. Adds focused test cases plus a consistency test
that pins the invariant: firstUncompletedTask returns non-empty iff
planTaskCounts reports outstanding tasks.