### PR TITLE
fix(git): branch new worktrees off remote default, not local HEAD

### DIFF
--- a/changelog.d/fix-worktree-remote-default-branch.md
+++ b/changelog.d/fix-worktree-remote-default-branch.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- New session worktrees are now always created off the remote default branch (`origin/HEAD`) rather than whatever the user happens to have checked out locally in the main worktree. Previously, if you ran `refrain` while sitting on `feature/unrelated`, the new worktree was cut from `origin/feature/unrelated`; it now correctly branches from `origin/main` (or your configured `DefaultBranch`). A new `git.RemoteDefaultBranch` helper reads `refs/remotes/origin/HEAD`, repopulating it via `git remote set-head origin -a` if absent; the local HEAD is only used as a last resort for repos with no `origin` remote.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1205,10 +1205,16 @@ func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
 		cfg.AgentProgram = settings.AgentProgram
 	}
 
-	// Determine base branch: use configured default, or auto-detect.
+	// Determine base branch: use configured default, otherwise the remote's
+	// default branch (origin/HEAD). The local HEAD is only used as a final
+	// fallback for repos without an origin remote — new worktrees should
+	// branch off the canonical trunk, not whatever happens to be checked
+	// out in the main working tree.
 	baseBranch := settings.DefaultBranch
 	if baseBranch == "" {
-		if detected, err := git.BaseBranch(m.repoPath); err == nil {
+		if detected, err := git.RemoteDefaultBranch(m.repoPath); err == nil {
+			baseBranch = detected
+		} else if detected, err := git.BaseBranch(m.repoPath); err == nil {
 			baseBranch = detected
 		}
 	}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -991,3 +991,83 @@ func TestManager_EmitDuringShutdownDoesNotPanic(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
+
+// setupTestRepoWithRemote creates a working repo backed by a bare "origin"
+// remote whose default branch is "main". Returns the working repo path.
+func setupTestRepoWithRemote(t *testing.T) string {
+	t.Helper()
+
+	bare := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "init", "--bare"},
+		{"git", "symbolic-ref", "HEAD", "refs/heads/main"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = bare
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup bare %v: %v\n%s", args, err, out)
+		}
+	}
+
+	work := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "clone", bare, "."},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "config", "commit.gpgsign", "false"},
+		{"git", "checkout", "-b", "main"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = work
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup work %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(work, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "initial"},
+		{"git", "push", "-u", "origin", "main"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = work
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup work %v: %v\n%s", args, err, out)
+		}
+	}
+
+	return work
+}
+
+// TestCreateSession_BranchesOffRemoteDefault verifies that a new session's
+// worktree is created from the remote default branch (origin/main) even when
+// the user has a different branch checked out locally in the main worktree.
+// This is a regression test for the bug where Refrain branched off whatever
+// HEAD pointed at locally.
+func TestCreateSession_BranchesOffRemoteDefault(t *testing.T) {
+	repo := setupTestRepoWithRemote(t)
+
+	// Check out a different local branch so HEAD != main.
+	cmd := exec.Command("git", "checkout", "-b", "feature-x")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("checkout feature-x: %v\n%s", err, out)
+	}
+
+	mgr := NewManager(repo, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	sess, _, err := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := sess.Worktree.BaseBranch; got != "main" {
+		t.Errorf("Worktree.BaseBranch = %q, want %q (must use remote default, not local HEAD)", got, "main")
+	}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -75,6 +75,55 @@ func TestBaseBranch(t *testing.T) {
 	}
 }
 
+func TestRemoteDefaultBranch(t *testing.T) {
+	work, _ := initTestRepoWithRemote(t)
+
+	// Check out a different local branch so HEAD is not the remote default.
+	cmd := exec.Command("git", "checkout", "-b", "feature-x")
+	cmd.Dir = work
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("checkout feature-x: %v\n%s", err, out)
+	}
+
+	got, err := git.RemoteDefaultBranch(work)
+	if err != nil {
+		t.Fatalf("RemoteDefaultBranch: %v", err)
+	}
+	if got != "main" {
+		t.Errorf("expected 'main', got %q", got)
+	}
+}
+
+func TestRemoteDefaultBranch_RepopulatesWhenSymrefMissing(t *testing.T) {
+	work, _ := initTestRepoWithRemote(t)
+
+	// Drop any cached origin/HEAD so RemoteDefaultBranch must run
+	// `git remote set-head origin -a` to repopulate it. Use `remote set-head
+	// --delete` because origin/HEAD may be either a symbolic ref or a regular
+	// ref depending on how the clone was set up.
+	cmd := exec.Command("git", "remote", "set-head", "origin", "--delete")
+	cmd.Dir = work
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("delete origin/HEAD: %v\n%s", err, out)
+	}
+
+	got, err := git.RemoteDefaultBranch(work)
+	if err != nil {
+		t.Fatalf("RemoteDefaultBranch: %v", err)
+	}
+	if got != "main" {
+		t.Errorf("expected 'main', got %q", got)
+	}
+}
+
+func TestRemoteDefaultBranch_NoOriginRemote(t *testing.T) {
+	repo := initTestRepo(t)
+
+	if _, err := git.RemoteDefaultBranch(repo); err == nil {
+		t.Error("expected error for repo with no origin remote, got nil")
+	}
+}
+
 func TestCreateWorktree(t *testing.T) {
 	repo := initTestRepo(t)
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -61,6 +61,25 @@ func BaseBranch(repoPath string) (string, error) {
 	return runGit(repoPath, "rev-parse", "--abbrev-ref", "HEAD")
 }
 
+// RemoteDefaultBranch returns the default branch of the "origin" remote
+// (e.g. "main"). It reads refs/remotes/origin/HEAD; if that symref isn't set
+// locally, it runs `git remote set-head origin -a` to populate it from the
+// remote, then re-reads. Returns an error if no origin remote exists or the
+// remote has no HEAD.
+func RemoteDefaultBranch(repoPath string) (string, error) {
+	if out, err := runGit(repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); err == nil && out != "" {
+		return strings.TrimPrefix(out, "origin/"), nil
+	}
+	if _, err := runGit(repoPath, "remote", "set-head", "origin", "-a"); err != nil {
+		return "", fmt.Errorf("resolving origin default branch: %w", err)
+	}
+	out, err := runGit(repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	if err != nil {
+		return "", fmt.Errorf("reading origin/HEAD: %w", err)
+	}
+	return strings.TrimPrefix(out, "origin/"), nil
+}
+
 // UpdateBaseBranch fetches the given branch from origin and attempts to
 // fast-forward the local ref to match. This is best-effort: if the fetch
 // fails (e.g. offline), an error is returned. If the fast-forward fails


### PR DESCRIPTION
When no DefaultBranch is configured, createSessionWorktree fell back to
git.BaseBranch (the locally checked-out branch in the main worktree), so
sessions started while sitting on a feature branch were cut from
origin/<feature-branch> instead of origin/main. Add git.RemoteDefaultBranch
which reads refs/remotes/origin/HEAD (repopulating via `git remote set-head
origin -a` if missing) and use it as the manager's fallback; only fall back
to local HEAD for repos with no origin remote.