### PR TITLE
test(songs): sharpen mutation coverage from 49% to 76%

### DIFF
--- a/internal/songs/songs_test.go
+++ b/internal/songs/songs_test.go
@@ -2,6 +2,7 @@ package songs
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -66,6 +67,74 @@ func TestPick_AvoidsCollision(t *testing.T) {
 		}
 		existing = append(existing, slug)
 	}
+}
+
+// TestSlug_ExactOutput asserts exact input→output mappings so that string-literal
+// and boundary mutations in Slug() diverge from the original.
+func TestSlug_ExactOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		// spaces → hyphens, lowercased
+		{"Bohemian Rhapsody", "bohemian-rhapsody"},
+		// leading special char replaced then trimmed
+		{"!Hello World", "hello-world"},
+		// digit-starting slug is valid
+		{"99 Problems", "99-problems"},
+		// exactly 40 chars: not truncated
+		{strings.Repeat("a", 40), strings.Repeat("a", 40)},
+		// 41 chars: truncated to exactly 40
+		{strings.Repeat("a", 41), strings.Repeat("a", 40)},
+		// well over 40 chars: truncated to exactly 40
+		{strings.Repeat("a", 50), strings.Repeat("a", 40)},
+		// slug starting with 'z': kills #3 (slug[0] > 'z' boundary — >= would reject 'z')
+		{"zero", "zero"},
+		// slug starting with '0': kills #4 (slug[0] < '0' boundary — <= would reject '0')
+		{"007 Goldeneye", "007-goldeneye"},
+		// digit + dash: slug[1]='-', kills #42 (index shift makes '-' < '0' true)
+		{"0 hello", "0-hello"},
+		// digit + letter: slug[1]='z', kills #44 (index shift makes 'z' > '9' true)
+		{"0z world", "0z-world"},
+	}
+	for _, tc := range cases {
+		got := Track{Name: tc.name}.Slug()
+		if got != tc.want {
+			t.Errorf("Track{Name:%q}.Slug() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestSlug_TruncateTrimsTrailingDash verifies that a dash landing at position 40
+// after truncation is removed by TrimRight.
+func TestSlug_TruncateTrimsTrailingDash(t *testing.T) {
+	// 39 a's + space + "b" → "aaa…a-b" (41 chars) → [:40] → "aaa…a-" → TrimRight → "aaa…a"
+	name := strings.Repeat("a", 39) + " b"
+	want := strings.Repeat("a", 39)
+	got := Track{Name: name}.Slug()
+	if got != want {
+		t.Errorf("Track{Name:%q}.Slug() = %q, want %q (len %d)", name, got, want, len(got))
+	}
+}
+
+// TestPick_PanicsOnEmptyCatalog exercises the guard at the top of Pick and checks
+// the exact panic message.
+func TestPick_PanicsOnEmptyCatalog(t *testing.T) {
+	saved := catalog
+	catalog = nil
+	defer func() { catalog = saved }()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Error("Pick with empty catalog should panic")
+			return
+		}
+		msg, ok := r.(string)
+		if !ok || msg != "songs: catalog is empty" {
+			t.Errorf("wrong panic value: %v", r)
+		}
+	}()
+	Pick(nil)
 }
 
 func TestPick_WithExistingAvoidsDuplicate(t *testing.T) {


### PR DESCRIPTION
## Summary

- Added three targeted tests to the internal/songs package that collectively kill 15 surviving mutants
  - **TestSlug_ExactOutput**: Comprehensive input→output table covering string-literal, boundary, and index-shift mutations in Slug()
  - **TestSlug_TruncateTrimsTrailingDash**: Verifies truncation correctly trims trailing dashes (39-'a's + space → 40-char slug minus dash)
  - **TestPick_PanicsOnEmptyCatalog**: Validates Pick panics with expected message on empty catalog
- Mutation score improved from 49% to 76% on the songs package
- Remaining 13 survivors are equivalent mutations (dead code paths after regex processing) or untestable init() panic paths

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] Mutation testing: `kanly run --format=llm --jobs=8 ./internal/songs`

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description