### PR TITLE
refactor(tui): encapsulate panel focus + modal lifetimes in Modals controller

### DIFF
--- a/changelog.d/refactor-modals-controller.md
+++ b/changelog.d/refactor-modals-controller.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Encapsulated the dashboard's panel-focus state machine in a `Modals` controller (`internal/tui/modals.go`). Each transition site now atomically sets focus and the modal model pointer through one typed call, and `Close()` always nils every owned model. The previous invariant — "the model for `panelFocus X` is non-nil iff `panelFocus == X`" — is now enforced by the type instead of by ~30 paired field assignments and ~28 guard-pair checks scattered across `update_*.go`. No behavior change.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -175,14 +175,17 @@ type App struct {
 
 	agentLimitModalActive bool
 	cursor                FocusedCursor // pipeline cursor: section + per-section indices
-	focusLaunchAgent      *agent.Agent
-	focusLaunchSession    *agent.Session
-	reviewDiffCache       map[string]*reviewDiffEntry                // keyed by session ID; lifetime exceeds panel
-	reviewPanel           *reviewPanelModel                          // non-nil while panelFocus == focusReview
-	shippingPanel         *shippingPanelModel                        // non-nil while panelFocus == focusShipping
-	feedbackTriage        map[string]map[string]*feedbackTriageEntry // keyed by sessionID → itemKey
-	planEditor            *planEditorModel                           // non-nil while panelFocus == focusPlanEditor
-	promptModal           promptModalModel                           // overlay for plan-first new-session prompt
+	// modals owns panel focus and the lifetime of every overlay model. The
+	// invariant "the model for panelFocus X is non-nil iff modals.Current() == X"
+	// is enforced by the Modals type; see internal/tui/modals.go. App callers
+	// must reach overlay models via modals.Review(), modals.Shipping(), etc.,
+	// and must transition via app.openReview / openShipping / openPlanEditor /
+	// openConfig / openLaunch / closeModal helpers (which keep the dashboard
+	// mirror fields in sync).
+	modals          Modals
+	reviewDiffCache map[string]*reviewDiffEntry                // keyed by session ID; lifetime exceeds panel
+	feedbackTriage  map[string]map[string]*feedbackTriageEntry // keyed by sessionID → itemKey
+	promptModal     promptModalModel                           // overlay for plan-first new-session prompt
 
 	// closingAgents and closingSessions track in-flight kill requests so the
 	// dashboard can render a "closing…" indicator while the async teardown runs.
@@ -220,6 +223,58 @@ type App struct {
 	// review panel (p key), where confirming the PR should transition the
 	// session to LifecycleShipping and close the review panel.
 	prModalTransitionShipping bool
+}
+
+// syncModalsToDashboard mirrors the current Modals state into the dashboard
+// model's render-time fields. The dashboard renderer reads these fields
+// directly; calling this after every Modals mutation keeps the two in sync.
+// Modal callers should prefer the openX / closeModal helpers below, which
+// invoke this automatically.
+func (a *App) syncModalsToDashboard() {
+	a.dashboard.panelFocus = a.modals.Current()
+	a.dashboard.repoConfigForm = a.modals.Config()
+	a.dashboard.configRepoPath = a.modals.ConfigRepoPath()
+	a.dashboard.focusLaunchAgent = a.modals.LaunchAgent()
+	a.dashboard.focusLaunchSession = a.modals.LaunchSession()
+}
+
+// openReview opens the review panel and syncs the dashboard mirror.
+func (a *App) openReview(rp *reviewPanelModel) {
+	a.modals.OpenReview(rp)
+	a.syncModalsToDashboard()
+}
+
+// openShipping opens the shipping panel and syncs the dashboard mirror.
+func (a *App) openShipping(sp *shippingPanelModel) {
+	a.modals.OpenShipping(sp)
+	a.syncModalsToDashboard()
+}
+
+// openPlanEditorPanel installs an existing plan editor model and syncs the
+// dashboard mirror. The high-level "open the plan editor for this session"
+// flow lives in openPlanEditor (which builds the model, then calls this).
+func (a *App) openPlanEditorPanel(pe *planEditorModel) {
+	a.modals.OpenPlanEditor(pe)
+	a.syncModalsToDashboard()
+}
+
+// openConfigForm opens the per-repo config form for repoPath and syncs.
+func (a *App) openConfigForm(form *configForm, repoPath string) {
+	a.modals.OpenConfig(form, repoPath)
+	a.syncModalsToDashboard()
+}
+
+// openLaunchPanel sets the fullscreen agent terminal target and syncs.
+func (a *App) openLaunchPanel(sess *agent.Session, ag *agent.Agent) {
+	a.modals.OpenLaunch(sess, ag)
+	a.syncModalsToDashboard()
+}
+
+// closeModal returns focus to the pipeline list and nils every overlay model.
+// This is the canonical "close any panel" path.
+func (a *App) closeModal() {
+	a.modals.Close()
+	a.syncModalsToDashboard()
 }
 
 func NewApp() App {
@@ -450,8 +505,9 @@ func (a *App) resizeAllForDashboard() {
 	if w <= 0 || h <= 0 {
 		return
 	}
+	launchAgent := a.modals.LaunchAgent()
 	for _, ag := range a.dashboard.agentItems() {
-		if a.focusLaunchAgent != nil && ag.ID == a.focusLaunchAgent.ID {
+		if launchAgent != nil && ag.ID == launchAgent.ID {
 			continue
 		}
 		ag.Resize(h, w)
@@ -489,10 +545,11 @@ func (a *App) focusLaunchTermHeight() int {
 // tab bar click at column x, or -1 if x doesn't land on any tab. Uses the same
 // label formula as renderFocusLaunchTabBar so click targets stay in sync.
 func (a *App) focusLaunchTabIndexAt(x int) int {
-	if a.focusLaunchSession == nil {
+	sess := a.modals.LaunchSession()
+	if sess == nil {
 		return -1
 	}
-	agents := a.focusLaunchSession.Agents()
+	agents := sess.Agents()
 	col := 0
 	for i, ag := range agents {
 		label := focusLaunchTabText(ag)
@@ -551,11 +608,8 @@ func (a *App) panelServices() PanelServices {
 		},
 		ClosePanel: func() {
 			// Drop the active overlay panel and return focus to the pipeline.
-			// Each panel reference is mutated; only the matching one will be
-			// non-nil at any given time so the others are no-ops.
-			a.reviewPanel = nil
-			a.shippingPanel = nil
-			a.dashboard.panelFocus = focusList
+			// Modals.Close enforces the invariant by nilling every owned model.
+			a.closeModal()
 		},
 		OpenInLaunch: func(sess *agent.Session) bool {
 			return a.openSessionInFocusLaunch(sess)
@@ -644,8 +698,7 @@ func (a *App) refreshAgentList() {
 	a.dashboard.prDraftSessionID = a.prDraftSessionID
 	a.dashboard.activeRepoName = a.activeRepoDisplayName()
 	a.dashboard.activeRepoPath = a.activeRepo
-	a.dashboard.focusLaunchAgent = a.focusLaunchAgent
-	a.dashboard.focusLaunchSession = a.focusLaunchSession
+	a.syncModalsToDashboard()
 	if a.cfg == nil {
 		// Fallback used in tests that set up managers directly without cfg.
 		if mgr := a.managers[a.activeRepo]; mgr != nil {
@@ -870,16 +923,14 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 		return nil, a.openSessionInFocusLaunch(sess)
 	case focusSectionReview:
 		sess.SetLifecyclePhase(agent.LifecycleInReview)
-		a.reviewPanel = newReviewPanel(sess, a.width, a.height)
-		a.dashboard.panelFocus = focusReview
+		a.openReview(newReviewPanel(sess, a.width, a.height))
 		if _, ok := a.reviewDiffCache[sess.ID]; !ok {
 			return a.fetchReviewDiffCmd(sess), true
 		}
-		a.reviewPanel.RefreshDiffViewport(a.panelServices())
+		a.modals.Review().RefreshDiffViewport(a.panelServices())
 		return nil, true
 	case focusSectionShipping:
-		a.shippingPanel = newShippingPanel(sess, a.width, a.height-1)
-		a.dashboard.panelFocus = focusShipping
+		a.openShipping(newShippingPanel(sess, a.width, a.height-1))
 		return nil, true
 	}
 	return nil, false
@@ -905,11 +956,9 @@ func (a *App) openSessionInFocusLaunch(sess *agent.Session) bool {
 			target = ag
 		}
 	}
-	a.focusLaunchAgent = target
-	a.focusLaunchSession = sess
-	a.dashboard.panelFocus = focusLaunch
+	a.openLaunchPanel(sess, target)
 	a.dashboard.scrollOffset = 0
-	a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+	target.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 	return true
 }
 
@@ -922,28 +971,28 @@ func (a App) View() tea.View {
 
 	switch a.view {
 	case ViewDashboard:
-		if a.dashboard.panelFocus == focusReview && a.reviewPanel != nil {
+		if rp := a.modals.Review(); rp != nil {
 			var panelStr string
 			if a.prComposeModal.Active() {
 				panelStr = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, a.prComposeModal.View())
 			} else {
-				panelStr = a.reviewPanel.View(a.panelServices())
+				panelStr = rp.View(a.panelServices())
 			}
 			v := tea.NewView(panelStr)
 			v.AltScreen = true
 			return v
 		}
-		if a.dashboard.panelFocus == focusShipping && a.shippingPanel != nil {
-			panel := a.shippingPanel.View(a.panelServices())
-			if a.shippingPanel.NoteActive() {
-				panel = lipgloss.Place(a.width, a.height, lipgloss.Center, lipgloss.Center, a.shippingPanel.NoteView())
+		if sp := a.modals.Shipping(); sp != nil {
+			panel := sp.View(a.panelServices())
+			if sp.NoteActive() {
+				panel = lipgloss.Place(a.width, a.height, lipgloss.Center, lipgloss.Center, sp.NoteView())
 			}
 			v := tea.NewView(panel)
 			v.AltScreen = true
 			return v
 		}
-		if a.dashboard.panelFocus == focusPlanEditor && a.planEditor != nil {
-			v := tea.NewView(a.planEditor.View())
+		if pe := a.modals.PlanEditor(); pe != nil {
+			v := tea.NewView(pe.View())
 			v.AltScreen = true
 			return v
 		}
@@ -1062,8 +1111,7 @@ func (a App) View() tea.View {
 	v.AltScreen = true
 	if a.view == ViewDashboard {
 		v.MouseMode = tea.MouseModeCellMotion
-		if a.dashboard.panelFocus == focusLaunch && a.dashboard.scrollOffset == 0 && a.focusLaunchAgent != nil {
-			ag := a.focusLaunchAgent
+		if ag := a.modals.LaunchAgent(); ag != nil && a.dashboard.scrollOffset == 0 {
 			if !ag.IsAltScreen() && ag.CursorVisible() {
 				cursorX, cursorY := ag.CursorPosition()
 				dashboardTopY := 0

--- a/internal/tui/app_keys_test.go
+++ b/internal/tui/app_keys_test.go
@@ -212,19 +212,20 @@ func appInFocusLaunch(t *testing.T) (App, *agent.Session, *agent.Agent) {
 	t.Helper()
 	app, sess, _ := appWithSeededSession(t, agent.LifecycleInProgress)
 	ag := sess.AddTestAgent("primary", false, agent.StatusIdle)
-	app.focusLaunchAgent = ag
-	app.focusLaunchSession = sess
-	app.dashboard.panelFocus = focusLaunch
+	app.openLaunchPanel(sess, ag)
 	return app, sess, ag
 }
 
 func TestFocusLaunch_NilAgent_RoutesBackToList(t *testing.T) {
-	// Pinned: app.go:2425-2429 returns to focusList when focusLaunchAgent is
+	// Pinned: updateFocusLaunchKeys returns to focusList when LaunchAgent() is
 	// nil. Guards against an accidental nil-check removal that would crash
 	// on any subsequent key.
 	app, _, _ := appWithSeededSession(t, agent.LifecycleInProgress)
-	app.dashboard.panelFocus = focusLaunch
-	app.focusLaunchAgent = nil
+	// Force panelFocus into focusLaunch with no agent by reaching into Modals
+	// directly — production code can't construct this state, but the guard at
+	// the top of updateFocusLaunchKeys must still handle it.
+	app.modals.OpenLaunch(nil, nil)
+	app.syncModalsToDashboard()
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	app = model.(App)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -604,8 +604,8 @@ func TestPipelineDoubleClickActivatesReview(t *testing.T) {
 	if app.dashboard.panelFocus != focusReview {
 		t.Fatalf("expected focusReview after double-click, got %v", app.dashboard.panelFocus)
 	}
-	if app.reviewPanel == nil || app.reviewPanel.Session() != sessR {
-		t.Fatalf("expected reviewSession=sessR, got %v", app.reviewPanel)
+	if app.modals.Review() == nil || app.modals.Review().Session() != sessR {
+		t.Fatalf("expected reviewSession=sessR, got %v", app.modals.Review())
 	}
 }
 
@@ -677,9 +677,7 @@ func TestMouseWheelForwardsInAltScreen(t *testing.T) {
 	app.dashboard.items = []listItem{
 		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
 	}
-	app.dashboard.panelFocus = focusLaunch
-	app.focusLaunchAgent = ag
-	app.focusLaunchSession = sess
+	app.openLaunchPanel(sess, ag)
 
 	// Set a non-zero offset so we can tell the wheel branch didn't mutate it.
 	app.dashboard.scrollOffset = 5
@@ -1207,8 +1205,8 @@ func TestFocusMode_RKey_OpensReviewWithItems(t *testing.T) {
 	if app.dashboard.panelFocus != focusReview {
 		t.Fatalf("expected panelFocus=focusReview after r, got %v", app.dashboard.panelFocus)
 	}
-	if app.reviewPanel == nil || app.reviewPanel.Session() != sessR {
-		t.Fatalf("expected reviewSession=sessR, got %v", app.reviewPanel)
+	if app.modals.Review() == nil || app.modals.Review().Session() != sessR {
+		t.Fatalf("expected reviewSession=sessR, got %v", app.modals.Review())
 	}
 	if sessR.LifecyclePhase() != agent.LifecycleInReview {
 		t.Errorf("expected sessR phase=InReview, got %v", sessR.LifecyclePhase())
@@ -1613,8 +1611,8 @@ func TestFocusModeEnterOnActiveOpensFocusLaunch(t *testing.T) {
 	if app.dashboard.panelFocus != focusLaunch {
 		t.Fatalf("expected panelFocus=focusLaunch after enter on active, got %v", app.dashboard.panelFocus)
 	}
-	if app.focusLaunchAgent == nil || app.focusLaunchAgent.ID != ag.ID {
-		t.Fatalf("expected focusLaunchAgent=ag, got %v", app.focusLaunchAgent)
+	if app.modals.LaunchAgent() == nil || app.modals.LaunchAgent().ID != ag.ID {
+		t.Fatalf("expected focusLaunchAgent=ag, got %v", app.modals.LaunchAgent())
 	}
 }
 
@@ -1745,9 +1743,7 @@ func TestFocusLaunch_FocusModeKeysForwardToAgent(t *testing.T) {
 		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
 		{kind: listItemSession, repoPath: dir, session: sessR},
 	}
-	app.dashboard.panelFocus = focusLaunch
-	app.focusLaunchAgent = ag
-	app.focusLaunchSession = sess
+	app.openLaunchPanel(sess, ag)
 
 	for _, ch := range []rune{'m', 'r'} {
 		model, _ := app.Update(tea.KeyPressMsg{Code: ch, Text: string(ch)})
@@ -1756,11 +1752,11 @@ func TestFocusLaunch_FocusModeKeysForwardToAgent(t *testing.T) {
 		if app.dashboard.panelFocus != focusLaunch {
 			t.Fatalf("press %q: expected panelFocus=focusLaunch (key forwarded to agent), got %v", ch, app.dashboard.panelFocus)
 		}
-		if app.focusLaunchAgent == nil || app.focusLaunchAgent.ID != ag.ID {
-			t.Fatalf("press %q: expected focusLaunchAgent unchanged, got %v", ch, app.focusLaunchAgent)
+		if app.modals.LaunchAgent() == nil || app.modals.LaunchAgent().ID != ag.ID {
+			t.Fatalf("press %q: expected focusLaunchAgent unchanged, got %v", ch, app.modals.LaunchAgent())
 		}
-		if app.focusLaunchSession == nil || app.focusLaunchSession.ID != sess.ID {
-			t.Fatalf("press %q: expected focusLaunchSession unchanged, got %v", ch, app.focusLaunchSession)
+		if app.modals.LaunchSession() == nil || app.modals.LaunchSession().ID != sess.ID {
+			t.Fatalf("press %q: expected focusLaunchSession unchanged, got %v", ch, app.modals.LaunchSession())
 		}
 		if sess.LifecyclePhase() != agent.LifecycleInProgress {
 			t.Fatalf("press %q: expected sess phase unchanged=InProgress, got %v", ch, sess.LifecyclePhase())
@@ -1768,8 +1764,8 @@ func TestFocusLaunch_FocusModeKeysForwardToAgent(t *testing.T) {
 		if sessR.LifecyclePhase() != agent.LifecycleReadyForReview {
 			t.Fatalf("press %q: expected sessR phase unchanged=ReadyForReview, got %v", ch, sessR.LifecyclePhase())
 		}
-		if app.reviewPanel != nil {
-			t.Fatalf("press %q: expected reviewSession=nil, got %v", ch, app.reviewPanel)
+		if app.modals.Review() != nil {
+			t.Fatalf("press %q: expected reviewSession=nil, got %v", ch, app.modals.Review())
 		}
 	}
 }
@@ -1936,8 +1932,8 @@ func TestFocusMode_RKey_EmptyQueue_ShowsError(t *testing.T) {
 	if app.dashboard.panelFocus == focusReview {
 		t.Error("expected panelFocus to stay focusList, got focusReview")
 	}
-	if app.reviewPanel != nil {
-		t.Errorf("expected reviewSession to stay nil, got %v", app.reviewPanel)
+	if app.modals.Review() != nil {
+		t.Errorf("expected reviewSession to stay nil, got %v", app.modals.Review())
 	}
 }
 
@@ -1958,8 +1954,8 @@ func TestFocusMode_RKey_NonEmptyQueue_OpensReviewPanel(t *testing.T) {
 	if app.dashboard.panelFocus != focusReview {
 		t.Errorf("expected panelFocus=focusReview, got %v", app.dashboard.panelFocus)
 	}
-	if app.reviewPanel == nil || app.reviewPanel.Session() != sessR {
-		t.Errorf("expected reviewSession=sessR, got %v", app.reviewPanel)
+	if app.modals.Review() == nil || app.modals.Review().Session() != sessR {
+		t.Errorf("expected reviewSession=sessR, got %v", app.modals.Review())
 	}
 	if sessR.LifecyclePhase() != agent.LifecycleInReview {
 		t.Errorf("expected sessR phase=InReview, got %v", sessR.LifecyclePhase())
@@ -1972,8 +1968,7 @@ func TestFocusMode_RKey_NonEmptyQueue_OpensReviewPanel(t *testing.T) {
 func TestReviewPanel_CKey_MarksComplete(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	app.reviewPanel = newReviewPanel(sessR, app.width, app.height)
-	app.dashboard.panelFocus = focusReview
+	app.openReview(newReviewPanel(sessR, app.width, app.height))
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 	app = model.(App)
@@ -1981,8 +1976,8 @@ func TestReviewPanel_CKey_MarksComplete(t *testing.T) {
 	if app.dashboard.panelFocus != focusList {
 		t.Errorf("expected panelFocus=focusList after c, got %v", app.dashboard.panelFocus)
 	}
-	if app.reviewPanel != nil {
-		t.Errorf("expected reviewSession cleared, got %v", app.reviewPanel)
+	if app.modals.Review() != nil {
+		t.Errorf("expected reviewSession cleared, got %v", app.modals.Review())
 	}
 }
 
@@ -1999,8 +1994,7 @@ func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.reviewPanel = newReviewPanel(sess, app.width, app.height)
-	app.dashboard.panelFocus = focusReview
+	app.openReview(newReviewPanel(sess, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -2010,8 +2004,8 @@ func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
 	if got.dashboard.panelFocus != focusList {
 		t.Errorf("expected panelFocus=focusList after c, got %v", got.dashboard.panelFocus)
 	}
-	if got.reviewPanel != nil {
-		t.Errorf("expected reviewSession cleared after c, got %v", got.reviewPanel)
+	if got.modals.Review() != nil {
+		t.Errorf("expected reviewSession cleared after c, got %v", got.modals.Review())
 	}
 	if cmd == nil {
 		t.Fatal("expected a cmd to trigger async session cleanup after marking complete")
@@ -2038,8 +2032,7 @@ func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
 func TestReviewPanel_TKey_NoAgents_ShowsError(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	app.reviewPanel = newReviewPanel(sessR, app.width, app.height)
-	app.dashboard.panelFocus = focusReview
+	app.openReview(newReviewPanel(sessR, app.width, app.height))
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
 	app = model.(App)
@@ -2050,8 +2043,8 @@ func TestReviewPanel_TKey_NoAgents_ShowsError(t *testing.T) {
 	if !strings.Contains(app.err, "no agents") {
 		t.Errorf("expected error to mention no agents, got %q", app.err)
 	}
-	if app.reviewPanel != nil {
-		t.Errorf("expected reviewSession cleared after t, got %v", app.reviewPanel)
+	if app.modals.Review() != nil {
+		t.Errorf("expected reviewSession cleared after t, got %v", app.modals.Review())
 	}
 	// Phase preserved so the session is still in REVIEW QUEUE.
 	if sessR.LifecyclePhase() != agent.LifecycleInReview {
@@ -2071,8 +2064,7 @@ func TestReviewPanel_ComposeModalRendersOverPanel(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.reviewPanel = newReviewPanel(sessR, app.width, app.height)
-	app.dashboard.panelFocus = focusReview
+	app.openReview(newReviewPanel(sessR, app.width, app.height))
 	app.prComposeModal.SetSize(120, 39)
 	_ = app.prComposeModal.Open("My PR Title", "My PR Body", false)
 
@@ -2092,8 +2084,7 @@ func TestReviewPanel_ComposeModalRendersOverPanel(t *testing.T) {
 func TestReviewPanel_PKey_NoPR_DoesNotOrphan(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	app.reviewPanel = newReviewPanel(sessR, app.width, app.height)
-	app.dashboard.panelFocus = focusReview
+	app.openReview(newReviewPanel(sessR, app.width, app.height))
 	// ghClient must be non-nil to pass the auth guard before startPRDraftCmd.
 	app.ghClient = &github.Client{}
 
@@ -2866,7 +2857,21 @@ func TestTick_BreakDoesNotEnterWhilePanelOpen(t *testing.T) {
 			app := NewApp()
 			app.wellness.focusSessionMinutes = 1
 			app.wellness.sessionStart = time.Now().Add(-2 * time.Minute) // long past deadline
-			app.dashboard.panelFocus = tc.focus
+			// Stub an overlay into the requested focus state. The break-defer
+			// guard reads modals.IsList(); the specific model doesn't matter.
+			switch tc.focus {
+			case focusLaunch:
+				app.modals.OpenLaunch(nil, nil)
+			case focusReview:
+				app.modals.OpenReview(&reviewPanelModel{})
+			case focusShipping:
+				app.modals.OpenShipping(&shippingPanelModel{})
+			case focusPlanEditor:
+				app.modals.OpenPlanEditor(&planEditorModel{})
+			case focusConfig:
+				app.modals.OpenConfig(&configForm{}, "/repo")
+			}
+			app.syncModalsToDashboard()
 
 			model, _ := app.Update(tickMsg(time.Now()))
 			app = model.(App)
@@ -2885,7 +2890,7 @@ func TestTick_BreakEntersOnPipeline(t *testing.T) {
 	app := NewApp()
 	app.wellness.focusSessionMinutes = 1
 	app.wellness.sessionStart = time.Now().Add(-2 * time.Minute)
-	app.dashboard.panelFocus = focusList
+	// Default modal state is focusList (zero value); no setup needed.
 
 	model, _ := app.Update(tickMsg(time.Now()))
 	app = model.(App)
@@ -2925,7 +2930,7 @@ func TestActivateFocusCursor_Shipping_OpensShippingPanel(t *testing.T) {
 	if app.dashboard.panelFocus != focusShipping {
 		t.Fatalf("expected panelFocus=focusShipping, got %v", app.dashboard.panelFocus)
 	}
-	if app.shippingPanel == nil || app.shippingPanel.Session() != sessS {
+	if app.modals.Shipping() == nil || app.modals.Shipping().Session() != sessS {
 		t.Fatalf("expected shippingSession to be set to the selected session")
 	}
 }
@@ -2970,8 +2975,7 @@ func TestMergePRMsg_ClosesPanel(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.shippingPanel = newShippingPanel(sess, app.width, app.height)
-	app.dashboard.panelFocus = focusShipping
+	app.openShipping(newShippingPanel(sess, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -2981,7 +2985,7 @@ func TestMergePRMsg_ClosesPanel(t *testing.T) {
 	if got.dashboard.panelFocus == focusShipping {
 		t.Error("shipping panel should close after successful merge")
 	}
-	if got.shippingPanel != nil {
+	if got.modals.Shipping() != nil {
 		t.Error("shippingSession should be nil after merge")
 	}
 	if cmd == nil {
@@ -3014,8 +3018,7 @@ func TestPRPollMsg_ExternalMergeClosesPanelAndTransitions(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.shippingPanel = newShippingPanel(sess, app.width, app.height)
-	app.dashboard.panelFocus = focusShipping
+	app.openShipping(newShippingPanel(sess, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -3029,7 +3032,7 @@ func TestPRPollMsg_ExternalMergeClosesPanelAndTransitions(t *testing.T) {
 	if got.dashboard.panelFocus == focusShipping {
 		t.Error("shipping panel should close when external merge is detected")
 	}
-	if got.shippingPanel != nil {
+	if got.modals.Shipping() != nil {
 		t.Error("shippingSession should be nil after external merge")
 	}
 	if cmd == nil {
@@ -3061,8 +3064,7 @@ func TestPRPollMsg_ExternalCloseCleansSession(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.shippingPanel = newShippingPanel(sess, app.width, app.height)
-	app.dashboard.panelFocus = focusShipping
+	app.openShipping(newShippingPanel(sess, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -3076,7 +3078,7 @@ func TestPRPollMsg_ExternalCloseCleansSession(t *testing.T) {
 	if got.dashboard.panelFocus == focusShipping {
 		t.Error("shipping panel should close when PR is closed")
 	}
-	if got.shippingPanel != nil {
+	if got.modals.Shipping() != nil {
 		t.Error("shippingSession should be nil after PR close")
 	}
 	if cmd == nil {
@@ -3162,8 +3164,7 @@ func TestPRPollMsg_ExternalOpenPRPromotesInReviewToShipping_ClosesReviewPanel(t 
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.reviewPanel = newReviewPanel(sess, app.width, app.height)
-	app.dashboard.panelFocus = focusReview
+	app.openReview(newReviewPanel(sess, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -3180,7 +3181,7 @@ func TestPRPollMsg_ExternalOpenPRPromotesInReviewToShipping_ClosesReviewPanel(t 
 	if got.dashboard.panelFocus != focusList {
 		t.Errorf("panelFocus = %v, want focusList", got.dashboard.panelFocus)
 	}
-	if got.reviewPanel != nil {
+	if got.modals.Review() != nil {
 		t.Error("reviewSession should be nil after auto-promotion closes the panel")
 	}
 }
@@ -3293,8 +3294,7 @@ func TestPRPollMsg_CompleteNotPromoted(t *testing.T) {
 // TestMergePRMsg_ErrorSetsError verifies that a mergePRMsg error is surfaced.
 func TestMergePRMsg_ErrorSetsError(t *testing.T) {
 	app := NewApp()
-	app.dashboard.panelFocus = focusShipping
-	app.shippingPanel = newShippingPanel(agent.NewSessionForTest("s", "ship"), app.width, app.height)
+	app.openShipping(newShippingPanel(agent.NewSessionForTest("s", "ship"), app.width, app.height))
 
 	model, _ := app.Update(mergePRMsg{sessionID: "s", err: errors.New("403 forbidden")})
 	got := model.(App)
@@ -3314,8 +3314,7 @@ func TestShippingPanel_MKeyGatedOnReady(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 
 	app := NewApp()
-	app.shippingPanel = newShippingPanel(sess, app.width, app.height)
-	app.dashboard.panelFocus = focusShipping
+	app.openShipping(newShippingPanel(sess, app.width, app.height))
 	app.prCache = map[string]*prCacheEntry{
 		sess.ID: {pr: &github.PRState{Number: 1, MergeableState: "dirty"}},
 	}
@@ -3995,7 +3994,7 @@ func TestPlannerQuestionMsg_AutoOpensPlanEditor(t *testing.T) {
 	app.activeRepo = dir
 	app.resolvedCache[dir] = config.ResolvedSettings{AgentProgram: "bash"}
 	// Confirm no editor is open.
-	if app.planEditor != nil {
+	if app.modals.PlanEditor() != nil {
 		t.Fatal("precondition: planEditor should be nil")
 	}
 
@@ -4015,16 +4014,16 @@ func TestPlannerQuestionMsg_AutoOpensPlanEditor(t *testing.T) {
 		app = model.(App)
 	}
 
-	if app.planEditor == nil {
+	if app.modals.PlanEditor() == nil {
 		t.Fatal("expected plan editor to open automatically on plannerQuestionMsg")
 	}
-	if app.planEditor.sess == nil || app.planEditor.sess.ID != sess.ID {
-		t.Errorf("editor opened for wrong session: got %v", app.planEditor.sess)
+	if app.modals.PlanEditor().sess == nil || app.modals.PlanEditor().sess.ID != sess.ID {
+		t.Errorf("editor opened for wrong session: got %v", app.modals.PlanEditor().sess)
 	}
 	if app.dashboard.panelFocus != focusPlanEditor {
 		t.Errorf("expected panelFocus=focusPlanEditor, got %v", app.dashboard.panelFocus)
 	}
-	if !app.planEditor.HasPendingQuestion() {
+	if !app.modals.PlanEditor().HasPendingQuestion() {
 		t.Error("expected editor to have a pending question after plannerQuestionMsg")
 	}
 }
@@ -4044,8 +4043,7 @@ func TestPlannerQuestionMsg_DoesNotReplaceOpenEditor(t *testing.T) {
 	app.dashboard.height = 39
 
 	editorA := newPlanEditor(sessA, "", 120, 39)
-	app.planEditor = &editorA
-	app.dashboard.panelFocus = focusPlanEditor
+	app.openPlanEditorPanel(&editorA)
 
 	answerCh := make(chan string, 1)
 	msg := plannerQuestionMsg{
@@ -4063,7 +4061,7 @@ func TestPlannerQuestionMsg_DoesNotReplaceOpenEditor(t *testing.T) {
 		app = model.(App)
 	}
 
-	if app.planEditor == nil || app.planEditor.sess != sessA {
+	if app.modals.PlanEditor() == nil || app.modals.PlanEditor().sess != sessA {
 		t.Error("session A's editor should remain open; got replaced or nil")
 	}
 	if app.dashboard.panelFocus != focusPlanEditor {
@@ -4211,8 +4209,7 @@ func TestPlannerQuestionMsg_SkippedSessionMissing(t *testing.T) {
 	app.dashboard.height = 39
 	app.managers[dir] = mgr
 	app.activeRepo = dir
-	// Dashboard visible, no editor open.
-	app.dashboard.panelFocus = focusList
+	// Dashboard visible, no editor open. modals zero value = focusList.
 
 	answerCh := make(chan string, 1)
 	msg := plannerQuestionMsg{
@@ -4240,7 +4237,7 @@ func TestPlannerQuestionMsg_SkippedSessionMissing(t *testing.T) {
 	if app.err == "" {
 		t.Error("expected app.err to be set when planner question is skipped")
 	}
-	if app.planEditor != nil {
+	if app.modals.PlanEditor() != nil {
 		t.Error("expected planEditor to remain nil when session is not found")
 	}
 }
@@ -4305,8 +4302,7 @@ func TestShippingPanel_CursorAndScrollKeys(t *testing.T) {
 	sess := agent.NewSessionForTest("ship-cs", "ship")
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 	app := NewApp()
-	app.shippingPanel = newShippingPanel(sess, app.width, app.height)
-	app.dashboard.panelFocus = focusShipping
+	app.openShipping(newShippingPanel(sess, app.width, app.height))
 	app.width = 120
 	app.height = 40
 	app.prCache[sess.ID] = &prCacheEntry{
@@ -4321,47 +4317,47 @@ func TestShippingPanel_CursorAndScrollKeys(t *testing.T) {
 	// j moves cursor down.
 	m, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	got := m.(App)
-	if got.shippingPanel.feedbackCursor != 1 {
-		t.Errorf("after j: cursor = %d, want 1", got.shippingPanel.feedbackCursor)
+	if got.modals.Shipping().feedbackCursor != 1 {
+		t.Errorf("after j: cursor = %d, want 1", got.modals.Shipping().feedbackCursor)
 	}
-	if got.shippingPanel.detailScroll != 0 {
-		t.Errorf("after j: scroll should reset to 0, got %d", got.shippingPanel.detailScroll)
+	if got.modals.Shipping().detailScroll != 0 {
+		t.Errorf("after j: scroll should reset to 0, got %d", got.modals.Shipping().detailScroll)
 	}
 
 	// j again.
 	m, _ = got.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	got = m.(App)
-	if got.shippingPanel.feedbackCursor != 2 {
-		t.Errorf("after j×2: cursor = %d, want 2", got.shippingPanel.feedbackCursor)
+	if got.modals.Shipping().feedbackCursor != 2 {
+		t.Errorf("after j×2: cursor = %d, want 2", got.modals.Shipping().feedbackCursor)
 	}
 
 	// j past end clamps.
 	m, _ = got.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	got = m.(App)
-	if got.shippingPanel.feedbackCursor != 2 {
-		t.Errorf("j past end: cursor = %d, want 2 (clamped)", got.shippingPanel.feedbackCursor)
+	if got.modals.Shipping().feedbackCursor != 2 {
+		t.Errorf("j past end: cursor = %d, want 2 (clamped)", got.modals.Shipping().feedbackCursor)
 	}
 
 	// k moves cursor up.
 	m, _ = got.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	got = m.(App)
-	if got.shippingPanel.feedbackCursor != 1 {
-		t.Errorf("after k: cursor = %d, want 1", got.shippingPanel.feedbackCursor)
+	if got.modals.Shipping().feedbackCursor != 1 {
+		t.Errorf("after k: cursor = %d, want 1", got.modals.Shipping().feedbackCursor)
 	}
 
 	// pgdn increments detail scroll.
-	got.shippingPanel.detailScroll = 0
+	got.modals.Shipping().detailScroll = 0
 	m, _ = got.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
 	got = m.(App)
-	if got.shippingPanel.detailScroll <= 0 {
-		t.Errorf("pgdn: scroll = %d, want >0", got.shippingPanel.detailScroll)
+	if got.modals.Shipping().detailScroll <= 0 {
+		t.Errorf("pgdn: scroll = %d, want >0", got.modals.Shipping().detailScroll)
 	}
 
 	// j resets detail scroll to 0.
 	m, _ = got.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	got = m.(App)
-	if got.shippingPanel.detailScroll != 0 {
-		t.Errorf("j after scroll: scroll should reset to 0, got %d", got.shippingPanel.detailScroll)
+	if got.modals.Shipping().detailScroll != 0 {
+		t.Errorf("j after scroll: scroll should reset to 0, got %d", got.modals.Shipping().detailScroll)
 	}
 }
 
@@ -4369,8 +4365,7 @@ func TestShippingPanel_VerdictKeys(t *testing.T) {
 	sess := agent.NewSessionForTest("ship-v", "ship")
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 	app := NewApp()
-	app.shippingPanel = newShippingPanel(sess, app.width, app.height)
-	app.dashboard.panelFocus = focusShipping
+	app.openShipping(newShippingPanel(sess, app.width, app.height))
 	app.width = 120
 	app.height = 40
 	// One inline comment with ID=42.
@@ -4420,8 +4415,7 @@ func TestAddressFeedback_ClearsTriage(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.shippingPanel = newShippingPanel(sess, app.width, app.height)
-	app.dashboard.panelFocus = focusShipping
+	app.openShipping(newShippingPanel(sess, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 	app.width = 120
@@ -4480,8 +4474,7 @@ func TestAddressFeedback_RefusesOnMergedPR(t *testing.T) {
 			mgr.AddSessionForTest(sess)
 
 			app := NewApp()
-			app.shippingPanel = newShippingPanel(sess, app.width, app.height)
-			app.dashboard.panelFocus = focusShipping
+			app.openShipping(newShippingPanel(sess, app.width, app.height))
 			app.managers[dir] = mgr
 			app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 			app.width = 120
@@ -4549,8 +4542,7 @@ func TestReviewPanel_EnterDoesNotChangeView(t *testing.T) {
 	app := NewApp()
 	app.width = 120
 	app.height = 40
-	app.reviewPanel = newReviewPanel(sessR, app.width, app.height)
-	app.dashboard.panelFocus = focusReview
+	app.openReview(newReviewPanel(sessR, app.width, app.height))
 	app.reviewDiffCache[sessR.ID] = entry
 
 	for _, key := range []string{"enter", "space"} {
@@ -4603,13 +4595,12 @@ func TestReviewPanel_ScrollBindingsAdvanceViewport(t *testing.T) {
 	app := NewApp()
 	app.width = 120
 	app.height = 40
-	app.reviewPanel = newReviewPanel(sessR, app.width, app.height)
-	app.dashboard.panelFocus = focusReview
+	app.openReview(newReviewPanel(sessR, app.width, app.height))
 	app.reviewDiffCache[sessR.ID] = entry
 	// Load diff content and set viewport dimensions before sending scroll keys.
-	app.reviewPanel.RefreshDiffViewport(app.panelServices())
+	app.modals.Review().RefreshDiffViewport(app.panelServices())
 
-	if !app.reviewPanel.diffVP.AtTop() {
+	if !app.modals.Review().diffVP.AtTop() {
 		t.Fatal("expected viewport at top before scrolling")
 	}
 
@@ -4617,7 +4608,7 @@ func TestReviewPanel_ScrollBindingsAdvanceViewport(t *testing.T) {
 	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
 	updated := model.(App)
 
-	if updated.reviewPanel.diffVP.AtTop() {
+	if updated.modals.Review().diffVP.AtTop() {
 		t.Error("pgdown: inline diff viewport did not scroll; viewport must advance when diff content exceeds viewport height")
 	}
 	if updated.dashboard.panelFocus != focusReview {
@@ -4655,8 +4646,8 @@ func TestCreateResult_SkipFocusLaunch_StaysOnDashboard(t *testing.T) {
 	if app.dashboard.panelFocus == focusLaunch {
 		t.Error("panelFocus: got focusLaunch, want focusList (skipFocusLaunch should suppress terminal open)")
 	}
-	if app.focusLaunchAgent != nil {
-		t.Errorf("focusLaunchAgent: got %v, want nil", app.focusLaunchAgent.ID)
+	if app.modals.LaunchAgent() != nil {
+		t.Errorf("focusLaunchAgent: got %v, want nil", app.modals.LaunchAgent().ID)
 	}
 	if app.cursor.Section() != focusSectionBuilding {
 		t.Errorf("focusCursorSection: got %v, want focusSectionBuilding", app.cursor.Section())
@@ -4750,8 +4741,8 @@ func TestApprovePlanAndSpawn_StaysOnDashboard(t *testing.T) {
 	if app.dashboard.panelFocus == focusLaunch {
 		t.Error("panelFocus: got focusLaunch after plan approval, want focusList")
 	}
-	if app.focusLaunchAgent != nil {
-		t.Errorf("focusLaunchAgent: got %v, want nil", app.focusLaunchAgent.ID)
+	if app.modals.LaunchAgent() != nil {
+		t.Errorf("focusLaunchAgent: got %v, want nil", app.modals.LaunchAgent().ID)
 	}
 }
 
@@ -4979,8 +4970,7 @@ func TestApp_PlanEditorRetryMsg_CallsStartDraftWithOriginalPrompt(t *testing.T) 
 	// Open the plan editor on the session so the App can refresh it on status
 	// changes; this mirrors the real flow where the editor was already open.
 	editor := newPlanEditor(sess, dir, 80, 30)
-	app.planEditor = &editor
-	app.dashboard.panelFocus = focusPlanEditor
+	app.openPlanEditorPanel(&editor)
 
 	// Dispatch planEditorRetryMsg — this should call StartDraft.
 	model, _ := app.Update(planEditorRetryMsg{sessionID: sess.ID, repoPath: dir})

--- a/internal/tui/modals.go
+++ b/internal/tui/modals.go
@@ -1,0 +1,171 @@
+package tui
+
+import "github.com/devenjarvis/refrain/internal/agent"
+
+// Modals owns the dashboard's panel focus and the lifetime of the modal
+// models that focus governs. The invariant -- "the model pointer for
+// panelFocus X is non-nil iff Current() == X" -- is enforced here: every
+// Open* call atomically sets focus + model, every Close call sets focus
+// to focusList and nils every owned pointer.
+//
+// Read accessors return non-nil only when their focus is current. This
+// collapses the previous "if panelFocus == X && app.X != nil" guard pairs
+// into a single typed lookup.
+type Modals struct {
+	current panelFocus
+
+	review      *reviewPanelModel
+	shipping    *shippingPanelModel
+	planEditor  *planEditorModel
+	config      *configForm
+	configRepo  string
+	launchAgent *agent.Agent
+	launchSess  *agent.Session
+}
+
+// Current returns the active panel focus.
+func (m *Modals) Current() panelFocus { return m.current }
+
+// Is reports whether the active focus is f.
+func (m *Modals) Is(f panelFocus) bool { return m.current == f }
+
+// IsList reports whether the pipeline list has focus (no overlay active).
+func (m *Modals) IsList() bool { return m.current == focusList }
+
+// Close returns focus to the pipeline list and nils every owned model.
+// Calling Close on an already-closed Modals is a no-op.
+func (m *Modals) Close() {
+	m.current = focusList
+	m.review = nil
+	m.shipping = nil
+	m.planEditor = nil
+	m.config = nil
+	m.configRepo = ""
+	m.launchAgent = nil
+	m.launchSess = nil
+}
+
+// OpenReview opens the review panel. Closes any prior modal first.
+func (m *Modals) OpenReview(p *reviewPanelModel) {
+	m.Close()
+	m.current = focusReview
+	m.review = p
+}
+
+// OpenShipping opens the shipping panel.
+func (m *Modals) OpenShipping(p *shippingPanelModel) {
+	m.Close()
+	m.current = focusShipping
+	m.shipping = p
+}
+
+// OpenPlanEditor opens the full-page plan editor.
+func (m *Modals) OpenPlanEditor(p *planEditorModel) {
+	m.Close()
+	m.current = focusPlanEditor
+	m.planEditor = p
+}
+
+// OpenConfig opens the per-repo config form for the given repo path.
+func (m *Modals) OpenConfig(form *configForm, repoPath string) {
+	m.Close()
+	m.current = focusConfig
+	m.config = form
+	m.configRepo = repoPath
+}
+
+// OpenLaunch opens the fullscreen agent terminal focused on ag (owned by sess).
+func (m *Modals) OpenLaunch(sess *agent.Session, ag *agent.Agent) {
+	m.Close()
+	m.current = focusLaunch
+	m.launchSess = sess
+	m.launchAgent = ag
+}
+
+// Review returns the review panel model if focusReview is current; otherwise nil.
+func (m *Modals) Review() *reviewPanelModel {
+	if m.current == focusReview {
+		return m.review
+	}
+	return nil
+}
+
+// Shipping returns the shipping panel model if focusShipping is current.
+func (m *Modals) Shipping() *shippingPanelModel {
+	if m.current == focusShipping {
+		return m.shipping
+	}
+	return nil
+}
+
+// PlanEditor returns the plan editor model if focusPlanEditor is current.
+func (m *Modals) PlanEditor() *planEditorModel {
+	if m.current == focusPlanEditor {
+		return m.planEditor
+	}
+	return nil
+}
+
+// Config returns the config form if focusConfig is current.
+func (m *Modals) Config() *configForm {
+	if m.current == focusConfig {
+		return m.config
+	}
+	return nil
+}
+
+// ConfigRepoPath returns the repo path the config form is editing, or "" if
+// focusConfig is not current.
+func (m *Modals) ConfigRepoPath() string {
+	if m.current == focusConfig {
+		return m.configRepo
+	}
+	return ""
+}
+
+// LaunchAgent returns the focused agent if focusLaunch is current.
+func (m *Modals) LaunchAgent() *agent.Agent {
+	if m.current == focusLaunch {
+		return m.launchAgent
+	}
+	return nil
+}
+
+// LaunchSession returns the focused session if focusLaunch is current.
+func (m *Modals) LaunchSession() *agent.Session {
+	if m.current == focusLaunch {
+		return m.launchSess
+	}
+	return nil
+}
+
+// SetLaunchAgent updates the launch agent without changing focus or the
+// session. Used when retargeting between sibling agents on the same session.
+// A no-op when focusLaunch is not current.
+func (m *Modals) SetLaunchAgent(ag *agent.Agent) {
+	if m.current == focusLaunch {
+		m.launchAgent = ag
+	}
+}
+
+// CompareAndSetReview replaces the review panel only if the currently held
+// pointer equals old and focusReview is current. Returns true on success.
+// Mirrors the snapshot-and-restore pattern used after a panel's Update may
+// have invoked svc.ClosePanel -- if the panel was closed during Update, the
+// stored pointer differs from old and the swap is skipped.
+func (m *Modals) CompareAndSetReview(old, fresh *reviewPanelModel) bool {
+	if m.current != focusReview || m.review != old {
+		return false
+	}
+	m.review = fresh
+	return true
+}
+
+// CompareAndSetShipping is the shipping panel's snapshot-and-swap variant.
+func (m *Modals) CompareAndSetShipping(old, fresh *shippingPanelModel) bool {
+	if m.current != focusShipping || m.shipping != old {
+		return false
+	}
+	m.shipping = fresh
+	return true
+}

--- a/internal/tui/modals_test.go
+++ b/internal/tui/modals_test.go
@@ -1,0 +1,333 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/devenjarvis/refrain/internal/agent"
+)
+
+// TestModals_ZeroValue verifies the zero-valued Modals is usable: no overlay
+// active, every accessor returns nil.
+func TestModals_ZeroValue(t *testing.T) {
+	var m Modals
+	if m.Current() != focusList {
+		t.Errorf("Current() = %d, want focusList", m.Current())
+	}
+	if !m.IsList() {
+		t.Error("IsList() = false, want true")
+	}
+	if m.Review() != nil {
+		t.Error("Review() should be nil on zero value")
+	}
+	if m.Shipping() != nil {
+		t.Error("Shipping() should be nil on zero value")
+	}
+	if m.PlanEditor() != nil {
+		t.Error("PlanEditor() should be nil on zero value")
+	}
+	if m.Config() != nil {
+		t.Error("Config() should be nil on zero value")
+	}
+	if m.LaunchAgent() != nil {
+		t.Error("LaunchAgent() should be nil on zero value")
+	}
+	if m.LaunchSession() != nil {
+		t.Error("LaunchSession() should be nil on zero value")
+	}
+}
+
+// TestModals_OpenReview_SetsCurrentAndPointer verifies the invariant: when
+// focusReview is opened, Is(focusReview) is true, Review() returns the panel,
+// and every other typed accessor returns nil.
+func TestModals_OpenReview_SetsCurrentAndPointer(t *testing.T) {
+	var m Modals
+	rp := &reviewPanelModel{}
+	m.OpenReview(rp)
+
+	if !m.Is(focusReview) {
+		t.Error("Is(focusReview) should be true after OpenReview")
+	}
+	if m.IsList() {
+		t.Error("IsList() should be false after OpenReview")
+	}
+	if m.Review() != rp {
+		t.Error("Review() should return the opened panel")
+	}
+	// Every other accessor must return nil while review is active.
+	if m.Shipping() != nil {
+		t.Error("Shipping() should be nil when focusReview is current")
+	}
+	if m.PlanEditor() != nil {
+		t.Error("PlanEditor() should be nil when focusReview is current")
+	}
+	if m.Config() != nil {
+		t.Error("Config() should be nil when focusReview is current")
+	}
+	if m.LaunchAgent() != nil {
+		t.Error("LaunchAgent() should be nil when focusReview is current")
+	}
+	if m.LaunchSession() != nil {
+		t.Error("LaunchSession() should be nil when focusReview is current")
+	}
+}
+
+// TestModals_Close_NilsEveryModel verifies that after opening each modal in
+// turn, Close() returns focus to the list AND every owned pointer is nil.
+// This is the bug the type was introduced to make impossible.
+func TestModals_Close_NilsEveryModel(t *testing.T) {
+	cases := []struct {
+		name string
+		open func(*Modals)
+	}{
+		{"review", func(m *Modals) { m.OpenReview(&reviewPanelModel{}) }},
+		{"shipping", func(m *Modals) { m.OpenShipping(&shippingPanelModel{}) }},
+		{"planEditor", func(m *Modals) { m.OpenPlanEditor(&planEditorModel{}) }},
+		{"config", func(m *Modals) { m.OpenConfig(&configForm{}, "/repo") }},
+		{"launch", func(m *Modals) { m.OpenLaunch(&agent.Session{}, &agent.Agent{}) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m Modals
+			tc.open(&m)
+			m.Close()
+
+			if m.Current() != focusList {
+				t.Errorf("Current() = %d after Close, want focusList", m.Current())
+			}
+			if m.Review() != nil {
+				t.Error("Review() not nil after Close")
+			}
+			if m.Shipping() != nil {
+				t.Error("Shipping() not nil after Close")
+			}
+			if m.PlanEditor() != nil {
+				t.Error("PlanEditor() not nil after Close")
+			}
+			if m.Config() != nil {
+				t.Error("Config() not nil after Close")
+			}
+			if m.ConfigRepoPath() != "" {
+				t.Errorf("ConfigRepoPath() = %q after Close, want empty", m.ConfigRepoPath())
+			}
+			if m.LaunchAgent() != nil {
+				t.Error("LaunchAgent() not nil after Close")
+			}
+			if m.LaunchSession() != nil {
+				t.Error("LaunchSession() not nil after Close")
+			}
+		})
+	}
+}
+
+// TestModals_Close_NilsInternalState verifies Close clears the internal
+// pointers (not just the typed accessors which already gate on focus).
+// Without this, a future bug could leave a stale model attached after focus
+// changed but Close wasn't called.
+func TestModals_Close_NilsInternalState(t *testing.T) {
+	var m Modals
+	m.OpenReview(&reviewPanelModel{})
+	m.Close()
+	if m.review != nil {
+		t.Error("internal review pointer should be nil after Close")
+	}
+	m.OpenShipping(&shippingPanelModel{})
+	m.Close()
+	if m.shipping != nil {
+		t.Error("internal shipping pointer should be nil after Close")
+	}
+	m.OpenPlanEditor(&planEditorModel{})
+	m.Close()
+	if m.planEditor != nil {
+		t.Error("internal planEditor pointer should be nil after Close")
+	}
+	m.OpenConfig(&configForm{}, "/repo")
+	m.Close()
+	if m.config != nil || m.configRepo != "" {
+		t.Error("internal config state should be empty after Close")
+	}
+	m.OpenLaunch(&agent.Session{}, &agent.Agent{})
+	m.Close()
+	if m.launchAgent != nil || m.launchSess != nil {
+		t.Error("internal launch refs should be nil after Close")
+	}
+}
+
+// TestModals_OpenReplacesPrevious verifies that opening one modal cleanly
+// supersedes any prior modal -- no stale pointers, only the newest is
+// accessible.
+func TestModals_OpenReplacesPrevious(t *testing.T) {
+	var m Modals
+	rp := &reviewPanelModel{}
+	sp := &shippingPanelModel{}
+
+	m.OpenReview(rp)
+	m.OpenShipping(sp)
+
+	if m.Current() != focusShipping {
+		t.Errorf("Current() = %d, want focusShipping", m.Current())
+	}
+	if m.Review() != nil {
+		t.Error("Review() should be nil after OpenShipping replaces it")
+	}
+	if m.Shipping() != sp {
+		t.Error("Shipping() should return the most recently opened panel")
+	}
+	// Internal state: the prior review pointer must also be cleared.
+	if m.review != nil {
+		t.Error("internal review pointer should be nil after replacement")
+	}
+}
+
+// TestModals_TableInvariant verifies the core invariant across every focus
+// state: after each Open*, exactly one typed accessor returns non-nil and
+// every other returns nil.
+func TestModals_TableInvariant(t *testing.T) {
+	cases := []struct {
+		name       string
+		open       func(*Modals)
+		wantFocus  panelFocus
+		wantNonNil string
+	}{
+		{
+			name:       "review",
+			open:       func(m *Modals) { m.OpenReview(&reviewPanelModel{}) },
+			wantFocus:  focusReview,
+			wantNonNil: "review",
+		},
+		{
+			name:       "shipping",
+			open:       func(m *Modals) { m.OpenShipping(&shippingPanelModel{}) },
+			wantFocus:  focusShipping,
+			wantNonNil: "shipping",
+		},
+		{
+			name:       "planEditor",
+			open:       func(m *Modals) { m.OpenPlanEditor(&planEditorModel{}) },
+			wantFocus:  focusPlanEditor,
+			wantNonNil: "planEditor",
+		},
+		{
+			name:       "config",
+			open:       func(m *Modals) { m.OpenConfig(&configForm{}, "/r") },
+			wantFocus:  focusConfig,
+			wantNonNil: "config",
+		},
+		{
+			name:       "launch",
+			open:       func(m *Modals) { m.OpenLaunch(&agent.Session{}, &agent.Agent{}) },
+			wantFocus:  focusLaunch,
+			wantNonNil: "launch",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m Modals
+			tc.open(&m)
+			if m.Current() != tc.wantFocus {
+				t.Errorf("Current() = %d, want %d", m.Current(), tc.wantFocus)
+			}
+			accessors := map[string]bool{
+				"review":     m.Review() != nil,
+				"shipping":   m.Shipping() != nil,
+				"planEditor": m.PlanEditor() != nil,
+				"config":     m.Config() != nil,
+				"launch":     m.LaunchAgent() != nil && m.LaunchSession() != nil,
+			}
+			for name, gotNonNil := range accessors {
+				wantNonNil := name == tc.wantNonNil
+				if gotNonNil != wantNonNil {
+					t.Errorf("accessor %q non-nil = %v, want %v", name, gotNonNil, wantNonNil)
+				}
+			}
+		})
+	}
+}
+
+// TestModals_CompareAndSetReview verifies the snapshot-and-swap defends
+// against a concurrent Close() that nilled the model during panel.Update.
+func TestModals_CompareAndSetReview(t *testing.T) {
+	var m Modals
+	original := &reviewPanelModel{}
+	fresh := &reviewPanelModel{}
+	m.OpenReview(original)
+
+	// Happy path: pointer matches, swap succeeds.
+	if !m.CompareAndSetReview(original, fresh) {
+		t.Fatal("CompareAndSetReview should succeed when pointer matches")
+	}
+	if m.Review() != fresh {
+		t.Error("Review() should return fresh after successful swap")
+	}
+
+	// Concurrent close during Update: pointer no longer matches.
+	m.Close()
+	if m.CompareAndSetReview(fresh, &reviewPanelModel{}) {
+		t.Error("CompareAndSetReview should fail when focus changed")
+	}
+	if m.Review() != nil {
+		t.Error("Review() should remain nil after failed CAS")
+	}
+}
+
+// TestModals_CompareAndSetShipping mirrors the review CAS test for shipping.
+func TestModals_CompareAndSetShipping(t *testing.T) {
+	var m Modals
+	original := &shippingPanelModel{}
+	fresh := &shippingPanelModel{}
+	m.OpenShipping(original)
+
+	if !m.CompareAndSetShipping(original, fresh) {
+		t.Fatal("CompareAndSetShipping should succeed when pointer matches")
+	}
+	if m.Shipping() != fresh {
+		t.Error("Shipping() should return fresh after successful swap")
+	}
+
+	m.Close()
+	if m.CompareAndSetShipping(fresh, &shippingPanelModel{}) {
+		t.Error("CompareAndSetShipping should fail when focus changed")
+	}
+}
+
+// TestModals_SetLaunchAgent allows retargeting the focused agent without
+// reopening the modal, but only while focusLaunch is current.
+func TestModals_SetLaunchAgent(t *testing.T) {
+	var m Modals
+	sess := &agent.Session{}
+	a1 := &agent.Agent{}
+	a2 := &agent.Agent{}
+
+	m.OpenLaunch(sess, a1)
+	if m.LaunchAgent() != a1 {
+		t.Fatal("LaunchAgent should return a1 after OpenLaunch")
+	}
+
+	m.SetLaunchAgent(a2)
+	if m.LaunchAgent() != a2 {
+		t.Error("SetLaunchAgent should retarget while focused")
+	}
+	if m.LaunchSession() != sess {
+		t.Error("SetLaunchAgent should not affect the session pointer")
+	}
+
+	// After Close, SetLaunchAgent must be a no-op.
+	m.Close()
+	m.SetLaunchAgent(a1)
+	if m.LaunchAgent() != nil {
+		t.Error("SetLaunchAgent should be a no-op when focusLaunch is not current")
+	}
+}
+
+// TestModals_ConfigRepoPath verifies the repo path is carried with the config
+// form and cleared on close.
+func TestModals_ConfigRepoPath(t *testing.T) {
+	var m Modals
+	m.OpenConfig(&configForm{}, "/path/to/repo")
+	if got := m.ConfigRepoPath(); got != "/path/to/repo" {
+		t.Errorf("ConfigRepoPath() = %q, want %q", got, "/path/to/repo")
+	}
+	m.Close()
+	if got := m.ConfigRepoPath(); got != "" {
+		t.Errorf("ConfigRepoPath() after Close = %q, want empty", got)
+	}
+}

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -20,9 +20,9 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case configFormSaveMsg:
 		// Repo config form saved.
-		if a.dashboard.repoConfigForm != nil && a.dashboard.configRepoPath != "" {
-			repoPath := a.dashboard.configRepoPath
-			alias := strings.TrimSpace(a.dashboard.repoConfigForm.textValue("Alias"))
+		if form := a.modals.Config(); form != nil && a.modals.ConfigRepoPath() != "" {
+			repoPath := a.modals.ConfigRepoPath()
+			alias := strings.TrimSpace(form.textValue("Alias"))
 			settings := a.extractRepoSettings()
 			if err := config.SaveRepoSettings(repoPath, settings); err != nil {
 				a.setError(err.Error())
@@ -62,8 +62,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmd := a.prComposeModal.Update(msg)
 			return a, cmd
 		}
-		if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
-			a.focusLaunchAgent.Paste(msg.Content)
+		if ag := a.modals.LaunchAgent(); ag != nil {
+			ag.Paste(msg.Content)
 			return a, nil
 		}
 
@@ -80,12 +80,12 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, cmd
 		}
 		// focusLaunch: forward all keys to the launch agent; esc/ctrl+e returns to focus pipeline.
-		if a.dashboard.panelFocus == focusLaunch {
+		if a.modals.Is(focusLaunch) {
 			return a.updateFocusLaunchKeys(msg)
 		}
 
 		// When the config panel has focus, skip all app-level bindings.
-		if a.dashboard.panelFocus == focusConfig {
+		if a.modals.Is(focusConfig) {
 			a.confirmQuit = false
 			break
 		}
@@ -124,7 +124,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Pipeline view key handling (the only dashboard mode).
-		if a.dashboard.panelFocus != focusReview && a.dashboard.panelFocus != focusShipping {
+		if !a.modals.Is(focusReview) && !a.modals.Is(focusShipping) {
 			switch msg.String() {
 			case "up", "k":
 				a.cursor.MoveUp(a.dashboard.sectionCounts())
@@ -233,12 +233,11 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				sess := reviewItems[idx].session
 				sess.SetLifecyclePhase(agent.LifecycleInReview)
-				a.reviewPanel = newReviewPanel(sess, a.width, a.height)
-				a.dashboard.panelFocus = focusReview
+				a.openReview(newReviewPanel(sess, a.width, a.height))
 				if _, ok := a.reviewDiffCache[sess.ID]; !ok {
 					return a, a.fetchReviewDiffCmd(sess)
 				}
-				a.reviewPanel.RefreshDiffViewport(a.panelServices())
+				a.modals.Review().RefreshDiffViewport(a.panelServices())
 				return a, nil
 			case "n":
 				if a.cfg != nil && len(a.cfg.Repos) > 1 {
@@ -273,7 +272,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Enter/right on a repo header: open repo config in right panel.
-		if (msg.String() == "enter" || msg.String() == "right") && a.dashboard.panelFocus == focusList {
+		if (msg.String() == "enter" || msg.String() == "right") && a.modals.IsList() {
 			item := a.dashboard.selectedItem()
 			if item != nil && item.kind == listItemRepo {
 				a.initRepoConfigForm(item.repoPath)
@@ -334,18 +333,19 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// focusLaunch: tab bar click switches the active agent; clicks inside
 		// the agent terminal seed a text selection.
-		if a.dashboard.panelFocus == focusLaunch && a.focusLaunchSession != nil {
+		if sess := a.modals.LaunchSession(); sess != nil {
 			tabBarY := dashboardTopY + 1
 			if msg.Y == tabBarY {
 				if idx := a.focusLaunchTabIndexAt(msg.X); idx >= 0 {
-					agents := a.focusLaunchSession.Agents()
-					a.focusLaunchAgent = agents[idx]
+					agents := sess.Agents()
+					a.modals.SetLaunchAgent(agents[idx])
+					a.syncModalsToDashboard()
 					a.dashboard.scrollOffset = 0
-					a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+					agents[idx].Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 				}
 				return a, nil
 			}
-			if a.focusLaunchAgent != nil {
+			if ag := a.modals.LaunchAgent(); ag != nil {
 				if termX, termY, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y); inVP {
 					a.dashboard.selection = selection{
 						anchorX: termX,
@@ -353,7 +353,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 						cursorX: termX,
 						cursorY: termY,
 						active:  true,
-						agentID: a.focusLaunchAgent.ID,
+						agentID: ag.ID,
 					}
 				} else {
 					a.dashboard.clearSelection()
@@ -363,10 +363,10 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// focusReview: delegate left-pane row clicks to the panel.
-		if a.dashboard.panelFocus == focusReview && a.reviewPanel != nil {
-			before := a.reviewPanel.TaskCursor()
-			a.reviewPanel.handleClick(msg, a.panelServices())
-			if a.reviewPanel.TaskCursor() != before {
+		if rp := a.modals.Review(); rp != nil {
+			before := rp.TaskCursor()
+			rp.handleClick(msg, a.panelServices())
+			if rp.TaskCursor() != before {
 				return a, nil
 			}
 		}
@@ -428,7 +428,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// only seed in focusLaunch (see MouseClickMsg), so any motion outside
 		// focusLaunch can be ignored here.
 		if a.dashboard.selection.active && msg.Button == tea.MouseLeft &&
-			a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
+			a.modals.LaunchAgent() != nil {
 			tx, ty, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
 			if inVP {
 				a.dashboard.selection.cursorX = tx
@@ -444,12 +444,11 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.dashboard.selection.dragSeen {
 				// Real drag — copy the highlighted region. Selections only seed
 				// in focusLaunch (see MouseClickMsg), so this is the only path.
-				if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == a.dashboard.selection.agentID {
+				if ag := a.modals.LaunchAgent(); ag != nil && ag.ID == a.dashboard.selection.agentID {
 					if sx, sy, ex, ey, ok := a.dashboard.selectionRect(); ok {
 						rect := vt.SelectionRect{
 							StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
 						}
-						ag := a.focusLaunchAgent
 						var text string
 						if a.dashboard.scrollOffset > 0 {
 							vpWidth := a.dashboard.width
@@ -473,8 +472,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if msg, ok := msg.(tea.MouseWheelMsg); ok {
-		if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
-			ag := a.focusLaunchAgent
+		if ag := a.modals.LaunchAgent(); ag != nil {
 			if ag.IsAltScreen() {
 				termX, termY, _ := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
 				if termX < 0 {
@@ -532,7 +530,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// remains in focusLaunch viewing the same agent. Any focus or agent
 	// change (esc back to pipeline, tab switch, etc.) drops it.
 	if a.dashboard.selection.active {
-		if a.dashboard.panelFocus != focusLaunch || a.focusLaunchAgent == nil || a.focusLaunchAgent.ID != a.dashboard.selection.agentID {
+		ag := a.modals.LaunchAgent()
+		if ag == nil || ag.ID != a.dashboard.selection.agentID {
 			a.dashboard.clearSelection()
 		}
 	}
@@ -547,22 +546,22 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 // off updateDashboard so the latter reads as a router, not a god-method.
 func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	a.confirmQuit = false
-	if a.focusLaunchAgent == nil {
-		a.dashboard.panelFocus = focusList
+	ag := a.modals.LaunchAgent()
+	sess := a.modals.LaunchSession()
+	if ag == nil {
+		a.closeModal()
 		a.dashboard.scrollOffset = 0
 		return a, nil
 	}
 	switch msg.String() {
 	case "esc", "ctrl+e":
-		a.resizeAgentForDashboard(a.focusLaunchAgent)
-		a.focusLaunchAgent = nil
-		a.focusLaunchSession = nil
-		a.dashboard.panelFocus = focusList
+		a.resizeAgentForDashboard(ag)
+		a.closeModal()
 		a.dashboard.scrollOffset = 0
 	case "shift+esc":
-		a.focusLaunchAgent.SendKey(xvt.KeyPressEvent{Code: tea.KeyEscape})
+		ag.SendKey(xvt.KeyPressEvent{Code: tea.KeyEscape})
 	case "pgup":
-		sbLines := len(a.focusLaunchAgent.ScrollbackLines())
+		sbLines := len(ag.ScrollbackLines())
 		maxScroll := sbLines
 		a.dashboard.scrollOffset += a.dashboard.height / 2
 		if a.dashboard.scrollOffset > maxScroll {
@@ -576,11 +575,11 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "home":
 		a.dashboard.scrollOffset = 0
 	case "alt+]", "alt+[":
-		if a.focusLaunchSession != nil {
-			agents := a.focusLaunchSession.Agents()
+		if sess != nil {
+			agents := sess.Agents()
 			idx := 0
-			for i, ag := range agents {
-				if ag.ID == a.focusLaunchAgent.ID {
+			for i, candidate := range agents {
+				if candidate.ID == ag.ID {
 					idx = i
 					break
 				}
@@ -590,13 +589,14 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			} else {
 				idx = (idx - 1 + len(agents)) % len(agents)
 			}
-			a.focusLaunchAgent = agents[idx]
+			a.modals.SetLaunchAgent(agents[idx])
+			a.syncModalsToDashboard()
 			a.dashboard.scrollOffset = 0
-			a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+			agents[idx].Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 		}
 	case "ctrl+t":
-		if a.focusLaunchSession != nil {
-			repoPath := a.repoPathForSession(a.focusLaunchSession.ID)
+		if sess != nil {
+			repoPath := a.repoPathForSession(sess.ID)
 			mgr := a.managers[repoPath]
 			if mgr != nil {
 				resolved := a.resolvedCache[repoPath]
@@ -605,8 +605,9 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 					Cols:              a.dashboard.width,
 					BypassPermissions: resolved.BypassPermissions,
 				}
-				if newAg, err := mgr.AddShell(a.focusLaunchSession.ID, cfg); err == nil {
-					a.focusLaunchAgent = newAg
+				if newAg, err := mgr.AddShell(sess.ID, cfg); err == nil {
+					a.modals.SetLaunchAgent(newAg)
+					a.syncModalsToDashboard()
 					a.dashboard.scrollOffset = 0
 				} else {
 					a.setError(err.Error())
@@ -614,8 +615,8 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "ctrl+n":
-		if a.focusLaunchSession != nil {
-			repoPath := a.repoPathForSession(a.focusLaunchSession.ID)
+		if sess != nil {
+			repoPath := a.repoPathForSession(sess.ID)
 			mgr := a.managers[repoPath]
 			if mgr != nil {
 				resolved := a.resolvedCache[repoPath]
@@ -627,8 +628,9 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 					AgentModel:        resolved.AgentModel,
 					BuildSystemPrompt: resolved.BuildSystemPrompt,
 				}
-				if newAg, err := mgr.AddAgent(a.focusLaunchSession.ID, cfg); err == nil {
-					a.focusLaunchAgent = newAg
+				if newAg, err := mgr.AddAgent(sess.ID, cfg); err == nil {
+					a.modals.SetLaunchAgent(newAg)
+					a.syncModalsToDashboard()
 					a.dashboard.scrollOffset = 0
 				} else {
 					a.setError(err.Error())
@@ -639,9 +641,9 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return a.closeFocusLaunchAgent()
 	default:
 		if msg.Text != "" {
-			a.focusLaunchAgent.SendText(msg.Text)
+			ag.SendText(msg.Text)
 		} else {
-			a.focusLaunchAgent.SendKey(xvt.KeyPressEvent(msg))
+			ag.SendKey(xvt.KeyPressEvent(msg))
 		}
 	}
 	return a, nil
@@ -653,39 +655,38 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 // asynchronously. Split from updateFocusLaunchKeys so the ctrl+w switch case
 // reads as one line.
 func (a App) closeFocusLaunchAgent() (tea.Model, tea.Cmd) {
-	if a.focusLaunchSession == nil || a.focusLaunchAgent == nil {
+	sess := a.modals.LaunchSession()
+	ag := a.modals.LaunchAgent()
+	if sess == nil || ag == nil {
 		return a, nil
 	}
-	agents := a.focusLaunchSession.Agents()
+	agents := sess.Agents()
 	if len(agents) == 0 {
-		a.focusLaunchAgent = nil
-		a.focusLaunchSession = nil
-		a.dashboard.panelFocus = focusList
+		a.closeModal()
 		a.dashboard.scrollOffset = 0
 		return a, nil
 	}
-	oldID := a.focusLaunchAgent.ID
-	sessionID := a.focusLaunchSession.ID
+	oldID := ag.ID
+	sessionID := sess.ID
 	currentIdx := 0
-	for i, ag := range agents {
-		if ag.ID == oldID {
+	for i, candidate := range agents {
+		if candidate.ID == oldID {
 			currentIdx = i
 			break
 		}
 	}
 	lastAgent := len(agents) == 1
 	if lastAgent {
-		a.focusLaunchAgent = nil
-		a.focusLaunchSession = nil
-		a.dashboard.panelFocus = focusList
+		a.closeModal()
 		a.dashboard.scrollOffset = 0
 	} else {
 		nextIdx := currentIdx + 1
 		if currentIdx == len(agents)-1 {
 			nextIdx = currentIdx - 1
 		}
-		a.focusLaunchAgent = agents[nextIdx]
-		a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+		a.modals.SetLaunchAgent(agents[nextIdx])
+		a.syncModalsToDashboard()
+		agents[nextIdx].Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 		a.dashboard.scrollOffset = 0
 	}
 	if a.closingAgents[oldID] {
@@ -712,27 +713,28 @@ func (a App) closeFocusLaunchAgent() (tea.Model, tea.Cmd) {
 // true exactly when the editor owns focus, signalling to the caller that no
 // further dispatch is needed.
 func (a App) handleKeysPlanEditor(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
-	if a.dashboard.panelFocus != focusPlanEditor || a.planEditor == nil {
+	pe := a.modals.PlanEditor()
+	if pe == nil {
 		return a, nil, false
 	}
-	cmd := a.planEditor.Update(msg)
+	cmd := pe.Update(msg)
 	return a, cmd, true
 }
 
 // handleKeysReviewPanel forwards a keypress to the review panel. handled is true
 // exactly when the review panel owns focus. The snapshot dance preserves the
 // invariant that svc.ClosePanel wins over a stale restore — if the panel was
-// closed mid-Update, we leave a.reviewPanel nil rather than restoring it.
+// closed mid-Update, CompareAndSetReview returns false and the modals state
+// stays nil.
 func (a App) handleKeysReviewPanel(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
-	if a.dashboard.panelFocus != focusReview || a.reviewPanel == nil {
+	snapshot := a.modals.Review()
+	if snapshot == nil {
 		return a, nil, false
 	}
-	snapshot := a.reviewPanel
 	updated, cmd := snapshot.Update(msg, a.panelServices())
-	if a.reviewPanel == snapshot {
-		if rp, ok := updated.(*reviewPanelModel); ok {
-			a.reviewPanel = rp
-		}
+	if rp, ok := updated.(*reviewPanelModel); ok {
+		a.modals.CompareAndSetReview(snapshot, rp)
+		a.syncModalsToDashboard()
 	}
 	return a, cmd, true
 }
@@ -740,15 +742,14 @@ func (a App) handleKeysReviewPanel(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 // handleKeysShippingPanel forwards a keypress to the shipping panel. Mirrors the
 // review-panel snapshot-and-restore pattern.
 func (a App) handleKeysShippingPanel(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
-	if a.dashboard.panelFocus != focusShipping || a.shippingPanel == nil {
+	snapshot := a.modals.Shipping()
+	if snapshot == nil {
 		return a, nil, false
 	}
-	snapshot := a.shippingPanel
 	updated, cmd := snapshot.Update(msg, a.panelServices())
-	if a.shippingPanel == snapshot {
-		if sp, ok := updated.(*shippingPanelModel); ok {
-			a.shippingPanel = sp
-		}
+	if sp, ok := updated.(*shippingPanelModel); ok {
+		a.modals.CompareAndSetShipping(snapshot, sp)
+		a.syncModalsToDashboard()
 	}
 	return a, cmd, true
 }
@@ -989,9 +990,7 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 			// Shell exists — open it in focusLaunch directly.
 			for _, ag := range sess.Agents() {
 				if ag.IsShell {
-					a.focusLaunchAgent = ag
-					a.focusLaunchSession = sess
-					a.dashboard.panelFocus = focusLaunch
+					a.openLaunchPanel(sess, ag)
 					a.dashboard.scrollOffset = 0
 					ag.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 					break

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -37,16 +37,16 @@ func (a App) handleWindowSize(msg tea.WindowSizeMsg) App {
 	// Resize agent terminals to match their current display container.
 	if a.view == ViewDashboard {
 		a.resizeAllForDashboard()
-		if a.dashboard.panelFocus == focusLaunch && a.focusLaunchAgent != nil {
-			a.focusLaunchAgent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+		if ag := a.modals.LaunchAgent(); ag != nil {
+			ag.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 		}
-		if a.dashboard.panelFocus == focusPlanEditor && a.planEditor != nil {
-			a.planEditor.SetSize(msg.Width, msg.Height-1)
+		if pe := a.modals.PlanEditor(); pe != nil {
+			pe.SetSize(msg.Width, msg.Height-1)
 		}
 		a.promptModal.SetSize(msg.Width, msg.Height-1)
 		a.prComposeModal.SetSize(msg.Width, msg.Height-1)
-		if a.shippingPanel != nil {
-			a.shippingPanel.Resize(msg.Width, msg.Height-1)
+		if sp := a.modals.Shipping(); sp != nil {
+			sp.Resize(msg.Width, msg.Height-1)
 		}
 	}
 	return a
@@ -224,7 +224,7 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	} else if a.wellness.focusSessionMinutes > 0 &&
-		a.dashboard.panelFocus == focusList &&
+		a.modals.IsList() &&
 		time.Since(a.wellness.sessionStart) >= time.Duration(a.wellness.focusSessionMinutes)*time.Minute {
 		// Auto-enter break when the work block elapses. The asymmetry
 		// with break-end (which waits for explicit `b`) is intentional:
@@ -282,7 +282,7 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 				// The focusLaunch agent renders fullscreen, so resize it
 				// to the fullscreen dimensions instead of shrinking it
 				// back to the preview size.
-				if a.focusLaunchAgent != nil && item.agent.ID == a.focusLaunchAgent.ID {
+				if launchAgent := a.modals.LaunchAgent(); launchAgent != nil && item.agent.ID == launchAgent.ID {
 					item.agent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 				} else {
 					item.agent.Resize(fixedH, fixedW)
@@ -419,8 +419,8 @@ func (a App) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd) {
 	// If the editor is open on the session whose drafting/revising just
 	// landed, refresh its content + state so the placeholder swaps to
 	// the rendered plan without requiring a re-open.
-	if msg.event.Type == agent.EventStatusChanged && a.planEditor != nil &&
-		a.planEditor.sess != nil && a.planEditor.sess.ID == msg.event.SessionID {
+	if pe := a.modals.PlanEditor(); msg.event.Type == agent.EventStatusChanged && pe != nil &&
+		pe.sess != nil && pe.sess.ID == msg.event.SessionID {
 		// Read both flags up-front so the Reload decision sees a coherent
 		// snapshot. RevisePlan emits EventStatusChanged synchronously with
 		// IsRevising=true (before runRevise spawns), so a naive
@@ -428,16 +428,16 @@ func (a App) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd) {
 		// the revise banner appears. Only Reload when neither subprocess
 		// is in flight — that's the single state where plan.md is stable
 		// and the editor view should reflect disk.
-		drafting := a.planEditor.sess.IsDrafting()
-		revising := a.planEditor.sess.IsRevising()
-		a.planEditor.SetDrafting(drafting)
-		a.planEditor.SetRevising(revising)
+		drafting := pe.sess.IsDrafting()
+		revising := pe.sess.IsRevising()
+		pe.SetDrafting(drafting)
+		pe.SetRevising(revising)
 		if !drafting && !revising {
-			a.planEditor.Reload()
-			if derr := a.planEditor.sess.DraftError(); derr != nil {
-				a.planEditor.SetError("draft failed: " + derr.Error())
-			} else if rerr := a.planEditor.sess.ReviseError(); rerr != nil {
-				a.planEditor.SetError("revise failed: " + rerr.Error())
+			pe.Reload()
+			if derr := pe.sess.DraftError(); derr != nil {
+				pe.SetError("draft failed: " + derr.Error())
+			} else if rerr := pe.sess.ReviseError(); rerr != nil {
+				pe.SetError("revise failed: " + rerr.Error())
 			}
 		}
 	}
@@ -473,9 +473,7 @@ func (a App) handleCreateResult(msg createResultMsg) (tea.Model, tea.Cmd) {
 			if item.kind == listItemAgent && item.agent != nil && item.agent.ID == msg.agentID {
 				a.dashboard.selected = i
 				if !msg.skipFocusLaunch {
-					a.focusLaunchAgent = item.agent
-					a.focusLaunchSession = item.session
-					a.dashboard.panelFocus = focusLaunch
+					a.openLaunchPanel(item.session, item.agent)
 					a.dashboard.scrollOffset = 0
 					item.agent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 				}
@@ -511,10 +509,8 @@ func (a App) handleKillResult(msg killResultMsg) (tea.Model, tea.Cmd) {
 		delete(a.closingAgents, msg.agentID)
 		delete(a.lastKnownStatus, msg.agentID)
 		// Exit focusLaunch if the killed agent is the one being viewed.
-		if a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == msg.agentID {
-			a.focusLaunchAgent = nil
-			a.focusLaunchSession = nil
-			a.dashboard.panelFocus = focusList
+		if ag := a.modals.LaunchAgent(); ag != nil && ag.ID == msg.agentID {
+			a.closeModal()
 			a.dashboard.scrollOffset = 0
 		}
 	case killScopeSession:
@@ -522,10 +518,8 @@ func (a App) handleKillResult(msg killResultMsg) (tea.Model, tea.Cmd) {
 		for _, id := range msg.agentIDs {
 			delete(a.closingAgents, id)
 			delete(a.lastKnownStatus, id)
-			if a.focusLaunchAgent != nil && a.focusLaunchAgent.ID == id {
-				a.focusLaunchAgent = nil
-				a.focusLaunchSession = nil
-				a.dashboard.panelFocus = focusList
+			if ag := a.modals.LaunchAgent(); ag != nil && ag.ID == id {
+				a.closeModal()
 				a.dashboard.scrollOffset = 0
 			}
 		}

--- a/internal/tui/update_plan.go
+++ b/internal/tui/update_plan.go
@@ -17,9 +17,9 @@ func (a App) handlePlannerQuestion(msg plannerQuestionMsg) (tea.Model, tea.Cmd) 
 	// discard session A's unsaved textarea edits. In that case fall through
 	// to the skip path below.
 	sessionID := msg.question.SessionID
-	focusAtArrival := panelFocusName(a.dashboard.panelFocus)
-	editorAlreadyOpen := a.planEditor != nil && a.planEditor.sess != nil &&
-		a.planEditor.sess.ID == sessionID
+	focusAtArrival := panelFocusName(a.modals.Current())
+	pe := a.modals.PlanEditor()
+	editorAlreadyOpen := pe != nil && pe.sess != nil && pe.sess.ID == sessionID
 
 	// Compute the skip disposition eagerly during the auto-open attempt so
 	// the skip path never needs a second ListSessions() call. The default
@@ -27,7 +27,7 @@ func (a App) handlePlannerQuestion(msg plannerQuestionMsg) (tea.Model, tea.Cmd) 
 	// active); the inner branches refine it for the manager-missing and
 	// session-missing cases so log readers can tell them apart.
 	skipDisp := "skipped-no-editor"
-	if !editorAlreadyOpen && a.dashboard.panelFocus != focusPlanEditor {
+	if !editorAlreadyOpen && !a.modals.Is(focusPlanEditor) {
 		mgr := a.managers[msg.repoPath]
 		if mgr == nil {
 			skipDisp = "skipped-no-manager"
@@ -36,22 +36,22 @@ func (a App) handlePlannerQuestion(msg plannerQuestionMsg) (tea.Model, tea.Cmd) 
 			for _, s := range mgr.ListSessions() {
 				if s.ID == sessionID {
 					a.openPlanEditor(s, msg.repoPath)
+					pe = a.modals.PlanEditor()
 					// Cleared because the happy-path block below logs
 					// "auto-opened" instead. openPlanEditor always sets
-					// a.planEditor, so the happy-path check is guaranteed
-					// to fire — this branch is unreachable if that
-					// guarantee ever breaks.
+					// modals.PlanEditor(), so the happy-path check is
+					// guaranteed to fire — this branch is unreachable if
+					// that guarantee ever breaks.
 					skipDisp = ""
 					break
 				}
 			}
 		}
 	}
-	if a.planEditor != nil && a.planEditor.sess != nil &&
-		a.planEditor.sess.ID == sessionID {
+	if pe != nil && pe.sess != nil && pe.sess.ID == sessionID {
 		disp := "auto-opened"
 		if editorAlreadyOpen {
-			if a.dashboard.panelFocus == focusPlanEditor {
+			if a.modals.Is(focusPlanEditor) {
 				disp = "routed-to-existing"
 			} else {
 				disp = "routed-to-background-editor"
@@ -70,7 +70,7 @@ func (a App) handlePlannerQuestion(msg plannerQuestionMsg) (tea.Model, tea.Cmd) 
 		if disp == "routed-to-background-editor" {
 			a.setError("planner question waiting — open the plan editor to answer")
 		}
-		cmd := a.planEditor.AskQuestion(msg.question.Question, msg.question.AnswerCh)
+		cmd := pe.AskQuestion(msg.question.Question, msg.question.AnswerCh)
 		if mgr := a.managers[msg.repoPath]; mgr != nil {
 			return a, tea.Batch(cmd, listenPlannerQuestions(mgr))
 		}
@@ -101,11 +101,10 @@ func (a App) handlePlanEditorClose(msg planEditorCloseMsg) (tea.Model, tea.Cmd) 
 	// If the editor was parked on a planner question, answer it with the
 	// skip-signal before tearing the editor down so the planner subprocess
 	// unblocks promptly instead of waiting for its server to close.
-	if a.planEditor != nil && a.planEditor.HasPendingQuestion() {
-		a.planEditor.resolveQuestion("")
+	if pe := a.modals.PlanEditor(); pe != nil && pe.HasPendingQuestion() {
+		pe.resolveQuestion("")
 	}
-	a.dashboard.panelFocus = focusList
-	a.planEditor = nil
+	a.closeModal()
 	return a, nil
 }
 
@@ -113,19 +112,19 @@ func (a App) handlePlanEditorAbandon(msg planEditorAbandonMsg) (tea.Model, tea.C
 	// Tear down the session entirely — the user explicitly chose to walk
 	// away from this plan. Resolve any pending planner question first so
 	// the in-flight draft drains cleanly while KillSession is in flight.
-	if a.planEditor != nil && a.planEditor.HasPendingQuestion() {
-		a.planEditor.resolveQuestion("")
+	pe := a.modals.PlanEditor()
+	if pe != nil && pe.HasPendingQuestion() {
+		pe.resolveQuestion("")
 	}
 	repoPath := msg.repoPath
-	if repoPath == "" && a.planEditor != nil {
-		repoPath = a.planEditor.repoPath
+	if repoPath == "" && pe != nil {
+		repoPath = pe.repoPath
 	}
 	if repoPath == "" {
 		repoPath = a.repoPathForSession(msg.sessionID)
 	}
 	mgr := a.managers[repoPath]
-	a.dashboard.panelFocus = focusList
-	a.planEditor = nil
+	a.closeModal()
 	if mgr == nil {
 		return a, nil
 	}
@@ -147,18 +146,18 @@ func (a App) handlePlanEditorRevise(msg planEditorReviseMsg) (tea.Model, tea.Cmd
 	// version. WritePlan errors flow up as an inline editor error and
 	// we abort the revise — otherwise the model would revise the wrong
 	// plan and overwrite the user's edits with the result.
-	if a.planEditor != nil && a.planEditor.dirty && a.planEditor.sess != nil {
-		val := a.planEditor.textarea.Value()
-		if err := a.planEditor.sess.WritePlan(val); err != nil {
-			a.planEditor.SetError("save plan: " + err.Error())
+	if a.modals.PlanEditor() != nil && a.modals.PlanEditor().dirty && a.modals.PlanEditor().sess != nil {
+		val := a.modals.PlanEditor().textarea.Value()
+		if err := a.modals.PlanEditor().sess.WritePlan(val); err != nil {
+			a.modals.PlanEditor().SetError("save plan: " + err.Error())
 			return a, nil
 		}
-		a.planEditor.plan = val
-		a.planEditor.dirty = false
+		a.modals.PlanEditor().plan = val
+		a.modals.PlanEditor().dirty = false
 	}
 	repoPath := msg.repoPath
-	if repoPath == "" && a.planEditor != nil {
-		repoPath = a.planEditor.repoPath
+	if repoPath == "" && a.modals.PlanEditor() != nil {
+		repoPath = a.modals.PlanEditor().repoPath
 	}
 	if repoPath == "" {
 		repoPath = a.repoPathForSession(msg.sessionID)
@@ -168,22 +167,22 @@ func (a App) handlePlanEditorRevise(msg planEditorReviseMsg) (tea.Model, tea.Cmd
 	}
 	mgr := a.managers[repoPath]
 	if mgr == nil {
-		if a.planEditor != nil {
-			a.planEditor.SetError("session manager not found")
+		if a.modals.PlanEditor() != nil {
+			a.modals.PlanEditor().SetError("session manager not found")
 		}
 		return a, nil
 	}
 	if err := mgr.RevisePlan(msg.sessionID, msg.critique); err != nil {
-		if a.planEditor != nil {
-			a.planEditor.SetError("revise: " + err.Error())
+		if a.modals.PlanEditor() != nil {
+			a.modals.PlanEditor().SetError("revise: " + err.Error())
 		}
 		return a, nil
 	}
 	// Reflect the revising state immediately; the EventStatusChanged
 	// dispatch above will keep it in sync as the goroutine progresses.
-	if a.planEditor != nil && a.planEditor.sess != nil &&
-		a.planEditor.sess.ID == msg.sessionID {
-		a.planEditor.SetRevising(true)
+	if a.modals.PlanEditor() != nil && a.modals.PlanEditor().sess != nil &&
+		a.modals.PlanEditor().sess.ID == msg.sessionID {
+		a.modals.PlanEditor().SetRevising(true)
 	}
 	return a, nil
 }
@@ -194,8 +193,8 @@ func (a App) handlePlanEditorRetry(msg planEditorRetryMsg) (tea.Model, tea.Cmd) 
 	// drafter retries from scratch. Mirrors createSessionFromPrompt's call
 	// to StartDraft at app.go:3859.
 	repoPath := msg.repoPath
-	if repoPath == "" && a.planEditor != nil {
-		repoPath = a.planEditor.repoPath
+	if repoPath == "" && a.modals.PlanEditor() != nil {
+		repoPath = a.modals.PlanEditor().repoPath
 	}
 	if repoPath == "" {
 		repoPath = a.repoPathForSession(msg.sessionID)
@@ -205,30 +204,30 @@ func (a App) handlePlanEditorRetry(msg planEditorRetryMsg) (tea.Model, tea.Cmd) 
 	}
 	mgr := a.managers[repoPath]
 	if mgr == nil {
-		if a.planEditor != nil {
-			a.planEditor.SetError("session manager not found")
+		if a.modals.PlanEditor() != nil {
+			a.modals.PlanEditor().SetError("session manager not found")
 		}
 		return a, nil
 	}
 	sess := mgr.GetSession(msg.sessionID)
 	if sess == nil {
-		if a.planEditor != nil {
-			a.planEditor.SetError("session not found")
+		if a.modals.PlanEditor() != nil {
+			a.modals.PlanEditor().SetError("session not found")
 		}
 		return a, nil
 	}
 	prompt := sess.OriginalPrompt()
 	if err := mgr.StartDraft(msg.sessionID, prompt); err != nil {
-		if a.planEditor != nil {
-			a.planEditor.SetError("retry draft: " + err.Error())
+		if a.modals.PlanEditor() != nil {
+			a.modals.PlanEditor().SetError("retry draft: " + err.Error())
 		}
 		return a, nil
 	}
 	// Reflect the drafting state immediately; EventStatusChanged will
 	// keep the editor in sync as the goroutine progresses.
-	if a.planEditor != nil && a.planEditor.sess != nil &&
-		a.planEditor.sess.ID == msg.sessionID {
-		a.planEditor.SetDrafting(true)
+	if a.modals.PlanEditor() != nil && a.modals.PlanEditor().sess != nil &&
+		a.modals.PlanEditor().sess.ID == msg.sessionID {
+		a.modals.PlanEditor().SetDrafting(true)
 	}
 	return a, nil
 }
@@ -236,21 +235,21 @@ func (a App) handlePlanEditorRetry(msg planEditorRetryMsg) (tea.Model, tea.Cmd) 
 func (a App) handlePlanEditorRestore(msg planEditorRestoreMsg) (tea.Model, tea.Cmd) {
 	// Single-step undo: restore plan.prev.md → plan.md and reload the
 	// editor. No-op when no snapshot exists.
-	if a.planEditor == nil || a.planEditor.sess == nil {
+	if a.modals.PlanEditor() == nil || a.modals.PlanEditor().sess == nil {
 		return a, nil
 	}
-	sess := a.planEditor.sess
+	sess := a.modals.PlanEditor().sess
 	if sess.ID != msg.sessionID {
 		return a, nil
 	}
 	_, restored, err := sess.RestorePrevPlan()
 	switch {
 	case err != nil:
-		a.planEditor.SetError("undo: " + err.Error())
+		a.modals.PlanEditor().SetError("undo: " + err.Error())
 	case !restored:
-		a.planEditor.SetError("nothing to undo")
+		a.modals.PlanEditor().SetError("nothing to undo")
 	default:
-		a.planEditor.Reload()
+		a.modals.PlanEditor().Reload()
 	}
 	return a, nil
 }
@@ -366,8 +365,7 @@ func (a *App) openPlanEditor(sess *agent.Session, repoPath string) {
 	if sess.IsDrafting() {
 		editor.SetDrafting(true)
 	}
-	a.planEditor = &editor
-	a.dashboard.panelFocus = focusPlanEditor
+	a.openPlanEditorPanel(&editor)
 	a.dashboard.scrollOffset = 0
 }
 
@@ -377,8 +375,8 @@ func (a *App) openPlanEditor(sess *agent.Session, repoPath string) {
 // on disk by the time this fires (the editor's `a` handler writes it).
 func (a *App) approvePlanAndSpawn(msg planEditorApproveMsg) (tea.Model, tea.Cmd) {
 	repoPath := msg.repoPath
-	if repoPath == "" && a.planEditor != nil {
-		repoPath = a.planEditor.repoPath
+	if repoPath == "" && a.modals.PlanEditor() != nil {
+		repoPath = a.modals.PlanEditor().repoPath
 	}
 	if repoPath == "" {
 		repoPath = a.repoPathForSession(msg.sessionID)
@@ -388,8 +386,7 @@ func (a *App) approvePlanAndSpawn(msg planEditorApproveMsg) (tea.Model, tea.Cmd)
 	}
 	mgr := a.managers[repoPath]
 	if mgr == nil {
-		a.dashboard.panelFocus = focusList
-		a.planEditor = nil
+		a.closeModal()
 		a.setError("session manager not found")
 		return a, nil
 	}
@@ -402,8 +399,7 @@ func (a *App) approvePlanAndSpawn(msg planEditorApproveMsg) (tea.Model, tea.Cmd)
 		}
 	}
 	if sess == nil {
-		a.dashboard.panelFocus = focusList
-		a.planEditor = nil
+		a.closeModal()
 		a.setError("session not found")
 		return a, nil
 	}
@@ -431,8 +427,7 @@ func (a *App) approvePlanAndSpawn(msg planEditorApproveMsg) (tea.Model, tea.Cmd)
 		Task:              prompt,
 	}
 
-	a.dashboard.panelFocus = focusList
-	a.planEditor = nil
+	a.closeModal()
 	sessID := sess.ID
 	// Phase transition is intentionally inside the closure: if AddAgent
 	// fails, the session stays in LifecyclePlanning so the user can retry

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -43,9 +43,8 @@ func (a App) handlePRCreated(msg prCreatedMsg) (tea.Model, tea.Cmd) {
 	if msg.transitionShipping {
 		if sess := a.sessionByID(msg.sessionID); sess != nil {
 			sess.SetLifecyclePhase(agent.LifecycleShipping)
-			if a.reviewPanel != nil && a.reviewPanel.SessionID() == msg.sessionID {
-				a.dashboard.panelFocus = focusList
-				a.reviewPanel = nil
+			if rp := a.modals.Review(); rp != nil && rp.SessionID() == msg.sessionID {
+				a.closeModal()
 			}
 		}
 	}
@@ -127,9 +126,8 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 			switch sess.LifecyclePhase() {
 			case agent.LifecycleInProgress, agent.LifecycleReadyForReview, agent.LifecycleInReview:
 				sess.SetLifecyclePhase(agent.LifecycleShipping)
-				if a.reviewPanel != nil && a.reviewPanel.SessionID() == msg.sessionID {
-					a.dashboard.panelFocus = focusList
-					a.reviewPanel = nil
+				if rp := a.modals.Review(); rp != nil && rp.SessionID() == msg.sessionID {
+					a.closeModal()
 				}
 			}
 		}
@@ -146,9 +144,8 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 						if !a.closingSessions[sessID] {
 							sess.SetLifecyclePhase(agent.LifecycleComplete)
 							// Close the shipping panel if this session is currently open in it.
-							if a.shippingPanel != nil && a.shippingPanel.SessionID() == sessID {
-								a.shippingPanel = nil
-								a.dashboard.panelFocus = focusList
+							if sp := a.modals.Shipping(); sp != nil && sp.SessionID() == sessID {
+								a.closeModal()
 							}
 							var agentIDs []string
 							for _, ag := range sess.Agents() {
@@ -202,8 +199,7 @@ func (a App) handleMergePR(msg mergePRMsg) (tea.Model, tea.Cmd) {
 		a.setError("merge failed: " + msg.err.Error())
 		return a, nil
 	}
-	a.shippingPanel = nil
-	a.dashboard.panelFocus = focusList
+	a.closeModal()
 	repoPath := a.repoPathForSession(msg.sessionID)
 	if repoPath == "" {
 		return a, nil

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -18,8 +18,8 @@ func (a App) handleReviewDiff(msg reviewDiffMsg) (tea.Model, tea.Cmd) {
 	if msg.err == nil && msg.entry != nil {
 		a.reviewDiffCache[msg.sessionID] = msg.entry
 		// Refresh the inline diff viewport when data arrives for the open session.
-		if a.reviewPanel != nil && a.reviewPanel.SessionID() == msg.sessionID && len(msg.entry.groups) > 0 {
-			a.reviewPanel.RefreshDiffViewport(a.panelServices())
+		if rp := a.modals.Review(); rp != nil && rp.SessionID() == msg.sessionID && len(msg.entry.groups) > 0 {
+			rp.RefreshDiffViewport(a.panelServices())
 		}
 		// If the entry has task groups, dispatch a reviewer per group.
 		if len(msg.entry.groups) > 0 {
@@ -236,8 +236,7 @@ func (a App) handleShippingFeedbackRequest(req shippingFeedbackRequestMsg) (tea.
 	}
 
 	sessID := sess.ID
-	a.shippingPanel = nil
-	a.dashboard.panelFocus = focusList
+	a.closeModal()
 	delete(a.feedbackTriage, sessID)
 	return a, func() tea.Msg {
 		ag, err := mgr.AddAgent(sessID, cfg)
@@ -441,9 +440,8 @@ func (a App) handleReviewReworkRequest(req reviewReworkRequestMsg) (tea.Model, t
 		Task:              req.prompt,
 	}
 	sessID := sess.ID
-	a.reviewPanel = nil
+	a.closeModal()
 	delete(a.reviewDiffCache, sessID)
-	a.dashboard.panelFocus = focusList
 	return a, func() tea.Msg {
 		ag, err := mgr.AddAgent(sessID, cfg)
 		if err != nil {

--- a/internal/tui/update_views.go
+++ b/internal/tui/update_views.go
@@ -14,14 +14,12 @@ func (a App) returnFromConfigForm() (tea.Model, tea.Cmd) {
 				counts[repo.Path] = mgr.AgentCount()
 			}
 		}
-		a.repoPicker.setRepos(a.cfg.Repos, counts, a.dashboard.configRepoPath)
-		a.dashboard.repoConfigForm = nil
-		a.dashboard.configRepoPath = ""
+		a.repoPicker.setRepos(a.cfg.Repos, counts, a.modals.ConfigRepoPath())
+		a.closeModal()
 		a.view = ViewRepoPicker
 		return a, nil
 	}
-	a.dashboard.panelFocus = focusList
-	a.dashboard.repoConfigForm = nil
+	a.closeModal()
 	return a, nil
 }
 
@@ -96,14 +94,12 @@ func (a *App) initRepoConfigForm(repoPath string) {
 	fields = addTextInput(fields, "Worktree Directory", worktreeDir, config.DefaultWorktreeDir, inputWidth)
 
 	form := newConfigForm(fields, a.dashboard.fixedTermWidth())
-	a.dashboard.repoConfigForm = &form
-	a.dashboard.configRepoPath = repoPath
-	a.dashboard.panelFocus = focusConfig
+	a.openConfigForm(&form, repoPath)
 }
 
 // extractRepoSettings reads form values and creates a RepoSettings struct.
 func (a App) extractRepoSettings() *config.RepoSettings {
-	form := a.dashboard.repoConfigForm
+	form := a.modals.Config()
 	if form == nil {
 		return &config.RepoSettings{}
 	}


### PR DESCRIPTION
## Summary

PR 1 of 4 in a stacked foundational maintainability pass on the TUI. Introduces `internal/tui/modals.go` with a `Modals` struct that owns the dashboard's `panelFocus` value **and** the lifetime of every modal model. The invariant — "the model for `panelFocus X` is non-nil iff `Current() == X`" — is now enforced by the type rather than by hand at every transition site.

## Motivation

Panel focus and modal model lifetime were entangled by convention across 6 files. ~30 scattered `a.dashboard.panelFocus = focusX` assignments paired with `a.X = newX(...)` / `a.X = nil` writes, plus ~28 `if a.dashboard.panelFocus == focusX && a.X != nil { ... }` guard pairs. The invariant lived in code comments at `app.go:181-184`; correctness depended on every transition site remembering to allocate or nil the model.

## What changed

- **New `internal/tui/modals.go`** — `Modals` struct with `OpenReview`, `OpenShipping`, `OpenPlanEditor`, `OpenConfig`, `OpenLaunch`, `Close` (atomic focus + model writes) and typed accessors (`Review()`, `Shipping()`, `PlanEditor()`, `Config()`, `LaunchAgent()`, `LaunchSession()`) that return non-nil only when their focus is current.
- `Close()` always returns to `focusList` and nils every owned pointer — the bug class the type was introduced to make impossible.
- The review/shipping snapshot-and-swap dance is now `Modals.CompareAndSetReview` / `CompareAndSetShipping`, baking the "skip if focus changed mid-Update" logic into the API.
- `App` struct shrinks by 5 fields (`reviewPanel`, `shippingPanel`, `planEditor`, `focusLaunchAgent`, `focusLaunchSession` all move into `Modals`). `app.openReview()` / `openShipping()` / `openPlanEditorPanel()` / `openConfigForm()` / `openLaunchPanel()` / `closeModal()` helpers wrap Modals mutations + dashboard mirror sync so call sites can't forget the sync.

Call-site replacements:
- 30+ scattered `a.dashboard.panelFocus = focusX` assignments → one `a.openX(...)` or `a.closeModal()` call.
- 28+ `if a.dashboard.panelFocus == focusX && a.X != nil { ... }` guard pairs → `if x := a.modals.X(); x != nil { ... }`.

## Tests

`internal/tui/modals_test.go` (new, 14 tests):
- `TestModals_ZeroValue` — zero-value Modals is usable.
- `TestModals_OpenReview_SetsCurrentAndPointer` — invariant for review.
- `TestModals_Close_NilsEveryModel` — table-driven across all 5 modal kinds.
- `TestModals_Close_NilsInternalState` — defends against future bugs by checking the underlying fields, not just the typed accessors.
- `TestModals_OpenReplacesPrevious` — opening one modal cleanly supersedes any prior modal.
- `TestModals_TableInvariant` — for every focus state, exactly one accessor returns non-nil.
- `TestModals_CompareAndSetReview` / `CompareAndSetShipping` — snapshot-and-swap guarantees.
- `TestModals_SetLaunchAgent` / `TestModals_ConfigRepoPath` — supporting accessors.

## Test plan

- [x] `go test -race ./internal/tui/...` — all existing tests pass, 14 new modal tests pass.
- [x] `go vet ./...` clean.
- [x] `gofumpt` clean.
- [ ] Manual smoke test on a real repo: open + close each modal (review `r`, shipping `space` on shipping row, plan editor, repo config, launch terminal, branch picker, repo picker), walk pipeline planning → building → review → ship → merge, confirm wellness break overlay still fires and audio chime suppression rules hold.

## Stack

This is the first of 4 stacked PRs:

1. **#this PR** — Modals controller (you are here)
2. Next — split `updateDashboard` into per-handler methods
3. Next — `SessionManager` interface for testability
4. Next — centralize TUI timing constants

[Session](https://claude.ai/code/session_01GCQSJxo4W8aNrE1vBnVEq7)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCQSJxo4W8aNrE1vBnVEq7)_