### PR TITLE
fix(tui): scope session-keyed caches per-repo to fix PR/review overlap

### DIFF
--- a/changelog.d/fix-pr-repo-overlap.md
+++ b/changelog.d/fix-pr-repo-overlap.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Multi-repo PR/review/shipping data no longer overlaps across repos. Session IDs are minted per-manager (each repo's manager starts at `session-1`), so the App-level caches keyed on bare session ID were clobbering across repos — the shipping panel could show another repo's PR, review comments could appear under the wrong session, and `m`/`X` could act on the wrong row. All session-scoped caches (`prCache`, `prPollStates`, `diffStatsCache`, `reviewDiffCache`, `feedbackTriage`, `closingSessions`) and agent-scoped caches (`closingAgents`, `lastKnownStatus`) are now keyed by `cacheKey(repoPath, sessionID)` / `agentCacheKey(repoPath, agentID)`. `repoPathForSession` fails closed when a session ID is ambiguous so callers can't silently route to the wrong repo.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -61,8 +61,14 @@ const (
 // killResultMsg carries the result of an async KillAgent/KillSession call.
 // agentID is empty for session-scoped kills; the closing-set cleanup iterates
 // the manager to find stale IDs instead.
+//
+// repoPath identifies which repo owns the killed session — required because
+// session IDs collide across managers (each manager mints session-1, session-2,
+// …). Without it the closing-set cleanup would key on bare sessionID and clear
+// the wrong repo's badge.
 type killResultMsg struct {
 	scope     killScope
+	repoPath  string
 	sessionID string
 	agentID   string
 	agentIDs  []string // for session scope: all agent IDs that were in the session
@@ -79,9 +85,13 @@ func filterNotFound(err error) error {
 	return err
 }
 
-// diffStatsMsg carries the result of an async diff stats refresh.
+// diffStatsMsg carries the result of an async diff stats refresh. repoPath
+// identifies the repo that owns sessionID so the handler keys the cache by
+// (repoPath, sessionID) rather than colliding across repos with the same
+// session counter (session-1, session-2, …).
 type diffStatsMsg struct {
 	sessionID string
+	repoPath  string
 	stats     *diffSummaryData
 }
 
@@ -171,7 +181,7 @@ type App struct {
 	errTicks    int // ticks remaining to show error
 	confirmQuit bool
 
-	lastKnownStatus map[string]agent.Status
+	lastKnownStatus map[string]agent.Status // keyed by agentCacheKey(repoPath, agentID)
 	audioPlayer     *audio.Player
 
 	// wellness owns the focus-block timer, break overlay, and counters
@@ -188,13 +198,17 @@ type App struct {
 	// openConfig / openLaunch / closeModal helpers (which keep the dashboard
 	// mirror fields in sync).
 	modals          Modals
-	reviewDiffCache map[string]*reviewDiffEntry                // keyed by session ID; lifetime exceeds panel
-	feedbackTriage  map[string]map[string]*feedbackTriageEntry // keyed by sessionID → itemKey
+	reviewDiffCache map[string]*reviewDiffEntry                // keyed by cacheKey(repoPath, sessionID); lifetime exceeds panel
+	feedbackTriage  map[string]map[string]*feedbackTriageEntry // keyed by cacheKey(repoPath, sessionID) → itemKey
 	promptModal     promptModalModel                           // overlay for plan-first new-session prompt
 
 	// closingAgents and closingSessions track in-flight kill requests so the
 	// dashboard can render a "closing…" indicator while the async teardown runs.
-	// Lives in the TUI because it's purely a UI concern.
+	// Lives in the TUI because it's purely a UI concern. closingAgents is
+	// keyed by agentCacheKey(repoPath, agentID) and closingSessions by
+	// cacheKey(repoPath, sessionID); without the repo prefix, two repos
+	// with overlapping session counters (session-1 in both) would clobber
+	// each other's closing badge.
 	closingAgents   map[string]bool
 	closingSessions map[string]bool
 
@@ -203,12 +217,12 @@ type App struct {
 	lastPipelineClickSec focusSection
 	lastPipelineClickIdx int
 
-	diffStatsCache      map[string]*diffStatsEntry // keyed by session ID
+	diffStatsCache      map[string]*diffStatsEntry // keyed by cacheKey(repoPath, sessionID)
 	diffRefreshInFlight bool
 
 	ghClient         *github.Client
-	prCache          map[string]*prCacheEntry   // keyed by session ID
-	prPollStates     map[string]*prSessionState // keyed by session ID
+	prCache          map[string]*prCacheEntry   // keyed by cacheKey(repoPath, sessionID)
+	prPollStates     map[string]*prSessionState // keyed by cacheKey(repoPath, sessionID)
 	prPollsInFlight  int                        // count of concurrent in-flight polls
 	prDraftInFlight  bool                       // true while startPRDraftCmd is running; prevents double-trigger
 	prDraftSessionID string                     // ID of the session whose PR draft is in flight; "" when idle
@@ -271,8 +285,10 @@ func (a *App) openConfigForm(form *configForm, repoPath string) {
 }
 
 // openLaunchPanel sets the fullscreen agent terminal target and syncs.
-func (a *App) openLaunchPanel(sess *agent.Session, ag *agent.Agent) {
-	a.modals.OpenLaunch(sess, ag)
+// repoPath pins which repo owns sess so ctrl+t/ctrl+n/ctrl+w inside the
+// launch view route to the right manager without re-searching by ID.
+func (a *App) openLaunchPanel(sess *agent.Session, ag *agent.Agent, repoPath string) {
+	a.modals.OpenLaunch(sess, ag, repoPath)
 	a.syncModalsToDashboard()
 }
 
@@ -603,19 +619,19 @@ func (a *App) panelServices() PanelServices {
 			return a.resolvedCache[repoPath]
 		},
 		GHClient: func() *github.Client { return a.ghClient },
-		PRCache: func(sessionID string) *prCacheEntry {
-			return a.prCache[sessionID]
+		PRCache: func(repoPath, sessionID string) *prCacheEntry {
+			return a.prCache[cacheKey(repoPath, sessionID)]
 		},
-		ReviewCache: func(sessionID string) *reviewDiffEntry {
-			return a.reviewDiffCache[sessionID]
+		ReviewCache: func(repoPath, sessionID string) *reviewDiffEntry {
+			return a.reviewDiffCache[cacheKey(repoPath, sessionID)]
 		},
 		ClosePanel: func() {
 			// Drop the active overlay panel and return focus to the pipeline.
 			// Modals.Close enforces the invariant by nilling every owned model.
 			a.closeModal()
 		},
-		OpenInLaunch: func(sess *agent.Session) bool {
-			return a.openSessionInFocusLaunch(sess)
+		OpenInLaunch: func(sess *agent.Session, repoPath string) bool {
+			return a.openSessionInFocusLaunch(sess, repoPath)
 		},
 		OpenPlanEditor: func(sess *agent.Session, repoPath string) {
 			a.openPlanEditor(sess, repoPath)
@@ -634,8 +650,7 @@ func (a *App) panelServices() PanelServices {
 			a.prModalTransitionShipping = transitionShipping
 			return a.startPRDraftCmd(sess, repoPath, transitionShipping)
 		},
-		KillSessionCmd: func(sess *agent.Session) tea.Cmd {
-			repoPath := a.repoPathForSession(sess.ID)
+		KillSessionCmd: func(sess *agent.Session, repoPath string) tea.Cmd {
 			if repoPath == "" {
 				return nil
 			}
@@ -646,13 +661,14 @@ func (a *App) panelServices() PanelServices {
 			var agentIDs []string
 			for _, ag := range sess.Agents() {
 				agentIDs = append(agentIDs, ag.ID)
-				a.closingAgents[ag.ID] = true
+				a.closingAgents[agentCacheKey(repoPath, ag.ID)] = true
 			}
 			sessID := sess.ID
-			a.closingSessions[sessID] = true
+			a.closingSessions[cacheKey(repoPath, sessID)] = true
 			return func() tea.Msg {
 				return killResultMsg{
 					scope:     killScopeSession,
+					repoPath:  repoPath,
 					sessionID: sessID,
 					agentIDs:  agentIDs,
 					err:       filterNotFound(mgr.KillSession(sessID)),
@@ -661,7 +677,9 @@ func (a *App) panelServices() PanelServices {
 		},
 		FetchReviewDiff:    func(sess *agent.Session, repoPath string) tea.Cmd { return a.fetchReviewDiffCmd(sess, repoPath) },
 		prDraftInFlightFor: func(sessionID string) bool { return a.prDraftInFlight && a.prDraftSessionID == sessionID },
-		FeedbackTriage:     func(sessionID string) map[string]*feedbackTriageEntry { return a.feedbackTriage[sessionID] },
+		FeedbackTriage: func(repoPath, sessionID string) map[string]*feedbackTriageEntry {
+			return a.feedbackTriage[cacheKey(repoPath, sessionID)]
+		},
 		SetFeedbackVerdict: a.setFeedbackVerdict,
 		SetFeedbackNote:    a.setFeedbackNote,
 	}
@@ -923,12 +941,12 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 		a.openPlanEditor(sess, items[idx].repoPath)
 		return nil, true
 	case focusSectionBuilding:
-		return nil, a.openSessionInFocusLaunch(sess)
+		return nil, a.openSessionInFocusLaunch(sess, items[idx].repoPath)
 	case focusSectionReview:
 		sess.SetLifecyclePhase(agent.LifecycleInReview)
 		rp := items[idx].repoPath
 		a.openReview(newReviewPanel(sess, rp, a.width, a.height))
-		if _, ok := a.reviewDiffCache[sess.ID]; !ok {
+		if _, ok := a.reviewDiffCache[cacheKey(rp, sess.ID)]; !ok {
 			return a.fetchReviewDiffCmd(sess, rp), true
 		}
 		a.modals.Review().RefreshDiffViewport(a.panelServices())
@@ -941,10 +959,12 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 }
 
 // openSessionInFocusLaunch picks the most-active agent in sess and opens it
-// fullscreen in focusLaunch. Priority is shared with Session.PrimaryAgent via
-// agent.AgentStatusPriority. Falls back to agents[0] when all have equal
-// priority.
-func (a *App) openSessionInFocusLaunch(sess *agent.Session) bool {
+// fullscreen in focusLaunch. repoPath is required so ctrl+t / ctrl+n / ctrl+w
+// inside the launch view can route to the correct repo without falling back
+// to an ambiguous sessionID lookup. Priority is shared with
+// Session.PrimaryAgent via agent.AgentStatusPriority. Falls back to agents[0]
+// when all have equal priority.
+func (a *App) openSessionInFocusLaunch(sess *agent.Session, repoPath string) bool {
 	if sess == nil {
 		return false
 	}
@@ -960,7 +980,7 @@ func (a *App) openSessionInFocusLaunch(sess *agent.Session) bool {
 			target = ag
 		}
 	}
-	a.openLaunchPanel(sess, target)
+	a.openLaunchPanel(sess, target, repoPath)
 	a.dashboard.scrollOffset = 0
 	target.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 	return true
@@ -1150,7 +1170,7 @@ func (a *App) refreshDiffStatsCmd() tea.Cmd {
 	return func() tea.Msg {
 		fileStats, agg, err := git.GetPerFileDiffStats(repoPath, wt)
 		if err != nil {
-			return diffStatsMsg{sessionID: sessionID, stats: nil}
+			return diffStatsMsg{sessionID: sessionID, repoPath: repoPath, stats: nil}
 		}
 		// Convert git.FileStat to diffFileStat.
 		var files []diffFileStat
@@ -1164,6 +1184,7 @@ func (a *App) refreshDiffStatsCmd() tea.Cmd {
 		}
 		return diffStatsMsg{
 			sessionID: sessionID,
+			repoPath:  repoPath,
 			stats: &diffSummaryData{
 				Files: files,
 				Aggregate: diffAggregateStats{
@@ -1183,7 +1204,12 @@ func (a *App) updateDashboardDiffStats() {
 		a.dashboard.diffStats = nil
 		return
 	}
-	if entry, ok := a.diffStatsCache[sess.ID]; ok {
+	repoPath := a.dashboard.selectedRepoPath()
+	if repoPath == "" {
+		a.dashboard.diffStats = nil
+		return
+	}
+	if entry, ok := a.diffStatsCache[cacheKey(repoPath, sess.ID)]; ok {
 		a.dashboard.diffStats = entry.stats
 	} else {
 		a.dashboard.diffStats = nil
@@ -1196,11 +1222,38 @@ func (a *App) updateDashboardPRCache() {
 	a.dashboard.prPollStates = a.prPollStates
 }
 
-// repoPathForSession returns the repo path containing the given session, or "" if not found.
+// cacheKey composes a repo-scoped key for App-level per-session caches.
+// Always use this — never key a session cache by sessionID alone. Session
+// IDs are minted by a per-manager counter (session-1, session-2, …), so with
+// multiple repos configured the same ID exists in two managers and a bare-ID
+// key clobbers across repos.
+//
+// The "\x00" separator is safe because POSIX paths and session IDs never
+// contain NUL.
+func cacheKey(repoPath, sessionID string) string {
+	return repoPath + "\x00" + sessionID
+}
+
+// agentCacheKey is the per-agent equivalent of cacheKey. Agent IDs are
+// generated as {sessionID}-agent-N (see internal/agent/session.go), so they
+// inherit the same per-manager collision and need the same scoping.
+func agentCacheKey(repoPath, agentID string) string {
+	return repoPath + "\x00" + agentID
+}
+
+// repoPathForSession returns the repo path containing the given session, or
+// "" if not found. Fails closed (returns "") when more than one repo claims
+// the same session ID, so callers don't silently route to the wrong repo.
+//
+// Prefer passing repoPath explicitly through messages and panel state. This
+// helper exists as a fallback for the few message paths (notably the plan
+// editor) where the editor model already holds repoPath but a fallback is
+// useful when that model has been torn down mid-flight.
 func (a *App) repoPathForSession(sessionID string) string {
 	if a.cfg == nil {
 		return ""
 	}
+	var found string
 	for _, repo := range a.cfg.Repos {
 		mgr := a.managers[repo.Path]
 		if mgr == nil {
@@ -1208,43 +1261,22 @@ func (a *App) repoPathForSession(sessionID string) string {
 		}
 		for _, sess := range mgr.ListSessions() {
 			if sess.ID == sessionID {
-				return repo.Path
+				if found != "" {
+					// Ambiguous: same session ID exists in multiple repos.
+					// Fail closed rather than guess.
+					return ""
+				}
+				found = repo.Path
 			}
 		}
 	}
-	return ""
-}
-
-// reviewTaskGroupAtCursor returns the taskReviewGroup at position cursor in the
-// review task list, following the same row ordering as renderTaskListPane: plan
-// tasks in index order, then the "Other changes" group (taskIndex == 0) last.
-// Returns nil if cursor is out of range or no groups exist.
-//
-// sessionByID returns the first session with the given ID across all repos.
-// It is ambiguous when the same session ID exists in multiple repos — use
-// sessionByIDInRepo instead when the repo is known.
-func (a *App) sessionByID(sessionID string) *agent.Session {
-	if a.cfg == nil {
-		return nil
-	}
-	for _, repo := range a.cfg.Repos {
-		mgr := a.managers[repo.Path]
-		if mgr == nil {
-			continue
-		}
-		for _, sess := range mgr.ListSessions() {
-			if sess.ID == sessionID {
-				return sess
-			}
-		}
-	}
-	return nil
+	return found
 }
 
 // sessionByIDInRepo returns the session with the given ID from the manager at
 // repoPath. Returns nil when the manager is not found or the session does not
-// exist. Unlike sessionByID, this is unambiguous when session IDs collide
-// across repos.
+// exist. This is the unambiguous lookup; callers must thread repoPath through
+// from a message, panel, or dashboard listItem rather than searching by ID.
 func (a *App) sessionByIDInRepo(repoPath, sessionID string) *agent.Session {
 	mgr := a.managers[repoPath]
 	if mgr == nil {
@@ -1258,27 +1290,49 @@ func (a *App) sessionByIDInRepo(repoPath, sessionID string) *agent.Session {
 	return nil
 }
 
-// cleanStaleCaches removes diff stats and PR cache entries for sessions that no longer exist.
+// cleanStaleCaches removes diff stats and PR cache entries for sessions that no
+// longer exist. Keys are composed via cacheKey(repoPath, sessionID), so the
+// active set must be built the same way — iterating the managers map gives both
+// repoPath and the session list together.
 func (a *App) cleanStaleCaches() {
 	activeSessions := make(map[string]bool)
-	for _, mgr := range a.managers {
+	activeAgents := make(map[string]bool)
+	for repoPath, mgr := range a.managers {
 		for _, sess := range mgr.ListSessions() {
-			activeSessions[sess.ID] = true
+			activeSessions[cacheKey(repoPath, sess.ID)] = true
+			for _, ag := range sess.Agents() {
+				activeAgents[agentCacheKey(repoPath, ag.ID)] = true
+			}
 		}
 	}
-	for id := range a.diffStatsCache {
-		if !activeSessions[id] {
-			delete(a.diffStatsCache, id)
+	for k := range a.diffStatsCache {
+		if !activeSessions[k] {
+			delete(a.diffStatsCache, k)
 		}
 	}
-	for id := range a.prCache {
-		if !activeSessions[id] {
-			delete(a.prCache, id)
+	for k := range a.prCache {
+		if !activeSessions[k] {
+			delete(a.prCache, k)
 		}
 	}
-	for id := range a.prPollStates {
-		if !activeSessions[id] {
-			delete(a.prPollStates, id)
+	for k := range a.prPollStates {
+		if !activeSessions[k] {
+			delete(a.prPollStates, k)
+		}
+	}
+	for k := range a.reviewDiffCache {
+		if !activeSessions[k] {
+			delete(a.reviewDiffCache, k)
+		}
+	}
+	for k := range a.feedbackTriage {
+		if !activeSessions[k] {
+			delete(a.feedbackTriage, k)
+		}
+	}
+	for k := range a.lastKnownStatus {
+		if !activeAgents[k] {
+			delete(a.lastKnownStatus, k)
 		}
 	}
 }
@@ -1445,8 +1499,11 @@ type reviewDiffMsg struct {
 }
 
 // reviewVerdictMsg carries the result of a single per-task reviewer subprocess.
+// repoPath identifies the repo that owns sessionID so the handler keys the
+// cache by (repoPath, sessionID) and never reads a colliding repo's entry.
 type reviewVerdictMsg struct {
 	sessionID string
+	repoPath  string
 	taskIndex int
 	verdict   agent.ReviewVerdict
 	err       error

--- a/internal/tui/app_keys_test.go
+++ b/internal/tui/app_keys_test.go
@@ -210,9 +210,9 @@ func TestPipeline_UnknownKey_NoOp(t *testing.T) {
 // Tests using this fixture do not spawn a real claude subprocess.
 func appInFocusLaunch(t *testing.T) (App, *agent.Session, *agent.Agent) {
 	t.Helper()
-	app, sess, _ := appWithSeededSession(t, agent.LifecycleInProgress)
+	app, sess, repoPath := appWithSeededSession(t, agent.LifecycleInProgress)
 	ag := sess.AddTestAgent("primary", false, agent.StatusIdle)
-	app.openLaunchPanel(sess, ag)
+	app.openLaunchPanel(sess, ag, repoPath)
 	return app, sess, ag
 }
 
@@ -224,7 +224,7 @@ func TestFocusLaunch_NilAgent_RoutesBackToList(t *testing.T) {
 	// Force panelFocus into focusLaunch with no agent by reaching into Modals
 	// directly — production code can't construct this state, but the guard at
 	// the top of updateFocusLaunchKeys must still handle it.
-	app.modals.OpenLaunch(nil, nil)
+	app.modals.OpenLaunch(nil, nil, "")
 	app.syncModalsToDashboard()
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -677,7 +677,7 @@ func TestMouseWheelForwardsInAltScreen(t *testing.T) {
 	app.dashboard.items = []listItem{
 		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
 	}
-	app.openLaunchPanel(sess, ag)
+	app.openLaunchPanel(sess, ag, dir)
 
 	// Set a non-zero offset so we can tell the wheel branch didn't mutate it.
 	app.dashboard.scrollOffset = 5
@@ -844,12 +844,13 @@ func TestKillAgentAsyncMarksClosing(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("Expected non-nil cmd from 'x' (async kill), got nil")
 	}
-	if !app.closingAgents[ag.ID] {
-		t.Fatalf("Expected closingAgents[%s]=true, got %v", ag.ID, app.closingAgents)
+	agentKey := agentCacheKey(dir, ag.ID)
+	if !app.closingAgents[agentKey] {
+		t.Fatalf("Expected closingAgents[%s]=true, got %v", agentKey, app.closingAgents)
 	}
 	// Dashboard should see the closing flag too.
-	if !app.dashboard.closingAgents[ag.ID] {
-		t.Fatalf("Expected dashboard.closingAgents[%s]=true", ag.ID)
+	if !app.dashboard.closingAgents[agentKey] {
+		t.Fatalf("Expected dashboard.closingAgents[%s]=true", agentKey)
 	}
 	// The manager still has the agent because the goroutine hasn't run yet.
 	if mgr.Get(ag.ID) == nil {
@@ -897,38 +898,44 @@ func TestKillResultMsgClearsClosingSet(t *testing.T) {
 	app.dashboard.width = 120
 	app.dashboard.height = 39
 
+	const repo = "/repo"
+	sessKey := cacheKey(repo, "sess-1")
+	agentAKey := agentCacheKey(repo, "agent-a")
+	agentBKey := agentCacheKey(repo, "agent-b")
+
 	// Pre-populate closing sets and diff cache as if 'X' had dispatched.
-	app.closingSessions["sess-1"] = true
-	app.closingAgents["agent-a"] = true
-	app.closingAgents["agent-b"] = true
-	app.lastKnownStatus["agent-a"] = agent.StatusActive
-	app.lastKnownStatus["agent-b"] = agent.StatusActive
-	app.diffStatsCache["sess-1"] = &diffStatsEntry{}
+	app.closingSessions[sessKey] = true
+	app.closingAgents[agentAKey] = true
+	app.closingAgents[agentBKey] = true
+	app.lastKnownStatus[agentAKey] = agent.StatusActive
+	app.lastKnownStatus[agentBKey] = agent.StatusActive
+	app.diffStatsCache[sessKey] = &diffStatsEntry{}
 
 	model, _ := app.Update(killResultMsg{
 		scope:     killScopeSession,
+		repoPath:  repo,
 		sessionID: "sess-1",
 		agentIDs:  []string{"agent-a", "agent-b"},
 	})
 	app = model.(App)
 
-	if app.closingSessions["sess-1"] {
+	if app.closingSessions[sessKey] {
 		t.Fatal("Expected closingSessions[sess-1] cleared")
 	}
-	if app.closingAgents["agent-a"] || app.closingAgents["agent-b"] {
+	if app.closingAgents[agentAKey] || app.closingAgents[agentBKey] {
 		t.Fatal("Expected closingAgents cleared for both agents")
 	}
-	if _, ok := app.diffStatsCache["sess-1"]; ok {
+	if _, ok := app.diffStatsCache[sessKey]; ok {
 		t.Fatal("Expected diffStatsCache[sess-1] removed")
 	}
-	if _, ok := app.lastKnownStatus["agent-a"]; ok {
+	if _, ok := app.lastKnownStatus[agentAKey]; ok {
 		t.Fatal("Expected lastKnownStatus cleared for agent-a")
 	}
 	// Dashboard should also see the cleared maps (refreshAgentList was called).
 	if app.dashboard.closingSessions == nil {
 		t.Fatal("Expected dashboard.closingSessions wired up after refresh")
 	}
-	if app.dashboard.closingSessions["sess-1"] {
+	if app.dashboard.closingSessions[sessKey] {
 		t.Fatal("Expected dashboard.closingSessions[sess-1] cleared after refresh")
 	}
 }
@@ -943,17 +950,20 @@ func TestKillResultMsgClearsClosingSetOnError(t *testing.T) {
 	app.dashboard.width = 120
 	app.dashboard.height = 39
 
-	app.closingAgents["agent-x"] = true
+	const repo = "/repo"
+	agentKey := agentCacheKey(repo, "agent-x")
+	app.closingAgents[agentKey] = true
 
 	model, _ := app.Update(killResultMsg{
 		scope:     killScopeAgent,
+		repoPath:  repo,
 		sessionID: "sess-1",
 		agentID:   "agent-x",
 		err:       errors.New("kill failed"),
 	})
 	app = model.(App)
 
-	if app.closingAgents["agent-x"] {
+	if app.closingAgents[agentKey] {
 		t.Fatal("Expected closingAgents[agent-x] cleared even on error")
 	}
 	if app.err != "kill failed" {
@@ -1743,7 +1753,7 @@ func TestFocusLaunch_FocusModeKeysForwardToAgent(t *testing.T) {
 		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
 		{kind: listItemSession, repoPath: dir, session: sessR},
 	}
-	app.openLaunchPanel(sess, ag)
+	app.openLaunchPanel(sess, ag, dir)
 
 	for _, ch := range []rune{'m', 'r'} {
 		model, _ := app.Update(tea.KeyPressMsg{Code: ch, Text: string(ch)})
@@ -2579,8 +2589,9 @@ func TestPipelinePRClickResetsDoubleClick(t *testing.T) {
 		{kind: listItemSession, repoPath: "/r", session: sessR},
 	}
 	// Seed a PR cache entry so the indicator shows up and the early-return path is reachable.
+	sessKey := cacheKey("/r", sessR.ID)
 	app.prCache = map[string]*prCacheEntry{
-		sessR.ID: {pr: &github.PRState{Number: 42, URL: ""}},
+		sessKey: {pr: &github.PRState{Number: 42, URL: ""}},
 	}
 
 	// First click on the right edge of the review row triggers the PR
@@ -2593,7 +2604,7 @@ func TestPipelinePRClickResetsDoubleClick(t *testing.T) {
 	if !app.lastPipelineClick.IsZero() {
 		// Empty URL skipped the early return — set a URL and try again so
 		// the test exercises the path we actually care about.
-		app.prCache[sessR.ID].pr.URL = "https://example/pr/42"
+		app.prCache[sessKey].pr.URL = "https://example/pr/42"
 		app.dashboard.prCache = app.prCache
 		model, _ = app.Update(prClick)
 		app = model.(App)
@@ -2718,7 +2729,6 @@ func TestSessionByIDInRepo_DisambiguatesAcrossRepos(t *testing.T) {
 	}
 
 	app := NewApp()
-	// repoA is listed first so sessionByID (first-match) returns repoA's session.
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: repoA}, {Path: repoB}}}
 	app.managers[repoA] = mgrA
 	app.managers[repoB] = mgrB
@@ -2742,10 +2752,11 @@ func TestSessionByIDInRepo_DisambiguatesAcrossRepos(t *testing.T) {
 		t.Errorf("sessionByIDInRepo(repoB) returned wrong session: got %p, want %p", gotB, sessB)
 	}
 
-	// Legacy sessionByID returns repoA's session (first-match).
-	firstMatch := app.sessionByID("session-1")
-	if firstMatch != sessA {
-		t.Errorf("sessionByID returned %p, want repoA's sessA %p (first-match behaviour)", firstMatch, sessA)
+	// repoPathForSession fails closed when the same ID lives in two repos.
+	// Pre-fix behaviour returned the first repo's path, which is the bug we
+	// are fixing — guard against regression.
+	if got := app.repoPathForSession("session-1"); got != "" {
+		t.Errorf("repoPathForSession returned %q for ambiguous session-1, want \"\" (fail-closed)", got)
 	}
 
 	// Unknown repo returns nil.
@@ -3046,7 +3057,7 @@ func TestTick_BreakDoesNotEnterWhilePanelOpen(t *testing.T) {
 			// guard reads modals.IsList(); the specific model doesn't matter.
 			switch tc.focus {
 			case focusLaunch:
-				app.modals.OpenLaunch(nil, nil)
+				app.modals.OpenLaunch(nil, nil, "")
 			case focusReview:
 				app.modals.OpenReview(&reviewPanelModel{})
 			case focusShipping:
@@ -4629,10 +4640,11 @@ func TestShippingPanel_CursorAndScrollKeys(t *testing.T) {
 	sess := agent.NewSessionForTest("ship-cs", "ship")
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
+	const repo = "/repo"
+	app.openShipping(newShippingPanel(sess, repo, app.width, app.height))
 	app.width = 120
 	app.height = 40
-	app.prCache[sess.ID] = &prCacheEntry{
+	app.prCache[cacheKey(repo, sess.ID)] = &prCacheEntry{
 		pr: &github.PRState{Number: 1, MergeableState: "clean"},
 		threads: []github.ReviewThread{
 			{Reviewer: "alice", State: "CHANGES_REQUESTED", Body: "fix a"},
@@ -4692,11 +4704,13 @@ func TestShippingPanel_VerdictKeys(t *testing.T) {
 	sess := agent.NewSessionForTest("ship-v", "ship")
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
+	const repo = "/repo"
+	app.openShipping(newShippingPanel(sess, repo, app.width, app.height))
 	app.width = 120
 	app.height = 40
+	sessKey := cacheKey(repo, sess.ID)
 	// One inline comment with ID=42.
-	app.prCache[sess.ID] = &prCacheEntry{
+	app.prCache[sessKey] = &prCacheEntry{
 		pr: &github.PRState{Number: 2, MergeableState: "clean"},
 		threads: []github.ReviewThread{
 			{
@@ -4713,21 +4727,21 @@ func TestShippingPanel_VerdictKeys(t *testing.T) {
 	// Press 'a' — approve.
 	m, _ := app.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
 	got := m.(App)
-	if e := got.feedbackTriage[sess.ID]["comment:42"]; e == nil || e.Verdict != feedbackApproved {
+	if e := got.feedbackTriage[sessKey]["comment:42"]; e == nil || e.Verdict != feedbackApproved {
 		t.Errorf("after a: want feedbackApproved, got %+v", e)
 	}
 
 	// Press 'x' — disagree.
 	m, _ = got.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
 	got = m.(App)
-	if e := got.feedbackTriage[sess.ID]["comment:42"]; e == nil || e.Verdict != feedbackDisagreed {
+	if e := got.feedbackTriage[sessKey]["comment:42"]; e == nil || e.Verdict != feedbackDisagreed {
 		t.Errorf("after x: want feedbackDisagreed, got %+v", e)
 	}
 
 	// Press 'u' — neutral (should remove the entry since no note).
 	m, _ = got.Update(tea.KeyPressMsg{Code: 'u', Text: "u"})
 	got = m.(App)
-	if e := got.feedbackTriage[sess.ID]["comment:42"]; e != nil {
+	if e := got.feedbackTriage[sessKey]["comment:42"]; e != nil {
 		t.Errorf("after u: expected entry removed (neutral+empty note), got %+v", e)
 	}
 }
@@ -4749,14 +4763,15 @@ func TestAddressFeedback_ClearsTriage(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.prCache[sess.ID] = &prCacheEntry{
+	sessKey := cacheKey(dir, sess.ID)
+	app.prCache[sessKey] = &prCacheEntry{
 		pr: &github.PRState{Number: 5, MergeableState: "clean"},
 		threads: []github.ReviewThread{
 			{Reviewer: "alice", State: "CHANGES_REQUESTED", Body: "fix it"},
 		},
 	}
 	// Seed triage.
-	app.feedbackTriage[sess.ID] = map[string]*feedbackTriageEntry{
+	app.feedbackTriage[sessKey] = map[string]*feedbackTriageEntry{
 		"thread:alice": {Verdict: feedbackDisagreed, Note: "n/a"},
 	}
 
@@ -4772,8 +4787,8 @@ func TestAddressFeedback_ClearsTriage(t *testing.T) {
 		}
 	}
 
-	if m := gotApp.feedbackTriage[sess.ID]; len(m) != 0 {
-		t.Errorf("expected feedbackTriage[%s] cleared after r, got: %v", sess.ID, m)
+	if m := gotApp.feedbackTriage[sessKey]; len(m) != 0 {
+		t.Errorf("expected feedbackTriage[%s] cleared after r, got: %v", sessKey, m)
 	}
 }
 
@@ -4808,7 +4823,7 @@ func TestAddressFeedback_RefusesOnMergedPR(t *testing.T) {
 			app.height = 40
 			app.dashboard.width = 120
 			app.dashboard.height = 39
-			app.prCache[sess.ID] = &prCacheEntry{
+			app.prCache[cacheKey(dir, sess.ID)] = &prCacheEntry{
 				pr: &github.PRState{Number: 5, State: tc.state},
 				threads: []github.ReviewThread{
 					{Reviewer: "alice", State: "CHANGES_REQUESTED", Body: "fix it"},
@@ -4870,7 +4885,7 @@ func TestReviewPanel_EnterDoesNotChangeView(t *testing.T) {
 	app.width = 120
 	app.height = 40
 	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
-	app.reviewDiffCache[sessR.ID] = entry
+	app.reviewDiffCache[cacheKey("", sessR.ID)] = entry
 
 	for _, key := range []string{"enter", "space"} {
 		msg := tea.KeyPressMsg{Code: tea.KeyEnter, Text: key}
@@ -4923,7 +4938,7 @@ func TestReviewPanel_ScrollBindingsAdvanceViewport(t *testing.T) {
 	app.width = 120
 	app.height = 40
 	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
-	app.reviewDiffCache[sessR.ID] = entry
+	app.reviewDiffCache[cacheKey("", sessR.ID)] = entry
 	// Load diff content and set viewport dimensions before sending scroll keys.
 	app.modals.Review().RefreshDiffViewport(app.panelServices())
 
@@ -5229,13 +5244,13 @@ func TestPollAllSessions_PassesCachedPRNumberForShippingOnly(t *testing.T) {
 	app := NewApp()
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
-	app.prCache[shipping.ID] = &prCacheEntry{pr: &github.PRState{Number: 42}}
-	app.prCache[building.ID] = &prCacheEntry{pr: &github.PRState{Number: 99}}
+	app.prCache[cacheKey(dir, shipping.ID)] = &prCacheEntry{pr: &github.PRState{Number: 42}}
+	app.prCache[cacheKey(dir, building.ID)] = &prCacheEntry{pr: &github.PRState{Number: 99}}
 
-	if got := app.cachedPRNumberForFallback(shipping); got != 42 {
+	if got := app.cachedPRNumberForFallback(dir, shipping); got != 42 {
 		t.Errorf("Shipping session: got %d, want 42", got)
 	}
-	if got := app.cachedPRNumberForFallback(building); got != 0 {
+	if got := app.cachedPRNumberForFallback(dir, building); got != 0 {
 		t.Errorf("InProgress session: got %d, want 0", got)
 	}
 }
@@ -5324,4 +5339,163 @@ func TestApp_PlanEditorRetryMsg_CallsStartDraftWithOriginalPrompt(t *testing.T) 
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Error("stub drafter was not called within 2s of planEditorRetryMsg dispatch")
+}
+
+// --- Multi-repo cache-collision regression tests --------------------------
+//
+// Session IDs are minted by a per-manager counter, so two repos can each have
+// a session-1. All App-level per-session caches must therefore be keyed by
+// (repoPath, sessionID); these tests pin that contract so a future regression
+// to bare-ID keys fails loud.
+
+// TestPRCache_PerRepo_NoCollision verifies that two managers with overlapping
+// session IDs (session-1 in each) write to distinct prCache entries.
+func TestPRCache_PerRepo_NoCollision(t *testing.T) {
+	const repoA, repoB = "/repo/a", "/repo/b"
+	app := NewApp()
+
+	keyA := cacheKey(repoA, "session-1")
+	keyB := cacheKey(repoB, "session-1")
+	app.prCache[keyA] = &prCacheEntry{pr: &github.PRState{Number: 100, State: "open"}}
+	app.prCache[keyB] = &prCacheEntry{pr: &github.PRState{Number: 200, State: "merged"}}
+
+	if got := app.prCache[keyA]; got == nil || got.pr.Number != 100 {
+		t.Errorf("repoA's session-1 cache clobbered: got %+v, want PR #100", got)
+	}
+	if got := app.prCache[keyB]; got == nil || got.pr.Number != 200 {
+		t.Errorf("repoB's session-1 cache clobbered: got %+v, want PR #200", got)
+	}
+}
+
+// TestHandlePRPoll_DoesNotClobberAcrossRepos drives two prPollMsg through
+// handlePRPoll back-to-back with the same sessionID but different repoPath
+// and verifies that each repo's cache lands in its own slot.
+func TestHandlePRPoll_DoesNotClobberAcrossRepos(t *testing.T) {
+	const repoA, repoB = "/repo/a", "/repo/b"
+	sessA := agent.NewSessionForTest("session-1", "branch-a")
+	sessA.SetLifecyclePhase(agent.LifecycleShipping)
+	sessB := agent.NewSessionForTest("session-1", "branch-b")
+	sessB.SetLifecyclePhase(agent.LifecycleShipping)
+
+	mgrA := agent.NewManager(repoA, config.Resolve(nil, nil))
+	defer mgrA.Shutdown()
+	mgrB := agent.NewManager(repoB, config.Resolve(nil, nil))
+	defer mgrB.Shutdown()
+	mgrA.AddSessionForTest(sessA)
+	mgrB.AddSessionForTest(sessB)
+
+	app := NewApp()
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: repoA}, {Path: repoB}}}
+	app.managers[repoA] = mgrA
+	app.managers[repoB] = mgrB
+	keyA := cacheKey(repoA, "session-1")
+	keyB := cacheKey(repoB, "session-1")
+	app.prPollStates[keyA] = &prSessionState{inFlight: true}
+	app.prPollStates[keyB] = &prSessionState{inFlight: true}
+	app.prPollsInFlight = 2
+
+	model, _ := app.Update(prPollMsg{
+		sessionID: "session-1",
+		repoPath:  repoA,
+		pr:        &github.PRState{Number: 100, State: "open", MergeableState: "clean"},
+	})
+	app = model.(App)
+	app.prPollsInFlight = 1
+	app.prPollStates[keyB].inFlight = true
+	model, _ = app.Update(prPollMsg{
+		sessionID: "session-1",
+		repoPath:  repoB,
+		pr:        &github.PRState{Number: 200, State: "open", MergeableState: "clean"},
+	})
+	app = model.(App)
+
+	if got := app.prCache[keyA]; got == nil || got.pr.Number != 100 {
+		t.Errorf("repoA's cache was clobbered by repoB's poll: got %+v, want PR #100", got)
+	}
+	if got := app.prCache[keyB]; got == nil || got.pr.Number != 200 {
+		t.Errorf("repoB's cache missing/wrong: got %+v, want PR #200", got)
+	}
+}
+
+// TestClosingSessions_PerRepo verifies that pressing X on repoB's session-1
+// does not flip the "closing…" badge for repoA's session-1.
+func TestClosingSessions_PerRepo(t *testing.T) {
+	const repoA, repoB = "/repo/a", "/repo/b"
+	keyA := cacheKey(repoA, "session-1")
+	keyB := cacheKey(repoB, "session-1")
+
+	app := NewApp()
+	app.closingSessions[keyB] = true
+
+	if app.closingSessions[keyA] {
+		t.Error("repoA's session-1 should NOT be marked closing when only repoB's was set")
+	}
+	if !app.closingSessions[keyB] {
+		t.Error("repoB's session-1 should be marked closing")
+	}
+}
+
+// TestLastKnownStatus_PerRepo verifies that emitting a status event for
+// {repoA, session-1-agent-1} does not overwrite repoB's same-named agent's
+// entry.
+func TestLastKnownStatus_PerRepo(t *testing.T) {
+	const repoA, repoB = "/repo/a", "/repo/b"
+	keyA := agentCacheKey(repoA, "session-1-agent-1")
+	keyB := agentCacheKey(repoB, "session-1-agent-1")
+
+	app := NewApp()
+	app.lastKnownStatus[keyA] = agent.StatusActive
+	app.lastKnownStatus[keyB] = agent.StatusIdle
+
+	app.Update(agentEventMsg{
+		repoPath: repoA,
+		event: agent.Event{
+			Type:    agent.EventStatusChanged,
+			AgentID: "session-1-agent-1",
+			Status:  agent.StatusDone,
+		},
+	})
+
+	if got := app.lastKnownStatus[keyA]; got != agent.StatusDone {
+		t.Errorf("repoA's agent status: got %v, want StatusDone", got)
+	}
+	if got := app.lastKnownStatus[keyB]; got != agent.StatusIdle {
+		t.Errorf("repoB's agent status was clobbered: got %v, want StatusIdle", got)
+	}
+}
+
+// TestCleanStaleCaches_ScopesByRepo verifies that when repoB's session-1 is
+// killed but repoA's session-1 is alive, the cleanup retains repoA's entries
+// and evicts only repoB's. This is the live-data view of the bug — a single
+// cleanup pass must not blow away both repos because the IDs match.
+func TestCleanStaleCaches_ScopesByRepo(t *testing.T) {
+	const repoA, repoB = "/repo/a", "/repo/b"
+
+	sessA := agent.NewSessionForTest("session-1", "branch-a")
+	mgrA := agent.NewManager(repoA, config.Resolve(nil, nil))
+	defer mgrA.Shutdown()
+	mgrA.AddSessionForTest(sessA)
+
+	// repoB has no live sessions — its session-1 is "dead".
+	mgrB := agent.NewManager(repoB, config.Resolve(nil, nil))
+	defer mgrB.Shutdown()
+
+	app := NewApp()
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: repoA}, {Path: repoB}}}
+	app.managers[repoA] = mgrA
+	app.managers[repoB] = mgrB
+
+	keyA := cacheKey(repoA, "session-1")
+	keyB := cacheKey(repoB, "session-1")
+	app.prCache[keyA] = &prCacheEntry{pr: &github.PRState{Number: 100}}
+	app.prCache[keyB] = &prCacheEntry{pr: &github.PRState{Number: 200}}
+
+	app.cleanStaleCaches()
+
+	if got := app.prCache[keyA]; got == nil {
+		t.Error("repoA's live cache entry was evicted (it should survive)")
+	}
+	if _, had := app.prCache[keyB]; had {
+		t.Error("repoB's dead cache entry survived cleanup (it should be evicted)")
+	}
 }

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -98,10 +98,10 @@ type dashboardModel struct {
 	panelFocus      panelFocus
 	scrollOffset    int
 	diffStats       *diffSummaryData           // nil when no session selected or no data
-	prCache         map[string]*prCacheEntry   // keyed by session ID, passed from App
-	prPollStates    map[string]*prSessionState // keyed by session ID, passed from App
-	closingAgents   map[string]bool            // keyed by agent ID, passed from App
-	closingSessions map[string]bool            // keyed by session ID, passed from App
+	prCache         map[string]*prCacheEntry   // keyed by cacheKey(repoPath, sessionID), passed from App
+	prPollStates    map[string]*prSessionState // keyed by cacheKey(repoPath, sessionID), passed from App
+	closingAgents   map[string]bool            // keyed by agentCacheKey(repoPath, agentID), passed from App
+	closingSessions map[string]bool            // keyed by cacheKey(repoPath, sessionID), passed from App
 
 	// Pipeline / wellness state, synced from App on every refresh.
 	sessionElapsed         time.Duration
@@ -159,10 +159,11 @@ func (d *dashboardModel) advanceTickers(now time.Time) {
 		sess := item.session
 		displayName := sess.GetDisplayName()
 
-		closing := d.closingSessions != nil && d.closingSessions[sess.ID]
+		sessKey := cacheKey(item.repoPath, sess.ID)
+		closing := d.closingSessions != nil && d.closingSessions[sessKey]
 		prSuffixLen := 0
 		if !closing {
-			if entry := d.prCache[sess.ID]; entry != nil && entry.pr != nil {
+			if entry := d.prCache[sessKey]; entry != nil && entry.pr != nil {
 				prSuffixLen = 1 + prIndicatorWidth(entry) // 1 for leading space
 			}
 		}
@@ -1636,7 +1637,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, StyleSubtle.Render("REVIEWING"))
 		for i, item := range reviewSessions {
 			selected := d.cursor.Section() == focusSectionReview && i == d.cursor.Index(focusSectionReview)
-			row := d.renderQueueRow(item.session, item.repoName, selected, ColorWarning, width)
+			row := d.renderQueueRow(item.session, item.repoName, item.repoPath, selected, ColorWarning, width)
 			lines = append(lines, row...)
 			if i < len(reviewSessions)-1 {
 				lines = append(lines, "")
@@ -1650,7 +1651,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, StyleSubtle.Render("SHIPPING"))
 		for i, item := range shippingItems {
 			selected := d.cursor.Section() == focusSectionShipping && i == d.cursor.Index(focusSectionShipping)
-			row := d.renderQueueRow(item.session, item.repoName, selected, lipgloss.Color("#5ab58a"), width)
+			row := d.renderQueueRow(item.session, item.repoName, item.repoPath, selected, lipgloss.Color("#5ab58a"), width)
 			lines = append(lines, row...)
 			if i < len(shippingItems)-1 {
 				lines = append(lines, "")
@@ -1666,7 +1667,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 // accent for the cursor stripe and prefix when selected (warning for review,
 // success for shipping). Used by both the REVIEWING and SHIPPING sections so
 // they share layout/age/prIndicator handling.
-func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName string, selected bool, selectedColor lipgloss.Color, width int) []string {
+func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName, repoPath string, selected bool, selectedColor lipgloss.Color, width int) []string {
 	name := sess.GetDisplayName()
 	age := ""
 	if !sess.DoneAt().IsZero() {
@@ -1696,7 +1697,7 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName string, sel
 	}
 	line1 := prefix + nameRendered
 	prIndSet := false
-	if prEntry := d.prCache[sess.ID]; prEntry != nil {
+	if prEntry := d.prCache[cacheKey(repoPath, sess.ID)]; prEntry != nil {
 		if prInd := prIndicator(prEntry); prInd != "" {
 			line1 = rightAlign(prefix+nameRendered, prInd, width)
 			prIndSet = true

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -713,7 +713,7 @@ func TestRenderQueueRow_PRDraftBadge(t *testing.T) {
 
 	// With prDraftSessionID matching the session: badge should appear.
 	d := dashboardModel{prDraftSessionID: sess.ID}
-	rows := d.renderQueueRow(sess, "", false, ColorWarning, 80)
+	rows := d.renderQueueRow(sess, "", "", false, ColorWarning, 80)
 	if len(rows) < 2 {
 		t.Fatalf("renderQueueRow returned %d lines, want 2", len(rows))
 	}
@@ -723,7 +723,7 @@ func TestRenderQueueRow_PRDraftBadge(t *testing.T) {
 
 	// With prDraftSessionID cleared: normal prompt should appear.
 	d.prDraftSessionID = ""
-	rows = d.renderQueueRow(sess, "", false, ColorWarning, 80)
+	rows = d.renderQueueRow(sess, "", "", false, ColorWarning, 80)
 	if strings.Contains(ansi.Strip(rows[1]), "drafting PR") {
 		t.Error("cleared state must not show badge; got 'drafting PR' on line 2")
 	}

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -375,7 +375,7 @@ func TestRenderQueueRow_RepoPrefix(t *testing.T) {
 		{kind: listItemSession, repoPath: "/a", repoName: "repoA", session: sess},
 	}
 
-	row := d.renderQueueRow(sess, "repoA", false, ColorWarning, 120)
+	row := d.renderQueueRow(sess, "repoA", "", false, ColorWarning, 120)
 	if len(row) == 0 {
 		t.Fatalf("expected at least one rendered line")
 	}
@@ -393,7 +393,7 @@ func TestRenderQueueRow_RepoPrefix(t *testing.T) {
 		}
 	}
 
-	bare := d.renderQueueRow(sess, "", false, ColorWarning, 120)
+	bare := d.renderQueueRow(sess, "", "", false, ColorWarning, 120)
 	if strings.Contains(ansi.Strip(bare[0]), "›") {
 		t.Errorf("empty repoName should not emit › separator, got %q", ansi.Strip(bare[0]))
 	}

--- a/internal/tui/manager_iface_test.go
+++ b/internal/tui/manager_iface_test.go
@@ -42,7 +42,7 @@ func TestSessionManager_FakeDrivesKillSession(t *testing.T) {
 	if svc.KillSessionCmd == nil {
 		t.Fatal("KillSessionCmd should be wired by panelServices")
 	}
-	cmd := svc.KillSessionCmd(sess)
+	cmd := svc.KillSessionCmd(sess, repo)
 	if cmd == nil {
 		t.Fatal("KillSessionCmd returned nil for a known session")
 	}

--- a/internal/tui/modals.go
+++ b/internal/tui/modals.go
@@ -21,6 +21,11 @@ type Modals struct {
 	configRepo  string
 	launchAgent *agent.Agent
 	launchSess  *agent.Session
+	// launchRepoPath is the repo that owns launchSess. Stored so the
+	// focusLaunch key handlers (ctrl+t shell, ctrl+n agent, ctrl+w kill)
+	// route to the right manager without a first-match session lookup, which
+	// is wrong when session IDs collide across repos.
+	launchRepoPath string
 }
 
 // Current returns the active panel focus.
@@ -43,6 +48,7 @@ func (m *Modals) Close() {
 	m.configRepo = ""
 	m.launchAgent = nil
 	m.launchSess = nil
+	m.launchRepoPath = ""
 }
 
 // OpenReview opens the review panel. Closes any prior modal first.
@@ -74,12 +80,16 @@ func (m *Modals) OpenConfig(form *configForm, repoPath string) {
 	m.configRepo = repoPath
 }
 
-// OpenLaunch opens the fullscreen agent terminal focused on ag (owned by sess).
-func (m *Modals) OpenLaunch(sess *agent.Session, ag *agent.Agent) {
+// OpenLaunch opens the fullscreen agent terminal focused on ag (owned by sess
+// in the repo at repoPath). repoPath is required so the focusLaunch key
+// handlers (ctrl+t / ctrl+n / ctrl+w) can route to the right manager when
+// session IDs collide across repos.
+func (m *Modals) OpenLaunch(sess *agent.Session, ag *agent.Agent, repoPath string) {
 	m.Close()
 	m.current = focusLaunch
 	m.launchSess = sess
 	m.launchAgent = ag
+	m.launchRepoPath = repoPath
 }
 
 // Review returns the review panel model if focusReview is current; otherwise nil.
@@ -137,6 +147,17 @@ func (m *Modals) LaunchSession() *agent.Session {
 		return m.launchSess
 	}
 	return nil
+}
+
+// LaunchRepoPath returns the repo path owning the focused session, or "" when
+// focusLaunch is not current. Use this instead of repoPathForSession in
+// focusLaunch handlers — repoPathForSession is ambiguous when two repos share
+// a session ID, and falls back to "".
+func (m *Modals) LaunchRepoPath() string {
+	if m.current == focusLaunch {
+		return m.launchRepoPath
+	}
+	return ""
 }
 
 // SetLaunchAgent updates the launch agent without changing focus or the

--- a/internal/tui/modals_test.go
+++ b/internal/tui/modals_test.go
@@ -83,7 +83,7 @@ func TestModals_Close_NilsEveryModel(t *testing.T) {
 		{"shipping", func(m *Modals) { m.OpenShipping(&shippingPanelModel{}) }},
 		{"planEditor", func(m *Modals) { m.OpenPlanEditor(&planEditorModel{}) }},
 		{"config", func(m *Modals) { m.OpenConfig(&configForm{}, "/repo") }},
-		{"launch", func(m *Modals) { m.OpenLaunch(&agent.Session{}, &agent.Agent{}) }},
+		{"launch", func(m *Modals) { m.OpenLaunch(&agent.Session{}, &agent.Agent{}, "") }},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -145,7 +145,7 @@ func TestModals_Close_NilsInternalState(t *testing.T) {
 	if m.config != nil || m.configRepo != "" {
 		t.Error("internal config state should be empty after Close")
 	}
-	m.OpenLaunch(&agent.Session{}, &agent.Agent{})
+	m.OpenLaunch(&agent.Session{}, &agent.Agent{}, "")
 	m.Close()
 	if m.launchAgent != nil || m.launchSess != nil {
 		t.Error("internal launch refs should be nil after Close")
@@ -214,7 +214,7 @@ func TestModals_TableInvariant(t *testing.T) {
 		},
 		{
 			name:       "launch",
-			open:       func(m *Modals) { m.OpenLaunch(&agent.Session{}, &agent.Agent{}) },
+			open:       func(m *Modals) { m.OpenLaunch(&agent.Session{}, &agent.Agent{}, "") },
 			wantFocus:  focusLaunch,
 			wantNonNil: "launch",
 		},
@@ -297,7 +297,7 @@ func TestModals_SetLaunchAgent(t *testing.T) {
 	a1 := &agent.Agent{}
 	a2 := &agent.Agent{}
 
-	m.OpenLaunch(sess, a1)
+	m.OpenLaunch(sess, a1, "")
 	if m.LaunchAgent() != a1 {
 		t.Fatal("LaunchAgent should return a1 after OpenLaunch")
 	}

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -41,16 +41,19 @@ type PanelServices struct {
 	Height        int
 	DashboardTopY int
 
-	// Lookups.
+	// Lookups. PRCache, ReviewCache, and FeedbackTriage take (repoPath,
+	// sessionID) because the App-level caches are keyed by the composite —
+	// see cacheKey in app.go. Session IDs collide across managers, so a
+	// bare-ID lookup would return the wrong repo's data.
 	Manager     func(repoPath string) SessionManager
 	Resolved    func(repoPath string) config.ResolvedSettings
 	GHClient    func() *github.Client
-	PRCache     func(sessionID string) *prCacheEntry
-	ReviewCache func(sessionID string) *reviewDiffEntry
+	PRCache     func(repoPath, sessionID string) *prCacheEntry
+	ReviewCache func(repoPath, sessionID string) *reviewDiffEntry
 
 	// Navigation / cross-panel actions.
 	ClosePanel     func()
-	OpenInLaunch   func(sess *agent.Session) bool
+	OpenInLaunch   func(sess *agent.Session, repoPath string) bool
 	OpenPlanEditor func(sess *agent.Session, repoPath string)
 	OpenURL        func(url string) error
 	SetError       func(msg string)
@@ -59,7 +62,7 @@ type PanelServices struct {
 	// mutate App state; the resulting tea.Msg flows back through App.Update.
 	MergePRCmd      func(sessionID, repoPath string, force bool) tea.Cmd
 	StartPRDraftCmd func(sess *agent.Session, repoPath string, transitionShipping bool) tea.Cmd
-	KillSessionCmd  func(sess *agent.Session) tea.Cmd
+	KillSessionCmd  func(sess *agent.Session, repoPath string) tea.Cmd
 	FetchReviewDiff func(sess *agent.Session, repoPath string) tea.Cmd
 
 	// prDraftInFlightFor reports whether a PR draft request is currently in
@@ -69,8 +72,9 @@ type PanelServices struct {
 
 	// Shipping-panel feedback triage state. Reads return the live map (or
 	// nil); the setters lazily allocate and apply the same cleanup rules as
-	// the original App methods (neutral+empty -> delete entry).
-	FeedbackTriage     func(sessionID string) map[string]*feedbackTriageEntry
-	SetFeedbackVerdict func(sessionID, itemKey string, v feedbackVerdict)
-	SetFeedbackNote    func(sessionID, itemKey, note string)
+	// the original App methods (neutral+empty -> delete entry). Keyed by
+	// (repoPath, sessionID); see PRCache notes.
+	FeedbackTriage     func(repoPath, sessionID string) map[string]*feedbackTriageEntry
+	SetFeedbackVerdict func(repoPath, sessionID, itemKey string, v feedbackVerdict)
+	SetFeedbackNote    func(repoPath, sessionID, itemKey, note string)
 }

--- a/internal/tui/pr_test.go
+++ b/internal/tui/pr_test.go
@@ -18,7 +18,7 @@ func TestPrPollInterval_BurstOverridesBaseline(t *testing.T) {
 	a := NewApp()
 	ps := &prSessionState{burstUntil: time.Now().Add(30 * time.Second)}
 	a.prPollStates["s1"] = ps
-	if got := a.prPollInterval("s1", ps); got != 2*time.Second {
+	if got := a.prPollInterval("/repo", "s1", ps); got != 2*time.Second {
 		t.Fatalf("burst interval = %v, want 2s", got)
 	}
 }
@@ -27,7 +27,7 @@ func TestPrPollInterval_ExpiredBurstFallsBackToBaseline(t *testing.T) {
 	a := NewApp()
 	ps := &prSessionState{burstUntil: time.Now().Add(-5 * time.Second)}
 	a.prPollStates["s1"] = ps
-	if got := a.prPollInterval("s1", ps); got != 30*time.Second {
+	if got := a.prPollInterval("/repo", "s1", ps); got != 30*time.Second {
 		t.Fatalf("expired burst should use 30s baseline, got %v", got)
 	}
 }
@@ -37,21 +37,24 @@ func TestPrPollInterval_ExpiredBurstFallsBackToBaseline(t *testing.T) {
 // so the next tick re-queries immediately.
 func TestBranchRenamedEventArmsBurst(t *testing.T) {
 	a := NewApp()
+	const repo = "/repo"
+	key := cacheKey(repo, "sess-1")
 	// Seed prior state so we can verify the handler resets it.
-	a.prPollStates["sess-1"] = &prSessionState{
+	a.prPollStates[key] = &prSessionState{
 		lastPoll:      time.Now(),
 		lastSHACheck:  time.Now(),
 		lastRemoteSHA: "oldsha",
 	}
 
 	model, _ := a.Update(agentEventMsg{
+		repoPath: repo,
 		event: agent.Event{
 			Type:      agent.EventBranchRenamed,
 			SessionID: "sess-1",
 			Branch:    "refrain/new-name",
 		},
 	})
-	got := model.(App).prPollStates["sess-1"]
+	got := model.(App).prPollStates[key]
 	if got == nil {
 		t.Fatal("prPollStates missing after event")
 	}
@@ -70,17 +73,19 @@ func TestBranchRenamedEventArmsBurst(t *testing.T) {
 // clobber a previously-cached PR entry.
 func TestPrPollMsg_ErrorPreservesCache(t *testing.T) {
 	a := NewApp()
+	const repo = "/repo"
+	key := cacheKey(repo, "sess-1")
 	a.prPollsInFlight = 1
-	a.prPollStates["sess-1"] = &prSessionState{inFlight: true}
+	a.prPollStates[key] = &prSessionState{inFlight: true}
 	prev := &prCacheEntry{}
-	a.prCache["sess-1"] = prev
+	a.prCache[key] = prev
 
-	model, _ := a.Update(prPollMsg{sessionID: "sess-1", err: errors.New("boom")})
+	model, _ := a.Update(prPollMsg{sessionID: "sess-1", repoPath: repo, err: errors.New("boom")})
 	got := model.(App)
-	if got.prCache["sess-1"] != prev {
+	if got.prCache[key] != prev {
 		t.Errorf("cache entry was clobbered on error")
 	}
-	if got.prPollStates["sess-1"].inFlight {
+	if got.prPollStates[key].inFlight {
 		t.Errorf("inFlight should be cleared after poll result")
 	}
 	if got.prPollsInFlight != 0 {
@@ -92,33 +97,35 @@ func TestPrPollMsg_ErrorPreservesCache(t *testing.T) {
 // the first nil preserves the cache entry, the second nil evicts it.
 func TestPrPollMsg_NilGracePeriod(t *testing.T) {
 	a := NewApp()
+	const repo = "/repo"
+	key := cacheKey(repo, "sess-1")
 	a.prPollsInFlight = 1
-	a.prPollStates["sess-1"] = &prSessionState{inFlight: true, lastCheckState: "success"}
-	a.prCache["sess-1"] = &prCacheEntry{}
+	a.prPollStates[key] = &prSessionState{inFlight: true, lastCheckState: "success"}
+	a.prCache[key] = &prCacheEntry{}
 
 	// First nil: cache should be preserved.
-	model, _ := a.Update(prPollMsg{sessionID: "sess-1"})
+	model, _ := a.Update(prPollMsg{sessionID: "sess-1", repoPath: repo})
 	got := model.(App)
-	if _, ok := got.prCache["sess-1"]; !ok {
+	if _, ok := got.prCache[key]; !ok {
 		t.Errorf("cache entry should be preserved on first nil poll (grace period)")
 	}
-	if got.prPollStates["sess-1"].consecutiveNilPolls != 1 {
-		t.Errorf("consecutiveNilPolls = %d, want 1", got.prPollStates["sess-1"].consecutiveNilPolls)
+	if got.prPollStates[key].consecutiveNilPolls != 1 {
+		t.Errorf("consecutiveNilPolls = %d, want 1", got.prPollStates[key].consecutiveNilPolls)
 	}
 
 	// Second nil: cache should be cleared.
 	got.prPollsInFlight = 1
-	got.prPollStates["sess-1"].inFlight = true
-	model2, _ := got.Update(prPollMsg{sessionID: "sess-1"})
+	got.prPollStates[key].inFlight = true
+	model2, _ := got.Update(prPollMsg{sessionID: "sess-1", repoPath: repo})
 	got2 := model2.(App)
-	if _, ok := got2.prCache["sess-1"]; ok {
+	if _, ok := got2.prCache[key]; ok {
 		t.Errorf("cache entry should be cleared after second consecutive nil poll")
 	}
-	if got2.prPollStates["sess-1"].lastCheckState != "" {
-		t.Errorf("lastCheckState should reset, got %q", got2.prPollStates["sess-1"].lastCheckState)
+	if got2.prPollStates[key].lastCheckState != "" {
+		t.Errorf("lastCheckState should reset, got %q", got2.prPollStates[key].lastCheckState)
 	}
-	if got2.prPollStates["sess-1"].consecutiveNilPolls != 0 {
-		t.Errorf("consecutiveNilPolls should reset to 0 after eviction, got %d", got2.prPollStates["sess-1"].consecutiveNilPolls)
+	if got2.prPollStates[key].consecutiveNilPolls != 0 {
+		t.Errorf("consecutiveNilPolls should reset to 0 after eviction, got %d", got2.prPollStates[key].consecutiveNilPolls)
 	}
 }
 
@@ -203,24 +210,26 @@ func TestResolveMergedFallback(t *testing.T) {
 // starts fresh on the next nil.
 func TestPrPollMsg_NilThenSuccessResetsCounter(t *testing.T) {
 	a := NewApp()
+	const repo = "/repo"
+	key := cacheKey(repo, "sess-1")
 	a.prPollsInFlight = 1
-	a.prPollStates["sess-1"] = &prSessionState{inFlight: true}
-	a.prCache["sess-1"] = &prCacheEntry{}
+	a.prPollStates[key] = &prSessionState{inFlight: true}
+	a.prCache[key] = &prCacheEntry{}
 
 	// First nil: increments counter.
-	model, _ := a.Update(prPollMsg{sessionID: "sess-1"})
+	model, _ := a.Update(prPollMsg{sessionID: "sess-1", repoPath: repo})
 	got := model.(App)
-	if got.prPollStates["sess-1"].consecutiveNilPolls != 1 {
-		t.Fatalf("consecutiveNilPolls after first nil = %d, want 1", got.prPollStates["sess-1"].consecutiveNilPolls)
+	if got.prPollStates[key].consecutiveNilPolls != 1 {
+		t.Fatalf("consecutiveNilPolls after first nil = %d, want 1", got.prPollStates[key].consecutiveNilPolls)
 	}
 
 	// Successful poll: counter resets.
 	got.prPollsInFlight = 1
-	got.prPollStates["sess-1"].inFlight = true
-	model2, _ := got.Update(prPollMsg{sessionID: "sess-1", pr: &github.PRState{Number: 1}})
+	got.prPollStates[key].inFlight = true
+	model2, _ := got.Update(prPollMsg{sessionID: "sess-1", repoPath: repo, pr: &github.PRState{Number: 1}})
 	got2 := model2.(App)
-	if got2.prPollStates["sess-1"].consecutiveNilPolls != 0 {
-		t.Errorf("consecutiveNilPolls should reset to 0 after success, got %d", got2.prPollStates["sess-1"].consecutiveNilPolls)
+	if got2.prPollStates[key].consecutiveNilPolls != 0 {
+		t.Errorf("consecutiveNilPolls should reset to 0 after success, got %d", got2.prPollStates[key].consecutiveNilPolls)
 	}
 }
 
@@ -228,15 +237,17 @@ func TestPrPollMsg_NilThenSuccessResetsCounter(t *testing.T) {
 // lookup for a session that never had a PR doesn't create spurious state.
 func TestPrPollMsg_NilWithNoPriorCacheIsNoop(t *testing.T) {
 	a := NewApp()
+	const repo = "/repo"
+	key := cacheKey(repo, "sess-1")
 	a.prPollsInFlight = 1
-	a.prPollStates["sess-1"] = &prSessionState{inFlight: true}
+	a.prPollStates[key] = &prSessionState{inFlight: true}
 
-	model, _ := a.Update(prPollMsg{sessionID: "sess-1"})
+	model, _ := a.Update(prPollMsg{sessionID: "sess-1", repoPath: repo})
 	got := model.(App)
-	if _, ok := got.prCache["sess-1"]; ok {
+	if _, ok := got.prCache[key]; ok {
 		t.Errorf("no cache entry should exist")
 	}
-	if got.prPollStates["sess-1"].inFlight {
+	if got.prPollStates[key].inFlight {
 		t.Errorf("inFlight should be cleared")
 	}
 }
@@ -391,14 +402,17 @@ func TestPrPollMsg_UnknownArmsBurst(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewApp()
+			const repo = "/repo"
+			key := cacheKey(repo, "s1")
 			a.prPollsInFlight = 1
-			a.prPollStates["s1"] = &prSessionState{inFlight: true}
+			a.prPollStates[key] = &prSessionState{inFlight: true}
 
 			model, _ := a.Update(prPollMsg{
 				sessionID: "s1",
+				repoPath:  repo,
 				pr:        &github.PRState{Number: 1, MergeableState: tc.mergeableState},
 			})
-			got := model.(App).prPollStates["s1"]
+			got := model.(App).prPollStates[key]
 			if got == nil {
 				t.Fatal("prPollStates missing after update")
 			}
@@ -413,14 +427,17 @@ func TestPrPollMsg_UnknownArmsBurst(t *testing.T) {
 // mergeable state (e.g. "clean") does not arm the burst window.
 func TestPrPollMsg_KnownDoesNotArmBurst(t *testing.T) {
 	a := NewApp()
+	const repo = "/repo"
+	key := cacheKey(repo, "s1")
 	a.prPollsInFlight = 1
-	a.prPollStates["s1"] = &prSessionState{inFlight: true}
+	a.prPollStates[key] = &prSessionState{inFlight: true}
 
 	model, _ := a.Update(prPollMsg{
 		sessionID: "s1",
+		repoPath:  repo,
 		pr:        &github.PRState{Number: 1, MergeableState: "clean"},
 	})
-	got := model.(App).prPollStates["s1"]
+	got := model.(App).prPollStates[key]
 	if got == nil {
 		t.Fatal("prPollStates missing after update")
 	}

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -107,7 +107,7 @@ func (m *reviewPanelModel) RefreshDiffViewport(svc PanelServices) {
 	m.diffVP.SetHeight(diffH)
 	m.diffVP.SetWidth(rightW)
 	m.diffVP.GotoTop()
-	entry := svc.ReviewCache(m.session.ID)
+	entry := svc.ReviewCache(m.repoPath, m.session.ID)
 	if entry == nil {
 		m.diffVP.SetContent("")
 		return
@@ -233,7 +233,7 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		return m, closeReviewPanel(svc)
 	case "p":
 		sess := m.session
-		entry := svc.PRCache(sess.ID)
+		entry := svc.PRCache(m.repoPath, sess.ID)
 		if entry != nil && entry.pr != nil && entry.pr.URL != "" {
 			if err := svc.OpenURL(entry.pr.URL); err != nil {
 				svc.SetError(err.Error())
@@ -250,11 +250,12 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		return m, svc.StartPRDraftCmd(sess, m.repoPath, true)
 	case "t":
 		sess := m.session
+		repoPath := m.repoPath
 		// Close first regardless of outcome: pressing 't' is an exit-the-panel
 		// intent. If the open fails, the error surfaces with the panel already
 		// closed, matching the pre-refactor behaviour.
 		closeReviewPanel(svc)
-		if !svc.OpenInLaunch(sess) {
+		if !svc.OpenInLaunch(sess, repoPath) {
 			svc.SetError("session has no agents to open")
 		}
 		return m, nil
@@ -265,12 +266,12 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		if mgr == nil {
 			return m, closeReviewPanel(svc)
 		}
-		return m, tea.Batch(closeReviewPanel(svc), svc.KillSessionCmd(sess))
+		return m, tea.Batch(closeReviewPanel(svc), svc.KillSessionCmd(sess, m.repoPath))
 	case "e":
 		reviewOpenIDECmd(m.session, m.repoPath, svc)
 		return m, nil
 	case "j", "down":
-		if entry := svc.ReviewCache(m.session.ID); entry != nil {
+		if entry := svc.ReviewCache(m.repoPath, m.session.ID); entry != nil {
 			maxIdx := reviewTaskCount(entry) - 1
 			if m.taskCursor < maxIdx {
 				m.taskCursor++
@@ -285,7 +286,7 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		}
 		return m, nil
 	case "f":
-		entry := svc.ReviewCache(m.session.ID)
+		entry := svc.ReviewCache(m.repoPath, m.session.ID)
 		if entry == nil {
 			return m, nil
 		}
@@ -304,7 +305,7 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		rec.userFlagged = !rec.userFlagged
 		return m, nil
 	case "b":
-		entry := svc.ReviewCache(m.session.ID)
+		entry := svc.ReviewCache(m.repoPath, m.session.ID)
 		prompt := buildReviewReworkPrompt(entry)
 		if prompt == "" {
 			svc.SetError("no tasks flagged or marked concerns/fail")
@@ -345,7 +346,7 @@ func (m *reviewPanelModel) handleClick(msg tea.MouseClickMsg, svc PanelServices)
 	if m == nil || m.session == nil {
 		return
 	}
-	entry := svc.ReviewCache(m.session.ID)
+	entry := svc.ReviewCache(m.repoPath, m.session.ID)
 	if entry == nil || m.width < 80 {
 		return
 	}
@@ -393,7 +394,7 @@ func (m *reviewPanelModel) View(svc PanelServices) string {
 		plan, _ := m.session.CachedPlan()
 		return renderReviewSpecOverlay(m.session, plan, m.specOverlayScroll, m.width, m.height)
 	}
-	entry := svc.ReviewCache(m.session.ID)
+	entry := svc.ReviewCache(m.repoPath, m.session.ID)
 	prDraftInFlight := svc.prDraftInFlightFor(m.session.ID)
 	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.diffVP.View())
 }

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -26,12 +26,12 @@ func newTestSvc() (PanelServices, *testServiceState) {
 		},
 		Resolved:    func(string) config.ResolvedSettings { return config.ResolvedSettings{} },
 		GHClient:    func() *github.Client { return nil },
-		PRCache:     func(string) *prCacheEntry { return nil },
-		ReviewCache: func(string) *reviewDiffEntry { return nil },
+		PRCache:     func(string, string) *prCacheEntry { return nil },
+		ReviewCache: func(string, string) *reviewDiffEntry { return nil },
 		ClosePanel: func() {
 			state.closed = true
 		},
-		OpenInLaunch: func(*agent.Session) bool {
+		OpenInLaunch: func(*agent.Session, string) bool {
 			state.openInLaunchCalled = true
 			return state.openInLaunchResult
 		},
@@ -44,16 +44,16 @@ func newTestSvc() (PanelServices, *testServiceState) {
 		StartPRDraftCmd: func(*agent.Session, string, bool) tea.Cmd {
 			return func() tea.Msg { return nil }
 		},
-		KillSessionCmd: func(*agent.Session) tea.Cmd {
+		KillSessionCmd: func(*agent.Session, string) tea.Cmd {
 			state.killSessionCalled = true
 			return func() tea.Msg { return nil }
 		},
 		FetchReviewDiff: func(*agent.Session, string) tea.Cmd { return nil },
-		FeedbackTriage: func(string) map[string]*feedbackTriageEntry {
+		FeedbackTriage: func(string, string) map[string]*feedbackTriageEntry {
 			return nil
 		},
-		SetFeedbackVerdict: func(string, string, feedbackVerdict) {},
-		SetFeedbackNote:    func(string, string, string) {},
+		SetFeedbackVerdict: func(string, string, string, feedbackVerdict) {},
+		SetFeedbackNote:    func(string, string, string, string) {},
 		prDraftInFlightFor: func(string) bool { return false },
 	}
 	return svc, state
@@ -168,7 +168,7 @@ func TestReviewPanelModel_TaskCursorMovesWithJK(t *testing.T) {
 		},
 	}
 	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string) *reviewDiffEntry { return entry }
+	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
 
 	if got := panel.TaskCursor(); got != 0 {
 		t.Fatalf("cursor starts at 0, got %d", got)
@@ -195,7 +195,7 @@ func TestReviewPanelModel_TaskCursorClampsAtTopAndBottom(t *testing.T) {
 		tasks: []agent.PlanTask{{Index: 1}, {Index: 2}},
 	}
 	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string) *reviewDiffEntry { return entry }
+	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
 
 	// k at top is a no-op.
 	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"}, svc)
@@ -219,7 +219,7 @@ func TestReviewPanelModel_FKey_TogglesUserFlag(t *testing.T) {
 		tasks: []agent.PlanTask{{Index: 7, Text: "task one"}},
 	}
 	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string) *reviewDiffEntry { return entry }
+	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
 
 	_, _ = panel.Update(tea.KeyPressMsg{Code: 'f', Text: "f"}, svc)
 	rec := entry.verdicts[7]
@@ -251,7 +251,7 @@ func TestReviewPanelModel_BKey_NoFlags_SetsError(t *testing.T) {
 		tasks: []agent.PlanTask{{Index: 1}},
 	}
 	svc, state := newTestSvc()
-	svc.ReviewCache = func(string) *reviewDiffEntry { return entry }
+	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
 	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'b', Text: "b"}, svc)
 	if cmd != nil {
 		t.Errorf("b without flagged tasks should return nil cmd, got %T", cmd())
@@ -272,7 +272,7 @@ func TestReviewPanelModel_BKey_WithFlag_EmitsReworkMsg(t *testing.T) {
 		},
 	}
 	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string) *reviewDiffEntry { return entry }
+	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
 	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'b', Text: "b"}, svc)
 	if cmd == nil {
 		t.Fatal("expected rework cmd")
@@ -456,7 +456,7 @@ func TestReviewPanelModel_PKey_WithCachedPR_OpensURL(t *testing.T) {
 	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 	var openedURL string
-	svc.PRCache = func(string) *prCacheEntry {
+	svc.PRCache = func(string, string) *prCacheEntry {
 		return &prCacheEntry{pr: &github.PRState{URL: "https://example.com/pr/1"}}
 	}
 	svc.OpenURL = func(u string) error {
@@ -556,7 +556,7 @@ func TestReviewPanel_PKey_UsesPinnedRepoPath_NotFirstMatch(t *testing.T) {
 	}
 	// non-nil GHClient so the code passes the auth check and reaches StartPRDraftCmd
 	svc.GHClient = func() *github.Client { return new(github.Client) }
-	svc.PRCache = func(string) *prCacheEntry { return nil }
+	svc.PRCache = func(string, string) *prCacheEntry { return nil }
 
 	_, _ = panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"}, svc)
 

--- a/internal/tui/shippingpanelmodel.go
+++ b/internal/tui/shippingpanelmodel.go
@@ -116,12 +116,12 @@ func (m *shippingPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (
 	if m.feedbackNote.Active() {
 		cmd, submitted, note := m.feedbackNote.Update(msg)
 		if submitted && svc.SetFeedbackNote != nil {
-			svc.SetFeedbackNote(m.session.ID, m.feedbackNote.itemKey, note)
+			svc.SetFeedbackNote(m.repoPath, m.session.ID, m.feedbackNote.itemKey, note)
 		}
 		return m, cmd
 	}
 
-	entry := svc.PRCache(m.session.ID)
+	entry := svc.PRCache(m.repoPath, m.session.ID)
 	items := feedbackItems(entryThreads(entry))
 	halfPane := m.height / 4
 	if halfPane < 1 {
@@ -156,24 +156,24 @@ func (m *shippingPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (
 	case "a":
 		if len(items) > 0 && m.feedbackCursor < len(items) && svc.SetFeedbackVerdict != nil {
 			key := feedbackItemKey(items[m.feedbackCursor])
-			svc.SetFeedbackVerdict(m.session.ID, key, feedbackApproved)
+			svc.SetFeedbackVerdict(m.repoPath, m.session.ID, key, feedbackApproved)
 		}
 	case "x":
 		if len(items) > 0 && m.feedbackCursor < len(items) && svc.SetFeedbackVerdict != nil {
 			key := feedbackItemKey(items[m.feedbackCursor])
-			svc.SetFeedbackVerdict(m.session.ID, key, feedbackDisagreed)
+			svc.SetFeedbackVerdict(m.repoPath, m.session.ID, key, feedbackDisagreed)
 		}
 	case "u":
 		if len(items) > 0 && m.feedbackCursor < len(items) && svc.SetFeedbackVerdict != nil {
 			key := feedbackItemKey(items[m.feedbackCursor])
-			svc.SetFeedbackVerdict(m.session.ID, key, feedbackNeutral)
+			svc.SetFeedbackVerdict(m.repoPath, m.session.ID, key, feedbackNeutral)
 		}
 	case "n":
 		if len(items) > 0 && m.feedbackCursor < len(items) {
 			item := items[m.feedbackCursor]
 			key := feedbackItemKey(item)
 			existing := ""
-			if triage := svc.FeedbackTriage(m.session.ID); triage != nil {
+			if triage := svc.FeedbackTriage(m.repoPath, m.session.ID); triage != nil {
 				if e := triage[key]; e != nil {
 					existing = e.Note
 				}
@@ -184,8 +184,9 @@ func (m *shippingPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (
 		return m, closeShippingPanel(svc)
 	case "t":
 		sess := m.session
+		repoPath := m.repoPath
 		closeShippingPanel(svc)
-		if !svc.OpenInLaunch(sess) {
+		if !svc.OpenInLaunch(sess, repoPath) {
 			svc.SetError("session has no agents to open")
 		}
 		return m, nil
@@ -225,8 +226,8 @@ func (m *shippingPanelModel) View(svc PanelServices) string {
 	if m == nil || m.session == nil {
 		return ""
 	}
-	entry := svc.PRCache(m.session.ID)
-	triage := svc.FeedbackTriage(m.session.ID)
+	entry := svc.PRCache(m.repoPath, m.session.ID)
+	triage := svc.FeedbackTriage(m.repoPath, m.session.ID)
 	return renderShippingPanel(m.session, entry, m.width, m.height, m.feedbackCursor, m.detailScroll, triage)
 }
 

--- a/internal/tui/shippingpanelmodel_test.go
+++ b/internal/tui/shippingpanelmodel_test.go
@@ -21,11 +21,11 @@ func newTestShippingSvc() (PanelServices, *testShippingSvcState) {
 		Manager: func(string) SessionManager {
 			return nil
 		},
-		PRCache: func(string) *prCacheEntry { return state.pr },
+		PRCache: func(string, string) *prCacheEntry { return state.pr },
 		ClosePanel: func() {
 			state.closed = true
 		},
-		OpenInLaunch: func(*agent.Session) bool {
+		OpenInLaunch: func(*agent.Session, string) bool {
 			return state.openInLaunchResult
 		},
 		SetError: func(msg string) {
@@ -40,16 +40,16 @@ func newTestShippingSvc() (PanelServices, *testShippingSvcState) {
 			state.mergeForce = force
 			return func() tea.Msg { return nil }
 		},
-		FeedbackTriage: func(string) map[string]*feedbackTriageEntry {
+		FeedbackTriage: func(string, string) map[string]*feedbackTriageEntry {
 			return state.triage
 		},
-		SetFeedbackVerdict: func(_, key string, v feedbackVerdict) {
+		SetFeedbackVerdict: func(_, _, key string, v feedbackVerdict) {
 			if state.triage[key] == nil {
 				state.triage[key] = &feedbackTriageEntry{}
 			}
 			state.triage[key].Verdict = v
 		},
-		SetFeedbackNote: func(_, key, note string) {
+		SetFeedbackNote: func(_, _, key, note string) {
 			if state.triage[key] == nil {
 				state.triage[key] = &feedbackTriageEntry{}
 			}

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -137,7 +137,11 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if a.dashboard.selected != prevSelected {
 		a.updateDashboardDiffStats()
 		if sess := a.dashboard.selectedSession(); sess != nil {
-			entry := a.diffStatsCache[sess.ID]
+			repoPath := a.dashboard.selectedRepoPath()
+			var entry *diffStatsEntry
+			if repoPath != "" {
+				entry = a.diffStatsCache[cacheKey(repoPath, sess.ID)]
+			}
 			if (entry == nil || time.Since(entry.lastRefresh) > DiffStatsCacheTTL) && !a.diffRefreshInFlight {
 				diffCmd := a.refreshDiffStatsCmd()
 				return a, tea.Batch(cmd, diffCmd)
@@ -214,7 +218,7 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	case "ctrl+t":
 		if sess != nil {
-			repoPath := a.repoPathForSession(sess.ID)
+			repoPath := a.modals.LaunchRepoPath()
 			mgr := a.managers[repoPath]
 			if mgr != nil {
 				resolved := a.resolvedCache[repoPath]
@@ -234,7 +238,7 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	case "ctrl+n":
 		if sess != nil {
-			repoPath := a.repoPathForSession(sess.ID)
+			repoPath := a.modals.LaunchRepoPath()
 			mgr := a.managers[repoPath]
 			if mgr != nil {
 				resolved := a.resolvedCache[repoPath]
@@ -307,19 +311,21 @@ func (a App) closeFocusLaunchAgent() (tea.Model, tea.Cmd) {
 		agents[nextIdx].Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 		a.dashboard.scrollOffset = 0
 	}
-	if a.closingAgents[oldID] {
+	repoPath := a.modals.LaunchRepoPath()
+	agentKey := agentCacheKey(repoPath, oldID)
+	if a.closingAgents[agentKey] {
 		return a, nil
 	}
-	repoPath := a.repoPathForSession(sessionID)
 	mgr := a.managers[repoPath]
 	if mgr == nil {
 		return a, nil
 	}
-	a.closingAgents[oldID] = true
+	a.closingAgents[agentKey] = true
 	return a, func() tea.Msg {
 		err := mgr.KillAgent(sessionID, oldID)
 		return killResultMsg{
 			scope:     killScopeAgent,
+			repoPath:  repoPath,
 			sessionID: sessionID,
 			agentID:   oldID,
 			err:       err,
@@ -606,9 +612,10 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 		}
 		if sess.HasShell() {
 			// Shell exists — open it in focusLaunch directly.
+			repoPath := a.cursorSelectedRepoPath()
 			for _, ag := range sess.Agents() {
 				if ag.IsShell {
-					a.openLaunchPanel(sess, ag)
+					a.openLaunchPanel(sess, ag, repoPath)
 					a.dashboard.scrollOffset = 0
 					ag.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 					break
@@ -645,7 +652,8 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 		// and draft a new one if no open PR exists yet.
 		sess := a.cursorSelectedSession()
 		if sess != nil {
-			if entry := a.prCache[sess.ID]; entry != nil && entry.pr != nil && entry.pr.URL != "" {
+			repoPath := a.cursorSelectedRepoPath()
+			if entry := a.prCache[cacheKey(repoPath, sess.ID)]; entry != nil && entry.pr != nil && entry.pr.URL != "" {
 				if err := openURL(entry.pr.URL); err != nil {
 					a.setError(err.Error())
 				}
@@ -663,7 +671,6 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 				}
 				a.prDraftInFlight = true
 				a.prDraftSessionID = sess.ID
-				repoPath := a.cursorSelectedRepoPath()
 				return a, a.startPRDraftCmd(sess, repoPath, false), true
 			}
 		}
@@ -731,16 +738,18 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 		}
 		agentID := ag.ID
 		sessionID := sess.ID
+		agentKey := agentCacheKey(repoPath, agentID)
 		// Already dispatched — no-op to avoid double-kills.
-		if a.closingAgents[agentID] {
+		if a.closingAgents[agentKey] {
 			return a, nil, true
 		}
-		a.closingAgents[agentID] = true
+		a.closingAgents[agentKey] = true
 		a.refreshAgentList()
 		return a, func() tea.Msg {
 			err := mgr.KillAgent(sessionID, agentID)
 			return killResultMsg{
 				scope:     killScopeAgent,
+				repoPath:  repoPath,
 				sessionID: sessionID,
 				agentID:   agentID,
 				err:       err,
@@ -759,21 +768,23 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 			return a, nil, true
 		}
 		sessID := sess.ID
+		sessKey := cacheKey(repoPath, sessID)
 		// Already dispatched — no-op.
-		if a.closingSessions[sessID] {
+		if a.closingSessions[sessKey] {
 			return a, nil, true
 		}
 		var agentIDs []string
 		for _, ag := range sess.Agents() {
 			agentIDs = append(agentIDs, ag.ID)
-			a.closingAgents[ag.ID] = true
+			a.closingAgents[agentCacheKey(repoPath, ag.ID)] = true
 		}
-		a.closingSessions[sessID] = true
+		a.closingSessions[sessKey] = true
 		a.refreshAgentList()
 		return a, func() tea.Msg {
 			err := mgr.KillSession(sessID)
 			return killResultMsg{
 				scope:     killScopeSession,
+				repoPath:  repoPath,
 				sessionID: sessID,
 				agentIDs:  agentIDs,
 				err:       err,
@@ -857,7 +868,7 @@ func (a App) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 		items := a.dashboard.sectionItems(section)
 		if idx < len(items) {
 			sess := items[idx].session
-			if entry := a.prCache[sess.ID]; entry != nil && entry.pr != nil && entry.pr.URL != "" {
+			if entry := a.prCache[cacheKey(items[idx].repoPath, sess.ID)]; entry != nil && entry.pr != nil && entry.pr.URL != "" {
 				indicatorWidth := prIndicatorWidth(entry)
 				if indicatorWidth > 0 && msg.X >= a.width-indicatorWidth-2 {
 					if err := openURL(entry.pr.URL); err != nil {
@@ -1158,7 +1169,7 @@ func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
 	sess := item.session
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
 	a.openReview(newReviewPanel(sess, item.repoPath, a.width, a.height))
-	if _, ok := a.reviewDiffCache[sess.ID]; !ok {
+	if _, ok := a.reviewDiffCache[cacheKey(item.repoPath, sess.ID)]; !ok {
 		return a, a.fetchReviewDiffCmd(sess, item.repoPath), true
 	}
 	a.modals.Review().RefreshDiffViewport(a.panelServices())

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -261,12 +261,13 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 		}
 		ag := item.agent
 		currentStatus := ag.Status()
-		if prev, ok := a.lastKnownStatus[ag.ID]; ok {
+		key := agentCacheKey(item.repoPath, ag.ID)
+		if prev, ok := a.lastKnownStatus[key]; ok {
 			if prev == agent.StatusActive && currentStatus == agent.StatusIdle && !ag.IsShell {
 				idleTransition = true
 			}
 		}
-		a.lastKnownStatus[ag.ID] = currentStatus
+		a.lastKnownStatus[key] = currentStatus
 	}
 	// Detect alt-screen transitions and trigger a resize so Claude's TUI
 	// redraws cleanly (replaces the old splashResizeMsg delayed timer).
@@ -308,7 +309,11 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 	// Refresh diff stats periodically or on idle transition.
 	var diffCmd tea.Cmd
 	if sess := a.dashboard.selectedSession(); sess != nil {
-		entry := a.diffStatsCache[sess.ID]
+		repoPath := a.dashboard.selectedRepoPath()
+		var entry *diffStatsEntry
+		if repoPath != "" {
+			entry = a.diffStatsCache[cacheKey(repoPath, sess.ID)]
+		}
 		stale := entry == nil || time.Since(entry.lastRefresh) > DiffStatsCacheTTL
 		if (stale || idleTransition) && !a.diffRefreshInFlight {
 			diffCmd = a.refreshDiffStatsCmd()
@@ -328,8 +333,11 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 func (a App) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd) {
 	var autoPromoteCmd tea.Cmd
 	// Clean up stale lastKnownStatus entries when a session auto-closes.
+	// lastKnownStatus is keyed by agentCacheKey(repoPath, agentID), so the
+	// stale prefix has to include the repoPath to avoid wiping a colliding
+	// agent ID in a different repo.
 	if msg.event.Type == agent.EventSessionClosed && msg.event.SessionID != "" {
-		prefix := msg.event.SessionID + "-agent-"
+		prefix := msg.repoPath + "\x00" + msg.event.SessionID + "-agent-"
 		for id := range a.lastKnownStatus {
 			if strings.HasPrefix(id, prefix) {
 				delete(a.lastKnownStatus, id)
@@ -366,7 +374,7 @@ func (a App) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
-		a.lastKnownStatus[msg.event.AgentID] = msg.event.Status
+		a.lastKnownStatus[agentCacheKey(msg.repoPath, msg.event.AgentID)] = msg.event.Status
 		// Auto-promote and MarkDone share a single FindAgentAndSession
 		// call, gated on the statuses that can trigger either transition.
 		if msg.event.Status == agent.StatusIdle ||
@@ -403,10 +411,11 @@ func (a App) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd) {
 	// quickly — do NOT clear the cache here; that happens only when the
 	// next poll confirms the PR is gone (handled in prPollMsg).
 	if msg.event.Type == agent.EventBranchRenamed && msg.event.SessionID != "" {
-		ps := a.prPollStates[msg.event.SessionID]
+		key := cacheKey(msg.repoPath, msg.event.SessionID)
+		ps := a.prPollStates[key]
 		if ps == nil {
 			ps = &prSessionState{}
-			a.prPollStates[msg.event.SessionID] = ps
+			a.prPollStates[key] = ps
 		}
 		ps.burstUntil = time.Now().Add(PRPollBurstAfterCreate)
 		ps.lastPoll = time.Time{}
@@ -473,7 +482,7 @@ func (a App) handleCreateResult(msg createResultMsg) (tea.Model, tea.Cmd) {
 			if item.kind == listItemAgent && item.agent != nil && item.agent.ID == msg.agentID {
 				a.dashboard.selected = i
 				if !msg.skipFocusLaunch {
-					a.openLaunchPanel(item.session, item.agent)
+					a.openLaunchPanel(item.session, item.agent, item.repoPath)
 					a.dashboard.scrollOffset = 0
 					item.agent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 				}
@@ -504,26 +513,37 @@ func (a App) handleCreateResult(msg createResultMsg) (tea.Model, tea.Cmd) {
 func (a App) handleKillResult(msg killResultMsg) (tea.Model, tea.Cmd) {
 	// Clean up closing-set entries regardless of error so the UI never
 	// gets stuck rendering "closing…" on a row whose kill failed.
+	if msg.repoPath == "" {
+		// Defensive: every producer of killResultMsg should populate
+		// repoPath. If one ever doesn't, drop with a visible error so the
+		// missing field is fixed at the source rather than corrupting
+		// closing-set cleanup across repos.
+		a.setError("internal: killResultMsg missing repoPath; closing-set may be stale")
+		return a, nil
+	}
 	switch msg.scope {
 	case killScopeAgent:
-		delete(a.closingAgents, msg.agentID)
-		delete(a.lastKnownStatus, msg.agentID)
+		agentKey := agentCacheKey(msg.repoPath, msg.agentID)
+		delete(a.closingAgents, agentKey)
+		delete(a.lastKnownStatus, agentKey)
 		// Exit focusLaunch if the killed agent is the one being viewed.
 		if ag := a.modals.LaunchAgent(); ag != nil && ag.ID == msg.agentID {
 			a.closeModal()
 			a.dashboard.scrollOffset = 0
 		}
 	case killScopeSession:
-		delete(a.closingSessions, msg.sessionID)
+		sessKey := cacheKey(msg.repoPath, msg.sessionID)
+		delete(a.closingSessions, sessKey)
 		for _, id := range msg.agentIDs {
-			delete(a.closingAgents, id)
-			delete(a.lastKnownStatus, id)
+			agentKey := agentCacheKey(msg.repoPath, id)
+			delete(a.closingAgents, agentKey)
+			delete(a.lastKnownStatus, agentKey)
 			if ag := a.modals.LaunchAgent(); ag != nil && ag.ID == id {
 				a.closeModal()
 				a.dashboard.scrollOffset = 0
 			}
 		}
-		delete(a.diffStatsCache, msg.sessionID)
+		delete(a.diffStatsCache, sessKey)
 	}
 	if msg.err != nil {
 		a.setError(msg.err.Error())
@@ -535,8 +555,13 @@ func (a App) handleKillResult(msg killResultMsg) (tea.Model, tea.Cmd) {
 
 func (a App) handleDiffStats(msg diffStatsMsg) (tea.Model, tea.Cmd) {
 	a.diffRefreshInFlight = false
+	if msg.repoPath == "" {
+		// Without a repoPath we can't key the cache safely; drop the result.
+		// All callers populate repoPath; this guard catches future regressions.
+		return a, nil
+	}
 	// Always update cache timestamp to prevent tight retry loops on persistent errors.
-	a.diffStatsCache[msg.sessionID] = &diffStatsEntry{
+	a.diffStatsCache[cacheKey(msg.repoPath, msg.sessionID)] = &diffStatsEntry{
 		stats:       msg.stats,
 		lastRefresh: time.Now(),
 	}

--- a/internal/tui/update_plan.go
+++ b/internal/tui/update_plan.go
@@ -129,11 +129,12 @@ func (a App) handlePlanEditorAbandon(msg planEditorAbandonMsg) (tea.Model, tea.C
 		return a, nil
 	}
 	sessID := msg.sessionID
-	a.closingSessions[sessID] = true
+	a.closingSessions[cacheKey(repoPath, sessID)] = true
 	return a, func() tea.Msg {
 		err := mgr.KillSession(sessID)
 		return killResultMsg{
 			scope:     killScopeSession,
+			repoPath:  repoPath,
 			sessionID: sessID,
 			err:       err,
 		}

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -40,18 +40,18 @@ func (a App) handlePRCreated(msg prCreatedMsg) (tea.Model, tea.Cmd) {
 		a.setError("create PR failed: " + msg.err.Error())
 		return a, nil
 	}
-	a.prCache[msg.sessionID] = &prCacheEntry{pr: msg.pr}
+	repoPath := msg.repoPath
+	if repoPath == "" {
+		repoPath = a.repoPathForSession(msg.sessionID)
+	}
+	if repoPath == "" {
+		a.setError("create PR succeeded but session repo unknown; refresh to see it")
+		return a, nil
+	}
+	key := cacheKey(repoPath, msg.sessionID)
+	a.prCache[key] = &prCacheEntry{pr: msg.pr}
 	if msg.transitionShipping {
-		repoPath := msg.repoPath
-		if repoPath == "" {
-			repoPath = a.repoPathForSession(msg.sessionID)
-		}
-		var sess *agent.Session
-		if repoPath != "" {
-			sess = a.sessionByIDInRepo(repoPath, msg.sessionID)
-		} else {
-			sess = a.sessionByID(msg.sessionID)
-		}
+		sess := a.sessionByIDInRepo(repoPath, msg.sessionID)
 		if sess != nil {
 			sess.SetLifecyclePhase(agent.LifecycleShipping)
 			if rp := a.modals.Review(); rp != nil && rp.SessionID() == msg.sessionID {
@@ -61,14 +61,10 @@ func (a App) handlePRCreated(msg prCreatedMsg) (tea.Model, tea.Cmd) {
 	}
 	a.updateDashboardPRCache()
 	// Re-arm a burst poll so the new PR is discovered quickly.
-	if ps := a.prPollStates[msg.sessionID]; ps != nil {
+	if ps := a.prPollStates[key]; ps != nil {
 		ps.burstUntil = time.Now().Add(PRPollBurstAfterCreate)
 	}
 	// Auto-open in browser if configured.
-	repoPath := msg.repoPath
-	if repoPath == "" {
-		repoPath = a.repoPathForSession(msg.sessionID)
-	}
 	resolved := a.resolvedCache[repoPath]
 	if resolved.AutoOpenPRInBrowser && msg.pr != nil && msg.pr.URL != "" {
 		if err := openURL(msg.pr.URL); err != nil {
@@ -83,7 +79,17 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 	if a.prPollsInFlight < 0 {
 		a.prPollsInFlight = 0
 	}
-	ps := a.prPollStates[msg.sessionID]
+	repoPath := msg.repoPath
+	if repoPath == "" {
+		repoPath = a.repoPathForSession(msg.sessionID)
+	}
+	// Without a repoPath we can't safely key the cache or look up the session
+	// — drop the result rather than risk a cross-repo clobber.
+	if repoPath == "" {
+		return a, nil
+	}
+	key := cacheKey(repoPath, msg.sessionID)
+	ps := a.prPollStates[key]
 	if ps != nil {
 		ps.inFlight = false
 	}
@@ -96,7 +102,7 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 	// gap (branch pushed under old name, remote SHA not yet updated) or a
 	// rapid force-push window. Two in a row means the PR is genuinely gone.
 	if msg.pr == nil {
-		if _, had := a.prCache[msg.sessionID]; had {
+		if _, had := a.prCache[key]; had {
 			// ps is always non-nil here: pollAllSessions initialises it before
 			// dispatching a poll, and prPollMsg can only arrive after dispatch.
 			// The nil guard is defensive; if ps were nil we skip the grace period
@@ -107,7 +113,7 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 					return a, nil
 				}
 			}
-			delete(a.prCache, msg.sessionID)
+			delete(a.prCache, key)
 			if ps != nil {
 				ps.lastCheckState = ""
 				ps.consecutiveNilPolls = 0
@@ -120,7 +126,7 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 	if ps != nil {
 		ps.consecutiveNilPolls = 0
 	}
-	a.prCache[msg.sessionID] = &prCacheEntry{
+	a.prCache[key] = &prCacheEntry{
 		pr:      msg.pr,
 		checks:  msg.checks,
 		reviews: msg.reviews,
@@ -135,17 +141,8 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	// Auto-promote to Shipping when an open PR is discovered externally.
-	if msg.pr != nil && msg.pr.State == "open" {
-		repoPath := msg.repoPath
-		if repoPath == "" {
-			repoPath = a.repoPathForSession(msg.sessionID)
-		}
-		var sess *agent.Session
-		if repoPath != "" {
-			sess = a.sessionByIDInRepo(repoPath, msg.sessionID)
-		} else {
-			sess = a.sessionByID(msg.sessionID)
-		}
+	if msg.pr.State == "open" {
+		sess := a.sessionByIDInRepo(repoPath, msg.sessionID)
 		if sess != nil {
 			switch sess.LifecyclePhase() {
 			case agent.LifecycleInProgress, agent.LifecycleReadyForReview, agent.LifecycleInReview:
@@ -158,37 +155,32 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 	}
 	// Detect PR merge/close and trigger async session cleanup.
 	var cmds []tea.Cmd
-	if msg.pr != nil && (msg.pr.State == "merged" || msg.pr.State == "closed") {
-		repoPath := msg.repoPath
-		if repoPath == "" {
-			repoPath = a.repoPathForSession(msg.sessionID)
-		}
-		if repoPath != "" {
-			if mgr := a.managers[repoPath]; mgr != nil {
-				if sess := mgr.GetSession(msg.sessionID); sess != nil {
-					if sess.LifecyclePhase() == agent.LifecycleShipping {
-						sessID := msg.sessionID
-						if !a.closingSessions[sessID] {
-							sess.SetLifecyclePhase(agent.LifecycleComplete)
-							// Close the shipping panel if this session is currently open in it.
-							if sp := a.modals.Shipping(); sp != nil && sp.SessionID() == sessID {
-								a.closeModal()
-							}
-							var agentIDs []string
-							for _, ag := range sess.Agents() {
-								agentIDs = append(agentIDs, ag.ID)
-								a.closingAgents[ag.ID] = true
-							}
-							a.closingSessions[sessID] = true
-							cmds = append(cmds, func() tea.Msg {
-								return killResultMsg{
-									scope:     killScopeSession,
-									sessionID: sessID,
-									agentIDs:  agentIDs,
-									err:       filterNotFound(mgr.KillSession(sessID)),
-								}
-							})
+	if msg.pr.State == "merged" || msg.pr.State == "closed" {
+		if mgr := a.managers[repoPath]; mgr != nil {
+			if sess := mgr.GetSession(msg.sessionID); sess != nil {
+				if sess.LifecyclePhase() == agent.LifecycleShipping {
+					sessID := msg.sessionID
+					if !a.closingSessions[key] {
+						sess.SetLifecyclePhase(agent.LifecycleComplete)
+						// Close the shipping panel if this session is currently open in it.
+						if sp := a.modals.Shipping(); sp != nil && sp.SessionID() == sessID {
+							a.closeModal()
 						}
+						var agentIDs []string
+						for _, ag := range sess.Agents() {
+							agentIDs = append(agentIDs, ag.ID)
+							a.closingAgents[agentCacheKey(repoPath, ag.ID)] = true
+						}
+						a.closingSessions[key] = true
+						cmds = append(cmds, func() tea.Msg {
+							return killResultMsg{
+								scope:     killScopeSession,
+								repoPath:  repoPath,
+								sessionID: sessID,
+								agentIDs:  agentIDs,
+								err:       filterNotFound(mgr.KillSession(sessID)),
+							}
+						})
 					}
 				}
 			}
@@ -208,14 +200,8 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 			}
 			// Play audio notification, gated by the session's repo AudioEnabled setting
 			// (same gate as the idle-transition notification above).
-			if a.audioPlayer != nil {
-				repoPath := msg.repoPath
-				if repoPath == "" {
-					repoPath = a.repoPathForSession(msg.sessionID)
-				}
-				if repoPath != "" && a.resolvedCache[repoPath].AudioEnabled {
-					a.audioPlayer.Play()
-				}
+			if a.audioPlayer != nil && a.resolvedCache[repoPath].AudioEnabled {
+				a.audioPlayer.Play()
 			}
 		}
 		ps.lastCheckState = newState
@@ -239,7 +225,8 @@ func (a App) handleMergePR(msg mergePRMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 	sess := mgr.GetSession(msg.sessionID)
-	if sess == nil || a.closingSessions[msg.sessionID] {
+	sessKey := cacheKey(repoPath, msg.sessionID)
+	if sess == nil || a.closingSessions[sessKey] {
 		return a, nil
 	}
 	sess.SetLifecyclePhase(agent.LifecycleComplete)
@@ -247,13 +234,14 @@ func (a App) handleMergePR(msg mergePRMsg) (tea.Model, tea.Cmd) {
 	agentIDs := make([]string, 0, len(agents))
 	for _, ag := range agents {
 		agentIDs = append(agentIDs, ag.ID)
-		a.closingAgents[ag.ID] = true
+		a.closingAgents[agentCacheKey(repoPath, ag.ID)] = true
 	}
 	sessID := msg.sessionID
-	a.closingSessions[sessID] = true
+	a.closingSessions[sessKey] = true
 	return a, func() tea.Msg {
 		return killResultMsg{
 			scope:     killScopeSession,
+			repoPath:  repoPath,
 			sessionID: sessID,
 			agentIDs:  agentIDs,
 			err:       filterNotFound(mgr.KillSession(sessID)),
@@ -281,17 +269,18 @@ outer:
 				break outer
 			}
 
-			ps := a.prPollStates[sess.ID]
+			key := cacheKey(repo.Path, sess.ID)
+			ps := a.prPollStates[key]
 			if ps == nil {
 				ps = &prSessionState{}
-				a.prPollStates[sess.ID] = ps
+				a.prPollStates[key] = ps
 			}
 			if ps.inFlight {
 				continue
 			}
 
 			// Determine adaptive polling interval.
-			interval := a.prPollInterval(sess.ID, ps)
+			interval := a.prPollInterval(repo.Path, sess.ID, ps)
 			if now.Sub(ps.lastPoll) < interval {
 				// Push detection runs for every session — including those with a
 				// cached PR — so new commits, force-pushes, and rewrites get
@@ -328,7 +317,7 @@ outer:
 			ps.inFlight = true
 			a.prPollsInFlight++
 			fetchThreads := sess.LifecyclePhase() == agent.LifecycleShipping
-			cachedPRNumber := a.cachedPRNumberForFallback(sess)
+			cachedPRNumber := a.cachedPRNumberForFallback(repo.Path, sess)
 			cmds = append(cmds, a.refreshPRStatusForSession(sess.ID, sess.Branch(), repo.Path, sess.Worktree.Path, fetchThreads, cachedPRNumber))
 		}
 	}
@@ -339,11 +328,11 @@ outer:
 // so the poll cmd can call resolveMergedFallback when the open-only lookup
 // returns nil. Returns 0 for non-Shipping sessions, preserving today's
 // 2-consecutive-nil eviction behaviour for Building/Reviewing sessions.
-func (a *App) cachedPRNumberForFallback(sess *agent.Session) int {
+func (a *App) cachedPRNumberForFallback(repoPath string, sess *agent.Session) int {
 	if sess.LifecyclePhase() != agent.LifecycleShipping {
 		return 0
 	}
-	entry := a.prCache[sess.ID]
+	entry := a.prCache[cacheKey(repoPath, sess.ID)]
 	if entry == nil || entry.pr == nil {
 		return 0
 	}
@@ -351,13 +340,13 @@ func (a *App) cachedPRNumberForFallback(sess *agent.Session) int {
 }
 
 // prPollInterval returns the adaptive polling interval for a session.
-func (a *App) prPollInterval(sessionID string, ps *prSessionState) time.Duration {
+func (a *App) prPollInterval(repoPath, sessionID string, ps *prSessionState) time.Duration {
 	// Event-driven burst (branch rename, new push): poll aggressively for a
 	// short window so state transitions become visible within ~2s.
 	if ps != nil && time.Now().Before(ps.burstUntil) {
 		return PRPollDuringBurst
 	}
-	entry := a.prCache[sessionID]
+	entry := a.prCache[cacheKey(repoPath, sessionID)]
 	// No PR found yet but branch may have been pushed.
 	if entry == nil || entry.pr == nil {
 		if ps.lastRemoteSHA != "" {
@@ -421,9 +410,12 @@ func getLocalHeadSHA(worktreePath string) string {
 func (a *App) refreshPRStatusForSession(sessionID, branch, repoPath, worktreePath string, fetchThreads bool, cachedPRNumber int) tea.Cmd {
 	// Guard: ensure the caller passed the repo that actually owns this session.
 	// This catches programming errors (e.g. passing cfg.Repos[0].Path for a
-	// session that belongs to a different repo) before the poll fires.
-	if owning := a.repoPathForSession(sessionID); owning != "" && owning != repoPath {
-		mismatchErr := fmt.Errorf("internal: refreshPRStatus: repoPath %q does not own session %s (owner=%q)", repoPath, sessionID, owning)
+	// session that belongs to a different repo) before the poll fires. With
+	// composite-keyed caches, an internal mismatch here would route a poll
+	// result to the wrong (repoPath, sessionID) bucket — fail loud rather
+	// than silently corrupt a repo's PR cache.
+	if a.sessionByIDInRepo(repoPath, sessionID) == nil {
+		mismatchErr := fmt.Errorf("internal: refreshPRStatus: repoPath %q does not own session %s", repoPath, sessionID)
 		return func() tea.Msg { return prPollMsg{sessionID: sessionID, repoPath: repoPath, err: mismatchErr} }
 	}
 	ghClient := a.ghClient
@@ -564,7 +556,7 @@ func (a *App) mergePRCmdWithMode(sessionID, repoPath string, force bool) tea.Cmd
 			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("GitHub client not available")}
 		}
 	}
-	entry := a.prCache[sessionID]
+	entry := a.prCache[cacheKey(repoPath, sessionID)]
 	if entry == nil || entry.pr == nil {
 		return func() tea.Msg {
 			return mergePRMsg{sessionID: sessionID, repoPath: repoPath, err: fmt.Errorf("no PR cached")}

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -16,17 +16,17 @@ import (
 
 func (a App) handleReviewDiff(msg reviewDiffMsg) (tea.Model, tea.Cmd) {
 	if msg.err == nil && msg.entry != nil {
-		a.reviewDiffCache[msg.sessionID] = msg.entry
+		repoPath := msg.repoPath
+		if repoPath == "" {
+			repoPath = a.activeRepo
+		}
+		a.reviewDiffCache[cacheKey(repoPath, msg.sessionID)] = msg.entry
 		// Refresh the inline diff viewport when data arrives for the open session.
 		if rp := a.modals.Review(); rp != nil && rp.SessionID() == msg.sessionID && len(msg.entry.groups) > 0 {
 			rp.RefreshDiffViewport(a.panelServices())
 		}
 		// If the entry has task groups, dispatch a reviewer per group.
 		if len(msg.entry.groups) > 0 {
-			repoPath := msg.repoPath
-			if repoPath == "" {
-				repoPath = a.activeRepo
-			}
 			var cmds []tea.Cmd
 			mgr := a.managers[repoPath]
 			var reviewer agent.ReviewerAgent
@@ -41,7 +41,7 @@ func (a App) handleReviewDiff(msg reviewDiffMsg) (tea.Model, tea.Cmd) {
 						if v, ok := msg.entry.verdicts[g.taskIndex]; ok {
 							v.state = verdictRunning
 						}
-						cmds = append(cmds, a.reviewTaskCmd(sess, g, reviewer))
+						cmds = append(cmds, a.reviewTaskCmd(sess, repoPath, g, reviewer))
 					}
 				}
 			}
@@ -62,7 +62,7 @@ func (a App) handleReviewDiff(msg reviewDiffMsg) (tea.Model, tea.Cmd) {
 }
 
 func (a App) handleReviewVerdict(msg reviewVerdictMsg) (tea.Model, tea.Cmd) {
-	entry := a.reviewDiffCache[msg.sessionID]
+	entry := a.reviewDiffCache[cacheKey(msg.repoPath, msg.sessionID)]
 	if entry != nil && entry.verdicts != nil {
 		rec := entry.verdicts[msg.taskIndex]
 		if rec != nil {
@@ -148,13 +148,15 @@ func reviewTaskCount(entry *reviewDiffEntry) int {
 	return n
 }
 
-// sessionByID returns the Session with the given ID across all managed repos,
-// or nil if not found.
-func (a *App) setFeedbackVerdict(sessID, itemKey string, v feedbackVerdict) {
-	if a.feedbackTriage[sessID] == nil {
-		a.feedbackTriage[sessID] = make(map[string]*feedbackTriageEntry)
+// setFeedbackVerdict records a triage verdict for one feedback item, scoped by
+// (repoPath, sessID) so two repos with overlapping session counters don't share
+// the same triage map.
+func (a *App) setFeedbackVerdict(repoPath, sessID, itemKey string, v feedbackVerdict) {
+	key := cacheKey(repoPath, sessID)
+	if a.feedbackTriage[key] == nil {
+		a.feedbackTriage[key] = make(map[string]*feedbackTriageEntry)
 	}
-	m := a.feedbackTriage[sessID]
+	m := a.feedbackTriage[key]
 	if v == feedbackNeutral {
 		if e := m[itemKey]; e == nil || strings.TrimSpace(e.Note) == "" {
 			delete(m, itemKey)
@@ -169,12 +171,14 @@ func (a *App) setFeedbackVerdict(sessID, itemKey string, v feedbackVerdict) {
 
 // setFeedbackNote lazily allocates the per-session triage map and sets the
 // note on the item. If the resulting entry is neutral with an empty note, it
-// is deleted.
-func (a *App) setFeedbackNote(sessID, itemKey, note string) {
-	if a.feedbackTriage[sessID] == nil {
-		a.feedbackTriage[sessID] = make(map[string]*feedbackTriageEntry)
+// is deleted. Keyed by (repoPath, sessID) for the same reason as
+// setFeedbackVerdict.
+func (a *App) setFeedbackNote(repoPath, sessID, itemKey, note string) {
+	key := cacheKey(repoPath, sessID)
+	if a.feedbackTriage[key] == nil {
+		a.feedbackTriage[key] = make(map[string]*feedbackTriageEntry)
 	}
-	m := a.feedbackTriage[sessID]
+	m := a.feedbackTriage[key]
 	if m[itemKey] == nil {
 		if note == "" {
 			return
@@ -211,12 +215,13 @@ func (a App) handleShippingFeedbackRequest(req shippingFeedbackRequestMsg) (tea.
 		return a, nil
 	}
 
-	entry := a.prCache[sess.ID]
+	sessKey := cacheKey(repoPath, sess.ID)
+	entry := a.prCache[sessKey]
 	if entry != nil && entry.pr != nil && entry.pr.State != "" && entry.pr.State != "open" {
 		a.setError(fmt.Sprintf("PR is %s; cannot address feedback on a closed/merged PR", entry.pr.State))
 		return a, nil
 	}
-	prompt := buildFeedbackPrompt(entry, a.feedbackTriage[sess.ID])
+	prompt := buildFeedbackPrompt(entry, a.feedbackTriage[sessKey])
 	if prompt == "" {
 		prompt = "Address the CI failures and review feedback on this PR."
 	}
@@ -240,7 +245,7 @@ func (a App) handleShippingFeedbackRequest(req shippingFeedbackRequestMsg) (tea.
 
 	sessID := sess.ID
 	a.closeModal()
-	delete(a.feedbackTriage, sessID)
+	delete(a.feedbackTriage, sessKey)
 	return a, func() tea.Msg {
 		ag, err := mgr.AddAgent(sessID, cfg)
 		if err != nil {
@@ -447,7 +452,7 @@ func (a App) handleReviewReworkRequest(req reviewReworkRequestMsg) (tea.Model, t
 	}
 	sessID := sess.ID
 	a.closeModal()
-	delete(a.reviewDiffCache, sessID)
+	delete(a.reviewDiffCache, cacheKey(repoPath, sessID))
 	return a, func() tea.Msg {
 		ag, err := mgr.AddAgent(sessID, cfg)
 		if err != nil {
@@ -631,8 +636,9 @@ func populateNoDiffVerdicts(entry *reviewDiffEntry) {
 }
 
 // reviewTaskCmd returns a Cmd that runs a reviewer subprocess for one task
-// group and returns a reviewVerdictMsg when done.
-func (a App) reviewTaskCmd(sess *agent.Session, group taskReviewGroup, reviewer agent.ReviewerAgent) tea.Cmd {
+// group and returns a reviewVerdictMsg when done. repoPath pins the repo so
+// the verdict handler can key the cache lookup by (repoPath, sessionID).
+func (a App) reviewTaskCmd(sess *agent.Session, repoPath string, group taskReviewGroup, reviewer agent.ReviewerAgent) tea.Cmd {
 	sessID := sess.ID
 	originalPrompt := sess.OriginalPrompt()
 	taskIndex := group.taskIndex
@@ -642,7 +648,7 @@ func (a App) reviewTaskCmd(sess *agent.Session, group taskReviewGroup, reviewer 
 	taskText := fmt.Sprintf("Task %d", taskIndex)
 	if taskIndex == 0 {
 		taskText = "Other changes"
-	} else if entry := a.reviewDiffCache[sessID]; entry != nil {
+	} else if entry := a.reviewDiffCache[cacheKey(repoPath, sessID)]; entry != nil {
 		for _, t := range entry.tasks {
 			if t.Index == taskIndex {
 				taskText = t.Text
@@ -660,7 +666,7 @@ func (a App) reviewTaskCmd(sess *agent.Session, group taskReviewGroup, reviewer 
 			TaskDiff:       rawDiff,
 			OriginalPrompt: originalPrompt,
 		})
-		return reviewVerdictMsg{sessionID: sessID, taskIndex: taskIndex, verdict: verdict, err: err}
+		return reviewVerdictMsg{sessionID: sessID, repoPath: repoPath, taskIndex: taskIndex, verdict: verdict, err: err}
 	}
 }
 


### PR DESCRIPTION
Each agent.Manager mints session IDs from its own counter ("session-1",
"session-2", ...), so with multiple repos configured the same ID exists
in two managers. App-level caches keyed on the bare ID were clobbering
across repos: the shipping panel could surface another repo's PR, review
threads could appear under the wrong session, and `m`/`X`/`r` could act
on the wrong row.

Introduce cacheKey(repoPath, sessionID) and agentCacheKey(repoPath,
agentID) helpers and rekey every session-scoped App map: prCache,
prPollStates, diffStatsCache, reviewDiffCache, feedbackTriage,
closingSessions, closingAgents, lastKnownStatus.

To thread repoPath everywhere a cache touch happens:
- Add repoPath to killResultMsg and diffStatsMsg (PR/draft/merge/review
  messages were already covered by 4f28cea).
- Add launchRepoPath to Modals so focusLaunch handlers (ctrl+t, ctrl+n,
  ctrl+w) route to the right manager without a first-match lookup.
- Widen PanelServices.{PRCache, ReviewCache, FeedbackTriage,
  SetFeedbackVerdict, SetFeedbackNote, KillSessionCmd, OpenInLaunch} to
  take repoPath alongside the session/agent ID.

Delete the first-match sessionByID helper — every remaining caller
already has repoPath in scope, and leaving the helper invites future
regressions. Harden repoPathForSession to return "" when more than one
repo claims the ID, so callers fail closed instead of guessing.

Five new regression tests in app_test.go pin the contract: PR cache,
poll-result handling, closing-session badge, agent last-known-status,
and stale-cache cleanup all stay scoped per repo when session IDs
collide.