### PR TITLE
Fix PR draft indicator leaking to sessions with colliding IDs across repos

### DIFF
--- a/changelog.d/fix-pr-indicator-multi-session.md
+++ b/changelog.d/fix-pr-indicator-multi-session.md
@@ -1,0 +1,2 @@
+### Fixed
+- PR "drafting PR…" indicator no longer appears on sessions in other repos that happen to share the same session ID.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -224,8 +224,9 @@ type App struct {
 	prCache          map[string]*prCacheEntry   // keyed by cacheKey(repoPath, sessionID)
 	prPollStates     map[string]*prSessionState // keyed by cacheKey(repoPath, sessionID)
 	prPollsInFlight  int                        // count of concurrent in-flight polls
-	prDraftInFlight  bool                       // true while startPRDraftCmd is running; prevents double-trigger
-	prDraftSessionID string                     // ID of the session whose PR draft is in flight; "" when idle
+	prDraftInFlight  bool   // true while startPRDraftCmd is running; prevents double-trigger
+	prDraftSessionID string // ID of the session whose PR draft is in flight; "" when idle
+	prDraftRepoPath  string // repo path of the session whose PR draft is in flight; "" when idle
 
 	// keys holds the dashboard action→key bindings. Stored on App so tests
 	// and future rebinding flows can swap a non-default map.
@@ -647,6 +648,7 @@ func (a *App) panelServices() PanelServices {
 		StartPRDraftCmd: func(sess *agent.Session, repoPath string, transitionShipping bool) tea.Cmd {
 			a.prDraftInFlight = true
 			a.prDraftSessionID = sess.ID
+			a.prDraftRepoPath = repoPath
 			a.prModalTransitionShipping = transitionShipping
 			return a.startPRDraftCmd(sess, repoPath, transitionShipping)
 		},
@@ -676,7 +678,9 @@ func (a *App) panelServices() PanelServices {
 			}
 		},
 		FetchReviewDiff:    func(sess *agent.Session, repoPath string) tea.Cmd { return a.fetchReviewDiffCmd(sess, repoPath) },
-		prDraftInFlightFor: func(sessionID string) bool { return a.prDraftInFlight && a.prDraftSessionID == sessionID },
+		prDraftInFlightFor: func(sessionID, repoPath string) bool {
+			return a.prDraftInFlight && a.prDraftSessionID == sessionID && a.prDraftRepoPath == repoPath
+		},
 		FeedbackTriage: func(repoPath, sessionID string) map[string]*feedbackTriageEntry {
 			return a.feedbackTriage[cacheKey(repoPath, sessionID)]
 		},
@@ -717,6 +721,7 @@ func (a *App) refreshAgentList() {
 	a.dashboard.focusBreakTimerUp = a.wellness.focusBreakTimerUp
 	a.dashboard.cursor = a.cursor
 	a.dashboard.prDraftSessionID = a.prDraftSessionID
+	a.dashboard.prDraftRepoPath = a.prDraftRepoPath
 	a.dashboard.activeRepoName = a.activeRepoDisplayName()
 	a.dashboard.activeRepoPath = a.activeRepo
 	a.syncModalsToDashboard()
@@ -912,6 +917,7 @@ func (a *App) cursorSelectedRepoPath() string {
 func (a *App) syncFocusCursorToDashboard() {
 	a.dashboard.cursor = a.cursor
 	a.dashboard.prDraftSessionID = a.prDraftSessionID
+	a.dashboard.prDraftRepoPath = a.prDraftRepoPath
 }
 
 // activateFocusCursor opens the row currently under the fullscreen-focus

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -116,6 +116,7 @@ type dashboardModel struct {
 	focusBreakTimerUp      bool
 	cursor                 FocusedCursor  // pipeline cursor mirror; synced from App on every refresh
 	prDraftSessionID       string         // session ID whose PR draft is in flight; "" when idle
+	prDraftRepoPath        string         // repo path whose PR draft is in flight; "" when idle
 	activeRepoName         string         // display name of the active repo
 	activeRepoPath         string         // canonical path of the active repo (for pipeline filtering)
 	focusLaunchAgent       *agent.Agent   // agent open in focusLaunch terminal; nil otherwise
@@ -1709,7 +1710,7 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName, repoPath s
 	}
 
 	var taskDisplay string
-	if d.prDraftSessionID != "" && sess.ID == d.prDraftSessionID {
+	if d.prDraftSessionID != "" && sess.ID == d.prDraftSessionID && repoPath == d.prDraftRepoPath {
 		taskDisplay = lipgloss.NewStyle().Foreground(ColorWarning).Render(reviewSpinnerFrame() + " drafting PR…")
 	} else {
 		origPrompt := sess.OriginalPrompt()

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
 	"github.com/devenjarvis/refrain/internal/hook"
+	"pgregory.net/rapid"
 )
 
 func TestSelectionRect_Inactive(t *testing.T) {
@@ -711,9 +713,11 @@ func TestRenderQueueRow_PRDraftBadge(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	// With prDraftSessionID matching the session: badge should appear.
-	d := dashboardModel{prDraftSessionID: sess.ID}
-	rows := d.renderQueueRow(sess, "", "", false, ColorWarning, 80)
+	repo := "/repo/a"
+
+	// With prDraftSessionID+prDraftRepoPath matching the session: badge should appear.
+	d := dashboardModel{prDraftSessionID: sess.ID, prDraftRepoPath: repo}
+	rows := d.renderQueueRow(sess, "", repo, false, ColorWarning, 80)
 	if len(rows) < 2 {
 		t.Fatalf("renderQueueRow returned %d lines, want 2", len(rows))
 	}
@@ -723,11 +727,65 @@ func TestRenderQueueRow_PRDraftBadge(t *testing.T) {
 
 	// With prDraftSessionID cleared: normal prompt should appear.
 	d.prDraftSessionID = ""
-	rows = d.renderQueueRow(sess, "", "", false, ColorWarning, 80)
+	d.prDraftRepoPath = ""
+	rows = d.renderQueueRow(sess, "", repo, false, ColorWarning, 80)
 	if strings.Contains(ansi.Strip(rows[1]), "drafting PR") {
 		t.Error("cleared state must not show badge; got 'drafting PR' on line 2")
 	}
 	if !strings.Contains(ansi.Strip(rows[1]), "Fix the auth bug") {
 		t.Errorf("cleared state line 2 = %q, want original prompt", rows[1])
 	}
+}
+
+// TestRenderQueueRow_PRDraftBadge_OnlyTargetSession is a property test that
+// verifies the "drafting PR…" indicator appears exclusively on the session
+// whose PR draft is in flight, never leaking to other sessions — even when
+// session IDs collide across different repos.
+func TestRenderQueueRow_PRDraftBadge_OnlyTargetSession(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		nRepos := rapid.IntRange(1, 4).Draw(t, "nRepos")
+		sessPerRepo := rapid.IntRange(1, 4).Draw(t, "sessPerRepo")
+
+		type repoSession struct {
+			sess     *agent.Session
+			repoPath string
+		}
+		var all []repoSession
+		for r := range nRepos {
+			repoPath := fmt.Sprintf("/repo/%d", r)
+			for s := range sessPerRepo {
+				id := fmt.Sprintf("session-%d", s+1)
+				sess := agent.NewSessionForTest(id, fmt.Sprintf("s%d", s))
+				sess.SetOriginalPrompt(fmt.Sprintf("task for %s in %s", id, repoPath))
+				sess.MarkDone()
+				all = append(all, repoSession{sess: sess, repoPath: repoPath})
+			}
+		}
+
+		targetIdx := rapid.IntRange(0, len(all)-1).Draw(t, "target")
+		target := all[targetIdx]
+
+		d := dashboardModel{
+			prDraftSessionID: target.sess.ID,
+			prDraftRepoPath:  target.repoPath,
+		}
+
+		for i, rs := range all {
+			rows := d.renderQueueRow(rs.sess, "", rs.repoPath, false, ColorWarning, 80)
+			if len(rows) < 2 {
+				t.Fatalf("renderQueueRow for item %d returned %d lines, want 2", i, len(rows))
+			}
+			line := ansi.Strip(rows[1])
+			hasBadge := strings.Contains(line, "drafting PR")
+
+			if i == targetIdx && !hasBadge {
+				t.Fatalf("target session (idx=%d, id=%q, repo=%q) missing 'drafting PR' badge: %q",
+					i, rs.sess.ID, rs.repoPath, line)
+			}
+			if i != targetIdx && hasBadge {
+				t.Fatalf("non-target session (idx=%d, id=%q, repo=%q) has 'drafting PR' badge: %q (target id=%q, repo=%q)",
+					i, rs.sess.ID, rs.repoPath, line, target.sess.ID, target.repoPath)
+			}
+		}
+	})
 }

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -66,9 +66,9 @@ type PanelServices struct {
 	FetchReviewDiff func(sess *agent.Session, repoPath string) tea.Cmd
 
 	// prDraftInFlightFor reports whether a PR draft request is currently in
-	// flight for the given session ID. The review panel uses this to render
-	// the "Drafting PR…" footer hint.
-	prDraftInFlightFor func(sessionID string) bool
+	// flight for the given (sessionID, repoPath) pair. The review panel uses
+	// this to render the "Drafting PR…" footer hint.
+	prDraftInFlightFor func(sessionID, repoPath string) bool
 
 	// Shipping-panel feedback triage state. Reads return the live map (or
 	// nil); the setters lazily allocate and apply the same cleanup rules as

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -395,6 +395,6 @@ func (m *reviewPanelModel) View(svc PanelServices) string {
 		return renderReviewSpecOverlay(m.session, plan, m.specOverlayScroll, m.width, m.height)
 	}
 	entry := svc.ReviewCache(m.repoPath, m.session.ID)
-	prDraftInFlight := svc.prDraftInFlightFor(m.session.ID)
+	prDraftInFlight := svc.prDraftInFlightFor(m.session.ID, m.repoPath)
 	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.diffVP.View())
 }

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -54,7 +54,7 @@ func newTestSvc() (PanelServices, *testServiceState) {
 		},
 		SetFeedbackVerdict: func(string, string, string, feedbackVerdict) {},
 		SetFeedbackNote:    func(string, string, string, string) {},
-		prDraftInFlightFor: func(string) bool { return false },
+		prDraftInFlightFor: func(string, string) bool { return false },
 	}
 	return svc, state
 }

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -671,6 +671,7 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 				}
 				a.prDraftInFlight = true
 				a.prDraftSessionID = sess.ID
+				a.prDraftRepoPath = repoPath
 				return a, a.startPRDraftCmd(sess, repoPath, false), true
 			}
 		}

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -18,6 +18,7 @@ import (
 func (a App) handlePRDraftReady(msg prDraftReadyMsg) (tea.Model, tea.Cmd) {
 	a.prDraftInFlight = false
 	a.prDraftSessionID = ""
+	a.prDraftRepoPath = ""
 	if msg.err != nil {
 		a.setError("PR draft failed: " + msg.err.Error())
 		return a, nil


### PR DESCRIPTION
Session IDs are sequential per-repo counters (session-1, session-2, …),
so prDraftSessionID alone can match the wrong session in a different repo.
Add prDraftRepoPath alongside prDraftSessionID and check both when
rendering the "drafting PR…" badge and in prDraftInFlightFor. Property
test confirms the indicator appears exclusively on the target session.

https://claude.ai/code/session_01M3u9KYng9X9Jdie5Rrbpn1