### PR TITLE
fix(tui): route multi-repo PR operations to correct session

### DIFF
--- a/changelog.d/fix-multirepo-session-id-collision.md
+++ b/changelog.d/fix-multirepo-session-id-collision.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Multi-repo session-ID collision: when two repos each held a `session-1`, pressing `p` in the review panel could open a PR against the wrong GitHub remote, and the AI reviewer could receive the original prompt from the wrong session. The fix pins an explicit `repoPath` on `reviewPanelModel` and `shippingPanelModel` at construction time and threads it through every async message (`reviewDiffMsg`, `reviewReworkRequestMsg`, `shippingFeedbackRequestMsg`, `mergePRMsg`, `prPollMsg`, `prCreatedMsg`). Handlers now prefer `msg.repoPath` over the first-match `repoPathForSession` fallback. A new `sessionByIDInRepo(repoPath, sessionID)` helper replaces `sessionByID` at all disambiguation-critical call sites. Follows the precedent set by `fix-plan-approve-wrong-repo.md`.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1219,6 +1219,10 @@ func (a *App) repoPathForSession(sessionID string) string {
 // review task list, following the same row ordering as renderTaskListPane: plan
 // tasks in index order, then the "Other changes" group (taskIndex == 0) last.
 // Returns nil if cursor is out of range or no groups exist.
+//
+// sessionByID returns the first session with the given ID across all repos.
+// It is ambiguous when the same session ID exists in multiple repos — use
+// sessionByIDInRepo instead when the repo is known.
 func (a *App) sessionByID(sessionID string) *agent.Session {
 	if a.cfg == nil {
 		return nil
@@ -1232,6 +1236,23 @@ func (a *App) sessionByID(sessionID string) *agent.Session {
 			if sess.ID == sessionID {
 				return sess
 			}
+		}
+	}
+	return nil
+}
+
+// sessionByIDInRepo returns the session with the given ID from the manager at
+// repoPath. Returns nil when the manager is not found or the session does not
+// exist. Unlike sessionByID, this is unambiguous when session IDs collide
+// across repos.
+func (a *App) sessionByIDInRepo(repoPath, sessionID string) *agent.Session {
+	mgr := a.managers[repoPath]
+	if mgr == nil {
+		return nil
+	}
+	for _, sess := range mgr.ListSessions() {
+		if sess.ID == sessionID {
+			return sess
 		}
 	}
 	return nil

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -114,6 +114,7 @@ type prDraftReadyMsg struct {
 // prCreatedMsg carries the result of the async github.Client.CreatePR call.
 type prCreatedMsg struct {
 	sessionID          string
+	repoPath           string
 	pr                 *github.PRState
 	transitionShipping bool
 	err                error
@@ -219,6 +220,7 @@ type App struct {
 	// PR compose modal and its associated session context.
 	prComposeModal   prComposeModal
 	prModalSessionID string
+	prModalRepoPath  string
 	prModalOwner     string
 	prModalRepo      string
 	prModalHead      string

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -593,12 +593,8 @@ func (a *App) panelServices() PanelServices {
 		Width:         a.width,
 		Height:        a.height,
 		DashboardTopY: a.dashboardTopY(),
-		ManagerFor: func(sessionID string) (SessionManager, string) {
-			repoPath := a.repoPathForSession(sessionID)
-			if repoPath == "" {
-				return nil, ""
-			}
-			return a.managers[repoPath], repoPath
+		Manager: func(repoPath string) SessionManager {
+			return a.managers[repoPath]
 		},
 		Resolved: func(repoPath string) config.ResolvedSettings {
 			return a.resolvedCache[repoPath]
@@ -927,7 +923,7 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 		return nil, a.openSessionInFocusLaunch(sess)
 	case focusSectionReview:
 		sess.SetLifecyclePhase(agent.LifecycleInReview)
-		a.openReview(newReviewPanel(sess, a.width, a.height))
+		a.openReview(newReviewPanel(sess, items[idx].repoPath, a.width, a.height))
 		if _, ok := a.reviewDiffCache[sess.ID]; !ok {
 			return a.fetchReviewDiffCmd(sess), true
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -122,6 +122,7 @@ type prCreatedMsg struct {
 // mergePRMsg carries the result of an async PR merge attempt.
 type mergePRMsg struct {
 	sessionID string
+	repoPath  string
 	err       error
 }
 
@@ -619,11 +620,11 @@ func (a *App) panelServices() PanelServices {
 		},
 		OpenURL:  openURL,
 		SetError: a.setError,
-		MergePRCmd: func(sessionID string, force bool) tea.Cmd {
+		MergePRCmd: func(sessionID, repoPath string, force bool) tea.Cmd {
 			if force {
-				return a.forceMergePRCmd(sessionID)
+				return a.forceMergePRCmd(sessionID, repoPath)
 			}
-			return a.mergePRCmd(sessionID)
+			return a.mergePRCmd(sessionID, repoPath)
 		},
 		StartPRDraftCmd: func(sess *agent.Session, repoPath string, transitionShipping bool) tea.Cmd {
 			a.prDraftInFlight = true
@@ -931,7 +932,7 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 		a.modals.Review().RefreshDiffViewport(a.panelServices())
 		return nil, true
 	case focusSectionShipping:
-		a.openShipping(newShippingPanel(sess, a.width, a.height-1))
+		a.openShipping(newShippingPanel(sess, items[idx].repoPath, a.width, a.height-1))
 		return nil, true
 	}
 	return nil, false

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -656,7 +656,7 @@ func (a *App) panelServices() PanelServices {
 				}
 			}
 		},
-		FetchReviewDiff:    func(sess *agent.Session) tea.Cmd { return a.fetchReviewDiffCmd(sess) },
+		FetchReviewDiff:    func(sess *agent.Session, repoPath string) tea.Cmd { return a.fetchReviewDiffCmd(sess, repoPath) },
 		prDraftInFlightFor: func(sessionID string) bool { return a.prDraftInFlight && a.prDraftSessionID == sessionID },
 		FeedbackTriage:     func(sessionID string) map[string]*feedbackTriageEntry { return a.feedbackTriage[sessionID] },
 		SetFeedbackVerdict: a.setFeedbackVerdict,
@@ -923,9 +923,10 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 		return nil, a.openSessionInFocusLaunch(sess)
 	case focusSectionReview:
 		sess.SetLifecyclePhase(agent.LifecycleInReview)
-		a.openReview(newReviewPanel(sess, items[idx].repoPath, a.width, a.height))
+		rp := items[idx].repoPath
+		a.openReview(newReviewPanel(sess, rp, a.width, a.height))
 		if _, ok := a.reviewDiffCache[sess.ID]; !ok {
-			return a.fetchReviewDiffCmd(sess), true
+			return a.fetchReviewDiffCmd(sess, rp), true
 		}
 		a.modals.Review().RefreshDiffViewport(a.panelServices())
 		return nil, true
@@ -1435,6 +1436,7 @@ type reviewDiffEntry struct {
 // reviewDiffMsg carries the result of an async review diff fetch.
 type reviewDiffMsg struct {
 	sessionID string
+	repoPath  string
 	entry     *reviewDiffEntry
 	err       error
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2754,6 +2754,101 @@ func TestSessionByIDInRepo_DisambiguatesAcrossRepos(t *testing.T) {
 	}
 }
 
+// capturePromptReviewer is a ReviewerAgent stub that records the last
+// OriginalPrompt passed to Review.
+type capturePromptReviewer struct {
+	capturedPrompt string
+}
+
+func (r *capturePromptReviewer) Review(_ context.Context, req agent.ReviewRequest) (agent.ReviewVerdict, error) {
+	r.capturedPrompt = req.OriginalPrompt
+	return agent.ReviewVerdict{}, nil
+}
+
+// TestHandleReviewDiff_UsesRepoPathFromMsg_NotFirstMatch verifies that
+// handleReviewDiff resolves the session via msg.repoPath so that when two
+// managers both hold session-1, the reviewer receives the original prompt from
+// the correct session (repoB's), not the first-match one (repoA's).
+func TestHandleReviewDiff_UsesRepoPathFromMsg_NotFirstMatch(t *testing.T) {
+	makeRepo := func() string {
+		dir, err := os.MkdirTemp("", "refrain-rvdiff-*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+		run := func(args ...string) {
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = dir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("cmd %v: %v\n%s", args, err, out)
+			}
+		}
+		run("git", "init")
+		run("git", "config", "commit.gpgsign", "false")
+		run("git", "commit", "--allow-empty", "-m", "init")
+		return dir
+	}
+
+	repoA, repoB := makeRepo(), makeRepo()
+
+	mgrA := agent.NewManager(repoA, config.Resolve(nil, nil))
+	t.Cleanup(mgrA.Shutdown)
+	mgrB := agent.NewManager(repoB, config.Resolve(nil, nil))
+	t.Cleanup(mgrB.Shutdown)
+
+	sessA, _, err := mgrA.CreateSessionWithCommand(agent.Config{
+		Name: "work", Task: "test-a", RepoPath: repoA, Rows: 24, Cols: 80,
+	}, func(_ string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 30") })
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessA.SetOriginalPrompt("prompt-for-repo-A")
+
+	sessB, _, err := mgrB.CreateSessionWithCommand(agent.Config{
+		Name: "work", Task: "test-b", RepoPath: repoB, Rows: 24, Cols: 80,
+	}, func(_ string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 30") })
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessB.SetOriginalPrompt("prompt-for-repo-B")
+
+	// Both managers independently mint session-1.
+	if sessA.ID != "session-1" || sessB.ID != "session-1" {
+		t.Fatalf("expected both sessions to be session-1, got %q and %q", sessA.ID, sessB.ID)
+	}
+
+	reviewerA := &capturePromptReviewer{}
+	reviewerB := &capturePromptReviewer{}
+	mgrA.SetReviewerAgent(reviewerA)
+	mgrB.SetReviewerAgent(reviewerB)
+
+	app := NewApp()
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: repoA}, {Path: repoB}}}
+	app.managers[repoA] = mgrA
+	app.managers[repoB] = mgrB
+
+	// A reviewDiffEntry with one group so handleReviewDiff dispatches a reviewer.
+	entry := &reviewDiffEntry{
+		groups:   []taskReviewGroup{{taskIndex: 1}},
+		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
+	}
+	msg := reviewDiffMsg{sessionID: "session-1", repoPath: repoB, entry: entry}
+
+	_, cmd := app.handleReviewDiff(msg)
+	if cmd == nil {
+		t.Fatal("handleReviewDiff returned nil cmd — expected a review task cmd for repoB's session")
+	}
+	// Execute the cmd so the reviewer is invoked.
+	_ = cmd()
+
+	if reviewerB.capturedPrompt != "prompt-for-repo-B" {
+		t.Errorf("repoB reviewer captured prompt=%q, want %q", reviewerB.capturedPrompt, "prompt-for-repo-B")
+	}
+	if reviewerA.capturedPrompt != "" {
+		t.Errorf("repoA reviewer should not have been called, but got prompt=%q", reviewerA.capturedPrompt)
+	}
+}
+
 // makeFourPhaseApp wires up an app with one session in each of the four
 // pipeline phases so tests can exercise navigation across all sections without
 // requiring a real manager / process. Sessions are constructed via

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1968,7 +1968,7 @@ func TestFocusMode_RKey_NonEmptyQueue_OpensReviewPanel(t *testing.T) {
 func TestReviewPanel_CKey_MarksComplete(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	app.openReview(newReviewPanel(sessR, app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 	app = model.(App)
@@ -1994,7 +1994,7 @@ func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openReview(newReviewPanel(sess, app.width, app.height))
+	app.openReview(newReviewPanel(sess, dir, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -2032,7 +2032,7 @@ func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
 func TestReviewPanel_TKey_NoAgents_ShowsError(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	app.openReview(newReviewPanel(sessR, app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
 	app = model.(App)
@@ -2064,7 +2064,7 @@ func TestReviewPanel_ComposeModalRendersOverPanel(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.openReview(newReviewPanel(sessR, app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 	app.prComposeModal.SetSize(120, 39)
 	_ = app.prComposeModal.Open("My PR Title", "My PR Body", false)
 
@@ -2084,7 +2084,7 @@ func TestReviewPanel_ComposeModalRendersOverPanel(t *testing.T) {
 func TestReviewPanel_PKey_NoPR_DoesNotOrphan(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	app.openReview(newReviewPanel(sessR, app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 	// ghClient must be non-nil to pass the auth guard before startPRDraftCmd.
 	app.ghClient = &github.Client{}
 
@@ -3254,7 +3254,7 @@ func TestPRPollMsg_ExternalOpenPRPromotesInReviewToShipping_ClosesReviewPanel(t 
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openReview(newReviewPanel(sess, app.width, app.height))
+	app.openReview(newReviewPanel(sess, dir, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -4632,7 +4632,7 @@ func TestReviewPanel_EnterDoesNotChangeView(t *testing.T) {
 	app := NewApp()
 	app.width = 120
 	app.height = 40
-	app.openReview(newReviewPanel(sessR, app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 	app.reviewDiffCache[sessR.ID] = entry
 
 	for _, key := range []string{"enter", "space"} {
@@ -4685,7 +4685,7 @@ func TestReviewPanel_ScrollBindingsAdvanceViewport(t *testing.T) {
 	app := NewApp()
 	app.width = 120
 	app.height = 40
-	app.openReview(newReviewPanel(sessR, app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 	app.reviewDiffCache[sessR.ID] = entry
 	// Load diff content and set viewport dimensions before sending scroll keys.
 	app.modals.Review().RefreshDiffViewport(app.panelServices())

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3561,6 +3561,63 @@ func TestHandlePRPoll_MultiRepo_MergeKillsCorrectSession(t *testing.T) {
 	}
 }
 
+// TestHandlePRCreated_UsesMsgRepoPath_ForAutoOpen verifies that handlePRCreated
+// reads AutoOpenPRInBrowser from the repo named in msg.repoPath, not the first
+// repo that owns the sessionID. With two repos each holding session-1, only the
+// named repo's setting is consulted.
+func TestHandlePRCreated_UsesMsgRepoPath_ForAutoOpen(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	var opened []string
+	origOpenURL := openURL
+	openURL = func(u string) error { opened = append(opened, u); return nil }
+	defer func() { openURL = origOpenURL }()
+
+	sessA := agent.NewSessionForTest("session-1", "branch-a")
+	sessB := agent.NewSessionForTest("session-1", "branch-b")
+	sessB.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	mgrA := agent.NewManager(repoA, config.Resolve(nil, nil))
+	defer mgrA.Shutdown()
+	mgrA.AddSessionForTest(sessA)
+
+	mgrB := agent.NewManager(repoB, config.Resolve(nil, nil))
+	defer mgrB.Shutdown()
+	mgrB.AddSessionForTest(sessB)
+
+	app := NewApp()
+	// repoA listed first (first-match would find it), but AutoOpenPRInBrowser only on repoB.
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: repoA}, {Path: repoB}}}
+	app.managers[repoA] = mgrA
+	app.managers[repoB] = mgrB
+	app.resolvedCache = map[string]config.ResolvedSettings{
+		repoA: {AutoOpenPRInBrowser: false},
+		repoB: {AutoOpenPRInBrowser: true},
+	}
+
+	// msg names repoB — URL should be opened (repoB has AutoOpenPRInBrowser=true).
+	app.Update(prCreatedMsg{
+		sessionID: "session-1",
+		repoPath:  repoB,
+		pr:        &github.PRState{URL: "https://github.com/example/repoB/pull/1"},
+	})
+	if len(opened) != 1 || opened[0] != "https://github.com/example/repoB/pull/1" {
+		t.Errorf("expected URL opened for repoB, got %v", opened)
+	}
+
+	// msg names repoA (AutoOpenPRInBrowser=false) — no URL should be opened.
+	opened = nil
+	app.Update(prCreatedMsg{
+		sessionID: "session-1",
+		repoPath:  repoA,
+		pr:        &github.PRState{URL: "https://github.com/example/repoA/pull/1"},
+	})
+	if len(opened) != 0 {
+		t.Errorf("expected no URL for repoA (AutoOpenPRInBrowser=false), got %v", opened)
+	}
+}
+
 // TestMergePRMsg_ErrorSetsError verifies that a mergePRMsg error is surfaced.
 func TestMergePRMsg_ErrorSetsError(t *testing.T) {
 	app := NewApp()

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3476,6 +3476,91 @@ func TestPRPollMsg_CompleteNotPromoted(t *testing.T) {
 	}
 }
 
+// TestHandlePRPoll_MultiRepo_DoesNotPromoteWrongSession verifies that when two
+// managers both have a session with the same ID, a prPollMsg carrying repoPath
+// for repo B only transitions repo B's session — not repo A's.
+func TestHandlePRPoll_MultiRepo_DoesNotPromoteWrongSession(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	sessA := agent.NewSessionForTest("session-1", "branch-a")
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessB := agent.NewSessionForTest("session-1", "branch-b")
+	sessB.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	mgrA := agent.NewManager(repoA, config.Resolve(nil, nil))
+	defer mgrA.Shutdown()
+	mgrA.AddSessionForTest(sessA)
+
+	mgrB := agent.NewManager(repoB, config.Resolve(nil, nil))
+	defer mgrB.Shutdown()
+	mgrB.AddSessionForTest(sessB)
+
+	app := NewApp()
+	// repoA listed first so sessionByID (first-match) would return repoA's session.
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: repoA}, {Path: repoB}}}
+	app.managers[repoA] = mgrA
+	app.managers[repoB] = mgrB
+
+	// Poll message carries repoB's path — only repoB's session should transition.
+	msg := prPollMsg{
+		sessionID: "session-1",
+		repoPath:  repoB,
+		pr:        &github.PRState{State: "open", Number: 42},
+	}
+	app.Update(msg)
+
+	if sessB.LifecyclePhase() != agent.LifecycleShipping {
+		t.Errorf("repoB session-1 phase = %v, want LifecycleShipping", sessB.LifecyclePhase())
+	}
+	if sessA.LifecyclePhase() != agent.LifecycleInProgress {
+		t.Errorf("repoA session-1 phase = %v, want LifecycleInProgress (should be unchanged)", sessA.LifecyclePhase())
+	}
+}
+
+// TestHandlePRPoll_MultiRepo_MergeKillsCorrectSession verifies that a
+// merged prPollMsg with a repoPath only triggers cleanup on the named repo's
+// manager, leaving the other repo's identically-named session untouched.
+func TestHandlePRPoll_MultiRepo_MergeKillsCorrectSession(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	sessA := agent.NewSessionForTest("session-1", "branch-a")
+	sessA.SetLifecyclePhase(agent.LifecycleShipping)
+	sessB := agent.NewSessionForTest("session-1", "branch-b")
+	sessB.SetLifecyclePhase(agent.LifecycleShipping)
+
+	mgrA := agent.NewManager(repoA, config.Resolve(nil, nil))
+	defer mgrA.Shutdown()
+	mgrA.AddSessionForTest(sessA)
+
+	mgrB := agent.NewManager(repoB, config.Resolve(nil, nil))
+	defer mgrB.Shutdown()
+	mgrB.AddSessionForTest(sessB)
+
+	app := NewApp()
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: repoA}, {Path: repoB}}}
+	app.managers[repoA] = mgrA
+	app.managers[repoB] = mgrB
+
+	msg := prPollMsg{
+		sessionID: "session-1",
+		repoPath:  repoB,
+		pr:        &github.PRState{State: "merged"},
+	}
+	_, cmd := app.Update(msg)
+
+	if cmd == nil {
+		t.Fatal("expected a kill cmd for repoB's session")
+	}
+	if sessB.LifecyclePhase() != agent.LifecycleComplete {
+		t.Errorf("repoB session-1 phase = %v, want LifecycleComplete", sessB.LifecyclePhase())
+	}
+	if sessA.LifecyclePhase() != agent.LifecycleShipping {
+		t.Errorf("repoA session-1 phase = %v, want LifecycleShipping (should be unchanged)", sessA.LifecyclePhase())
+	}
+}
+
 // TestMergePRMsg_ErrorSetsError verifies that a mergePRMsg error is surfaced.
 func TestMergePRMsg_ErrorSetsError(t *testing.T) {
 	app := NewApp()

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -3160,11 +3160,11 @@ func TestMergePRMsg_ClosesPanel(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, dir, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
-	model, cmd := app.Update(mergePRMsg{sessionID: "sess-1"})
+	model, cmd := app.Update(mergePRMsg{sessionID: "sess-1", repoPath: dir})
 	got := model.(App)
 
 	if got.dashboard.panelFocus == focusShipping {
@@ -3203,7 +3203,7 @@ func TestPRPollMsg_ExternalMergeClosesPanelAndTransitions(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -3249,7 +3249,7 @@ func TestPRPollMsg_ExternalCloseCleansSession(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -3479,7 +3479,7 @@ func TestPRPollMsg_CompleteNotPromoted(t *testing.T) {
 // TestMergePRMsg_ErrorSetsError verifies that a mergePRMsg error is surfaced.
 func TestMergePRMsg_ErrorSetsError(t *testing.T) {
 	app := NewApp()
-	app.openShipping(newShippingPanel(agent.NewSessionForTest("s", "ship"), app.width, app.height))
+	app.openShipping(newShippingPanel(agent.NewSessionForTest("s", "ship"), "", app.width, app.height))
 
 	model, _ := app.Update(mergePRMsg{sessionID: "s", err: errors.New("403 forbidden")})
 	got := model.(App)
@@ -3499,7 +3499,7 @@ func TestShippingPanel_MKeyGatedOnReady(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
 	app.prCache = map[string]*prCacheEntry{
 		sess.ID: {pr: &github.PRState{Number: 1, MergeableState: "dirty"}},
 	}
@@ -4487,7 +4487,7 @@ func TestShippingPanel_CursorAndScrollKeys(t *testing.T) {
 	sess := agent.NewSessionForTest("ship-cs", "ship")
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
 	app.width = 120
 	app.height = 40
 	app.prCache[sess.ID] = &prCacheEntry{
@@ -4550,7 +4550,7 @@ func TestShippingPanel_VerdictKeys(t *testing.T) {
 	sess := agent.NewSessionForTest("ship-v", "ship")
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
 	app.width = 120
 	app.height = 40
 	// One inline comment with ID=42.
@@ -4600,7 +4600,7 @@ func TestAddressFeedback_ClearsTriage(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, dir, app.width, app.height))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 	app.width = 120
@@ -4659,7 +4659,7 @@ func TestAddressFeedback_RefusesOnMergedPR(t *testing.T) {
 			mgr.AddSessionForTest(sess)
 
 			app := NewApp()
-			app.openShipping(newShippingPanel(sess, app.width, app.height))
+			app.openShipping(newShippingPanel(sess, dir, app.width, app.height))
 			app.managers[dir] = mgr
 			app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 			app.width = 120

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2664,6 +2664,96 @@ func TestRepoPathForSession_FindsSessionsAcrossMultiRepo(t *testing.T) {
 	}
 }
 
+// TestSessionByIDInRepo_DisambiguatesAcrossRepos verifies that sessionByIDInRepo
+// returns the session owned by the named repo's manager, not the first-match
+// session, when two managers both have a session with the same ID.
+func TestSessionByIDInRepo_DisambiguatesAcrossRepos(t *testing.T) {
+	makeRepo := func(t *testing.T) string {
+		t.Helper()
+		dir, err := os.MkdirTemp("", "refrain-repobyid-*")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+		run := func(args ...string) {
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = dir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("cmd %v: %v\n%s", args, err, out)
+			}
+		}
+		run("git", "init")
+		run("git", "config", "commit.gpgsign", "false")
+		run("git", "commit", "--allow-empty", "-m", "init")
+		return dir
+	}
+
+	repoA := makeRepo(t)
+	repoB := makeRepo(t)
+
+	mgrA := agent.NewManager(repoA, config.Resolve(nil, nil))
+	t.Cleanup(mgrA.Shutdown)
+	mgrB := agent.NewManager(repoB, config.Resolve(nil, nil))
+	t.Cleanup(mgrB.Shutdown)
+
+	sessA, _, err := mgrA.CreateSessionWithCommand(agent.Config{
+		Name: "work", Task: "test-a", RepoPath: repoA, Rows: 24, Cols: 80,
+	}, func(_ string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 30") })
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessB, _, err := mgrB.CreateSessionWithCommand(agent.Config{
+		Name: "work", Task: "test-b", RepoPath: repoB, Rows: 24, Cols: 80,
+	}, func(_ string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 30") })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Both managers mint session-1 independently.
+	if sessA.ID != "session-1" {
+		t.Fatalf("sessA.ID = %q, want session-1", sessA.ID)
+	}
+	if sessB.ID != "session-1" {
+		t.Fatalf("sessB.ID = %q, want session-1", sessB.ID)
+	}
+
+	app := NewApp()
+	// repoA is listed first so sessionByID (first-match) returns repoA's session.
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: repoA}, {Path: repoB}}}
+	app.managers[repoA] = mgrA
+	app.managers[repoB] = mgrB
+
+	gotA := app.sessionByIDInRepo(repoA, "session-1")
+	gotB := app.sessionByIDInRepo(repoB, "session-1")
+
+	if gotA == nil {
+		t.Fatal("sessionByIDInRepo(repoA, session-1) = nil, want sessA")
+	}
+	if gotB == nil {
+		t.Fatal("sessionByIDInRepo(repoB, session-1) = nil, want sessB")
+	}
+	if gotA == gotB {
+		t.Error("sessionByIDInRepo returned the same session for repoA and repoB — collision not disambiguated")
+	}
+	if gotA != sessA {
+		t.Errorf("sessionByIDInRepo(repoA) returned wrong session: got %p, want %p", gotA, sessA)
+	}
+	if gotB != sessB {
+		t.Errorf("sessionByIDInRepo(repoB) returned wrong session: got %p, want %p", gotB, sessB)
+	}
+
+	// Legacy sessionByID returns repoA's session (first-match).
+	firstMatch := app.sessionByID("session-1")
+	if firstMatch != sessA {
+		t.Errorf("sessionByID returned %p, want repoA's sessA %p (first-match behaviour)", firstMatch, sessA)
+	}
+
+	// Unknown repo returns nil.
+	if got := app.sessionByIDInRepo("/nonexistent", "session-1"); got != nil {
+		t.Errorf("sessionByIDInRepo(unknown repo) = %p, want nil", got)
+	}
+}
+
 // makeFourPhaseApp wires up an app with one session in each of the four
 // pipeline phases so tests can exercise navigation across all sections without
 // requiring a real manager / process. Sessions are constructed via

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -42,7 +42,7 @@ type PanelServices struct {
 	DashboardTopY int
 
 	// Lookups.
-	ManagerFor  func(sessionID string) (mgr SessionManager, repoPath string)
+	Manager     func(repoPath string) SessionManager
 	Resolved    func(repoPath string) config.ResolvedSettings
 	GHClient    func() *github.Client
 	PRCache     func(sessionID string) *prCacheEntry

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -57,7 +57,7 @@ type PanelServices struct {
 
 	// Cmd factories. Each MUST be pure: build the tea.Cmd, but never
 	// mutate App state; the resulting tea.Msg flows back through App.Update.
-	MergePRCmd      func(sessionID string, force bool) tea.Cmd
+	MergePRCmd      func(sessionID, repoPath string, force bool) tea.Cmd
 	StartPRDraftCmd func(sess *agent.Session, repoPath string, transitionShipping bool) tea.Cmd
 	KillSessionCmd  func(sess *agent.Session) tea.Cmd
 	FetchReviewDiff func(sess *agent.Session, repoPath string) tea.Cmd

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -60,7 +60,7 @@ type PanelServices struct {
 	MergePRCmd      func(sessionID string, force bool) tea.Cmd
 	StartPRDraftCmd func(sess *agent.Session, repoPath string, transitionShipping bool) tea.Cmd
 	KillSessionCmd  func(sess *agent.Session) tea.Cmd
-	FetchReviewDiff func(sess *agent.Session) tea.Cmd
+	FetchReviewDiff func(sess *agent.Session, repoPath string) tea.Cmd
 
 	// prDraftInFlightFor reports whether a PR draft request is currently in
 	// flight for the given session ID. The review panel uses this to render

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -45,6 +45,7 @@ func rowStatePhrase(entry *prCacheEntry) string {
 //   - err == nil, pr != nil: update cache.
 type prPollMsg struct {
 	sessionID string
+	repoPath  string
 	pr        *github.PRState
 	checks    *github.CheckStatus
 	reviews   *github.ReviewStatus

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -17,6 +17,7 @@ import (
 // App because its lifetime exceeds a single panel session.
 type reviewPanelModel struct {
 	session           *agent.Session
+	repoPath          string
 	taskCursor        int
 	diffVP            viewport.Model
 	diffCacheByTask   map[int]*diffmodel.Model
@@ -27,11 +28,14 @@ type reviewPanelModel struct {
 }
 
 // newReviewPanel constructs a review panel for sess at the given size.
+// repoPath pins which repo's manager is used for all key handlers — it must
+// match the repo the session belongs to so multi-repo ID collisions are safe.
 // The diff viewport is fresh; the caller should invoke RefreshDiffViewport
 // after the reviewDiffCache entry lands.
-func newReviewPanel(sess *agent.Session, width, height int) *reviewPanelModel {
+func newReviewPanel(sess *agent.Session, repoPath string, width, height int) *reviewPanelModel {
 	return &reviewPanelModel{
 		session:         sess,
+		repoPath:        repoPath,
 		diffVP:          viewport.New(),
 		diffCacheByTask: make(map[int]*diffmodel.Model),
 		width:           width,
@@ -149,12 +153,10 @@ type reviewReworkRequestMsg struct {
 // reviewOpenIDECmd opens the configured IDE on the session's worktree.
 // Mirrors the inline 'i' / 'e' key handler shape: silent if the worktree is
 // missing, errors via svc.SetError when the IDE command isn't set.
-func reviewOpenIDECmd(sess *agent.Session, svc PanelServices) {
+func reviewOpenIDECmd(sess *agent.Session, repoPath string, svc PanelServices) {
 	if sess == nil || sess.Worktree == nil {
 		return
 	}
-	mgr, repoPath := svc.ManagerFor(sess.ID)
-	_ = mgr
 	if repoPath == "" {
 		return
 	}
@@ -244,8 +246,7 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 			svc.SetError("GitHub auth not available")
 			return m, nil
 		}
-		_, repoPath := svc.ManagerFor(sess.ID)
-		return m, svc.StartPRDraftCmd(sess, repoPath, true)
+		return m, svc.StartPRDraftCmd(sess, m.repoPath, true)
 	case "t":
 		sess := m.session
 		// Close first regardless of outcome: pressing 't' is an exit-the-panel
@@ -259,13 +260,13 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 	case "c":
 		sess := m.session
 		sess.SetLifecyclePhase(agent.LifecycleComplete)
-		mgr, _ := svc.ManagerFor(sess.ID)
+		mgr := svc.Manager(m.repoPath)
 		if mgr == nil {
 			return m, closeReviewPanel(svc)
 		}
 		return m, tea.Batch(closeReviewPanel(svc), svc.KillSessionCmd(sess))
 	case "e":
-		reviewOpenIDECmd(m.session, svc)
+		reviewOpenIDECmd(m.session, m.repoPath, svc)
 		return m, nil
 	case "j", "down":
 		if entry := svc.ReviewCache(m.session.ID); entry != nil {

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -147,6 +147,7 @@ func closeReviewPanel(svc PanelServices) tea.Cmd {
 // panel only signals intent.
 type reviewReworkRequestMsg struct {
 	sessionID string
+	repoPath  string
 	prompt    string
 }
 
@@ -310,8 +311,9 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 			return m, nil
 		}
 		sessID := m.session.ID
+		repoPath := m.repoPath
 		return m, func() tea.Msg {
-			return reviewReworkRequestMsg{sessionID: sessID, prompt: prompt}
+			return reviewReworkRequestMsg{sessionID: sessID, repoPath: repoPath, prompt: prompt}
 		}
 	case "enter", "space":
 		return m, nil

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -48,7 +48,7 @@ func newTestSvc() (PanelServices, *testServiceState) {
 			state.killSessionCalled = true
 			return func() tea.Msg { return nil }
 		},
-		FetchReviewDiff: func(*agent.Session) tea.Cmd { return nil },
+		FetchReviewDiff: func(*agent.Session, string) tea.Cmd { return nil },
 		FeedbackTriage: func(string) map[string]*feedbackTriageEntry {
 			return nil
 		},

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -21,8 +21,8 @@ func newTestSvc() (PanelServices, *testServiceState) {
 	svc := PanelServices{
 		Width:  120,
 		Height: 40,
-		ManagerFor: func(string) (SessionManager, string) {
-			return nil, ""
+		Manager: func(string) SessionManager {
+			return nil
 		},
 		Resolved:    func(string) config.ResolvedSettings { return config.ResolvedSettings{} },
 		GHClient:    func() *github.Client { return nil },
@@ -72,7 +72,7 @@ type testServiceState struct {
 func TestReviewPanelModel_EscCloses(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 
 	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape}, svc)
@@ -90,7 +90,7 @@ func TestReviewPanelModel_EscCloses(t *testing.T) {
 func TestReviewPanelModel_DKeyDefers(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 
 	_, _ = panel.Update(tea.KeyPressMsg{Code: 'd', Text: "d"}, svc)
@@ -110,7 +110,7 @@ func TestReviewPanelModel_DKeyDefers(t *testing.T) {
 func TestReviewPanelModel_TKeyClosesEvenOnFailure(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 	state.openInLaunchResult = false
 
@@ -129,13 +129,13 @@ func TestReviewPanelModel_TKeyClosesEvenOnFailure(t *testing.T) {
 func TestReviewPanelModel_CKeyMarksComplete(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
-	// Wire ManagerFor to a non-nil-looking entry so the panel reaches the
+	// Wire Manager to return a non-nil SessionManager so the panel reaches the
 	// kill path. The actual manager pointer is not exercised here because
 	// KillSessionCmd is stubbed.
-	svc.ManagerFor = func(string) (SessionManager, string) {
-		return &agent.Manager{}, "/repo"
+	svc.Manager = func(string) SessionManager {
+		return &agent.Manager{}
 	}
 
 	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'c', Text: "c"}, svc)
@@ -159,7 +159,7 @@ func TestReviewPanelModel_CKeyMarksComplete(t *testing.T) {
 func TestReviewPanelModel_TaskCursorMovesWithJK(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{
 			{Index: 1, Text: "task one"},
@@ -190,7 +190,7 @@ func TestReviewPanelModel_TaskCursorMovesWithJK(t *testing.T) {
 func TestReviewPanelModel_TaskCursorClampsAtTopAndBottom(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 1}, {Index: 2}},
 	}
@@ -214,7 +214,7 @@ func TestReviewPanelModel_TaskCursorClampsAtTopAndBottom(t *testing.T) {
 func TestReviewPanelModel_FKey_TogglesUserFlag(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 7, Text: "task one"}},
 	}
@@ -235,7 +235,7 @@ func TestReviewPanelModel_FKey_TogglesUserFlag(t *testing.T) {
 
 func TestReviewPanelModel_FKey_NoCache_NoOp(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, _ := newTestSvc() // ReviewCache returns nil
 	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'f', Text: "f"}, svc)
 	if cmd != nil {
@@ -246,7 +246,7 @@ func TestReviewPanelModel_FKey_NoCache_NoOp(t *testing.T) {
 func TestReviewPanelModel_BKey_NoFlags_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 1}},
 	}
@@ -264,7 +264,7 @@ func TestReviewPanelModel_BKey_NoFlags_SetsError(t *testing.T) {
 func TestReviewPanelModel_BKey_WithFlag_EmitsReworkMsg(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 1, Text: "task one"}},
 		verdicts: map[int]*taskVerdictRecord{
@@ -295,7 +295,7 @@ func TestReviewPanelModel_EnterAndSpace_AreNoOp(t *testing.T) {
 	// noticed.
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 
 	for _, k := range []tea.KeyPressMsg{
@@ -320,7 +320,7 @@ func TestReviewPanelModel_DiffScrollKeys_DoNotChangeCursorOrClose(t *testing.T) 
 	// The taskCursor must stay put and the panel must stay open.
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 
 	keys := []tea.KeyPressMsg{
@@ -351,7 +351,7 @@ func TestReviewPanelModel_QKey_NoPlan_DoesNotOpenSpec(t *testing.T) {
 	if sess.HasPlan() {
 		t.Skip("test prereq: session should not have a plan")
 	}
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, _ := newTestSvc()
 	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"}, svc)
 	if panel.specOverlay {
@@ -370,7 +370,7 @@ func TestReviewPanelModel_QKey_WithPlan_OpensSpec(t *testing.T) {
 	if !sess.HasPlan() {
 		t.Fatal("test prereq: HasPlan should be true after writing plan.md")
 	}
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, _ := newTestSvc()
 	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"}, svc)
 	if !panel.specOverlay {
@@ -385,7 +385,7 @@ func TestReviewPanelModel_SpecOverlay_Keys(t *testing.T) {
 	if err := writePlanForTest(planDir, sess, "# Goal\n"); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, _ := newTestSvc()
 	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"}, svc)
 	if !panel.specOverlay {
@@ -429,7 +429,7 @@ func TestReviewPanelModel_SpecOverlay_OtherKeys_AreSwallowed(t *testing.T) {
 		t.Fatalf("write plan: %v", err)
 	}
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"}, svc)
 
@@ -450,7 +450,7 @@ func TestReviewPanelModel_SpecOverlay_OtherKeys_AreSwallowed(t *testing.T) {
 func TestReviewPanelModel_PKey_WithCachedPR_OpensURL(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 	var openedURL string
 	svc.PRCache = func(string) *prCacheEntry {
@@ -474,7 +474,7 @@ func TestReviewPanelModel_PKey_WithCachedPR_OpensURL(t *testing.T) {
 
 func TestReviewPanelModel_PKey_NoPR_NoGHClient_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 	svc.GHClient = func() *github.Client { return nil }
 	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"}, svc)
@@ -488,9 +488,8 @@ func TestReviewPanelModel_PKey_NoPR_NoGHClient_SetsError(t *testing.T) {
 
 func TestReviewPanelModel_EKey_NoIDECommand_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTestWithPath("s1", "fix-auth", t.TempDir())
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "/repo", 120, 40)
 	svc, state := newTestSvc()
-	svc.ManagerFor = func(string) (SessionManager, string) { return nil, "/repo" }
 	svc.Resolved = func(string) config.ResolvedSettings {
 		return config.ResolvedSettings{IDECommand: ""}
 	}
@@ -503,7 +502,7 @@ func TestReviewPanelModel_EKey_NoIDECommand_SetsError(t *testing.T) {
 func TestReviewPanelModel_UnknownKey_NoOp(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, 120, 40)
+	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 
 	before := struct {
@@ -535,6 +534,56 @@ func TestReviewPanelModel_UnknownKey_NoOp(t *testing.T) {
 
 	if before != after {
 		t.Errorf("unknown keys changed state: before=%+v after=%+v", before, after)
+	}
+}
+
+// TestReviewPanel_PKey_UsesPinnedRepoPath_NotFirstMatch verifies that pressing
+// 'p' (draft PR) passes the panel's pinned repoPath to StartPRDraftCmd, not
+// the first-match repoPath from ManagerFor — the multi-repo collision fix.
+func TestReviewPanel_PKey_UsesPinnedRepoPath_NotFirstMatch(t *testing.T) {
+	sess := agent.NewSessionForTest("session-1", "my-task")
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+	panel := newReviewPanel(sess, "/repoB", 120, 40)
+	svc, _ := newTestSvc()
+
+	var recordedRepoPath string
+	svc.StartPRDraftCmd = func(_ *agent.Session, repoPath string, _ bool) tea.Cmd {
+		recordedRepoPath = repoPath
+		return func() tea.Msg { return nil }
+	}
+	// non-nil GHClient so the code passes the auth check and reaches StartPRDraftCmd
+	svc.GHClient = func() *github.Client { return new(github.Client) }
+	svc.PRCache = func(string) *prCacheEntry { return nil }
+
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"}, svc)
+
+	if recordedRepoPath != "/repoB" {
+		t.Errorf("StartPRDraftCmd received repoPath=%q, want /repoB (pinned)", recordedRepoPath)
+	}
+}
+
+// TestReviewPanel_CKey_UsesPinnedManager verifies that pressing 'c' (mark
+// complete) resolves the manager via the panel's pinned repoPath, not the
+// first-match lookup.
+func TestReviewPanel_CKey_UsesPinnedManager(t *testing.T) {
+	sess := agent.NewSessionForTest("session-1", "my-task")
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+	panel := newReviewPanel(sess, "/repoB", 120, 40)
+	svc, state := newTestSvc()
+
+	var managerCalledWith string
+	svc.Manager = func(repoPath string) SessionManager {
+		managerCalledWith = repoPath
+		return &agent.Manager{} // non-nil so kill path is taken
+	}
+
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'c', Text: "c"}, svc)
+
+	if managerCalledWith != "/repoB" {
+		t.Errorf("Manager called with %q, want /repoB (pinned)", managerCalledWith)
+	}
+	if !state.killSessionCalled {
+		t.Error("expected KillSessionCmd to be invoked on non-nil manager")
 	}
 }
 

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -40,7 +40,7 @@ func newTestSvc() (PanelServices, *testServiceState) {
 		SetError: func(msg string) {
 			state.errMsg = msg
 		},
-		MergePRCmd: func(string, bool) tea.Cmd { return nil },
+		MergePRCmd: func(string, string, bool) tea.Cmd { return nil },
 		StartPRDraftCmd: func(*agent.Session, string, bool) tea.Cmd {
 			return func() tea.Msg { return nil }
 		},

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -264,7 +264,7 @@ func TestReviewPanelModel_BKey_NoFlags_SetsError(t *testing.T) {
 func TestReviewPanelModel_BKey_WithFlag_EmitsReworkMsg(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
+	panel := newReviewPanel(sess, "/repoB", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 1, Text: "task one"}},
 		verdicts: map[int]*taskVerdictRecord{
@@ -286,6 +286,9 @@ func TestReviewPanelModel_BKey_WithFlag_EmitsReworkMsg(t *testing.T) {
 	}
 	if msg.prompt == "" {
 		t.Error("prompt should be non-empty when tasks are flagged")
+	}
+	if msg.repoPath != "/repoB" {
+		t.Errorf("repoPath = %q, want /repoB (pinned from panel)", msg.repoPath)
 	}
 }
 

--- a/internal/tui/shippingpanelmodel.go
+++ b/internal/tui/shippingpanelmodel.go
@@ -12,6 +12,7 @@ import (
 // App because it survives panel close/reopen.
 type shippingPanelModel struct {
 	session        *agent.Session
+	repoPath       string
 	feedbackCursor int
 	detailScroll   int
 	feedbackNote   feedbackNoteModal
@@ -19,13 +20,17 @@ type shippingPanelModel struct {
 	width, height int
 }
 
-// newShippingPanel constructs a shipping panel for sess. The nested
-// feedbackNote modal is initialised but inactive until the user presses 'n'.
-func newShippingPanel(sess *agent.Session, width, height int) *shippingPanelModel {
+// newShippingPanel constructs a shipping panel for sess. repoPath pins which
+// repo's manager is used for merge and feedback key handlers, preventing
+// multi-repo session-ID collisions from routing operations to the wrong repo.
+// The nested feedbackNote modal is initialised but inactive until the user
+// presses 'n'.
+func newShippingPanel(sess *agent.Session, repoPath string, width, height int) *shippingPanelModel {
 	note := newFeedbackNoteModal()
 	note.SetSize(width, height+1)
 	return &shippingPanelModel{
 		session:      sess,
+		repoPath:     repoPath,
 		feedbackNote: note,
 		width:        width,
 		height:       height,
@@ -78,6 +83,7 @@ func (m *shippingPanelModel) Resize(w, h int) {
 // 'r' to address feedback. App handles the cross-cutting effects.
 type shippingFeedbackRequestMsg struct {
 	sessionID string
+	repoPath  string
 }
 
 // closeShippingPanel invokes svc.ClosePanel(). Returns nil for inline
@@ -196,17 +202,18 @@ func (m *shippingPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (
 			svc.SetError("not ready to merge — use M to force")
 			return m, nil
 		}
-		return m, svc.MergePRCmd(m.session.ID, false)
+		return m, svc.MergePRCmd(m.session.ID, m.repoPath, false)
 	case "M":
 		if entry == nil || entry.pr == nil {
 			svc.SetError("no PR found")
 			return m, nil
 		}
-		return m, svc.MergePRCmd(m.session.ID, true)
+		return m, svc.MergePRCmd(m.session.ID, m.repoPath, true)
 	case "r":
 		sessID := m.session.ID
+		repoPath := m.repoPath
 		return m, func() tea.Msg {
-			return shippingFeedbackRequestMsg{sessionID: sessID}
+			return shippingFeedbackRequestMsg{sessionID: sessID, repoPath: repoPath}
 		}
 	}
 	return m, nil

--- a/internal/tui/shippingpanelmodel_test.go
+++ b/internal/tui/shippingpanelmodel_test.go
@@ -35,7 +35,7 @@ func newTestShippingSvc() (PanelServices, *testShippingSvcState) {
 			state.openedURL = true
 			return nil
 		},
-		MergePRCmd: func(sessionID string, force bool) tea.Cmd {
+		MergePRCmd: func(sessionID, repoPath string, force bool) tea.Cmd {
 			state.mergeRequested = true
 			state.mergeForce = force
 			return func() tea.Msg { return nil }
@@ -73,7 +73,7 @@ type testShippingSvcState struct {
 // TestShippingPanelModel_EscCloses verifies esc closes the panel.
 func TestShippingPanelModel_EscCloses(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, state := newTestShippingSvc()
 
 	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape}, svc)
@@ -86,7 +86,7 @@ func TestShippingPanelModel_EscCloses(t *testing.T) {
 // error and does not call MergePRCmd when the PR isn't merge-ready.
 func TestShippingPanelModel_MergeBlockedWhenNotReady(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, state := newTestShippingSvc()
 	// No PR entry => not merge-ready.
 
@@ -103,7 +103,7 @@ func TestShippingPanelModel_MergeBlockedWhenNotReady(t *testing.T) {
 // gate and calls MergePRCmd with force=true.
 func TestShippingPanelModel_ForceMergeBypasses(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, state := newTestShippingSvc()
 	state.pr = &prCacheEntry{pr: &github.PRState{Number: 1}}
 
@@ -120,7 +120,7 @@ func TestShippingPanelModel_ForceMergeBypasses(t *testing.T) {
 // a URL is cached.
 func TestShippingPanelModel_PKeyOpensPRURL(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, state := newTestShippingSvc()
 	state.pr = &prCacheEntry{pr: &github.PRState{URL: "https://example/pr/1"}}
 
@@ -134,7 +134,7 @@ func TestShippingPanelModel_PKeyOpensPRURL(t *testing.T) {
 // two feedback items so cursor/verdict/note keys can be exercised.
 func shippingPanelWithFeedback() (*shippingPanelModel, PanelServices, *testShippingSvcState) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, state := newTestShippingSvc()
 	state.pr = &prCacheEntry{
 		pr: &github.PRState{Number: 1, URL: "https://example/pr/1"},
@@ -268,7 +268,7 @@ func TestShippingPanelModel_AXU_NoItems_NoOp(t *testing.T) {
 	// Without any feedback items, the verdict keys must be no-ops, not
 	// crashes or off-by-one writes.
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, state := newTestShippingSvc()
 	for _, k := range []rune{'a', 'x', 'u'} {
 		_, _ = panel.Update(tea.KeyPressMsg{Code: k, Text: string(k)}, svc)
@@ -291,7 +291,7 @@ func TestShippingPanelModel_NKey_OpensFeedbackNoteModal(t *testing.T) {
 
 func TestShippingPanelModel_NKey_NoItems_DoesNotOpenModal(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, _ := newTestShippingSvc()
 	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"}, svc)
 	if panel.NoteActive() {
@@ -361,7 +361,7 @@ func TestShippingPanelModel_TKey_OpenFail_SetsError(t *testing.T) {
 
 func TestShippingPanelModel_PKey_NoURL_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, state := newTestShippingSvc()
 	// No PR entry => no URL.
 	_, _ = panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"}, svc)
@@ -375,7 +375,7 @@ func TestShippingPanelModel_PKey_NoURL_SetsError(t *testing.T) {
 
 func TestShippingPanelModel_MergeReady_CallsMergeCmd(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, state := newTestShippingSvc()
 	state.pr = &prCacheEntry{
 		pr:      &github.PRState{Number: 1, MergeableState: "clean"},
@@ -396,7 +396,7 @@ func TestShippingPanelModel_MergeReady_CallsMergeCmd(t *testing.T) {
 
 func TestShippingPanelModel_ForceMerge_NoPR_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, 120, 40)
+	panel := newShippingPanel(sess, "", 120, 40)
 	svc, state := newTestShippingSvc()
 	// No PR entry.
 	_, _ = panel.Update(tea.KeyPressMsg{Code: 'M', Text: "M"}, svc)
@@ -453,5 +453,51 @@ func TestShippingPanelModel_UnknownKey_NoOp(t *testing.T) {
 	}{panel.FeedbackCursor(), panel.DetailScroll(), state.closed, state.errMsg, state.mergeRequested}
 	if before != after {
 		t.Errorf("unknown keys changed state: before=%+v after=%+v", before, after)
+	}
+}
+
+// TestShippingPanel_MergeKey_UsesPinnedRepoPath verifies that 'm' passes the
+// panel's pinned repoPath to MergePRCmd, not a first-match lookup.
+func TestShippingPanel_MergeKey_UsesPinnedRepoPath(t *testing.T) {
+	sess := agent.NewSessionForTest("session-1", "ship")
+	panel := newShippingPanel(sess, "/repoB", 120, 40)
+	svc, state := newTestShippingSvc()
+	var recordedRepoPath string
+	svc.MergePRCmd = func(sessionID, repoPath string, force bool) tea.Cmd {
+		state.mergeRequested = true
+		state.mergeForce = force
+		recordedRepoPath = repoPath
+		return func() tea.Msg { return nil }
+	}
+	state.pr = &prCacheEntry{
+		pr:      &github.PRState{Number: 1, MergeableState: "clean"},
+		checks:  &github.CheckStatus{State: "success", Total: 1},
+		reviews: &github.ReviewStatus{State: "approved"},
+	}
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'm', Text: "m"}, svc)
+	if !state.mergeRequested {
+		t.Fatal("m should call MergePRCmd when ready")
+	}
+	if recordedRepoPath != "/repoB" {
+		t.Errorf("MergePRCmd received repoPath=%q, want /repoB (pinned)", recordedRepoPath)
+	}
+}
+
+// TestShippingPanel_FeedbackKey_EmitsRepoPath verifies that 'r' embeds the
+// panel's pinned repoPath in the emitted shippingFeedbackRequestMsg.
+func TestShippingPanel_FeedbackKey_EmitsRepoPath(t *testing.T) {
+	sess := agent.NewSessionForTest("session-1", "ship")
+	panel := newShippingPanel(sess, "/repoB", 120, 40)
+	svc, _ := newTestShippingSvc()
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'r', Text: "r"}, svc)
+	if cmd == nil {
+		t.Fatal("expected cmd from r")
+	}
+	msg, ok := cmd().(shippingFeedbackRequestMsg)
+	if !ok {
+		t.Fatalf("got %T, want shippingFeedbackRequestMsg", cmd())
+	}
+	if msg.repoPath != "/repoB" {
+		t.Errorf("repoPath = %q, want /repoB (pinned)", msg.repoPath)
 	}
 }

--- a/internal/tui/shippingpanelmodel_test.go
+++ b/internal/tui/shippingpanelmodel_test.go
@@ -18,8 +18,8 @@ func newTestShippingSvc() (PanelServices, *testShippingSvcState) {
 	svc := PanelServices{
 		Width:  120,
 		Height: 40,
-		ManagerFor: func(string) (SessionManager, string) {
-			return nil, ""
+		Manager: func(string) SessionManager {
+			return nil
 		},
 		PRCache: func(string) *prCacheEntry { return state.pr },
 		ClosePanel: func() {

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -1104,16 +1104,19 @@ func (a App) handlePipelineKeys(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 // session regardless of phase.
 func (a App) handlePipelineMarkReady() (App, tea.Cmd, bool) {
 	var sess *agent.Session
+	var repoPath string
 	switch a.cursor.Section() {
 	case focusSectionPlanning:
 		planning := a.dashboard.planningSessions()
 		if pi := a.cursor.Index(focusSectionPlanning); pi < len(planning) {
 			sess = planning[pi].session
+			repoPath = planning[pi].repoPath
 		}
 	case focusSectionBuilding:
 		building := a.dashboard.buildingSessions()
 		if bi := a.cursor.Index(focusSectionBuilding); bi < len(building) {
 			sess = building[bi].session
+			repoPath = building[bi].repoPath
 		}
 	default:
 		a.setError("nothing to mark — cursor isn't on a Planning or Building session")
@@ -1136,7 +1139,7 @@ func (a App) handlePipelineMarkReady() (App, tea.Cmd, bool) {
 	}
 	sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
 	a.cursor.SetIndex(focusSectionReview, 0)
-	return a, a.fetchReviewDiffCmd(sess), true
+	return a, a.fetchReviewDiffCmd(sess, repoPath), true
 }
 
 // handlePipelineOpenReview opens the review panel on the cursor-selected
@@ -1151,11 +1154,12 @@ func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
 	if idx >= len(reviewItems) {
 		idx = len(reviewItems) - 1
 	}
-	sess := reviewItems[idx].session
+	item := reviewItems[idx]
+	sess := item.session
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	a.openReview(newReviewPanel(sess, reviewItems[idx].repoPath, a.width, a.height))
+	a.openReview(newReviewPanel(sess, item.repoPath, a.width, a.height))
 	if _, ok := a.reviewDiffCache[sess.ID]; !ok {
-		return a, a.fetchReviewDiffCmd(sess), true
+		return a, a.fetchReviewDiffCmd(sess, item.repoPath), true
 	}
 	a.modals.Review().RefreshDiffViewport(a.panelServices())
 	return a, nil, true

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -1153,7 +1153,7 @@ func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
 	}
 	sess := reviewItems[idx].session
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	a.openReview(newReviewPanel(sess, a.width, a.height))
+	a.openReview(newReviewPanel(sess, reviewItems[idx].repoPath, a.width, a.height))
 	if _, ok := a.reviewDiffCache[sess.ID]; !ok {
 		return a, a.fetchReviewDiffCmd(sess), true
 	}

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -379,7 +379,7 @@ func (a App) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd) {
 					// phase gate makes it idempotent on subsequent events).
 					if sess.LifecyclePhase() == agent.LifecycleInProgress && sess.IsReviewable() {
 						sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
-						autoPromoteCmd = a.fetchReviewDiffCmd(sess)
+						autoPromoteCmd = a.fetchReviewDiffCmd(sess, msg.repoPath)
 					}
 					// Mark session done when all non-shell agents have exited.
 					if msg.event.Status == agent.StatusDone || msg.event.Status == agent.StatusError {

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -24,6 +24,7 @@ func (a App) handlePRDraftReady(msg prDraftReadyMsg) (tea.Model, tea.Cmd) {
 	}
 	// Store context for the CreatePR call that follows confirmation.
 	a.prModalSessionID = msg.sessionID
+	a.prModalRepoPath = msg.repoPath
 	a.prModalOwner = msg.owner
 	a.prModalRepo = msg.repo
 	a.prModalHead = msg.head
@@ -41,7 +42,17 @@ func (a App) handlePRCreated(msg prCreatedMsg) (tea.Model, tea.Cmd) {
 	}
 	a.prCache[msg.sessionID] = &prCacheEntry{pr: msg.pr}
 	if msg.transitionShipping {
-		if sess := a.sessionByID(msg.sessionID); sess != nil {
+		repoPath := msg.repoPath
+		if repoPath == "" {
+			repoPath = a.repoPathForSession(msg.sessionID)
+		}
+		var sess *agent.Session
+		if repoPath != "" {
+			sess = a.sessionByIDInRepo(repoPath, msg.sessionID)
+		} else {
+			sess = a.sessionByID(msg.sessionID)
+		}
+		if sess != nil {
 			sess.SetLifecyclePhase(agent.LifecycleShipping)
 			if rp := a.modals.Review(); rp != nil && rp.SessionID() == msg.sessionID {
 				a.closeModal()
@@ -54,7 +65,10 @@ func (a App) handlePRCreated(msg prCreatedMsg) (tea.Model, tea.Cmd) {
 		ps.burstUntil = time.Now().Add(PRPollBurstAfterCreate)
 	}
 	// Auto-open in browser if configured.
-	repoPath := a.repoPathForSession(msg.sessionID)
+	repoPath := msg.repoPath
+	if repoPath == "" {
+		repoPath = a.repoPathForSession(msg.sessionID)
+	}
 	resolved := a.resolvedCache[repoPath]
 	if resolved.AutoOpenPRInBrowser && msg.pr != nil && msg.pr.URL != "" {
 		if err := openURL(msg.pr.URL); err != nil {
@@ -730,7 +744,7 @@ func (a *App) submitPRComposeModal(msg prComposeSubmitMsg) (tea.Model, tea.Cmd) 
 	ghClient := a.ghClient
 	if ghClient == nil {
 		return a, func() tea.Msg {
-			return prCreatedMsg{sessionID: a.prModalSessionID, err: fmt.Errorf("GitHub auth not available")}
+			return prCreatedMsg{sessionID: a.prModalSessionID, repoPath: a.prModalRepoPath, err: fmt.Errorf("GitHub auth not available")}
 		}
 	}
 	owner := a.prModalOwner
@@ -738,15 +752,16 @@ func (a *App) submitPRComposeModal(msg prComposeSubmitMsg) (tea.Model, tea.Cmd) 
 	head := a.prModalHead
 	base := a.prModalBase
 	sessionID := a.prModalSessionID
+	repoPath := a.prModalRepoPath
 	transitionShipping := a.prModalTransitionShipping
 	return a, func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		pr, err := ghClient.CreatePR(ctx, owner, repo, head, base, msg.title, msg.body, msg.draft)
 		if err != nil {
-			return prCreatedMsg{sessionID: sessionID, err: err}
+			return prCreatedMsg{sessionID: sessionID, repoPath: repoPath, err: err}
 		}
-		return prCreatedMsg{sessionID: sessionID, pr: pr, transitionShipping: transitionShipping}
+		return prCreatedMsg{sessionID: sessionID, repoPath: repoPath, pr: pr, transitionShipping: transitionShipping}
 	}
 }
 

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -122,7 +122,17 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 	}
 	// Auto-promote to Shipping when an open PR is discovered externally.
 	if msg.pr != nil && msg.pr.State == "open" {
-		if sess := a.sessionByID(msg.sessionID); sess != nil {
+		repoPath := msg.repoPath
+		if repoPath == "" {
+			repoPath = a.repoPathForSession(msg.sessionID)
+		}
+		var sess *agent.Session
+		if repoPath != "" {
+			sess = a.sessionByIDInRepo(repoPath, msg.sessionID)
+		} else {
+			sess = a.sessionByID(msg.sessionID)
+		}
+		if sess != nil {
 			switch sess.LifecyclePhase() {
 			case agent.LifecycleInProgress, agent.LifecycleReadyForReview, agent.LifecycleInReview:
 				sess.SetLifecyclePhase(agent.LifecycleShipping)
@@ -135,7 +145,10 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 	// Detect PR merge/close and trigger async session cleanup.
 	var cmds []tea.Cmd
 	if msg.pr != nil && (msg.pr.State == "merged" || msg.pr.State == "closed") {
-		repoPath := a.repoPathForSession(msg.sessionID)
+		repoPath := msg.repoPath
+		if repoPath == "" {
+			repoPath = a.repoPathForSession(msg.sessionID)
+		}
 		if repoPath != "" {
 			if mgr := a.managers[repoPath]; mgr != nil {
 				if sess := mgr.GetSession(msg.sessionID); sess != nil {
@@ -182,7 +195,10 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 			// Play audio notification, gated by the session's repo AudioEnabled setting
 			// (same gate as the idle-transition notification above).
 			if a.audioPlayer != nil {
-				repoPath := a.repoPathForSession(msg.sessionID)
+				repoPath := msg.repoPath
+				if repoPath == "" {
+					repoPath = a.repoPathForSession(msg.sessionID)
+				}
 				if repoPath != "" && a.resolvedCache[repoPath].AudioEnabled {
 					a.audioPlayer.Play()
 				}
@@ -394,7 +410,7 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 	// session that belongs to a different repo) before the poll fires.
 	if owning := a.repoPathForSession(sessionID); owning != "" && owning != repoPath {
 		mismatchErr := fmt.Errorf("internal: refreshPRStatus: repoPath %q does not own session %s (owner=%q)", repoPath, sessionID, owning)
-		return func() tea.Msg { return prPollMsg{sessionID: sessionID, err: mismatchErr} }
+		return func() tea.Msg { return prPollMsg{sessionID: sessionID, repoPath: repoPath, err: mismatchErr} }
 	}
 	ghClient := a.ghClient
 	return func() tea.Msg {
@@ -403,11 +419,11 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 
 		rawURL, err := git.GetRemoteURL(repoPath)
 		if err != nil {
-			return prPollMsg{sessionID: sessionID, err: err}
+			return prPollMsg{sessionID: sessionID, repoPath: repoPath, err: err}
 		}
 		owner, repo, err := github.ParseRemoteURL(rawURL)
 		if err != nil {
-			return prPollMsg{sessionID: sessionID, err: err}
+			return prPollMsg{sessionID: sessionID, repoPath: repoPath, err: err}
 		}
 
 		// Prefer SHA-based lookup: invariant to branch renames, so a PR opened
@@ -431,7 +447,7 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 			var err error
 			pr, err = ghClient.GetPR(ctx, owner, repo, branch)
 			if err != nil {
-				return prPollMsg{sessionID: sessionID, err: err}
+				return prPollMsg{sessionID: sessionID, repoPath: repoPath, err: err}
 			}
 		}
 		// Shipping sessions: if the open-only lookups all returned nil, check
@@ -452,11 +468,11 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 			}
 			checks, err = ghClient.GetChecks(ctx, owner, repo, checkRef)
 			if err != nil {
-				return prPollMsg{sessionID: sessionID, err: err}
+				return prPollMsg{sessionID: sessionID, repoPath: repoPath, err: err}
 			}
 			reviews, err = ghClient.GetReviews(ctx, owner, repo, pr.Number)
 			if err != nil {
-				return prPollMsg{sessionID: sessionID, err: err}
+				return prPollMsg{sessionID: sessionID, repoPath: repoPath, err: err}
 			}
 			// Threads are only needed for the shipping panel — skip the fetch for
 			// building/reviewing sessions to avoid doubling review API calls.
@@ -495,6 +511,7 @@ func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePat
 
 		return prPollMsg{
 			sessionID: sessionID,
+			repoPath:  repoPath,
 			pr:        pr,
 			checks:    checks,
 			reviews:   reviews,

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -200,13 +200,16 @@ func (a App) handleMergePR(msg mergePRMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 	a.closeModal()
-	repoPath := a.repoPathForSession(msg.sessionID)
+	repoPath := msg.repoPath
 	if repoPath == "" {
-		return a, nil
+		repoPath = a.activeRepo
 	}
 	mgr := a.managers[repoPath]
+	if mgr == nil {
+		return a, nil
+	}
 	sess := mgr.GetSession(msg.sessionID)
-	if mgr == nil || sess == nil || a.closingSessions[msg.sessionID] {
+	if sess == nil || a.closingSessions[msg.sessionID] {
 		return a, nil
 	}
 	sess.SetLifecyclePhase(agent.LifecycleComplete)
@@ -512,28 +515,34 @@ func entryThreads(entry *prCacheEntry) []github.ReviewThread {
 // setFeedbackVerdict lazily allocates the per-session triage map and sets the
 // verdict on the item with the given key. For feedbackNeutral with an empty
 // note, the entry is deleted to keep the map clean.
-func (a *App) mergePRCmd(sessionID string) tea.Cmd {
-	return a.mergePRCmdWithMode(sessionID, false)
+func (a *App) mergePRCmd(sessionID, repoPath string) tea.Cmd {
+	return a.mergePRCmdWithMode(sessionID, repoPath, false)
 }
 
-func (a *App) forceMergePRCmd(sessionID string) tea.Cmd {
-	return a.mergePRCmdWithMode(sessionID, true)
+func (a *App) forceMergePRCmd(sessionID, repoPath string) tea.Cmd {
+	return a.mergePRCmdWithMode(sessionID, repoPath, true)
 }
 
-func (a *App) mergePRCmdWithMode(sessionID string, force bool) tea.Cmd {
+func (a *App) mergePRCmdWithMode(sessionID, repoPath string, force bool) tea.Cmd {
+	if repoPath == "" {
+		repoPath = a.activeRepo
+	}
 	ghClient := a.ghClient
 	if ghClient == nil {
 		return func() tea.Msg {
-			return mergePRMsg{sessionID: sessionID, err: fmt.Errorf("GitHub client not available")}
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("GitHub client not available")}
 		}
 	}
 	entry := a.prCache[sessionID]
 	if entry == nil || entry.pr == nil {
-		return func() tea.Msg { return mergePRMsg{sessionID: sessionID, err: fmt.Errorf("no PR cached")} }
+		return func() tea.Msg {
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("no PR cached")}
+		}
 	}
-	repoPath := a.repoPathForSession(sessionID)
 	if repoPath == "" {
-		return func() tea.Msg { return mergePRMsg{sessionID: sessionID, err: fmt.Errorf("session repo not found")} }
+		return func() tea.Msg {
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("session repo not found")}
+		}
 	}
 	method := a.resolvedCache[repoPath].MergeMethod
 	switch method {
@@ -542,7 +551,7 @@ func (a *App) mergePRCmdWithMode(sessionID string, force bool) tea.Cmd {
 		method = "squash"
 	default:
 		return func() tea.Msg {
-			return mergePRMsg{sessionID: sessionID, err: fmt.Errorf("invalid merge_method %q: must be merge, squash, or rebase", method)}
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("invalid merge_method %q: must be merge, squash, or rebase", method)}
 		}
 	}
 	prNum := entry.pr.Number
@@ -551,31 +560,31 @@ func (a *App) mergePRCmdWithMode(sessionID string, force bool) tea.Cmd {
 		defer cancel()
 		rawURL, err := git.GetRemoteURL(repoPath)
 		if err != nil {
-			return mergePRMsg{sessionID: sessionID, err: err}
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: err}
 		}
 		owner, repo, err := github.ParseRemoteURL(rawURL)
 		if err != nil {
-			return mergePRMsg{sessionID: sessionID, err: err}
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: err}
 		}
 
 		fresh, err := ghClient.RefreshPR(ctx, owner, repo, prNum)
 		if err != nil {
-			return mergePRMsg{sessionID: sessionID, err: fmt.Errorf("refreshing PR state: %w", err)}
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("refreshing PR state: %w", err)}
 		}
 		if fresh == nil {
-			return mergePRMsg{sessionID: sessionID, err: fmt.Errorf("PR #%d no longer exists", prNum)}
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("PR #%d no longer exists", prNum)}
 		}
 		if fresh.State != "open" {
-			return mergePRMsg{sessionID: sessionID, err: fmt.Errorf("PR #%d is %s, cannot merge", prNum, fresh.State)}
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("PR #%d is %s, cannot merge", prNum, fresh.State)}
 		}
 		if !force && fresh.MergeableState != "clean" {
-			return mergePRMsg{sessionID: sessionID, err: fmt.Errorf("PR mergeable state is %q (was %q when gate ran); refresh and retry", fresh.MergeableState, entry.pr.MergeableState)}
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("PR mergeable state is %q (was %q when gate ran); refresh and retry", fresh.MergeableState, entry.pr.MergeableState)}
 		}
 
 		if err := ghClient.MergePR(ctx, owner, repo, prNum, method); err != nil {
-			return mergePRMsg{sessionID: sessionID, err: err}
+			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: err}
 		}
-		return mergePRMsg{sessionID: sessionID}
+		return mergePRMsg{sessionID: sessionID, repoPath: repoPath}
 	}
 }
 

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -193,11 +193,14 @@ func (a *App) setFeedbackNote(sessID, itemKey, note string) {
 // comments, and transitions the session back to LifecycleInProgress. The
 // PR stays open.
 func (a App) handleShippingFeedbackRequest(req shippingFeedbackRequestMsg) (tea.Model, tea.Cmd) {
-	sess := a.sessionByID(req.sessionID)
+	repoPath := req.repoPath
+	if repoPath == "" {
+		repoPath = a.activeRepo
+	}
+	sess := a.sessionByIDInRepo(repoPath, req.sessionID)
 	if sess == nil {
 		return a, nil
 	}
-	repoPath := a.repoPathForSession(sess.ID)
 	if repoPath == "" {
 		a.setError("no repo found for session")
 		return a, nil

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -23,7 +23,7 @@ func (a App) handleReviewDiff(msg reviewDiffMsg) (tea.Model, tea.Cmd) {
 		}
 		// If the entry has task groups, dispatch a reviewer per group.
 		if len(msg.entry.groups) > 0 {
-			repoPath := a.repoPathForSession(msg.sessionID)
+			repoPath := msg.repoPath
 			if repoPath == "" {
 				repoPath = a.activeRepo
 			}
@@ -34,7 +34,7 @@ func (a App) handleReviewDiff(msg reviewDiffMsg) (tea.Model, tea.Cmd) {
 				reviewer = mgr.ReviewerAgent()
 			}
 			if reviewer != nil {
-				sess := a.sessionByID(msg.sessionID)
+				sess := a.sessionByIDInRepo(repoPath, msg.sessionID)
 				if sess != nil {
 					for _, g := range msg.entry.groups {
 						// Mark running before dispatching so the spinner shows.
@@ -557,14 +557,9 @@ func buildReviewReworkPrompt(entry *reviewDiffEntry) string {
 // `force` is true for the `M` force-merge keybind, which bypasses the
 // readiness gate but still respects state == open (you cannot force-merge a
 // PR that's already merged or closed).
-func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
+func (a App) fetchReviewDiffCmd(sess *agent.Session, repoPath string) tea.Cmd {
 	sessID := sess.ID
 	wt := sess.Worktree
-	// Use the session's owning repo, not a.activeRepo: with cursor-based
-	// selection the targeted session can live in any registered repo. Falling
-	// back to activeRepo only when the lookup fails keeps single-repo flows
-	// working as before.
-	repoPath := a.repoPathForSession(sessID)
 	if repoPath == "" {
 		repoPath = a.activeRepo
 	}
@@ -572,7 +567,7 @@ func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
 	return func() tea.Msg {
 		files, agg, err := git.GetPerFileDiffStats(repoPath, wt)
 		if err != nil {
-			return reviewDiffMsg{sessionID: sessID, err: err}
+			return reviewDiffMsg{sessionID: sessID, repoPath: repoPath, err: err}
 		}
 		entry := &reviewDiffEntry{files: files, aggregate: agg}
 
@@ -613,7 +608,7 @@ func (a App) fetchReviewDiffCmd(sess *agent.Session) tea.Cmd {
 			}
 		}
 
-		return reviewDiffMsg{sessionID: sessID, entry: entry}
+		return reviewDiffMsg{sessionID: sessID, repoPath: repoPath, entry: entry}
 	}
 }
 

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -409,11 +409,14 @@ func fenceAsData(s string) string {
 // The reviewDiffCache entry is cleared so the next entry into review re-runs
 // the AI reviewer on the new commit history.
 func (a App) handleReviewReworkRequest(req reviewReworkRequestMsg) (tea.Model, tea.Cmd) {
-	sess := a.sessionByID(req.sessionID)
+	repoPath := req.repoPath
+	if repoPath == "" {
+		repoPath = a.activeRepo
+	}
+	sess := a.sessionByIDInRepo(repoPath, req.sessionID)
 	if sess == nil {
 		return a, nil
 	}
-	repoPath := a.repoPathForSession(sess.ID)
 	if repoPath == "" {
 		a.setError("no repo found for session")
 		return a, nil


### PR DESCRIPTION
## Summary

When multiple concurrent sessions share the same PR ID across different repositories, PR operations (merge, rework requests, status polls, creation) would route to the wrong session's repository context due to ambiguous first-match lookups in the session manager.

This PR fixes the issue by:
- Adding a `sessionByIDInRepo` helper to disambiguate sessions within a specific repository
- Pinning an immutable `repoPath` on `reviewPanelModel` and `shippingPanelModel` at construction time
- Threading `repoPath` through all message types (`reviewDiffMsg`, `reviewReworkRequestMsg`, `prPollMsg`, `prCreatedMsg`)
- Updating all message handlers to prefer the explicit `repoPath` over fallback lookups, resolving sessions via `sessionByIDInRepo`

This ensures that even when two managers share a session ID, each key handler routes to the correct repository's session.

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI: Open multiple repos concurrently and verify PR operations (merge, rework, feedback) apply to the correct repo

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]`
- [ ] New behavior has tests (multi-repo session collision scenarios covered)
- [ ] No new public API surface