### PR TITLE
refactor(tui): introduce SessionManager interface for testability

### DIFF
--- a/changelog.d/refactor-session-manager-interface.md
+++ b/changelog.d/refactor-session-manager-interface.md
@@ -1,0 +1,3 @@
+### Changed
+
+- TUI now depends on a narrow `SessionManager` interface (`internal/tui/manager_iface.go`) rather than the concrete `*agent.Manager` pointer. `App.managers` is now `map[string]SessionManager`, `PanelServices.ManagerFor` returns a `SessionManager`, and the `listenEvents` / `listenPlannerQuestions` helpers accept the interface. A compile-time assertion (`var _ SessionManager = (*agent.Manager)(nil)`) guarantees `*agent.Manager` continues to satisfy the contract. The seam unlocks fast unit tests via the new `fakeManager` test helper, which implements the full interface without spinning up PTYs, git worktrees, or a hook socket.

--- a/changelog.d/refactor-split-update-dashboard.md
+++ b/changelog.d/refactor-split-update-dashboard.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Split the monolithic `updateDashboard` dispatcher (`internal/tui/update_keys.go`, 521 lines) into per-handler methods: `handlePipelineKeys` (pipeline navigation + cursor-action keys), `handlePipelineMarkReady` / `handlePipelineOpenReview` (m / r workflow paths), `handleQuitKey` (q / ctrl+c with confirm-quit gesture), `handleConfigFormSave`, `handleDashboardPaste`, `handleMouseClick` / `handleMouseMotion` / `handleMouseRelease` / `handleMouseWheel`. `updateDashboard` is now a 139-line router. No behavior change.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -133,7 +133,10 @@ type diffStatsEntry struct {
 
 // App is the root Bubble Tea model.
 type App struct {
-	managers     map[string]*agent.Manager
+	// managers is keyed by repo path. The value satisfies the narrow
+	// SessionManager interface (see manager_iface.go); production uses
+	// *agent.Manager but tests can inject a deterministic fake.
+	managers     map[string]SessionManager
 	activeRepo   string
 	cfg          *config.Config
 	repoBrowser  fileBrowserModel
@@ -284,7 +287,7 @@ func NewApp() App {
 		cursor:          NewFocusedCursor(),
 		keys:            DefaultKeyMap(),
 		wellness:        newWellnessState(),
-		managers:        make(map[string]*agent.Manager),
+		managers:        make(map[string]SessionManager),
 		repoSettings:    make(map[string]*config.RepoSettings),
 		resolvedCache:   make(map[string]config.ResolvedSettings),
 		lastKnownStatus: make(map[string]agent.Status),
@@ -331,7 +334,7 @@ func tickCmd() tea.Cmd {
 	})
 }
 
-func listenEvents(mgr *agent.Manager) tea.Cmd {
+func listenEvents(mgr SessionManager) tea.Cmd {
 	return func() tea.Msg {
 		e, ok := <-mgr.Events()
 		if !ok {
@@ -349,7 +352,7 @@ type plannerQuestionMsg struct {
 	repoPath string
 }
 
-func listenPlannerQuestions(mgr *agent.Manager) tea.Cmd {
+func listenPlannerQuestions(mgr SessionManager) tea.Cmd {
 	return func() tea.Msg {
 		q, ok := <-mgr.PlannerQuestions()
 		if !ok {
@@ -589,7 +592,7 @@ func (a *App) panelServices() PanelServices {
 		Width:         a.width,
 		Height:        a.height,
 		DashboardTopY: a.dashboardTopY(),
-		ManagerFor: func(sessionID string) (*agent.Manager, string) {
+		ManagerFor: func(sessionID string) (SessionManager, string) {
 			repoPath := a.repoPathForSession(sessionID)
 			if repoPath == "" {
 				return nil, ""

--- a/internal/tui/fake_manager_test.go
+++ b/internal/tui/fake_manager_test.go
@@ -1,0 +1,151 @@
+package tui
+
+import (
+	"os/exec"
+
+	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
+	"github.com/devenjarvis/refrain/internal/state"
+)
+
+// fakeManager is a deterministic in-memory SessionManager for TUI unit tests.
+// It satisfies the full interface without spinning up PTYs, git worktrees, or
+// a hook socket. Test code constructs one inline, seeds whatever sessions it
+// needs via newFakeManager, and drives App.Update against it.
+//
+// Each method records its call (so tests can assert on dispatch) and returns
+// either the seeded data or a sensible zero value. New methods get default
+// no-op behavior — flesh them out only when a test actually depends on the
+// response.
+type fakeManager struct {
+	repoPath         string
+	sessions         []*agent.Session
+	events           chan agent.Event
+	plannerQuestions chan agent.PlannerQuestion
+
+	// Invocation counters; tests assert on these where behavior matters.
+	killSessionCalls map[string]int
+	killAgentCalls   map[string]int
+	shutdownCalls    int
+	updateSettings   []config.ResolvedSettings
+}
+
+// Compile-time guarantee: keep fakeManager in sync with the SessionManager
+// interface. The whole point of the fake is that tests can rely on it being
+// a drop-in for *agent.Manager.
+var _ SessionManager = (*fakeManager)(nil)
+
+func newFakeManager(repoPath string, sessions ...*agent.Session) *fakeManager {
+	return &fakeManager{
+		repoPath:         repoPath,
+		sessions:         sessions,
+		events:           make(chan agent.Event, 16),
+		plannerQuestions: make(chan agent.PlannerQuestion, 8),
+		killSessionCalls: make(map[string]int),
+		killAgentCalls:   make(map[string]int),
+	}
+}
+
+func (f *fakeManager) AgentCount() int {
+	n := 0
+	for _, s := range f.sessions {
+		n += len(s.Agents())
+	}
+	return n
+}
+
+func (f *fakeManager) RepoPath() string { return f.repoPath }
+
+func (f *fakeManager) ListSessions() []*agent.Session {
+	out := make([]*agent.Session, len(f.sessions))
+	copy(out, f.sessions)
+	return out
+}
+
+func (f *fakeManager) GetSession(id string) *agent.Session {
+	for _, s := range f.sessions {
+		if s.ID == id {
+			return s
+		}
+	}
+	return nil
+}
+
+func (f *fakeManager) Get(id string) *agent.Agent {
+	for _, s := range f.sessions {
+		for _, ag := range s.Agents() {
+			if ag.ID == id {
+				return ag
+			}
+		}
+	}
+	return nil
+}
+
+func (f *fakeManager) FindAgentAndSession(agentID string) (*agent.Agent, *agent.Session) {
+	for _, s := range f.sessions {
+		for _, ag := range s.Agents() {
+			if ag.ID == agentID {
+				return ag, s
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeManager) Events() <-chan agent.Event                     { return f.events }
+func (f *fakeManager) PlannerQuestions() <-chan agent.PlannerQuestion { return f.plannerQuestions }
+
+func (f *fakeManager) CreateSession(_ agent.Config) (*agent.Session, *agent.Agent, error) {
+	return nil, nil, nil
+}
+
+func (f *fakeManager) CreateSessionWithCommand(_ agent.Config, _ func(string) *exec.Cmd) (*agent.Session, *agent.Agent, error) {
+	return nil, nil, nil
+}
+
+func (f *fakeManager) CreateSessionOnBranch(_ string, _ string, _ agent.Config) (*agent.Session, *agent.Agent, error) {
+	return nil, nil, nil
+}
+
+func (f *fakeManager) CreateSessionForPlanning(_ agent.Config) (*agent.Session, error) {
+	return nil, nil
+}
+
+func (f *fakeManager) AddAgent(_ string, _ agent.Config) (*agent.Agent, error) {
+	return nil, nil
+}
+
+func (f *fakeManager) AddShell(_ string, _ agent.Config) (*agent.Agent, error) {
+	return nil, nil
+}
+
+func (f *fakeManager) KillAgent(sessionID, agentID string) error {
+	f.killAgentCalls[sessionID+"/"+agentID]++
+	return nil
+}
+
+func (f *fakeManager) KillSession(sessionID string) error {
+	f.killSessionCalls[sessionID]++
+	return nil
+}
+
+func (f *fakeManager) ResumeSession(_ state.SessionState, _ agent.Config) error { return nil }
+
+func (f *fakeManager) StartDraft(_ string, _ string) error              { return nil }
+func (f *fakeManager) RevisePlan(_ string, _ string) error              { return nil }
+func (f *fakeManager) SetPlanDrafter(_ agent.PlanDrafter)               {}
+func (f *fakeManager) ReviewerAgent() agent.ReviewerAgent               { return nil }
+func (f *fakeManager) ReconcileExternalBranchRename(_ string, _ string) {}
+
+func (f *fakeManager) UpdateSettings(s config.ResolvedSettings) {
+	f.updateSettings = append(f.updateSettings, s)
+}
+
+func (f *fakeManager) Detach() *state.RefrainState { return nil }
+
+func (f *fakeManager) Shutdown() {
+	f.shutdownCalls++
+	close(f.events)
+	close(f.plannerQuestions)
+}

--- a/internal/tui/manager_iface.go
+++ b/internal/tui/manager_iface.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"os/exec"
+
+	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
+	"github.com/devenjarvis/refrain/internal/state"
+)
+
+// SessionManager is the slice of agent.Manager the TUI actually depends on.
+// The TUI holds map[string]SessionManager rather than map[string]*agent.Manager
+// so unit tests can inject a deterministic in-memory fake without spinning up
+// real PTYs, git worktrees, or a hook socket.
+//
+// New TUI -> Manager call sites add the corresponding method here; the
+// compile-time assertion at the bottom of this file guarantees *agent.Manager
+// still satisfies the interface, so this seam never silently drifts.
+type SessionManager interface {
+	// Lifecycle / lookup
+	AgentCount() int
+	RepoPath() string
+	ListSessions() []*agent.Session
+	GetSession(id string) *agent.Session
+	Get(id string) *agent.Agent
+	FindAgentAndSession(agentID string) (*agent.Agent, *agent.Session)
+
+	// Event streams
+	Events() <-chan agent.Event
+	PlannerQuestions() <-chan agent.PlannerQuestion
+
+	// Session / agent CRUD
+	CreateSession(cfg agent.Config) (*agent.Session, *agent.Agent, error)
+	CreateSessionWithCommand(cfg agent.Config, cmd func(name string) *exec.Cmd) (*agent.Session, *agent.Agent, error)
+	CreateSessionOnBranch(branch, baseBranch string, cfg agent.Config) (*agent.Session, *agent.Agent, error)
+	CreateSessionForPlanning(cfg agent.Config) (*agent.Session, error)
+	AddAgent(sessionID string, cfg agent.Config) (*agent.Agent, error)
+	AddShell(sessionID string, cfg agent.Config) (*agent.Agent, error)
+	KillAgent(sessionID, agentID string) error
+	KillSession(sessionID string) error
+	ResumeSession(ss state.SessionState, cfg agent.Config) error
+
+	// Planning subprocess control
+	StartDraft(sessionID, prompt string) error
+	RevisePlan(sessionID, critique string) error
+	SetPlanDrafter(p agent.PlanDrafter)
+
+	// Review subprocess
+	ReviewerAgent() agent.ReviewerAgent
+
+	// External coordination
+	ReconcileExternalBranchRename(sessionID, newBranch string)
+	UpdateSettings(s config.ResolvedSettings)
+
+	// Teardown
+	Detach() *state.RefrainState
+	Shutdown()
+}
+
+// Compile-time assertion: *agent.Manager must satisfy SessionManager. If a
+// future agent.Manager method-signature change breaks this seam, the
+// compiler flags it here rather than at every call site.
+var _ SessionManager = (*agent.Manager)(nil)

--- a/internal/tui/manager_iface_test.go
+++ b/internal/tui/manager_iface_test.go
@@ -1,0 +1,88 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
+)
+
+// TestSessionManager_AgentSatisfies pins the compile-time guarantee in a
+// runtime test as well: *agent.Manager must satisfy SessionManager. Without
+// this, a future agent.Manager method-signature change could silently break
+// the seam if the var-assertion in manager_iface.go is removed.
+func TestSessionManager_AgentSatisfies(t *testing.T) {
+	var _ SessionManager = (*agent.Manager)(nil)
+}
+
+// TestSessionManager_FakeSatisfies pins the same guarantee for the in-memory
+// fake used by the tests below.
+func TestSessionManager_FakeSatisfies(t *testing.T) {
+	var _ SessionManager = (*fakeManager)(nil)
+}
+
+// TestSessionManager_FakeDrivesKillSession demonstrates the unit-testing seam:
+// a fake manager is injected into App, App.KillSessionCmd via PanelServices is
+// invoked, and the test asserts on the fake's call counters without ever
+// starting a real PTY/git/hook stack.
+func TestSessionManager_FakeDrivesKillSession(t *testing.T) {
+	sess := agent.NewSessionForTest("s1", "session-one")
+	repo := "/fake/repo"
+	fake := newFakeManager(repo, sess)
+
+	app := NewApp()
+	app.activeRepo = repo
+	app.managers[repo] = fake
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: repo}}}
+	app.resolvedCache[repo] = config.Resolve(nil, nil)
+
+	// Drive KillSessionCmd through the panel-services seam (the same path
+	// the shipping panel takes when the user confirms session teardown).
+	svc := app.panelServices()
+	if svc.KillSessionCmd == nil {
+		t.Fatal("KillSessionCmd should be wired by panelServices")
+	}
+	cmd := svc.KillSessionCmd(sess)
+	if cmd == nil {
+		t.Fatal("KillSessionCmd returned nil for a known session")
+	}
+
+	// Executing the returned tea.Cmd is what calls into the manager.
+	_ = cmd()
+
+	if fake.killSessionCalls[sess.ID] != 1 {
+		t.Errorf("KillSession call count = %d, want 1", fake.killSessionCalls[sess.ID])
+	}
+}
+
+// TestSessionManager_FakeReportsListSessions covers the read-side path the
+// dashboard uses on every refresh.
+func TestSessionManager_FakeReportsListSessions(t *testing.T) {
+	s1 := agent.NewSessionForTest("s1", "one")
+	s2 := agent.NewSessionForTest("s2", "two")
+	fake := newFakeManager("/r", s1, s2)
+
+	got := fake.ListSessions()
+	if len(got) != 2 {
+		t.Fatalf("ListSessions returned %d sessions, want 2", len(got))
+	}
+	if got[0].ID != "s1" || got[1].ID != "s2" {
+		t.Errorf("ListSessions order: got [%s %s], want [s1 s2]", got[0].ID, got[1].ID)
+	}
+	// Mutating the returned slice must not affect the manager's state.
+	got[0] = nil
+	if fake.ListSessions()[0] == nil {
+		t.Error("ListSessions should return a defensive copy")
+	}
+}
+
+// TestSessionManager_FakeUpdateSettings records pushed settings so a test
+// can assert that App propagated a global-config change.
+func TestSessionManager_FakeUpdateSettings(t *testing.T) {
+	fake := newFakeManager("/r")
+	rs := config.Resolve(nil, nil)
+	fake.UpdateSettings(rs)
+	if len(fake.updateSettings) != 1 {
+		t.Fatalf("UpdateSettings recorded %d calls, want 1", len(fake.updateSettings))
+	}
+}

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -42,7 +42,7 @@ type PanelServices struct {
 	DashboardTopY int
 
 	// Lookups.
-	ManagerFor  func(sessionID string) (mgr *agent.Manager, repoPath string)
+	ManagerFor  func(sessionID string) (mgr SessionManager, repoPath string)
 	Resolved    func(repoPath string) config.ResolvedSettings
 	GHClient    func() *github.Client
 	PRCache     func(sessionID string) *prCacheEntry

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -21,7 +21,7 @@ func newTestSvc() (PanelServices, *testServiceState) {
 	svc := PanelServices{
 		Width:  120,
 		Height: 40,
-		ManagerFor: func(string) (*agent.Manager, string) {
+		ManagerFor: func(string) (SessionManager, string) {
 			return nil, ""
 		},
 		Resolved:    func(string) config.ResolvedSettings { return config.ResolvedSettings{} },
@@ -134,7 +134,7 @@ func TestReviewPanelModel_CKeyMarksComplete(t *testing.T) {
 	// Wire ManagerFor to a non-nil-looking entry so the panel reaches the
 	// kill path. The actual manager pointer is not exercised here because
 	// KillSessionCmd is stubbed.
-	svc.ManagerFor = func(string) (*agent.Manager, string) {
+	svc.ManagerFor = func(string) (SessionManager, string) {
 		return &agent.Manager{}, "/repo"
 	}
 
@@ -490,7 +490,7 @@ func TestReviewPanelModel_EKey_NoIDECommand_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTestWithPath("s1", "fix-auth", t.TempDir())
 	panel := newReviewPanel(sess, 120, 40)
 	svc, state := newTestSvc()
-	svc.ManagerFor = func(string) (*agent.Manager, string) { return nil, "/repo" }
+	svc.ManagerFor = func(string) (SessionManager, string) { return nil, "/repo" }
 	svc.Resolved = func(string) config.ResolvedSettings {
 		return config.ResolvedSettings{IDECommand: ""}
 	}

--- a/internal/tui/shippingpanelmodel_test.go
+++ b/internal/tui/shippingpanelmodel_test.go
@@ -18,7 +18,7 @@ func newTestShippingSvc() (PanelServices, *testShippingSvcState) {
 	svc := PanelServices{
 		Width:  120,
 		Height: 40,
-		ManagerFor: func(string) (*agent.Manager, string) {
+		ManagerFor: func(string) (SessionManager, string) {
 			return nil, ""
 		},
 		PRCache: func(string) *prCacheEntry { return state.pr },

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -19,53 +19,14 @@ import (
 func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case configFormSaveMsg:
-		// Repo config form saved.
-		if form := a.modals.Config(); form != nil && a.modals.ConfigRepoPath() != "" {
-			repoPath := a.modals.ConfigRepoPath()
-			alias := strings.TrimSpace(form.textValue("Alias"))
-			settings := a.extractRepoSettings()
-			if err := config.SaveRepoSettings(repoPath, settings); err != nil {
-				a.setError(err.Error())
-			} else {
-				a.repoSettings[repoPath] = settings
-				a.resolvedCache[repoPath] = config.Resolve(a.globalSettings, settings)
-				if mgr := a.managers[repoPath]; mgr != nil {
-					mgr.UpdateSettings(a.resolvedCache[repoPath])
-				}
-			}
-			for i, r := range a.cfg.Repos {
-				if r.Path == repoPath && r.Alias != alias {
-					a.cfg.Repos[i].Alias = alias
-					if err := config.Save(a.cfg); err != nil {
-						a.setError(err.Error())
-					}
-					a.refreshAgentList()
-					break
-				}
-			}
-		}
-		return a.returnFromConfigForm()
+		return a.handleConfigFormSave()
 
 	case configFormCancelMsg:
 		// Repo config form cancelled.
 		return a.returnFromConfigForm()
 
 	case tea.PasteMsg:
-		// Prompt modal consumes paste while open (same precedence as the
-		// KeyPressMsg branch below) so cmd+v / bracketed paste inserts into
-		// the textarea instead of being swallowed by the focusLaunch path.
-		if a.promptModal.Active() {
-			cmd := a.promptModal.Update(msg)
-			return a, cmd
-		}
-		if a.prComposeModal.Active() {
-			cmd := a.prComposeModal.Update(msg)
-			return a, cmd
-		}
-		if ag := a.modals.LaunchAgent(); ag != nil {
-			ag.Paste(msg.Content)
-			return a, nil
-		}
+		return a.handleDashboardPaste(msg)
 
 	case tea.KeyPressMsg:
 		// Prompt modal consumes all keys while open (it's a modal overlay).
@@ -123,152 +84,13 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return newA, cmd
 		}
 
-		// Pipeline view key handling (the only dashboard mode).
-		if !a.modals.Is(focusReview) && !a.modals.Is(focusShipping) {
-			switch msg.String() {
-			case "up", "k":
-				a.cursor.MoveUp(a.dashboard.sectionCounts())
-				a.syncFocusCursorToDashboard()
-				return a, nil
-			case "down", "j":
-				a.cursor.MoveDown(a.dashboard.sectionCounts())
-				a.syncFocusCursorToDashboard()
-				return a, nil
-			case "space", "enter":
-				if cmd, ok := a.activateFocusCursor(); ok {
-					return a, cmd
-				}
-				// Cursor section had no actionable row: fall through to normal enter handling.
-			case "N":
-				if a.cfg != nil && len(a.cfg.Repos) > 0 {
-					currentIdx := -1
-					for i, repo := range a.cfg.Repos {
-						if repo.Path == a.activeRepo {
-							currentIdx = i
-							break
-						}
-					}
-					nextIdx := (currentIdx + 1) % len(a.cfg.Repos)
-					a.activeRepo = a.cfg.Repos[nextIdx].Path
-					a.refreshAgentList()
-				}
-				return a, nil
-			case "b":
-				// Context-sensitive: when the cursor is on a Planning row,
-				// 'b' advances it to Building. Otherwise we leave the case
-				// without returning so the global "take a break" handler in
-				// the switch below catches the press. Picking a Planning row
-				// to advance is a deliberate action, while taking a break is
-				// the catch-all everywhere else — so the cursor location is
-				// the disambiguator the user already has at hand.
-				if !a.wellness.focusBreakMode && a.cursor.Section() == focusSectionPlanning {
-					planning := a.dashboard.planningSessions()
-					if len(planning) > 0 {
-						idx := a.cursor.Index(focusSectionPlanning)
-						if idx >= len(planning) {
-							idx = len(planning) - 1
-						}
-						if sess := planning[idx].session; sess != nil {
-							sess.SetLifecyclePhase(agent.LifecycleInProgress)
-							a.cursor.Clamp(a.dashboard.sectionCounts())
-							a.syncFocusCursorToDashboard()
-						}
-					}
-					// Cursor is on Planning — even if the section was empty in
-					// a fast-tick race window, swallow the press here so we
-					// don't accidentally trigger the wellness break.
-					return a, nil
-				}
-				// Fall through to the global break handler below.
-			case "m":
-				// Mark the cursor-selected Planning or Building session as
-				// ReadyForReview. We accept Planning too so the natural flow
-				// works when Claude finishes the work in one shot — the
-				// idle-reviewable cue ("press m to review") is rendered for
-				// any reviewable session regardless of phase, and pressing m
-				// shouldn't surprise the user with an error in that case.
-				var sess *agent.Session
-				switch a.cursor.Section() {
-				case focusSectionPlanning:
-					planning := a.dashboard.planningSessions()
-					if pi := a.cursor.Index(focusSectionPlanning); pi < len(planning) {
-						sess = planning[pi].session
-					}
-				case focusSectionBuilding:
-					building := a.dashboard.buildingSessions()
-					if bi := a.cursor.Index(focusSectionBuilding); bi < len(building) {
-						sess = building[bi].session
-					}
-				default:
-					a.setError("nothing to mark — cursor isn't on a Planning or Building session")
-					return a, nil
-				}
-				if sess == nil {
-					a.setError("no session under cursor")
-					return a, nil
-				}
-				if !sess.IsReviewable() {
-					switch sess.Status() {
-					case agent.StatusActive:
-						a.setError("session is still running — wait for Claude to finish its turn")
-					case agent.StatusWaiting:
-						a.setError("session is waiting for input — resolve the prompt first")
-					default:
-						a.setError("session is still running — wait for Claude to finish its turn")
-					}
-					return a, nil
-				}
-				sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
-				a.cursor.SetIndex(focusSectionReview, 0)
-				return a, a.fetchReviewDiffCmd(sess)
-			case "r":
-				reviewItems := a.dashboard.reviewQueueSessions()
-				if len(reviewItems) == 0 {
-					a.setError("review queue is empty — press m on a finished session first")
-					return a, nil
-				}
-				idx := a.cursor.Index(focusSectionReview)
-				if idx >= len(reviewItems) {
-					idx = len(reviewItems) - 1
-				}
-				sess := reviewItems[idx].session
-				sess.SetLifecyclePhase(agent.LifecycleInReview)
-				a.openReview(newReviewPanel(sess, a.width, a.height))
-				if _, ok := a.reviewDiffCache[sess.ID]; !ok {
-					return a, a.fetchReviewDiffCmd(sess)
-				}
-				a.modals.Review().RefreshDiffViewport(a.panelServices())
-				return a, nil
-			case "n":
-				if a.cfg != nil && len(a.cfg.Repos) > 1 {
-					// Apply the same soft agent-count guard as the single-repo
-					// path before opening the picker.
-					resolved := a.resolvedCache[a.activeRepo]
-					if resolved.MaxConcurrentAgents > 0 && a.activeAgentCount() >= resolved.MaxConcurrentAgents {
-						if !a.agentLimitModalActive {
-							a.agentLimitModalActive = true
-							return a, nil
-						}
-						a.agentLimitModalActive = false
-					}
-					counts := make(map[string]int, len(a.cfg.Repos))
-					for _, repo := range a.cfg.Repos {
-						if mgr := a.managers[repo.Path]; mgr != nil {
-							counts[repo.Path] = mgr.AgentCount()
-						}
-					}
-					a.repoPicker = newRepoPickerModel()
-					a.repoPicker.width = a.width
-					a.repoPicker.height = a.height - 1
-					a.repoPicker.SetMode(repoPickerModeSession)
-					a.repoPicker.setRepos(a.cfg.Repos, counts, a.activeRepo)
-					a.view = ViewRepoPicker
-					return a, nil
-				}
-				// Single repo: exits this case without returning, so control
-				// falls through to the general "n" handler below, which contains
-				// the agent-count and backlog soft-limit checks.
-			}
+		// Pipeline view key handling (the only dashboard mode). The handler
+		// consumes terminal keys (up/down/N/m/r) outright; partial-match cases
+		// (space/enter with no actionable row, b not on Planning, n on a
+		// single-repo install) return handled=false and fall through to the
+		// repo-header enter / q-quit / handleKeysWorkflow stages below.
+		if newA, cmd, handled := a.handlePipelineKeys(msg); handled {
+			return newA, cmd
 		}
 
 		// Enter/right on a repo header: open repo config in right panel.
@@ -280,37 +102,12 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		switch msg.String() {
-		case "q", "ctrl+c":
-			// Detach path: save state and exit, preserving worktrees.
-			hasRunning := false
-			for _, mgr := range a.managers {
-				if mgr.AgentCount() > 0 {
-					hasRunning = true
-					break
-				}
-			}
-			if hasRunning && !a.confirmQuit {
-				a.confirmQuit = true
-				return a, nil
-			}
-			// Detach all managers and save state.
-			for repoPath, mgr := range a.managers {
-				bs := mgr.Detach()
-				if bs != nil {
-					_ = state.Save(repoPath, bs)
-				} else {
-					_ = state.Remove(repoPath)
-				}
-			}
-			if a.audioPlayer != nil {
-				a.audioPlayer.Close()
-			}
-			a.writeWellnessLog()
-			return a, tea.Quit
-		default:
-			a.confirmQuit = false
+		newA, cmd, handled := a.handleQuitKey(msg)
+		if handled {
+			return newA, cmd
 		}
+		// handleQuitKey clears confirmQuit on any non-quit key; preserve that.
+		a = newA
 
 		if newA, cmd, handled := a.handleKeysWorkflow(msg); handled {
 			return newA, cmd
@@ -318,198 +115,19 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if msg, ok := msg.(tea.MouseClickMsg); ok {
-		// Compute offset before clearing confirmQuit — reflects what was on screen.
-		dashboardTopY := 0
-		if a.err != "" {
-			dashboardTopY++
-		}
-		if a.confirmQuit {
-			dashboardTopY++
-		}
-		a.confirmQuit = false
-		if msg.Button != tea.MouseLeft {
-			return a, nil
-		}
-
-		// focusLaunch: tab bar click switches the active agent; clicks inside
-		// the agent terminal seed a text selection.
-		if sess := a.modals.LaunchSession(); sess != nil {
-			tabBarY := dashboardTopY + 1
-			if msg.Y == tabBarY {
-				if idx := a.focusLaunchTabIndexAt(msg.X); idx >= 0 {
-					agents := sess.Agents()
-					a.modals.SetLaunchAgent(agents[idx])
-					a.syncModalsToDashboard()
-					a.dashboard.scrollOffset = 0
-					agents[idx].Resize(a.focusLaunchTermHeight(), a.dashboard.width)
-				}
-				return a, nil
-			}
-			if ag := a.modals.LaunchAgent(); ag != nil {
-				if termX, termY, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y); inVP {
-					a.dashboard.selection = selection{
-						anchorX: termX,
-						anchorY: termY,
-						cursorX: termX,
-						cursorY: termY,
-						active:  true,
-						agentID: ag.ID,
-					}
-				} else {
-					a.dashboard.clearSelection()
-				}
-			}
-			return a, nil
-		}
-
-		// focusReview: delegate left-pane row clicks to the panel.
-		if rp := a.modals.Review(); rp != nil {
-			before := rp.TaskCursor()
-			rp.handleClick(msg, a.panelServices())
-			if rp.TaskCursor() != before {
-				return a, nil
-			}
-		}
-
-		// Pipeline view: click on a session card moves the cursor; double-click
-		// activates (focusLaunch for active sessions, review panel for queue).
-		// PR-indicator click on a queue row opens the PR in the browser.
-		section, idx, hit := a.pipelineHitTest(msg.Y - dashboardTopY)
-		if !hit {
-			return a, nil
-		}
-		// Detect a PR-indicator click on review/shipping rows: the prIndicator
-		// is right-aligned on the card; the X-column check below narrows the
-		// hit region without needing per-row Y granularity from pipelineHitTest.
-		if section == focusSectionReview || section == focusSectionShipping {
-			items := a.dashboard.sectionItems(section)
-			if idx < len(items) {
-				sess := items[idx].session
-				if entry := a.prCache[sess.ID]; entry != nil && entry.pr != nil && entry.pr.URL != "" {
-					indicatorWidth := prIndicatorWidth(entry)
-					if indicatorWidth > 0 && msg.X >= a.width-indicatorWidth-2 {
-						if err := openURL(entry.pr.URL); err != nil {
-							a.setError(err.Error())
-						}
-						// Reset double-click bookkeeping: this click was a PR
-						// activation, not a card selection. Without this, a
-						// quick follow-up card click on the same section/idx
-						// could read a stale lastPipelineClick and fire a
-						// phantom double-click into the review panel.
-						a.lastPipelineClick = time.Time{}
-						return a, nil
-					}
-				}
-			}
-		}
-		// Move the cursor to the clicked session.
-		now := time.Now()
-		isDoubleClick := !a.lastPipelineClick.IsZero() &&
-			now.Sub(a.lastPipelineClick) < 500*time.Millisecond &&
-			a.lastPipelineClickSec == section &&
-			a.lastPipelineClickIdx == idx
-		a.lastPipelineClick = now
-		a.lastPipelineClickSec = section
-		a.lastPipelineClickIdx = idx
-
-		a.cursor.JumpTo(section, idx)
-		a.syncFocusCursorToDashboard()
-
-		if isDoubleClick {
-			if cmd, ok := a.activateFocusCursor(); ok {
-				return a, cmd
-			}
-		}
-		return a, nil
+		return a.handleMouseClick(msg)
 	}
 
 	if msg, ok := msg.(tea.MouseMotionMsg); ok {
-		// Drag updates the cursor end of an in-flight selection. Selections
-		// only seed in focusLaunch (see MouseClickMsg), so any motion outside
-		// focusLaunch can be ignored here.
-		if a.dashboard.selection.active && msg.Button == tea.MouseLeft &&
-			a.modals.LaunchAgent() != nil {
-			tx, ty, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
-			if inVP {
-				a.dashboard.selection.cursorX = tx
-				a.dashboard.selection.cursorY = ty
-				a.dashboard.selection.dragSeen = true
-			}
-		}
-		return a, nil
+		return a.handleMouseMotion(msg)
 	}
 
 	if _, ok := msg.(tea.MouseReleaseMsg); ok {
-		if a.dashboard.selection.active {
-			if a.dashboard.selection.dragSeen {
-				// Real drag — copy the highlighted region. Selections only seed
-				// in focusLaunch (see MouseClickMsg), so this is the only path.
-				if ag := a.modals.LaunchAgent(); ag != nil && ag.ID == a.dashboard.selection.agentID {
-					if sx, sy, ex, ey, ok := a.dashboard.selectionRect(); ok {
-						rect := vt.SelectionRect{
-							StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
-						}
-						var text string
-						if a.dashboard.scrollOffset > 0 {
-							vpWidth := a.dashboard.width
-							vpHeight := a.focusLaunchTermHeight()
-							text = ag.ExtractTextFromSnapshot(vpWidth, vpHeight, a.dashboard.scrollOffset, rect)
-						} else {
-							text = ag.ExtractText(rect)
-						}
-						if text != "" {
-							return a, tea.SetClipboard(text)
-						}
-					}
-				}
-			} else {
-				// Plain click — drop the seeded selection. Focus already moved
-				// in the click handler.
-				a.dashboard.clearSelection()
-			}
-		}
-		return a, nil
+		return a.handleMouseRelease()
 	}
 
 	if msg, ok := msg.(tea.MouseWheelMsg); ok {
-		if ag := a.modals.LaunchAgent(); ag != nil {
-			if ag.IsAltScreen() {
-				termX, termY, _ := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
-				if termX < 0 {
-					termX = 0
-				}
-				if termX >= a.dashboard.width {
-					termX = a.dashboard.width - 1
-				}
-				if termY < 0 {
-					termY = 0
-				}
-				if termY >= a.focusLaunchTermHeight() {
-					termY = a.focusLaunchTermHeight() - 1
-				}
-				ag.SendMouse(xvt.MouseWheel{
-					X:      termX,
-					Y:      termY,
-					Button: xvt.MouseButton(msg.Button),
-					Mod:    xvt.KeyMod(msg.Mod),
-				})
-				return a, nil
-			}
-			if msg.Button == tea.MouseWheelUp {
-				sbLines := len(ag.ScrollbackLines())
-				max := sbLines
-				a.dashboard.scrollOffset += 3
-				if a.dashboard.scrollOffset > max {
-					a.dashboard.scrollOffset = max
-				}
-			} else {
-				a.dashboard.scrollOffset -= 3
-				if a.dashboard.scrollOffset < 0 {
-					a.dashboard.scrollOffset = 0
-				}
-			}
-		}
-		return a, nil
+		return a.handleMouseWheel(msg)
 	}
 
 	prevSelected := a.dashboard.selected
@@ -1164,4 +782,479 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 
 	}
 	return a, nil, false
+}
+
+// handleMouseClick routes a left-click depending on the active panel:
+// focusLaunch tab bar switches the active agent and the agent terminal seeds
+// a text selection, focusReview delegates left-pane row clicks to the panel,
+// and otherwise the click lands on a pipeline card (with double-click
+// activation and a PR-indicator hit region on review/shipping rows).
+func (a App) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
+	// Compute offset before clearing confirmQuit — reflects what was on screen.
+	dashboardTopY := 0
+	if a.err != "" {
+		dashboardTopY++
+	}
+	if a.confirmQuit {
+		dashboardTopY++
+	}
+	a.confirmQuit = false
+	if msg.Button != tea.MouseLeft {
+		return a, nil
+	}
+
+	// focusLaunch: tab bar click switches the active agent; clicks inside
+	// the agent terminal seed a text selection.
+	if sess := a.modals.LaunchSession(); sess != nil {
+		tabBarY := dashboardTopY + 1
+		if msg.Y == tabBarY {
+			if idx := a.focusLaunchTabIndexAt(msg.X); idx >= 0 {
+				agents := sess.Agents()
+				a.modals.SetLaunchAgent(agents[idx])
+				a.syncModalsToDashboard()
+				a.dashboard.scrollOffset = 0
+				agents[idx].Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+			}
+			return a, nil
+		}
+		if ag := a.modals.LaunchAgent(); ag != nil {
+			if termX, termY, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y); inVP {
+				a.dashboard.selection = selection{
+					anchorX: termX,
+					anchorY: termY,
+					cursorX: termX,
+					cursorY: termY,
+					active:  true,
+					agentID: ag.ID,
+				}
+			} else {
+				a.dashboard.clearSelection()
+			}
+		}
+		return a, nil
+	}
+
+	// focusReview: delegate left-pane row clicks to the panel.
+	if rp := a.modals.Review(); rp != nil {
+		before := rp.TaskCursor()
+		rp.handleClick(msg, a.panelServices())
+		if rp.TaskCursor() != before {
+			return a, nil
+		}
+	}
+
+	// Pipeline view: click on a session card moves the cursor; double-click
+	// activates (focusLaunch for active sessions, review panel for queue).
+	// PR-indicator click on a queue row opens the PR in the browser.
+	section, idx, hit := a.pipelineHitTest(msg.Y - dashboardTopY)
+	if !hit {
+		return a, nil
+	}
+	// Detect a PR-indicator click on review/shipping rows: the prIndicator
+	// is right-aligned on the card; the X-column check below narrows the
+	// hit region without needing per-row Y granularity from pipelineHitTest.
+	if section == focusSectionReview || section == focusSectionShipping {
+		items := a.dashboard.sectionItems(section)
+		if idx < len(items) {
+			sess := items[idx].session
+			if entry := a.prCache[sess.ID]; entry != nil && entry.pr != nil && entry.pr.URL != "" {
+				indicatorWidth := prIndicatorWidth(entry)
+				if indicatorWidth > 0 && msg.X >= a.width-indicatorWidth-2 {
+					if err := openURL(entry.pr.URL); err != nil {
+						a.setError(err.Error())
+					}
+					// Reset double-click bookkeeping: this click was a PR
+					// activation, not a card selection. Without this, a
+					// quick follow-up card click on the same section/idx
+					// could read a stale lastPipelineClick and fire a
+					// phantom double-click into the review panel.
+					a.lastPipelineClick = time.Time{}
+					return a, nil
+				}
+			}
+		}
+	}
+	// Move the cursor to the clicked session.
+	now := time.Now()
+	isDoubleClick := !a.lastPipelineClick.IsZero() &&
+		now.Sub(a.lastPipelineClick) < 500*time.Millisecond &&
+		a.lastPipelineClickSec == section &&
+		a.lastPipelineClickIdx == idx
+	a.lastPipelineClick = now
+	a.lastPipelineClickSec = section
+	a.lastPipelineClickIdx = idx
+
+	a.cursor.JumpTo(section, idx)
+	a.syncFocusCursorToDashboard()
+
+	if isDoubleClick {
+		if cmd, ok := a.activateFocusCursor(); ok {
+			return a, cmd
+		}
+	}
+	return a, nil
+}
+
+// handleMouseMotion updates the cursor end of an in-flight text selection
+// inside the focusLaunch agent terminal. Selections only seed in focusLaunch
+// (see handleMouseClick), so motion outside that mode is ignored.
+func (a App) handleMouseMotion(msg tea.MouseMotionMsg) (tea.Model, tea.Cmd) {
+	if a.dashboard.selection.active && msg.Button == tea.MouseLeft &&
+		a.modals.LaunchAgent() != nil {
+		tx, ty, inVP := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
+		if inVP {
+			a.dashboard.selection.cursorX = tx
+			a.dashboard.selection.cursorY = ty
+			a.dashboard.selection.dragSeen = true
+		}
+	}
+	return a, nil
+}
+
+// handleMouseRelease finalises a drag-to-select (copy the highlighted region
+// to the clipboard) or drops a seeded selection on a plain click.
+func (a App) handleMouseRelease() (tea.Model, tea.Cmd) {
+	if !a.dashboard.selection.active {
+		return a, nil
+	}
+	if !a.dashboard.selection.dragSeen {
+		// Plain click — drop the seeded selection. Focus already moved
+		// in the click handler.
+		a.dashboard.clearSelection()
+		return a, nil
+	}
+	// Real drag — copy the highlighted region. Selections only seed
+	// in focusLaunch (see handleMouseClick), so this is the only path.
+	ag := a.modals.LaunchAgent()
+	if ag == nil || ag.ID != a.dashboard.selection.agentID {
+		return a, nil
+	}
+	sx, sy, ex, ey, ok := a.dashboard.selectionRect()
+	if !ok {
+		return a, nil
+	}
+	rect := vt.SelectionRect{
+		StartX: sx, StartY: sy, EndX: ex, EndY: ey, Active: true,
+	}
+	var text string
+	if a.dashboard.scrollOffset > 0 {
+		vpWidth := a.dashboard.width
+		vpHeight := a.focusLaunchTermHeight()
+		text = ag.ExtractTextFromSnapshot(vpWidth, vpHeight, a.dashboard.scrollOffset, rect)
+	} else {
+		text = ag.ExtractText(rect)
+	}
+	if text != "" {
+		return a, tea.SetClipboard(text)
+	}
+	return a, nil
+}
+
+// handleMouseWheel scrolls the focusLaunch agent terminal: in alt-screen mode
+// the wheel is forwarded to the PTY as a mouse-wheel event; otherwise it
+// adjusts the dashboard scrollback offset.
+func (a App) handleMouseWheel(msg tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
+	ag := a.modals.LaunchAgent()
+	if ag == nil {
+		return a, nil
+	}
+	if ag.IsAltScreen() {
+		termX, termY, _ := a.screenToTermCellFocusLaunch(msg.X, msg.Y)
+		if termX < 0 {
+			termX = 0
+		}
+		if termX >= a.dashboard.width {
+			termX = a.dashboard.width - 1
+		}
+		if termY < 0 {
+			termY = 0
+		}
+		if termY >= a.focusLaunchTermHeight() {
+			termY = a.focusLaunchTermHeight() - 1
+		}
+		ag.SendMouse(xvt.MouseWheel{
+			X:      termX,
+			Y:      termY,
+			Button: xvt.MouseButton(msg.Button),
+			Mod:    xvt.KeyMod(msg.Mod),
+		})
+		return a, nil
+	}
+	if msg.Button == tea.MouseWheelUp {
+		sbLines := len(ag.ScrollbackLines())
+		max := sbLines
+		a.dashboard.scrollOffset += 3
+		if a.dashboard.scrollOffset > max {
+			a.dashboard.scrollOffset = max
+		}
+	} else {
+		a.dashboard.scrollOffset -= 3
+		if a.dashboard.scrollOffset < 0 {
+			a.dashboard.scrollOffset = 0
+		}
+	}
+	return a, nil
+}
+
+// handlePipelineKeys dispatches the dashboard-pipeline keypress switch
+// (up/down/space/enter/N/b/m/r/n) when no overlay panel owns focus. Returns
+// handled=true when the key was consumed terminally; handled=false signals
+// the partial-match cases (space/enter with no actionable row, b not on a
+// Planning row, n on a single-repo install) that fall through to the
+// repo-header / quit / workflow stages.
+func (a App) handlePipelineKeys(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
+	if a.modals.Is(focusReview) || a.modals.Is(focusShipping) {
+		return a, nil, false
+	}
+	switch msg.String() {
+	case "up", "k":
+		a.cursor.MoveUp(a.dashboard.sectionCounts())
+		a.syncFocusCursorToDashboard()
+		return a, nil, true
+	case "down", "j":
+		a.cursor.MoveDown(a.dashboard.sectionCounts())
+		a.syncFocusCursorToDashboard()
+		return a, nil, true
+	case "space", "enter":
+		if cmd, ok := a.activateFocusCursor(); ok {
+			return a, cmd, true
+		}
+		// Cursor section had no actionable row: fall through to normal enter handling.
+	case "N":
+		if a.cfg != nil && len(a.cfg.Repos) > 0 {
+			currentIdx := -1
+			for i, repo := range a.cfg.Repos {
+				if repo.Path == a.activeRepo {
+					currentIdx = i
+					break
+				}
+			}
+			nextIdx := (currentIdx + 1) % len(a.cfg.Repos)
+			a.activeRepo = a.cfg.Repos[nextIdx].Path
+			a.refreshAgentList()
+		}
+		return a, nil, true
+	case "b":
+		// Context-sensitive: when the cursor is on a Planning row,
+		// 'b' advances it to Building. Otherwise we leave the case
+		// without returning so the global "take a break" handler in
+		// the switch below catches the press. Picking a Planning row
+		// to advance is a deliberate action, while taking a break is
+		// the catch-all everywhere else — so the cursor location is
+		// the disambiguator the user already has at hand.
+		if !a.wellness.focusBreakMode && a.cursor.Section() == focusSectionPlanning {
+			planning := a.dashboard.planningSessions()
+			if len(planning) > 0 {
+				idx := a.cursor.Index(focusSectionPlanning)
+				if idx >= len(planning) {
+					idx = len(planning) - 1
+				}
+				if sess := planning[idx].session; sess != nil {
+					sess.SetLifecyclePhase(agent.LifecycleInProgress)
+					a.cursor.Clamp(a.dashboard.sectionCounts())
+					a.syncFocusCursorToDashboard()
+				}
+			}
+			// Cursor is on Planning — even if the section was empty in
+			// a fast-tick race window, swallow the press here so we
+			// don't accidentally trigger the wellness break.
+			return a, nil, true
+		}
+		// Fall through to the global break handler.
+	case "m":
+		return a.handlePipelineMarkReady()
+	case "r":
+		return a.handlePipelineOpenReview()
+	case "n":
+		if a.cfg != nil && len(a.cfg.Repos) > 1 {
+			// Apply the same soft agent-count guard as the single-repo
+			// path before opening the picker.
+			resolved := a.resolvedCache[a.activeRepo]
+			if resolved.MaxConcurrentAgents > 0 && a.activeAgentCount() >= resolved.MaxConcurrentAgents {
+				if !a.agentLimitModalActive {
+					a.agentLimitModalActive = true
+					return a, nil, true
+				}
+				a.agentLimitModalActive = false
+			}
+			counts := make(map[string]int, len(a.cfg.Repos))
+			for _, repo := range a.cfg.Repos {
+				if mgr := a.managers[repo.Path]; mgr != nil {
+					counts[repo.Path] = mgr.AgentCount()
+				}
+			}
+			a.repoPicker = newRepoPickerModel()
+			a.repoPicker.width = a.width
+			a.repoPicker.height = a.height - 1
+			a.repoPicker.SetMode(repoPickerModeSession)
+			a.repoPicker.setRepos(a.cfg.Repos, counts, a.activeRepo)
+			a.view = ViewRepoPicker
+			return a, nil, true
+		}
+		// Single repo: fall through to the general "n" handler, which
+		// contains the agent-count and backlog soft-limit checks.
+	}
+	return a, nil, false
+}
+
+// handlePipelineMarkReady promotes the cursor-selected Planning or Building
+// session to ReadyForReview (m key). We accept Planning too so the natural
+// flow works when Claude finishes the work in one shot — the
+// idle-reviewable cue ("press m to review") is rendered for any reviewable
+// session regardless of phase.
+func (a App) handlePipelineMarkReady() (App, tea.Cmd, bool) {
+	var sess *agent.Session
+	switch a.cursor.Section() {
+	case focusSectionPlanning:
+		planning := a.dashboard.planningSessions()
+		if pi := a.cursor.Index(focusSectionPlanning); pi < len(planning) {
+			sess = planning[pi].session
+		}
+	case focusSectionBuilding:
+		building := a.dashboard.buildingSessions()
+		if bi := a.cursor.Index(focusSectionBuilding); bi < len(building) {
+			sess = building[bi].session
+		}
+	default:
+		a.setError("nothing to mark — cursor isn't on a Planning or Building session")
+		return a, nil, true
+	}
+	if sess == nil {
+		a.setError("no session under cursor")
+		return a, nil, true
+	}
+	if !sess.IsReviewable() {
+		switch sess.Status() {
+		case agent.StatusActive:
+			a.setError("session is still running — wait for Claude to finish its turn")
+		case agent.StatusWaiting:
+			a.setError("session is waiting for input — resolve the prompt first")
+		default:
+			a.setError("session is still running — wait for Claude to finish its turn")
+		}
+		return a, nil, true
+	}
+	sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
+	a.cursor.SetIndex(focusSectionReview, 0)
+	return a, a.fetchReviewDiffCmd(sess), true
+}
+
+// handlePipelineOpenReview opens the review panel on the cursor-selected
+// review-queue session (r key).
+func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
+	reviewItems := a.dashboard.reviewQueueSessions()
+	if len(reviewItems) == 0 {
+		a.setError("review queue is empty — press m on a finished session first")
+		return a, nil, true
+	}
+	idx := a.cursor.Index(focusSectionReview)
+	if idx >= len(reviewItems) {
+		idx = len(reviewItems) - 1
+	}
+	sess := reviewItems[idx].session
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+	a.openReview(newReviewPanel(sess, a.width, a.height))
+	if _, ok := a.reviewDiffCache[sess.ID]; !ok {
+		return a, a.fetchReviewDiffCmd(sess), true
+	}
+	a.modals.Review().RefreshDiffViewport(a.panelServices())
+	return a, nil, true
+}
+
+// handleConfigFormSave persists the in-flight repo config form. On success
+// the repo's alias may have changed, in which case the config file is also
+// saved and the dashboard list is rebuilt to reflect the new label. Either
+// way the form is closed and focus returns to the pipeline.
+func (a App) handleConfigFormSave() (tea.Model, tea.Cmd) {
+	if form := a.modals.Config(); form != nil && a.modals.ConfigRepoPath() != "" {
+		repoPath := a.modals.ConfigRepoPath()
+		alias := strings.TrimSpace(form.textValue("Alias"))
+		settings := a.extractRepoSettings()
+		if err := config.SaveRepoSettings(repoPath, settings); err != nil {
+			a.setError(err.Error())
+		} else {
+			a.repoSettings[repoPath] = settings
+			a.resolvedCache[repoPath] = config.Resolve(a.globalSettings, settings)
+			if mgr := a.managers[repoPath]; mgr != nil {
+				mgr.UpdateSettings(a.resolvedCache[repoPath])
+			}
+		}
+		for i, r := range a.cfg.Repos {
+			if r.Path == repoPath && r.Alias != alias {
+				a.cfg.Repos[i].Alias = alias
+				if err := config.Save(a.cfg); err != nil {
+					a.setError(err.Error())
+				}
+				a.refreshAgentList()
+				break
+			}
+		}
+	}
+	return a.returnFromConfigForm()
+}
+
+// handleDashboardPaste routes a paste event to whichever modal owns focus:
+// the prompt modal, the PR compose modal, or the focusLaunch agent terminal.
+// When no consumer is active the paste is dropped (no panel consumes
+// arbitrary text on the pipeline).
+func (a App) handleDashboardPaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
+	// Prompt modal consumes paste while open (same precedence as the
+	// KeyPressMsg branch) so cmd+v / bracketed paste inserts into the
+	// textarea instead of being swallowed by the focusLaunch path.
+	if a.promptModal.Active() {
+		cmd := a.promptModal.Update(msg)
+		return a, cmd
+	}
+	if a.prComposeModal.Active() {
+		cmd := a.prComposeModal.Update(msg)
+		return a, cmd
+	}
+	if ag := a.modals.LaunchAgent(); ag != nil {
+		ag.Paste(msg.Content)
+		return a, nil
+	}
+	return a, nil
+}
+
+// handleQuitKey implements the q / ctrl+c detach-and-exit gesture. With
+// running agents the first press arms a confirm prompt; the second press
+// (or first press when no agents are running) detaches all managers,
+// persists per-repo state, writes the wellness log, and quits.
+//
+// Returns handled=true when q/ctrl+c was pressed. On any other key the
+// confirm flag is cleared and handled=false is returned so the dispatch
+// continues to the workflow handler.
+func (a App) handleQuitKey(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+	default:
+		a.confirmQuit = false
+		return a, nil, false
+	}
+	// Detach path: save state and exit, preserving worktrees.
+	hasRunning := false
+	for _, mgr := range a.managers {
+		if mgr.AgentCount() > 0 {
+			hasRunning = true
+			break
+		}
+	}
+	if hasRunning && !a.confirmQuit {
+		a.confirmQuit = true
+		return a, nil, true
+	}
+	// Detach all managers and save state.
+	for repoPath, mgr := range a.managers {
+		bs := mgr.Detach()
+		if bs != nil {
+			_ = state.Save(repoPath, bs)
+		} else {
+			_ = state.Remove(repoPath)
+		}
+	}
+	if a.audioPlayer != nil {
+		a.audioPlayer.Close()
+	}
+	a.writeWellnessLog()
+	return a, tea.Quit, true
 }

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -110,7 +110,7 @@ func (a App) handleInit(msg initAppMsg) (tea.Model, tea.Cmd) {
 	// Build resume work to run in the background so the TUI renders immediately.
 	type resumeItem struct {
 		repoPath  string
-		mgr       *agent.Manager
+		mgr       SessionManager
 		resumeCfg agent.Config
 		sessions  []state.SessionState
 	}
@@ -181,7 +181,7 @@ func (a App) handleInit(msg initAppMsg) (tea.Model, tea.Cmd) {
 			for _, ri := range resumeItems {
 				for _, ss := range ri.sessions {
 					wg.Add(1)
-					go func(mgr *agent.Manager, ss state.SessionState, cfg agent.Config) {
+					go func(mgr SessionManager, ss state.SessionState, cfg agent.Config) {
 						defer wg.Done()
 						_ = mgr.ResumeSession(ss, cfg)
 					}(ri.mgr, ss, ri.resumeCfg)


### PR DESCRIPTION
## Summary

PR 3 of 4 in a stacked foundational maintainability pass on the TUI. The TUI now depends on a narrow `SessionManager` interface (`internal/tui/manager_iface.go`) rather than the concrete `*agent.Manager` pointer. The seam unlocks fast unit tests via a new `fakeManager` test helper that satisfies the full interface without spinning up PTYs, git worktrees, or a hook socket.

## Motivation

`App` embedded concrete `*agent.Manager` pointers and called manager methods directly (`CreateSession`, `KillSession`, `ListSessions`, `Detach`, etc.). The TUI could not be unit-tested without standing up a real manager — PTY, git worktrees, hook server, `claude` on PATH. This is the underlying reason `app_test.go` is 173 KB of plumbing.

## What changed

- **New `internal/tui/manager_iface.go`** — declares `SessionManager`, the narrow interface listing the 25 methods the TUI actually calls on `*agent.Manager` (lifecycle/lookup, event streams, session/agent CRUD, planning subprocess control, review subprocess, external coordination, teardown).
- Compile-time assertion `var _ SessionManager = (*agent.Manager)(nil)` guarantees the contract. Future `agent.Manager` method-signature changes break the build here rather than at every call site.
- `App.managers` becomes `map[string]SessionManager`, `PanelServices.ManagerFor` returns the interface, `listenEvents` / `listenPlannerQuestions` accept the interface.
- Test files (`reviewpanelmodel_test.go`, `shippingpanelmodel_test.go`) updated to the new `ManagerFor` return type.

## fakeManager

New `internal/tui/fake_manager_test.go` provides a deterministic in-memory `SessionManager` implementation:
- No PTY, no git, no goroutines, no hook socket.
- Records invocation counters (`killSessionCalls`, `killAgentCalls`, `updateSettings`, `shutdownCalls`) so tests can assert on dispatch.
- Each method returns the seeded data or a sensible zero value; new methods get default no-op behavior — flesh them out only when a test actually depends on the response.
- `var _ SessionManager = (*fakeManager)(nil)` compile-time guarantee keeps the fake in sync with the interface.

## Tests

`internal/tui/manager_iface_test.go` (new, 4 tests):
- `TestSessionManager_AgentSatisfies` / `TestSessionManager_FakeSatisfies` — pin the compile-time guarantee at runtime as well.
- `TestSessionManager_FakeDrivesKillSession` — demonstrates the end-to-end seam: a fake injected into `App.managers` + `PanelServices.KillSessionCmd` invocation + assertion on `fake.killSessionCalls`, no real manager needed.
- `TestSessionManager_FakeReportsListSessions` and `TestSessionManager_FakeUpdateSettings` — cover the read-side paths used by dashboard refresh and global-config save flow.

## Test plan

- [x] `go test -race ./internal/tui/...` — all existing tests pass, 4 new tests demonstrating the seam pass.
- [x] `go vet ./...` clean.
- [x] `gofumpt` clean.
- [x] Verified `*agent.Manager` still satisfies the interface (compile-time + runtime assertion).

## Stack

1. #211 — Modals controller
2. #212 — split `updateDashboard`
3. **#this PR** — `SessionManager` interface (you are here)
4. Next — centralize TUI timing constants

[Session](https://claude.ai/code/session_01GCQSJxo4W8aNrE1vBnVEq7)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCQSJxo4W8aNrE1vBnVEq7)_