### PR TITLE
Fix Claude code reviewer authentication

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,7 +42,7 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-haiku-4-5-20251001 --max-turns 4"
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} for SECURITY issues ONLY.
@@ -77,7 +77,7 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-haiku-4-5-20251001 --max-turns 4"
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} for PERFORMANCE issues ONLY.
@@ -108,7 +108,7 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-haiku-4-5-20251001 --max-turns 4"
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} for TEST COVERAGE issues ONLY.
@@ -138,7 +138,7 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-haiku-4-5-20251001 --max-turns 4"
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} for CORRECTNESS / LOGIC issues ONLY.
@@ -183,7 +183,7 @@ jobs:
         run: ls -la /tmp/findings || true
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-haiku-4-5-20251001 --max-turns 10"
           prompt: |
             You are the final reviewer for PR #${{ github.event.pull_request.number }}.

--- a/changelog.d/fix-claude-code-review-auth.md
+++ b/changelog.d/fix-claude-code-review-auth.md
@@ -1,0 +1,3 @@
+### Fixed
+
+The Claude PR Review workflow now authenticates with `CLAUDE_CODE_OAUTH_TOKEN` instead of `ANTHROPIC_API_KEY`, matching the `@claude` mention workflow and unblocking the multi-agent reviewer for accounts that authenticate via Claude Code OAuth rather than a raw Anthropic API key.


### PR DESCRIPTION
## Summary

- Updated `claude-code-review.yml` to use `CLAUDE_CODE_OAUTH_TOKEN` for authentication instead of the deprecated `ANTHROPIC_API_KEY`
- Resolves broken Claude code reviewer due to incorrect authentication mechanism

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI:

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description