### PR TITLE
Fix release-readiness gaps: Linux support, --version, NO_COLOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 A terminal-native dashboard for running [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents in parallel — designed around how many agents a human can actually oversee, not how many you can launch.
 
-<!-- TODO: record demo GIF and replace placeholder -->
-![Refrain demo](docs/demo.gif)
-
 > **Alpha software — v0.1.0 shipped.** The core loop is working and stabilizing, but rough edges remain. APIs, config schema, and keybindings may change between versions. Git operations are conservative — Refrain only writes to `refrain/*` branches inside `.refrain/worktrees/` and uses `git merge --no-ff` with explicit confirmation — but keep your work committed and file issues when things break.
 
 ## Install
@@ -31,9 +28,14 @@ go build -o refrain .
 
 ## Requirements
 
+- **Platforms:** macOS (amd64, arm64) and Linux (amd64, arm64). Windows is not currently supported.
 - Git 2.20+
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude` on PATH, with `--settings` support for hook integration)
 - Optional: `gh` CLI or `GITHUB_TOKEN` for PR creation and checks polling
+
+**Platform notes:**
+- Audio chimes work on macOS (`afplay`) and Linux (`paplay` or `aplay`). Silent on other platforms.
+- IDE detection auto-discovers editors on macOS (`.app` bundles) and Linux (PATH lookup). The `IDECommand` setting works everywhere.
 
 Verify your environment:
 

--- a/changelog.d/release-readiness.md
+++ b/changelog.d/release-readiness.md
@@ -1,0 +1,11 @@
+### Added
+
+- Linux audio chime support: tries `paplay` (PulseAudio), then `aplay` (ALSA). Silent on unsupported platforms.
+- Linux editor detection: probes PATH for `code`, `zed`, `cursor`, `idea`, and other editor CLIs. Also picks up `$VISUAL` and `$EDITOR`.
+- `--version` flag (in addition to the existing `refrain version` subcommand).
+- `NO_COLOR` environment variable support: when set, all hardcoded colors are suppressed.
+
+### Fixed
+
+- Removed broken demo GIF image tag from README.
+- Added platform notes to README Requirements section (macOS + Linux support, no Windows).

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	rootCmd.Version = resolvedVersion()
+}
+
 var rootCmd = &cobra.Command{
 	Use:   "refrain",
 	Short: "A terminal-native tool for orchestrating multiple Claude Code agents",

--- a/internal/audio/player.go
+++ b/internal/audio/player.go
@@ -3,6 +3,7 @@ package audio
 import (
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 	"time"
 )
@@ -13,8 +14,28 @@ const debounceDuration = 2 * time.Second
 // All errors are silent — audio is best-effort.
 type Player struct {
 	chimePath  string
+	playCmd    string
 	lastPlayed time.Time
 	mu         sync.Mutex
+}
+
+// resolvePlayCmd returns the platform audio command, or "" if none is available.
+var resolvePlayCmd = defaultResolvePlayCmd
+
+func defaultResolvePlayCmd() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "afplay"
+	case "linux":
+		for _, cmd := range []string{"paplay", "aplay"} {
+			if _, err := exec.LookPath(cmd); err == nil {
+				return cmd
+			}
+		}
+		return ""
+	default:
+		return ""
+	}
 }
 
 // NewPlayer generates a chime WAV file and returns a Player that can play it.
@@ -23,7 +44,7 @@ func NewPlayer() (*Player, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Player{chimePath: path}, nil
+	return &Player{chimePath: path, playCmd: resolvePlayCmd()}, nil
 }
 
 // Play plays the chime sound if at least 2 seconds have elapsed since the last play.
@@ -32,13 +53,17 @@ func (p *Player) Play() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if p.playCmd == "" {
+		return
+	}
+
 	if time.Since(p.lastPlayed) < debounceDuration {
 		return
 	}
 	p.lastPlayed = time.Now()
 
 	go func() {
-		_ = exec.Command("afplay", p.chimePath).Run()
+		_ = exec.Command(p.playCmd, p.chimePath).Run()
 	}()
 }
 

--- a/internal/audio/player_test.go
+++ b/internal/audio/player_test.go
@@ -41,8 +41,9 @@ func TestPlayer_Debounce(t *testing.T) {
 	}
 	defer p.Close()
 
-	// Override chimePath to a nonexistent file so afplay fails silently
-	// (we only care about debounce logic, not actual playback).
+	// Use "true" as a no-op command so Play() sets lastPlayed without
+	// needing a real audio player.
+	p.playCmd = "true"
 	p.chimePath = "/dev/null"
 
 	// First call should update lastPlayed.
@@ -60,5 +61,20 @@ func TestPlayer_Debounce(t *testing.T) {
 
 	if !second.Equal(first) {
 		t.Errorf("expected debounce to suppress second Play(); lastPlayed changed from %v to %v", first, second)
+	}
+}
+
+func TestPlayer_NoPlayCmd_Noop(t *testing.T) {
+	p, err := NewPlayer()
+	if err != nil {
+		t.Fatalf("NewPlayer() error: %v", err)
+	}
+	defer p.Close()
+
+	p.playCmd = ""
+	p.Play()
+
+	if !p.LastPlayedTime().IsZero() {
+		t.Error("expected Play() to be a no-op when playCmd is empty")
 	}
 }

--- a/internal/editor/detect.go
+++ b/internal/editor/detect.go
@@ -1,10 +1,11 @@
-// Package editor detects installed GUI editors on macOS and maps stored
-// launch commands back to detected editors for UI pre-selection.
+// Package editor detects installed GUI editors on macOS and Linux and maps
+// stored launch commands back to detected editors for UI pre-selection.
 package editor
 
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 )
@@ -36,6 +37,24 @@ var curatedApps = []struct {
 	{"RustRover", "RustRover.app"},
 }
 
+// curatedCLIs lists editor CLI commands to probe on Linux, in display order.
+var curatedCLIs = []struct {
+	Name string
+	Cmd  string
+}{
+	{"Zed", "zed"},
+	{"Visual Studio Code", "code"},
+	{"Cursor", "cursor"},
+	{"IntelliJ IDEA", "idea"},
+	{"GoLand", "goland"},
+	{"PyCharm", "pycharm"},
+	{"WebStorm", "webstorm"},
+	{"RubyMine", "rubymine"},
+	{"PhpStorm", "phpstorm"},
+	{"CLion", "clion"},
+	{"RustRover", "rustrover"},
+}
+
 // searchRoots returns the directories to probe for .app bundles on macOS.
 // Overridden in tests via setSearchRoots.
 var searchRoots = defaultSearchRoots
@@ -48,12 +67,24 @@ func defaultSearchRoots() []string {
 	return roots
 }
 
-// Detect probes known locations for editor .app bundles on macOS and returns
-// the matches in curated-list order. On non-darwin platforms returns nil.
+// lookPath is overridden in tests.
+var lookPath = exec.LookPath
+
+// Detect probes known locations for editors and returns matches in curated
+// order. On macOS it probes .app bundles; on Linux it checks PATH for CLI
+// commands and $VISUAL/$EDITOR. On other platforms returns nil.
 func Detect() []Editor {
-	if runtime.GOOS != "darwin" {
+	switch runtime.GOOS {
+	case "darwin":
+		return detectDarwin()
+	case "linux":
+		return detectLinux()
+	default:
 		return nil
 	}
+}
+
+func detectDarwin() []Editor {
 	roots := searchRoots()
 	out := make([]Editor, 0, len(curatedApps))
 	for _, app := range curatedApps {
@@ -70,6 +101,32 @@ func Detect() []Editor {
 	return out
 }
 
+func detectLinux() []Editor {
+	out := make([]Editor, 0, len(curatedCLIs))
+	seen := make(map[string]bool)
+	for _, cli := range curatedCLIs {
+		if _, err := lookPath(cli.Cmd); err == nil {
+			out = append(out, Editor{
+				Name:    cli.Name,
+				Command: cli.Cmd,
+			})
+			seen[cli.Cmd] = true
+		}
+	}
+	for _, env := range []string{"VISUAL", "EDITOR"} {
+		if val := os.Getenv(env); val != "" && !seen[val] {
+			if _, err := lookPath(val); err == nil {
+				out = append(out, Editor{
+					Name:    "$" + env + " (" + val + ")",
+					Command: val,
+				})
+				seen[val] = true
+			}
+		}
+	}
+	return out
+}
+
 // MatchCommand reverse-looks up a stored command string to a curated editor.
 // Returns nil if no exact match. Used to pre-select the dropdown when loading
 // an existing config.
@@ -78,6 +135,11 @@ func MatchCommand(cmd string) *Editor {
 		expected := fmt.Sprintf(`open -a %q`, app.Name)
 		if cmd == expected {
 			return &Editor{Name: app.Name, Command: expected}
+		}
+	}
+	for _, cli := range curatedCLIs {
+		if cmd == cli.Cmd {
+			return &Editor{Name: cli.Name, Command: cli.Cmd}
 		}
 	}
 	return nil

--- a/internal/editor/detect_test.go
+++ b/internal/editor/detect_test.go
@@ -2,14 +2,15 @@ package editor
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 )
 
-func TestDetect_NonDarwin(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("only runs on non-darwin")
+func TestDetect_UnsupportedPlatform(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		t.Skip("only runs on unsupported platforms")
 	}
 	if got := Detect(); got != nil {
 		t.Fatalf("Detect on %s: want nil, got %v", runtime.GOOS, got)
@@ -95,6 +96,81 @@ func TestMatchCommand(t *testing.T) {
 	}
 }
 
+func TestDetect_Linux_FindsCLIs(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("only runs on linux")
+	}
+	available := map[string]bool{"code": true, "zed": true}
+	withLookPath(t, func(name string) (string, error) {
+		if available[name] {
+			return "/usr/bin/" + name, nil
+		}
+		return "", exec.ErrNotFound
+	})
+
+	got := detectLinux()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 editors, got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "Zed" || got[0].Command != "zed" {
+		t.Fatalf("expected Zed first, got %+v", got[0])
+	}
+	if got[1].Name != "Visual Studio Code" || got[1].Command != "code" {
+		t.Fatalf("expected VS Code second, got %+v", got[1])
+	}
+}
+
+func TestDetect_Linux_IncludesEnvEditors(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("only runs on linux")
+	}
+	withLookPath(t, func(name string) (string, error) {
+		if name == "nvim" {
+			return "/usr/bin/nvim", nil
+		}
+		return "", exec.ErrNotFound
+	})
+	t.Setenv("VISUAL", "nvim")
+	t.Setenv("EDITOR", "")
+
+	got := detectLinux()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 editor from $VISUAL, got %d: %+v", len(got), got)
+	}
+	if got[0].Command != "nvim" {
+		t.Fatalf("expected nvim, got %+v", got[0])
+	}
+}
+
+func TestDetect_Linux_NoDuplicateEnv(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("only runs on linux")
+	}
+	withLookPath(t, func(name string) (string, error) {
+		if name == "code" {
+			return "/usr/bin/code", nil
+		}
+		return "", exec.ErrNotFound
+	})
+	t.Setenv("VISUAL", "code")
+
+	got := detectLinux()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 (no duplicate from $VISUAL), got %d: %+v", len(got), got)
+	}
+}
+
+func TestMatchCommand_LinuxCLI(t *testing.T) {
+	got := MatchCommand("code")
+	if got == nil || got.Name != "Visual Studio Code" {
+		t.Fatalf("MatchCommand(\"code\") = %+v, want VS Code", got)
+	}
+	got = MatchCommand("zed")
+	if got == nil || got.Name != "Zed" {
+		t.Fatalf("MatchCommand(\"zed\") = %+v, want Zed", got)
+	}
+}
+
 // mkAppBundle creates a directory simulating a .app bundle under root.
 func mkAppBundle(t *testing.T, root, name string) {
 	t.Helper()
@@ -109,4 +185,12 @@ func withSearchRoots(t *testing.T, roots []string) {
 	prev := searchRoots
 	searchRoots = func() []string { return roots }
 	t.Cleanup(func() { searchRoots = prev })
+}
+
+// withLookPath swaps the package-level lookPath for the duration of a test.
+func withLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	prev := lookPath
+	lookPath = fn
+	t.Cleanup(func() { lookPath = prev })
 }

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -49,7 +49,7 @@ type sessionTicker struct {
 // ColorWaiting is the accent used for agents in StatusWaiting (permission
 // prompts, input blocks). Scoped to the dashboard because no other view
 // needs it today — add to theme.go if another view ever surfaces waiting.
-var ColorWaiting = lipgloss.Color("#D946EF")
+var ColorWaiting = initColor("#D946EF")
 
 // listItemKind distinguishes repo headers, session rows, and agent rows in the dashboard list.
 type listItemKind int

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,16 +1,22 @@
 package tui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var noColor = os.Getenv("NO_COLOR") != ""
 
 var (
-	ColorPrimary   = lipgloss.Color("#7C3AED")
-	ColorSecondary = lipgloss.Color("#06B6D4")
-	ColorSuccess   = lipgloss.Color("#10B981")
-	ColorWarning   = lipgloss.Color("#F59E0B")
-	ColorError     = lipgloss.Color("#EF4444")
-	ColorMuted     = lipgloss.Color("#6B7280")
-	ColorText      = lipgloss.Color("#F9FAFB")
-	ColorBg        = lipgloss.Color("#111827")
+	ColorPrimary   = initColor("#7C3AED")
+	ColorSecondary = initColor("#06B6D4")
+	ColorSuccess   = initColor("#10B981")
+	ColorWarning   = initColor("#F59E0B")
+	ColorError     = initColor("#EF4444")
+	ColorMuted     = initColor("#6B7280")
+	ColorText      = initColor("#F9FAFB")
+	ColorBg        = initColor("#111827")
 
 	StyleTitle = lipgloss.NewStyle().
 			Bold(true).
@@ -37,6 +43,13 @@ var (
 
 	StyleStatusBar = lipgloss.NewStyle().
 			Foreground(ColorText).
-			Background(lipgloss.Color("#1F2937")).
+			Background(initColor("#1F2937")).
 			Padding(0, 1)
 )
+
+func initColor(hex string) lipgloss.Color {
+	if noColor {
+		return lipgloss.Color("")
+	}
+	return lipgloss.Color(hex)
+}


### PR DESCRIPTION
- Add Linux audio chime support (paplay/aplay fallback), silent no-op
  when no player is available instead of spawning a failing afplay
- Add Linux editor detection via PATH probing (code, zed, cursor,
  idea, etc.) and $VISUAL/$EDITOR env vars
- Add --version flag via rootCmd.Version (supplements `refrain version`)
- Add NO_COLOR env var support: when set, all theme colors are suppressed
- Remove broken demo GIF image tag from README
- Add platform notes to README Requirements section
- Add MatchCommand support for Linux CLI editor names

https://claude.ai/code/session_01Xj3zt2n8G1MgG76bUTvEft