### PR TITLE
refactor(tui): centralize PR-polling and dashboard timing constants

### DIFF
--- a/changelog.d/refactor-tui-timing-constants.md
+++ b/changelog.d/refactor-tui-timing-constants.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Centralized TUI timing literals in `internal/tui/consts.go`. PR poller intervals (`PRPollBurstAfterCreate`, `PRPollDuringBurst`, `PRPollAfterPush`, `PRPollCIPending`, `PRPollStable`), the burst-on-unknown-mergeable window, the SHA-check throttle, the CI flash duration, the gh-client per-call and parent timeouts, the concurrent-poll cap, the dashboard tick cadence, the pipeline double-click window, the diff-stats cache TTL, and the error overlay duration are now named constants with doc comments explaining the cadence each value drives. Tuning a single behavior is now a one-place edit instead of a grep-and-replace across `update_pr.go`, `update_keys.go`, `update_lifecycle.go`, and `app.go`. No behavior change.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -329,7 +329,7 @@ func initAppCmd() tea.Cmd {
 }
 
 func tickCmd() tea.Cmd {
-	return tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg {
+	return tea.Tick(DashboardTickInterval, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
 }
@@ -517,10 +517,11 @@ func (a *App) resizeAllForDashboard() {
 	}
 }
 
-// setError sets an error message that displays for ~3 seconds (30 ticks at 100ms).
+// setError sets an error message that displays for ErrorOverlayTicks of the
+// dashboard tick (~3 seconds at the current 100ms tick interval).
 func (a *App) setError(msg string) {
 	a.err = msg
-	a.errTicks = 30
+	a.errTicks = ErrorOverlayTicks
 }
 
 // activeRepoDisplayName returns the display name for the active repo (alias or base path).

--- a/internal/tui/consts.go
+++ b/internal/tui/consts.go
@@ -1,0 +1,83 @@
+package tui
+
+import "time"
+
+// Polling and adaptive-interval timing for the GitHub PR poller. The poller
+// runs from App.Update on every tick (DashboardTickInterval); these constants
+// are the wall-clock thresholds it consults to decide what to do for each
+// session. See prPollInterval in update_pr.go for the adaptive ladder.
+const (
+	// PRPollBurstAfterCreate is the post-create burst window: after refrain
+	// creates or detects a new PR, poll aggressively for this long so the
+	// PR's `unknown` mergeable state resolves quickly.
+	PRPollBurstAfterCreate = 60 * time.Second
+
+	// PRPollBurstUnknownMergeable is a shorter burst armed each time the
+	// poller observes a `""` / `"unknown"` mergeable state, so the next
+	// poll picks up the resolved state within ~2s.
+	PRPollBurstUnknownMergeable = 15 * time.Second
+
+	// PRPollDuringBurst is the in-burst interval (2s -> visible transitions
+	// within one tick of arming the burst).
+	PRPollDuringBurst = 2 * time.Second
+
+	// PRPollAfterPush is the interval used after a branch push has been
+	// detected but no PR exists yet — fast enough to catch the PR landing
+	// without hammering the API.
+	PRPollAfterPush = 10 * time.Second
+
+	// PRPollCIPending is the interval used while at least one check run is
+	// in `pending` so success/failure transitions render promptly.
+	PRPollCIPending = 5 * time.Second
+
+	// PRPollStable is the steady-state interval — no active burst, no
+	// pending CI, no recent push. Same value is used both for "no PR yet"
+	// and "PR exists with terminal CI state" because the cost of the API
+	// call is the same and both want the same baseline freshness.
+	PRPollStable = 30 * time.Second
+
+	// PRSHACheckInterval throttles the git rev-parse origin/<branch> probe
+	// the poller uses to detect external pushes. Keeping this tight (2s)
+	// makes pushes visible quickly without blocking the Bubble Tea main
+	// goroutine on every tick.
+	PRSHACheckInterval = 2 * time.Second
+
+	// PRCIFlashDuration is how long a session row "flashes" green/red
+	// after a CI state transition lands.
+	PRCIFlashDuration = 2 * time.Second
+
+	// MaxConcurrentPRPolls caps the number of in-flight gh API calls so
+	// the poller can't saturate a tight rate limit.
+	MaxConcurrentPRPolls = 3
+
+	// PRPollClientTimeout is the per-call context timeout for the GitHub
+	// client. Bounds individual API calls; the poller's overall budget is
+	// the surrounding tick cycle.
+	PRPollClientTimeout = 20 * time.Second
+
+	// PRPollParentTimeout is the parent context budget for a full
+	// session-poll round (PR + checks + reviews + threads + stack).
+	PRPollParentTimeout = 90 * time.Second
+)
+
+// Dashboard UI cadence.
+const (
+	// DashboardTickInterval is the Bubble Tea tick cadence driving the
+	// dashboard ticker, PR poller, wellness timer, and error-overlay
+	// countdown. 100ms keeps the marquee and timer responsive without
+	// burning CPU on idle sessions.
+	DashboardTickInterval = 100 * time.Millisecond
+
+	// PipelineDoubleClickWindow is the maximum gap between two clicks on
+	// the same pipeline row that still counts as a double-click activation.
+	PipelineDoubleClickWindow = 500 * time.Millisecond
+
+	// DiffStatsCacheTTL is how long App.diffStatsCache entries are
+	// considered fresh before the dashboard triggers a background refresh.
+	DiffStatsCacheTTL = 5 * time.Second
+
+	// ErrorOverlayTicks is the number of dashboard ticks the bottom-row
+	// error message stays visible after setError() (3 seconds at the
+	// 100ms tick interval).
+	ErrorOverlayTicks = 30
+)

--- a/internal/tui/fake_manager_test.go
+++ b/internal/tui/fake_manager_test.go
@@ -104,7 +104,7 @@ func (f *fakeManager) CreateSessionWithCommand(_ agent.Config, _ func(string) *e
 	return nil, nil, nil
 }
 
-func (f *fakeManager) CreateSessionOnBranch(_ string, _ string, _ agent.Config) (*agent.Session, *agent.Agent, error) {
+func (f *fakeManager) CreateSessionOnBranch(_, _ string, _ agent.Config) (*agent.Session, *agent.Agent, error) {
 	return nil, nil, nil
 }
 
@@ -132,11 +132,11 @@ func (f *fakeManager) KillSession(sessionID string) error {
 
 func (f *fakeManager) ResumeSession(_ state.SessionState, _ agent.Config) error { return nil }
 
-func (f *fakeManager) StartDraft(_ string, _ string) error              { return nil }
-func (f *fakeManager) RevisePlan(_ string, _ string) error              { return nil }
-func (f *fakeManager) SetPlanDrafter(_ agent.PlanDrafter)               {}
-func (f *fakeManager) ReviewerAgent() agent.ReviewerAgent               { return nil }
-func (f *fakeManager) ReconcileExternalBranchRename(_ string, _ string) {}
+func (f *fakeManager) StartDraft(_, _ string) error              { return nil }
+func (f *fakeManager) RevisePlan(_, _ string) error              { return nil }
+func (f *fakeManager) SetPlanDrafter(_ agent.PlanDrafter)        {}
+func (f *fakeManager) ReviewerAgent() agent.ReviewerAgent        { return nil }
+func (f *fakeManager) ReconcileExternalBranchRename(_, _ string) {}
 
 func (f *fakeManager) UpdateSettings(s config.ResolvedSettings) {
 	f.updateSettings = append(f.updateSettings, s)

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -138,7 +138,7 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.updateDashboardDiffStats()
 		if sess := a.dashboard.selectedSession(); sess != nil {
 			entry := a.diffStatsCache[sess.ID]
-			if (entry == nil || time.Since(entry.lastRefresh) > 5*time.Second) && !a.diffRefreshInFlight {
+			if (entry == nil || time.Since(entry.lastRefresh) > DiffStatsCacheTTL) && !a.diffRefreshInFlight {
 				diffCmd := a.refreshDiffStatsCmd()
 				return a, tea.Batch(cmd, diffCmd)
 			}
@@ -877,7 +877,7 @@ func (a App) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	// Move the cursor to the clicked session.
 	now := time.Now()
 	isDoubleClick := !a.lastPipelineClick.IsZero() &&
-		now.Sub(a.lastPipelineClick) < 500*time.Millisecond &&
+		now.Sub(a.lastPipelineClick) < PipelineDoubleClickWindow &&
 		a.lastPipelineClickSec == section &&
 		a.lastPipelineClickIdx == idx
 	a.lastPipelineClick = now

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -309,7 +309,7 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 	var diffCmd tea.Cmd
 	if sess := a.dashboard.selectedSession(); sess != nil {
 		entry := a.diffStatsCache[sess.ID]
-		stale := entry == nil || time.Since(entry.lastRefresh) > 5*time.Second
+		stale := entry == nil || time.Since(entry.lastRefresh) > DiffStatsCacheTTL
 		if (stale || idleTransition) && !a.diffRefreshInFlight {
 			diffCmd = a.refreshDiffStatsCmd()
 		}
@@ -408,7 +408,7 @@ func (a App) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd) {
 			ps = &prSessionState{}
 			a.prPollStates[msg.event.SessionID] = ps
 		}
-		ps.burstUntil = time.Now().Add(60 * time.Second)
+		ps.burstUntil = time.Now().Add(PRPollBurstAfterCreate)
 		ps.lastPoll = time.Time{}
 		// Clearing lastRemoteSHA forces getRemoteSHA to re-check against
 		// the new branch name on the next tick instead of comparing against

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -51,7 +51,7 @@ func (a App) handlePRCreated(msg prCreatedMsg) (tea.Model, tea.Cmd) {
 	a.updateDashboardPRCache()
 	// Re-arm a burst poll so the new PR is discovered quickly.
 	if ps := a.prPollStates[msg.sessionID]; ps != nil {
-		ps.burstUntil = time.Now().Add(60 * time.Second)
+		ps.burstUntil = time.Now().Add(PRPollBurstAfterCreate)
 	}
 	// Auto-open in browser if configured.
 	repoPath := a.repoPathForSession(msg.sessionID)
@@ -116,7 +116,7 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 	// Arm a short burst so the unknown → known transition resolves promptly.
 	// Use max semantics to preserve a longer push burst that may already be active.
 	if ps != nil && (msg.pr.MergeableState == "" || msg.pr.MergeableState == "unknown") {
-		if newBurst := time.Now().Add(15 * time.Second); newBurst.After(ps.burstUntil) {
+		if newBurst := time.Now().Add(PRPollBurstUnknownMergeable); newBurst.After(ps.burstUntil) {
 			ps.burstUntil = newBurst
 		}
 	}
@@ -173,7 +173,7 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 		newState := msg.checks.State
 		if prevState == "pending" && (newState == "success" || newState == "failure") {
 			// Flash the session row.
-			ps.flashUntil = time.Now().Add(2 * time.Second)
+			ps.flashUntil = time.Now().Add(PRCIFlashDuration)
 			if newState == "success" {
 				ps.flashColor = "success"
 			} else {
@@ -230,8 +230,8 @@ func (a App) handleMergePR(msg mergePRMsg) (tea.Model, tea.Cmd) {
 
 func (a *App) pollAllSessions() []tea.Cmd {
 	const (
-		maxConcurrent    = 3
-		shaCheckInterval = 2 * time.Second
+		maxConcurrent    = MaxConcurrentPRPolls
+		shaCheckInterval = PRSHACheckInterval
 	)
 
 	var cmds []tea.Cmd
@@ -288,7 +288,7 @@ outer:
 				// SHA changed — arm a burst so the next minute of polls runs
 				// on the short (2s) cadence, then fall through to schedule an
 				// immediate poll.
-				ps.burstUntil = now.Add(60 * time.Second)
+				ps.burstUntil = now.Add(PRPollBurstAfterCreate)
 			}
 
 			ps.lastPoll = now
@@ -322,21 +322,21 @@ func (a *App) prPollInterval(sessionID string, ps *prSessionState) time.Duration
 	// Event-driven burst (branch rename, new push): poll aggressively for a
 	// short window so state transitions become visible within ~2s.
 	if ps != nil && time.Now().Before(ps.burstUntil) {
-		return 2 * time.Second
+		return PRPollDuringBurst
 	}
 	entry := a.prCache[sessionID]
 	// No PR found yet but branch may have been pushed.
 	if entry == nil || entry.pr == nil {
 		if ps.lastRemoteSHA != "" {
-			return 10 * time.Second // branch pushed, waiting for PR
+			return PRPollAfterPush // branch pushed, waiting for PR
 		}
-		return 30 * time.Second // stable, no activity
+		return PRPollStable // stable, no activity
 	}
 	// PR exists — adapt based on check state.
 	if entry.checks != nil && entry.checks.State == "pending" {
-		return 5 * time.Second
+		return PRPollCIPending
 	}
-	return 30 * time.Second
+	return PRPollStable
 }
 
 // getRemoteSHA runs `git rev-parse origin/<branch>` to detect pushes.
@@ -395,7 +395,7 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 	}
 	ghClient := a.ghClient
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), PRPollClientTimeout)
 		defer cancel()
 
 		rawURL, err := git.GetRemoteURL(repoPath)
@@ -547,7 +547,7 @@ func (a *App) mergePRCmdWithMode(sessionID string, force bool) tea.Cmd {
 	}
 	prNum := entry.pr.Number
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), PRPollClientTimeout)
 		defer cancel()
 		rawURL, err := git.GetRemoteURL(repoPath)
 		if err != nil {
@@ -595,7 +595,7 @@ func (a *App) startPRDraftCmd(sess *agent.Session, repoPath string, transitionSh
 	sessionID := sess.ID
 
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), PRPollParentTimeout)
 		defer cancel()
 
 		// Resolve owner/repo from the parent repo's remote URL.


### PR DESCRIPTION
## Summary

PR 4 of 4 in a stacked foundational maintainability pass on the TUI. Pulls scattered `time.Duration` literals out of `update_pr.go`, `update_keys.go`, `update_lifecycle.go`, and `app.go` into a new `internal/tui/consts.go` with named constants and doc comments explaining the cadence each value drives.

**No behavior change** — tuning a single cadence value is now a one-place edit instead of a grep across four files.

## What got named

**PR-poller cadence** (the dominant cluster):

| Constant | Value | Drives |
|---|---|---|
| `PRPollBurstAfterCreate` | 60s | post-create / shipping-transition burst |
| `PRPollBurstUnknownMergeable` | 15s | shorter burst armed on `""` / `"unknown"` mergeable state |
| `PRPollDuringBurst` | 2s | in-burst poll interval |
| `PRPollAfterPush` | 10s | branch pushed, no PR yet |
| `PRPollCIPending` | 5s | PR exists, at least one check pending |
| `PRPollStable` | 30s | steady-state baseline |
| `PRSHACheckInterval` | 2s | throttles the `git rev-parse` probe |
| `PRCIFlashDuration` | 2s | session row flash window |
| `MaxConcurrentPRPolls` | 3 | in-flight gh API cap |
| `PRPollClientTimeout` | 20s | per-call context timeout |
| `PRPollParentTimeout` | 90s | full poll-round budget |

**Dashboard cadence**:

| Constant | Value | Drives |
|---|---|---|
| `DashboardTickInterval` | 100ms | Bubble Tea tick (marquee, poller, wellness timer, error countdown) |
| `PipelineDoubleClickWindow` | 500ms | pipeline double-click activation |
| `DiffStatsCacheTTL` | 5s | `App.diffStatsCache` freshness |
| `ErrorOverlayTicks` | 30 | ~3s at the current tick interval |

`setError`'s previous magic `30` references `ErrorOverlayTicks` now; the adaptive `prPollInterval` ladder, the burst-arming sites, and the gh-client timeouts all reference the new constants instead of inline numerics.

## Test plan

- [x] `go test -race ./internal/tui/...` — all existing tests pass.
- [x] `go vet ./...` clean.
- [x] `gofumpt` clean.

## Stack

1. #211 — Modals controller
2. #212 — split `updateDashboard`
3. #213 — `SessionManager` interface
4. **#this PR** — TUI timing constants (you are here)

[Session](https://claude.ai/code/session_01GCQSJxo4W8aNrE1vBnVEq7)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCQSJxo4W8aNrE1vBnVEq7)_