### PR TITLE
Redesign planning display with research-backed TUI typography and layout

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -220,12 +220,13 @@ type App struct {
 	diffStatsCache      map[string]*diffStatsEntry // keyed by cacheKey(repoPath, sessionID)
 	diffRefreshInFlight bool
 
-	ghClient         *github.Client
-	prCache          map[string]*prCacheEntry   // keyed by cacheKey(repoPath, sessionID)
-	prPollStates     map[string]*prSessionState // keyed by cacheKey(repoPath, sessionID)
-	prPollsInFlight  int                        // count of concurrent in-flight polls
-	prDraftInFlight  bool                       // true while startPRDraftCmd is running; prevents double-trigger
-	prDraftSessionID string                     // ID of the session whose PR draft is in flight; "" when idle
+	ghClient        *github.Client
+	prCache         map[string]*prCacheEntry   // keyed by cacheKey(repoPath, sessionID)
+	prPollStates    map[string]*prSessionState // keyed by cacheKey(repoPath, sessionID)
+	prPollsInFlight int                        // count of concurrent in-flight polls
+
+	prDraftInFlight  bool   // true while startPRDraftCmd is running; prevents double-trigger
+	prDraftSessionID string // ID of the session whose PR draft is in flight; "" when idle
 
 	// keys holds the dashboard action→key bindings. Stored on App so tests
 	// and future rebinding flows can swap a non-default map.

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -623,7 +623,7 @@ var (
 
 	styleBold       = lipgloss.NewStyle().Bold(true)
 	styleItalic     = lipgloss.NewStyle().Italic(true)
-	styleInlineCode = lipgloss.NewStyle().Foreground(colCodeFG)
+	styleInlineCode = lipgloss.NewStyle().Foreground(colCodeFG).Background(lipgloss.Color("#2D2D2D"))
 	styleLink       = lipgloss.NewStyle().Foreground(colLink).Underline(true)
 	styleBlockquote = lipgloss.NewStyle().Foreground(colQuote).Italic(true)
 	styleHR         = lipgloss.NewStyle().Foreground(colHR)

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -178,13 +178,28 @@ func (r *Renderer) RenderLines(plan string, width int) []string {
 		if i < len(ctxs) {
 			ctx = ctxs[i]
 		}
-		segments := wrapPlain(line, width)
+		// Fence lines get a │ bar prefix in scroll mode (2 chars wide), so
+		// wrap at width-2 to keep the total within the content measure.
+		isFenceLine := ctx.Kind == LineFenceContent || ctx.Kind == LineFenceOpen || ctx.Kind == LineFenceClose
+		wrapWidth := width
+		if isFenceLine && width > 2 {
+			wrapWidth = width - 2
+		}
+		segments := wrapPlain(line, wrapWidth)
+		fenceBar := styleFenceBar.Render("│") + " "
 		if len(segments) == 0 {
-			out = append(out, r.StyleSegment("", ctx, false))
+			styled := r.StyleSegment("", ctx, false)
+			if isFenceLine {
+				styled = fenceBar + styled
+			}
+			out = append(out, styled)
 		} else {
 			col := 0
 			for j, seg := range segments {
 				styled := r.styleSegmentWithFence(seg, ctx, j > 0, col)
+				if isFenceLine {
+					styled = fenceBar + styled
+				}
 				out = append(out, styled)
 				col += ansi.StringWidth(seg)
 			}
@@ -569,6 +584,7 @@ var (
 
 	colMuted          = lipgloss.Color("#6B7280")
 	colCodeFG         = lipgloss.Color("#FBBF24") // amber for inline code
+	colCodeBg         = lipgloss.Color("#1A1D23") // subtle dark background for code blocks
 	colLink           = lipgloss.Color("#06B6D4")
 	colQuote          = lipgloss.Color("#9CA3AF")
 	colHR             = lipgloss.Color("#374151")
@@ -594,8 +610,10 @@ var (
 
 	// Fence-marker line ("```go", "```"): muted to keep attention on content.
 	styleFenceMarker = lipgloss.NewStyle().Foreground(colMuted)
-	// Fallback for fence content when chroma fails.
-	styleFenceContent = lipgloss.NewStyle().Foreground(colCodeFG)
+	// Fallback for fence content when chroma fails; includes background tint.
+	styleFenceContent = lipgloss.NewStyle().Foreground(colCodeFG).Background(colCodeBg)
+	// Bar glyph prepended to fence lines in scroll mode.
+	styleFenceBar = lipgloss.NewStyle().Foreground(colMuted)
 )
 
 func styleHeading(level int) lipgloss.Style {

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -358,7 +358,7 @@ func (r *Renderer) styleSegmentWithFence(segment string, parent LineCtx, isConti
 	case LineBlank:
 		return segment
 	default:
-		return styleInline(segment)
+		return styleParagraph.Render(styleInline(segment))
 	}
 }
 
@@ -613,6 +613,7 @@ var (
 	colBullet         = lipgloss.Color("#A78BFA")
 	colListNum        = lipgloss.Color("#A78BFA")
 	colCheckboxDone   = lipgloss.Color("#10B981") // success green
+	colParagraph      = lipgloss.Color("#D1D5DB") // softer white for prose
 
 	styleH1 = lipgloss.NewStyle().Foreground(colHeading1).Bold(true)
 	styleH2 = lipgloss.NewStyle().Foreground(colHeading2).Bold(true)
@@ -629,6 +630,9 @@ var (
 	styleHR         = lipgloss.NewStyle().Foreground(colHR)
 	styleBullet     = lipgloss.NewStyle().Foreground(colBullet).Bold(true)
 	styleListOrdNum = lipgloss.NewStyle().Foreground(colListNum).Bold(true)
+
+	// Paragraph prose: softer white to reduce glare for extended reading.
+	styleParagraph = lipgloss.NewStyle().Foreground(colParagraph)
 
 	// Fence-marker line ("```go", "```"): muted to keep attention on content.
 	styleFenceMarker = lipgloss.NewStyle().Foreground(colMuted)

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -188,7 +188,7 @@ func (r *Renderer) RenderLines(plan string, width int) []string {
 		segments := wrapPlain(line, wrapWidth)
 		fenceBar := styleFenceBar.Render("│") + " "
 		if len(segments) == 0 {
-			styled := r.StyleSegment("", ctx, false)
+			styled := r.styleSegmentWithFence("", ctx, false, 0, wrapWidth)
 			if isFenceLine {
 				styled = fenceBar + styled
 			}
@@ -196,7 +196,7 @@ func (r *Renderer) RenderLines(plan string, width int) []string {
 		} else {
 			col := 0
 			for j, seg := range segments {
-				styled := r.styleSegmentWithFence(seg, ctx, j > 0, col)
+				styled := r.styleSegmentWithFence(seg, ctx, j > 0, col, wrapWidth)
 				if isFenceLine {
 					styled = fenceBar + styled
 				}
@@ -297,7 +297,7 @@ func (r *Renderer) LineContexts(plan string) []LineCtx {
 // pre-lexed line; callers that wrap a fence line into multiple segments
 // should use StyleLine, which tracks the cumulative column for each segment.
 func (r *Renderer) StyleSegment(segment string, parent LineCtx, isContinuation bool) string {
-	return r.styleSegmentWithFence(segment, parent, isContinuation, 0)
+	return r.styleSegmentWithFence(segment, parent, isContinuation, 0, ansi.StringWidth(segment))
 }
 
 // StyleLine wraps and styles one source line into width-respecting display
@@ -307,18 +307,18 @@ func (r *Renderer) StyleSegment(segment string, parent LineCtx, isContinuation b
 func (r *Renderer) StyleLine(line string, ctx LineCtx, width int) []string {
 	segments := wrapPlain(line, width)
 	if len(segments) == 0 {
-		return []string{r.styleSegmentWithFence("", ctx, false, 0)}
+		return []string{r.styleSegmentWithFence("", ctx, false, 0, width)}
 	}
 	out := make([]string, 0, len(segments))
 	col := 0
 	for j, seg := range segments {
-		out = append(out, r.styleSegmentWithFence(seg, ctx, j > 0, col))
+		out = append(out, r.styleSegmentWithFence(seg, ctx, j > 0, col, width))
 		col += ansi.StringWidth(seg)
 	}
 	return out
 }
 
-func (r *Renderer) styleSegmentWithFence(segment string, parent LineCtx, isContinuation bool, fenceCol int) string {
+func (r *Renderer) styleSegmentWithFence(segment string, parent LineCtx, isContinuation bool, fenceCol int, lineWidth int) string {
 	switch parent.Kind {
 	case LineFenceContent:
 		// Use the pre-lexed styled line if we have it; slice it at fenceCol
@@ -337,7 +337,11 @@ func (r *Renderer) styleSegmentWithFence(segment string, parent LineCtx, isConti
 	case LineHeading:
 		return styleHeading(parent.HeadingLevel).Render(segment)
 	case LineHR:
-		return styleHR.Render(segment)
+		w := lineWidth
+		if w < 1 {
+			w = ansi.StringWidth(segment)
+		}
+		return styleHR.Render(strings.Repeat("─", w))
 	case LineBlockquote:
 		depth := parent.BlockquoteDepth
 		if depth < 1 {

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -339,10 +339,19 @@ func (r *Renderer) styleSegmentWithFence(segment string, parent LineCtx, isConti
 	case LineHR:
 		return styleHR.Render(segment)
 	case LineBlockquote:
-		// Blockquotes get a subtle marker treatment over the whole line; we
-		// don't try to style the `>` glyph differently from the body since
-		// the wrap can split between marker and content.
-		return styleBlockquote.Render(segment)
+		depth := parent.BlockquoteDepth
+		if depth < 1 {
+			depth = 1
+		}
+		barStyle := lipgloss.NewStyle().Foreground(colQuote)
+		bar := barStyle.Render(strings.Repeat("│", depth)) + " "
+		if isContinuation {
+			// Align continuation text under the body column.
+			indent := strings.Repeat(" ", depth+1)
+			return indent + styleItalic.Render(segment)
+		}
+		body := stripBlockquotePrefix(segment, depth)
+		return bar + styleItalic.Render(body)
 	case LineList:
 		styled := styleListSegment(segment, parent, isContinuation)
 		return styled
@@ -517,6 +526,19 @@ func blockquoteDepth(trimmed string) int {
 		}
 	}
 	return depth
+}
+
+// stripBlockquotePrefix strips depth `>` markers and their adjacent spaces
+// from the start of a blockquote segment, returning the body text.
+func stripBlockquotePrefix(segment string, depth int) string {
+	s := strings.TrimLeft(segment, " \t")
+	for i := 0; i < depth && len(s) > 0; i++ {
+		if s[0] == '>' {
+			s = s[1:]
+			s = strings.TrimLeft(s, " \t")
+		}
+	}
+	return s
 }
 
 // listMarker detects unordered (-, *, +) and simple ordered (1.) bullets.

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -634,7 +634,7 @@ var (
 
 	styleBold       = lipgloss.NewStyle().Bold(true)
 	styleItalic     = lipgloss.NewStyle().Italic(true)
-	styleInlineCode = lipgloss.NewStyle().Foreground(colCodeFG).Background(lipgloss.Color("#2D2D2D"))
+	styleInlineCode = lipgloss.NewStyle().Foreground(colCodeFG).Background(lipgloss.AdaptiveColor{Dark: "#2D2D2D", Light: "#E8E8E8"})
 	styleLink       = lipgloss.NewStyle().Foreground(colLink).Underline(true)
 	styleHR         = lipgloss.NewStyle().Foreground(colHR)
 	styleBullet     = lipgloss.NewStyle().Foreground(colBullet).Bold(true)

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -95,6 +95,17 @@ type fenceKey struct {
 	bodyHash [32]byte
 }
 
+// ContentMeasure returns the effective content width and left-margin padding
+// for centering content within a terminal. When termWidth > maxMeasure the
+// content is capped at maxMeasure and centered with equal left/right margins;
+// otherwise no margin is applied and the full termWidth is used.
+func ContentMeasure(termWidth, maxMeasure int) (measure, leftPad int) {
+	if termWidth > maxMeasure {
+		return maxMeasure, (termWidth - maxMeasure) / 2
+	}
+	return termWidth, 0
+}
+
 // New constructs a renderer that uses the given chroma style id for fence
 // highlighting. Unknown style names fall through to chroma's Fallback so
 // rendering never panics; callers that want strict validation should

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -61,14 +61,14 @@ const (
 // Index correspondence: LineContexts returns one entry per `\n`-separated
 // source line of the input plan. Callers must use the same split convention.
 type LineCtx struct {
-	Kind             LineKind
-	HeadingLevel     int    // 1..6 when Kind == LineHeading; 0 otherwise
-	FenceLang        string // language tag from the opening ``` (empty for plaintext)
-	BlockquoteDepth  int    // count of leading `>` markers
-	ListBullet       string // "-", "*", "+", or "1." (the literal marker token)
-	ListIndent       int    // visible-width of the bullet+space prefix
-	IsCheckbox       bool   // true when list item starts with "[ ] " or "[x] "
-	CheckboxChecked  bool   // true when IsCheckbox and the box is checked
+	Kind            LineKind
+	HeadingLevel    int    // 1..6 when Kind == LineHeading; 0 otherwise
+	FenceLang       string // language tag from the opening ``` (empty for plaintext)
+	BlockquoteDepth int    // count of leading `>` markers
+	ListBullet      string // "-", "*", "+", or "1." (the literal marker token)
+	ListIndent      int    // visible-width of the bullet+space prefix
+	IsCheckbox      bool   // true when list item starts with "[ ] " or "[x] "
+	CheckboxChecked bool   // true when IsCheckbox and the box is checked
 	// fencedStyledLine is the chroma-formatted ANSI output for this source
 	// line when Kind == LineFenceContent. Empty for everything else.
 	fencedStyledLine string
@@ -132,10 +132,10 @@ func New(styleName string) *Renderer {
 // StyleName returns the chroma style id this renderer was constructed with.
 func (r *Renderer) StyleName() string { return r.styleName }
 
-// headingUnderline returns a synthetic underline display line for H1/H2
+// HeadingUnderline returns a synthetic underline display line for H1/H2
 // headings. H1 uses a heavy ━ rule spanning maxWidth; H2 uses a thin ─ rule
 // spanning min(headingWidth, maxWidth) in a muted color.
-func (r *Renderer) headingUnderline(level, headingWidth, maxWidth int) string {
+func (r *Renderer) HeadingUnderline(level, headingWidth, maxWidth int) string {
 	if level == 1 {
 		color := styleH1.GetForeground()
 		return lipgloss.NewStyle().Foreground(color).Render(strings.Repeat("━", maxWidth))
@@ -206,7 +206,7 @@ func (r *Renderer) RenderLines(plan string, width int) []string {
 		}
 		// Inject underline decoration after H1/H2 heading lines.
 		if ctx.Kind == LineHeading && ctx.HeadingLevel <= 2 {
-			out = append(out, r.headingUnderline(ctx.HeadingLevel, ansi.StringWidth(line), width))
+			out = append(out, r.HeadingUnderline(ctx.HeadingLevel, ansi.StringWidth(line), width))
 		}
 	}
 
@@ -318,7 +318,13 @@ func (r *Renderer) StyleLine(line string, ctx LineCtx, width int) []string {
 	return out
 }
 
-func (r *Renderer) styleSegmentWithFence(segment string, parent LineCtx, isContinuation bool, fenceCol int, lineWidth int) string {
+func (r *Renderer) styleSegmentWithFence(
+	segment string,
+	parent LineCtx,
+	isContinuation bool,
+	fenceCol int,
+	lineWidth int,
+) string {
 	switch parent.Kind {
 	case LineFenceContent:
 		// Use the pre-lexed styled line if we have it; slice it at fenceCol
@@ -608,16 +614,16 @@ var (
 	colHeading5 = lipgloss.Color("#A78BFA") // light purple
 	colHeading6 = lipgloss.Color("#9CA3AF") // light gray
 
-	colMuted          = lipgloss.Color("#6B7280")
-	colCodeFG         = lipgloss.Color("#FBBF24") // amber for inline code
-	colCodeBg         = lipgloss.Color("#1A1D23") // subtle dark background for code blocks
-	colLink           = lipgloss.Color("#06B6D4")
-	colQuote          = lipgloss.Color("#9CA3AF")
-	colHR             = lipgloss.Color("#374151")
-	colBullet         = lipgloss.Color("#A78BFA")
-	colListNum        = lipgloss.Color("#A78BFA")
-	colCheckboxDone   = lipgloss.Color("#10B981") // success green
-	colParagraph      = lipgloss.Color("#D1D5DB") // softer white for prose
+	colMuted        = lipgloss.Color("#6B7280")
+	colCodeFG       = lipgloss.Color("#FBBF24") // amber for inline code
+	colCodeBg       = lipgloss.Color("#1A1D23") // subtle dark background for code blocks
+	colLink         = lipgloss.Color("#06B6D4")
+	colQuote        = lipgloss.Color("#9CA3AF")
+	colHR           = lipgloss.Color("#374151")
+	colBullet       = lipgloss.Color("#A78BFA")
+	colListNum      = lipgloss.Color("#A78BFA")
+	colCheckboxDone = lipgloss.Color("#10B981") // success green
+	colParagraph    = lipgloss.Color("#D1D5DB") // softer white for prose
 
 	styleH1 = lipgloss.NewStyle().Foreground(colHeading1).Bold(true)
 	styleH2 = lipgloss.NewStyle().Foreground(colHeading2).Bold(true)
@@ -630,7 +636,6 @@ var (
 	styleItalic     = lipgloss.NewStyle().Italic(true)
 	styleInlineCode = lipgloss.NewStyle().Foreground(colCodeFG).Background(lipgloss.Color("#2D2D2D"))
 	styleLink       = lipgloss.NewStyle().Foreground(colLink).Underline(true)
-	styleBlockquote = lipgloss.NewStyle().Foreground(colQuote).Italic(true)
 	styleHR         = lipgloss.NewStyle().Foreground(colHR)
 	styleBullet     = lipgloss.NewStyle().Foreground(colBullet).Bold(true)
 	styleListOrdNum = lipgloss.NewStyle().Foreground(colListNum).Bold(true)

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -178,18 +178,19 @@ func (r *Renderer) RenderLines(plan string, width int) []string {
 		if i < len(ctxs) {
 			ctx = ctxs[i]
 		}
-		// Fence lines get a │ bar prefix in scroll mode (2 chars wide), so
-		// wrap at width-2 to keep the total within the content measure.
-		isFenceLine := ctx.Kind == LineFenceContent || ctx.Kind == LineFenceOpen || ctx.Kind == LineFenceClose
+		// Content lines inside fenced blocks get a │ bar prefix (2 chars wide),
+		// so wrap at width-2 to keep the total within the content measure.
+		// Open and close fence markers (```go, ```) do not get the bar.
+		isFenceContent := ctx.Kind == LineFenceContent
 		wrapWidth := width
-		if isFenceLine && width > 2 {
+		if isFenceContent && width > 2 {
 			wrapWidth = width - 2
 		}
 		segments := wrapPlain(line, wrapWidth)
 		fenceBar := styleFenceBar.Render("│") + " "
 		if len(segments) == 0 {
 			styled := r.styleSegmentWithFence("", ctx, false, 0, wrapWidth)
-			if isFenceLine {
+			if isFenceContent {
 				styled = fenceBar + styled
 			}
 			out = append(out, styled)
@@ -197,7 +198,7 @@ func (r *Renderer) RenderLines(plan string, width int) []string {
 			col := 0
 			for j, seg := range segments {
 				styled := r.styleSegmentWithFence(seg, ctx, j > 0, col, wrapWidth)
-				if isFenceLine {
+				if isFenceContent {
 					styled = fenceBar + styled
 				}
 				out = append(out, styled)
@@ -334,10 +335,9 @@ func (r *Renderer) styleSegmentWithFence(
 		}
 		segWidth := ansi.StringWidth(segment)
 		styled := ansi.Cut(parent.fencedStyledLine, fenceCol, fenceCol+segWidth)
-		// chroma may not paint a background; the leading whitespace of an
-		// indented code line should still feel like code, but we keep it
-		// understated to avoid overpowering the plan body.
-		return styled
+		// Apply the code-block background tint so chroma-highlighted lines
+		// share the same subtle background as the plaintext fallback path.
+		return lipgloss.NewStyle().Background(colCodeBg).Render(styled)
 	case LineFenceOpen, LineFenceClose:
 		return styleFenceMarker.Render(segment)
 	case LineHeading:

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -130,6 +130,25 @@ func New(styleName string) *Renderer {
 // StyleName returns the chroma style id this renderer was constructed with.
 func (r *Renderer) StyleName() string { return r.styleName }
 
+// headingUnderline returns a synthetic underline display line for H1/H2
+// headings. H1 uses a heavy ━ rule spanning maxWidth; H2 uses a thin ─ rule
+// spanning min(headingWidth, maxWidth) in a muted color.
+func (r *Renderer) headingUnderline(level, headingWidth, maxWidth int) string {
+	if level == 1 {
+		color := styleH1.GetForeground()
+		return lipgloss.NewStyle().Foreground(color).Render(strings.Repeat("━", maxWidth))
+	}
+	// H2: thin rule no wider than the heading text.
+	w := headingWidth
+	if w > maxWidth {
+		w = maxWidth
+	}
+	if w < 1 {
+		w = 1
+	}
+	return lipgloss.NewStyle().Foreground(colMuted).Render(strings.Repeat("─", w))
+}
+
 // RenderLines is the full-buffer pass: parse, wrap, style, and return the
 // post-wrap ANSI display lines for scroll mode. Result is cached by
 // (sha256(plan), styleName, width).
@@ -160,13 +179,17 @@ func (r *Renderer) RenderLines(plan string, width int) []string {
 		segments := wrapPlain(line, width)
 		if len(segments) == 0 {
 			out = append(out, r.StyleSegment("", ctx, false))
-			continue
+		} else {
+			col := 0
+			for j, seg := range segments {
+				styled := r.styleSegmentWithFence(seg, ctx, j > 0, col)
+				out = append(out, styled)
+				col += ansi.StringWidth(seg)
+			}
 		}
-		col := 0
-		for j, seg := range segments {
-			styled := r.styleSegmentWithFence(seg, ctx, j > 0, col)
-			out = append(out, styled)
-			col += ansi.StringWidth(seg)
+		// Inject underline decoration after H1/H2 heading lines.
+		if ctx.Kind == LineHeading && ctx.HeadingLevel <= 2 {
+			out = append(out, r.headingUnderline(ctx.HeadingLevel, ansi.StringWidth(line), width))
 		}
 	}
 

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -61,12 +61,14 @@ const (
 // Index correspondence: LineContexts returns one entry per `\n`-separated
 // source line of the input plan. Callers must use the same split convention.
 type LineCtx struct {
-	Kind            LineKind
-	HeadingLevel    int    // 1..6 when Kind == LineHeading; 0 otherwise
-	FenceLang       string // language tag from the opening ``` (empty for plaintext)
-	BlockquoteDepth int    // count of leading `>` markers
-	ListBullet      string // "-", "*", "+", or "1." (the literal marker token)
-	ListIndent      int    // visible-width of the bullet+space prefix
+	Kind             LineKind
+	HeadingLevel     int    // 1..6 when Kind == LineHeading; 0 otherwise
+	FenceLang        string // language tag from the opening ``` (empty for plaintext)
+	BlockquoteDepth  int    // count of leading `>` markers
+	ListBullet       string // "-", "*", "+", or "1." (the literal marker token)
+	ListIndent       int    // visible-width of the bullet+space prefix
+	IsCheckbox       bool   // true when list item starts with "[ ] " or "[x] "
+	CheckboxChecked  bool   // true when IsCheckbox and the box is checked
 	// fencedStyledLine is the chroma-formatted ANSI output for this source
 	// line when Kind == LineFenceContent. Empty for everything else.
 	fencedStyledLine string
@@ -404,7 +406,18 @@ func classifyLine(line string) LineCtx {
 		return LineCtx{Kind: LineBlockquote, BlockquoteDepth: depth}
 	}
 	if bullet, indent, ok := listMarker(line); ok {
-		return LineCtx{Kind: LineList, ListBullet: bullet, ListIndent: indent}
+		ctx := LineCtx{Kind: LineList, ListBullet: bullet, ListIndent: indent}
+		// Detect GFM-style checkbox syntax after the bullet+space.
+		body := line[indent:]
+		switch {
+		case strings.HasPrefix(body, "[ ] ") || body == "[ ]":
+			ctx.IsCheckbox = true
+		case strings.HasPrefix(body, "[x] ") || body == "[x]" ||
+			strings.HasPrefix(body, "[X] ") || body == "[X]":
+			ctx.IsCheckbox = true
+			ctx.CheckboxChecked = true
+		}
+		return ctx
 	}
 	return LineCtx{Kind: LineParagraph}
 }
@@ -554,13 +567,14 @@ var (
 	colHeading5 = lipgloss.Color("#A78BFA") // light purple
 	colHeading6 = lipgloss.Color("#9CA3AF") // light gray
 
-	colMuted   = lipgloss.Color("#6B7280")
-	colCodeFG  = lipgloss.Color("#FBBF24") // amber for inline code
-	colLink    = lipgloss.Color("#06B6D4")
-	colQuote   = lipgloss.Color("#9CA3AF")
-	colHR      = lipgloss.Color("#374151")
-	colBullet  = lipgloss.Color("#A78BFA")
-	colListNum = lipgloss.Color("#A78BFA")
+	colMuted          = lipgloss.Color("#6B7280")
+	colCodeFG         = lipgloss.Color("#FBBF24") // amber for inline code
+	colLink           = lipgloss.Color("#06B6D4")
+	colQuote          = lipgloss.Color("#9CA3AF")
+	colHR             = lipgloss.Color("#374151")
+	colBullet         = lipgloss.Color("#A78BFA")
+	colListNum        = lipgloss.Color("#A78BFA")
+	colCheckboxDone   = lipgloss.Color("#10B981") // success green
 
 	styleH1 = lipgloss.NewStyle().Foreground(colHeading1).Bold(true)
 	styleH2 = lipgloss.NewStyle().Foreground(colHeading2).Bold(true)
@@ -652,6 +666,22 @@ func styleListSegment(segment string, ctx LineCtx, isContinuation bool) string {
 	}
 	prefix := segment[:leading] + bulletStyle.Render(segment[leading:tailStart])
 	body := segment[tailStart:]
+
+	// Render checkbox glyphs for task-list items on the first segment.
+	if ctx.IsCheckbox {
+		if ctx.CheckboxChecked {
+			for _, pfx := range []string{"[x] ", "[X] "} {
+				if strings.HasPrefix(body, pfx) {
+					glyph := lipgloss.NewStyle().Foreground(colCheckboxDone).Render("✓")
+					return prefix + glyph + " " + styleInline(body[4:])
+				}
+			}
+		} else if strings.HasPrefix(body, "[ ] ") {
+			glyph := lipgloss.NewStyle().Foreground(colMuted).Render("☐")
+			return prefix + glyph + " " + styleInline(body[4:])
+		}
+	}
+
 	return prefix + styleInline(body)
 }
 

--- a/internal/tui/mdrender/render_test.go
+++ b/internal/tui/mdrender/render_test.go
@@ -351,6 +351,36 @@ func TestStyleLine_FenceContentMultiSegmentColumnTracking(t *testing.T) {
 	}
 }
 
+func TestRenderLines_CheckboxUncheckedRendersGlyph(t *testing.T) {
+	r := New("monokai")
+	got := r.RenderLines("- [ ] task\n", 80)
+	if len(got) == 0 {
+		t.Fatal("no output lines")
+	}
+	stripped := testutil.StripANSI(got[0])
+	if strings.Contains(stripped, "[ ]") {
+		t.Errorf("unchecked checkbox still shows [ ] in %q", stripped)
+	}
+	if !strings.Contains(stripped, "☐") {
+		t.Errorf("unchecked checkbox missing ☐ glyph in %q", stripped)
+	}
+}
+
+func TestRenderLines_CheckboxCheckedRendersGlyph(t *testing.T) {
+	r := New("monokai")
+	got := r.RenderLines("- [x] done\n", 80)
+	if len(got) == 0 {
+		t.Fatal("no output lines")
+	}
+	stripped := testutil.StripANSI(got[0])
+	if strings.Contains(stripped, "[x]") {
+		t.Errorf("checked checkbox still shows [x] in %q", stripped)
+	}
+	if !strings.Contains(stripped, "✓") {
+		t.Errorf("checked checkbox missing ✓ glyph in %q", stripped)
+	}
+}
+
 func TestRenderLines_ListContinuationIndents(t *testing.T) {
 	r := New("monokai")
 	plan := "- this is a list item that is long enough to wrap somewhere\n"

--- a/internal/tui/mdrender/render_test.go
+++ b/internal/tui/mdrender/render_test.go
@@ -347,6 +347,21 @@ func TestStyleLine_FenceContentMultiSegmentColumnTracking(t *testing.T) {
 	}
 }
 
+func TestRenderLines_BlockquoteLeftBar(t *testing.T) {
+	r := New("monokai")
+	got := r.RenderLines("> quoted text\n", 80)
+	if len(got) == 0 {
+		t.Fatal("no output lines")
+	}
+	stripped := testutil.StripANSI(got[0])
+	if !strings.HasPrefix(stripped, "│ ") {
+		t.Errorf("blockquote line does not start with '│ ': %q", stripped)
+	}
+	if strings.Contains(stripped, ">") {
+		t.Errorf("blockquote line still contains '>': %q", stripped)
+	}
+}
+
 func TestRenderLines_FenceContentHasLeftBar(t *testing.T) {
 	r := New("monokai")
 	got := r.RenderLines("```go\nfunc X() {}\n```\n", 80)

--- a/internal/tui/mdrender/render_test.go
+++ b/internal/tui/mdrender/render_test.go
@@ -347,6 +347,22 @@ func TestStyleLine_FenceContentMultiSegmentColumnTracking(t *testing.T) {
 	}
 }
 
+func TestRenderLines_ParagraphTextIsStyled(t *testing.T) {
+	r := New("monokai")
+	got := r.RenderLines("plain paragraph\n", 80)
+	if len(got) == 0 {
+		t.Fatal("no output lines")
+	}
+	if !containsCSI(got[0]) {
+		t.Errorf("paragraph line has no ANSI styling: %q", got[0])
+	}
+	// Plain text without any inline spans should carry paragraph foreground color.
+	stripped := testutil.StripANSI(got[0])
+	if stripped != "plain paragraph" {
+		t.Errorf("stripped = %q, want %q", stripped, "plain paragraph")
+	}
+}
+
 func TestStyleInline_InlineCodeHasBackground(t *testing.T) {
 	r := New("monokai")
 	got := r.RenderLines("see `code` here\n", 80)

--- a/internal/tui/mdrender/render_test.go
+++ b/internal/tui/mdrender/render_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/tui/mdrender/testutil"
 	"github.com/muesli/termenv"
 )
@@ -34,26 +35,99 @@ func TestRenderLines_HeadingsLevels1To6(t *testing.T) {
 	r := New("monokai")
 	plan := "# h1\n## h2\n### h3\n#### h4\n##### h5\n###### h6\n"
 	got := r.RenderLines(plan, 80)
-	if len(got) < 6 {
-		t.Fatalf("got %d display lines, want >= 6\n%v", len(got), got)
+	// H1 and H2 each get an underline line, so total ≥ 8 (6 headings + 2 underlines).
+	if len(got) < 8 {
+		t.Fatalf("got %d display lines, want >= 8\n%v", len(got), got)
 	}
-	// Each heading line must contain CSI styling and the plain text.
-	plainLines := []string{"# h1", "## h2", "### h3", "#### h4", "##### h5", "###### h6"}
-	for i, want := range plainLines {
-		line := got[i]
+	// H1 underline at got[1], H2 underline at got[3]; headings at got[0,2,4,5,6,7].
+	type headingCheck struct {
+		idx  int
+		want string
+	}
+	checks := []headingCheck{
+		{0, "# h1"},
+		{2, "## h2"},
+		{4, "### h3"},
+		{5, "#### h4"},
+		{6, "##### h5"},
+		{7, "###### h6"},
+	}
+	for _, c := range checks {
+		line := got[c.idx]
 		if !containsCSI(line) {
-			t.Errorf("line %d: missing ANSI styling: %q", i, line)
+			t.Errorf("got[%d]: missing ANSI styling: %q", c.idx, line)
 		}
-		if testutil.StripANSI(line) != want {
-			t.Errorf("line %d: stripped = %q, want %q", i, testutil.StripANSI(line), want)
+		if testutil.StripANSI(line) != c.want {
+			t.Errorf("got[%d]: stripped = %q, want %q", c.idx, testutil.StripANSI(line), c.want)
 		}
 	}
-	// Different heading levels should produce different SGR sequences.
-	if got[0] == got[1] {
+	// H1 underline: all ━ characters.
+	h1Under := testutil.StripANSI(got[1])
+	for _, ch := range h1Under {
+		if ch != '━' {
+			t.Errorf("H1 underline got[1] contains non-━ rune %q: %q", string(ch), h1Under)
+			break
+		}
+	}
+	// H2 underline: all ─ characters.
+	h2Under := testutil.StripANSI(got[3])
+	for _, ch := range h2Under {
+		if ch != '─' {
+			t.Errorf("H2 underline got[3] contains non-─ rune %q: %q", string(ch), h2Under)
+			break
+		}
+	}
+	// H1 and H2 heading lines should have distinct foregrounds (different levels).
+	if got[0] == got[2] {
 		t.Errorf("h1 and h2 styled identically; expected distinct foregrounds")
 	}
-	if got[2] == got[3] {
+	if got[4] == got[5] {
 		t.Errorf("h3 and h4 styled identically; expected distinct foregrounds")
+	}
+}
+
+func TestRenderLines_H1UnderlineDecoration(t *testing.T) {
+	r := New("monokai")
+	got := r.RenderLines("# Title\nbody\n", 80)
+	if len(got) < 3 {
+		t.Fatalf("got %d lines, want >= 3 (heading + underline + body)", len(got))
+	}
+	under := testutil.StripANSI(got[1])
+	if len(under) == 0 {
+		t.Fatal("H1 underline line is empty")
+	}
+	for _, ch := range under {
+		if ch != '━' {
+			t.Errorf("H1 underline contains non-━ rune %q: %q", string(ch), under)
+			break
+		}
+	}
+	if !containsCSI(got[1]) {
+		t.Errorf("H1 underline has no ANSI styling: %q", got[1])
+	}
+}
+
+func TestRenderLines_H2UnderlineDecoration(t *testing.T) {
+	r := New("monokai")
+	got := r.RenderLines("## Sub\nbody\n", 80)
+	if len(got) < 3 {
+		t.Fatalf("got %d lines, want >= 3 (heading + underline + body)", len(got))
+	}
+	under := testutil.StripANSI(got[1])
+	if len(under) == 0 {
+		t.Fatal("H2 underline line is empty")
+	}
+	for _, ch := range under {
+		if ch != '─' {
+			t.Errorf("H2 underline contains non-─ rune %q: %q", string(ch), under)
+			break
+		}
+	}
+	// H2 underline should not exceed the heading text width.
+	headingWidth := ansi.StringWidth("## Sub")
+	underWidth := ansi.StringWidth(under)
+	if underWidth > headingWidth {
+		t.Errorf("H2 underline width %d > heading width %d", underWidth, headingWidth)
 	}
 }
 

--- a/internal/tui/mdrender/render_test.go
+++ b/internal/tui/mdrender/render_test.go
@@ -347,6 +347,24 @@ func TestStyleLine_FenceContentMultiSegmentColumnTracking(t *testing.T) {
 	}
 }
 
+func TestRenderLines_HRRendersCleanLine(t *testing.T) {
+	r := New("monokai")
+	got := r.RenderLines("---\n", 80)
+	if len(got) == 0 {
+		t.Fatal("no output lines")
+	}
+	stripped := testutil.StripANSI(got[0])
+	if stripped == "---" {
+		t.Errorf("HR still renders as raw '---'; expected ─ characters")
+	}
+	for _, ch := range stripped {
+		if ch != '─' {
+			t.Errorf("HR line contains non-─ rune %q: %q", string(ch), stripped)
+			break
+		}
+	}
+}
+
 func TestRenderLines_ParagraphTextIsStyled(t *testing.T) {
 	r := New("monokai")
 	got := r.RenderLines("plain paragraph\n", 80)

--- a/internal/tui/mdrender/render_test.go
+++ b/internal/tui/mdrender/render_test.go
@@ -416,15 +416,23 @@ func TestRenderLines_FenceContentHasLeftBar(t *testing.T) {
 	if len(got) < 3 {
 		t.Fatalf("got %d lines, want >= 3", len(got))
 	}
-	// Fence content line must start with "│ ".
+	// Fence content line must start with "│ " and carry the background tint.
 	contentStripped := testutil.StripANSI(got[1])
 	if !strings.HasPrefix(contentStripped, "│ ") {
 		t.Errorf("fence content line[1] does not start with '│ ': %q", contentStripped)
 	}
-	// Fence open line must also have the bar.
+	if !strings.Contains(got[1], "48;2;") {
+		t.Errorf("fence content line[1] missing background-color SGR: %q", got[1])
+	}
+	// Fence open and close marker lines must NOT have the bar — they are
+	// delimiters, not code content, and the bar would be visual noise.
 	openStripped := testutil.StripANSI(got[0])
-	if !strings.HasPrefix(openStripped, "│ ") {
-		t.Errorf("fence open line[0] does not start with '│ ': %q", openStripped)
+	if strings.HasPrefix(openStripped, "│") {
+		t.Errorf("fence open line[0] unexpectedly has '│' prefix: %q", openStripped)
+	}
+	closeStripped := testutil.StripANSI(got[2])
+	if strings.HasPrefix(closeStripped, "│") {
+		t.Errorf("fence close line[2] unexpectedly has '│' prefix: %q", closeStripped)
 	}
 }
 

--- a/internal/tui/mdrender/render_test.go
+++ b/internal/tui/mdrender/render_test.go
@@ -332,3 +332,20 @@ func TestStyleName_Roundtrip(t *testing.T) {
 		t.Errorf("StyleName() = %q, want monokai", r.StyleName())
 	}
 }
+
+func TestContentMeasure_CapsAtMaxAndCenters(t *testing.T) {
+	tests := []struct {
+		termWidth, maxMeasure, wantMeasure, wantPad int
+	}{
+		{120, 72, 72, 24},
+		{60, 72, 60, 0},
+		{72, 72, 72, 0},
+	}
+	for _, tt := range tests {
+		m, p := ContentMeasure(tt.termWidth, tt.maxMeasure)
+		if m != tt.wantMeasure || p != tt.wantPad {
+			t.Errorf("ContentMeasure(%d, %d) = (%d, %d), want (%d, %d)",
+				tt.termWidth, tt.maxMeasure, m, p, tt.wantMeasure, tt.wantPad)
+		}
+	}
+}

--- a/internal/tui/mdrender/render_test.go
+++ b/internal/tui/mdrender/render_test.go
@@ -347,6 +347,19 @@ func TestStyleLine_FenceContentMultiSegmentColumnTracking(t *testing.T) {
 	}
 }
 
+func TestStyleInline_InlineCodeHasBackground(t *testing.T) {
+	r := New("monokai")
+	got := r.RenderLines("see `code` here\n", 80)
+	if len(got) == 0 {
+		t.Fatal("no output")
+	}
+	// Background SGR is 48;2;R;G;B in TrueColor mode (forced by TestMain).
+	// Lipgloss may combine foreground and background in one escape sequence.
+	if !strings.Contains(got[0], "48;2;") {
+		t.Errorf("no background-color SGR in inline code span; line: %q", got[0])
+	}
+}
+
 func TestRenderLines_BlockquoteLeftBar(t *testing.T) {
 	r := New("monokai")
 	got := r.RenderLines("> quoted text\n", 80)

--- a/internal/tui/mdrender/render_test.go
+++ b/internal/tui/mdrender/render_test.go
@@ -169,22 +169,20 @@ func TestRenderLines_FenceGoLexed(t *testing.T) {
 	if !containsCSI(got[0]) {
 		t.Errorf("fence open not styled: %q", got[0])
 	}
-	// Content lines should carry chroma-injected SGR (multiple sequences) for
-	// keywords like `package`, `func`. We don't pin exact codes; we just
-	// require *some* styling beyond the leading reset.
+	// Content lines carry a │ bar prefix and chroma-injected SGR for keywords.
 	pkgLine := got[1]
 	if !containsCSI(pkgLine) {
 		t.Errorf("package line not styled: %q", pkgLine)
 	}
-	if testutil.StripANSI(pkgLine) != "package main" {
-		t.Errorf("package line stripped = %q, want %q", testutil.StripANSI(pkgLine), "package main")
+	if testutil.StripANSI(pkgLine) != "│ package main" {
+		t.Errorf("package line stripped = %q, want %q", testutil.StripANSI(pkgLine), "│ package main")
 	}
 	funcLine := got[3]
 	if !containsCSI(funcLine) {
 		t.Errorf("func line not styled: %q", funcLine)
 	}
-	if testutil.StripANSI(funcLine) != "func main() {}" {
-		t.Errorf("func line stripped = %q, want %q", testutil.StripANSI(funcLine), "func main() {}")
+	if testutil.StripANSI(funcLine) != "│ func main() {}" {
+		t.Errorf("func line stripped = %q, want %q", testutil.StripANSI(funcLine), "│ func main() {}")
 	}
 }
 
@@ -198,8 +196,8 @@ func TestRenderLines_FenceBashLexed(t *testing.T) {
 	if !containsCSI(got[1]) {
 		t.Errorf("bash content not styled: %q", got[1])
 	}
-	if testutil.StripANSI(got[1]) != "echo hello" {
-		t.Errorf("bash line stripped = %q, want %q", testutil.StripANSI(got[1]), "echo hello")
+	if testutil.StripANSI(got[1]) != "│ echo hello" {
+		t.Errorf("bash line stripped = %q, want %q", testutil.StripANSI(got[1]), "│ echo hello")
 	}
 }
 
@@ -210,12 +208,9 @@ func TestRenderLines_FenceNoLangFallsBackToPlaintext(t *testing.T) {
 	if len(got) < 3 {
 		t.Fatalf("got %d display lines, want >= 3", len(got))
 	}
-	// Plaintext lexer doesn't add color tokens, but our wrapper still wraps
-	// the line in the styleFenceContent fallback when the pre-lexed line is
-	// empty *or* the line passes through unstyled. Just assert plain text is
-	// preserved verbatim under StripANSI.
-	if testutil.StripANSI(got[1]) != "some text" {
-		t.Errorf("plaintext stripped = %q, want %q", testutil.StripANSI(got[1]), "some text")
+	// Content line has │ bar prefix; plain text is preserved after it.
+	if testutil.StripANSI(got[1]) != "│ some text" {
+		t.Errorf("plaintext stripped = %q, want %q", testutil.StripANSI(got[1]), "│ some text")
 	}
 }
 
@@ -223,17 +218,18 @@ func TestRenderLines_FenceUnknownLangDoesNotPanic(t *testing.T) {
 	r := New("monokai")
 	plan := "```not-a-real-lang-xyzzy\nfoo bar\n```\n"
 	got := r.RenderLines(plan, 80)
-	// chroma falls through to a generic lexer; we just assert it doesn't crash
-	// and the plain text survives.
+	// chroma falls through to a generic lexer; we assert it doesn't crash
+	// and the plain text survives (with bar prefix).
 	found := false
 	for _, line := range got {
-		if testutil.StripANSI(line) == "foo bar" {
+		stripped := testutil.StripANSI(line)
+		if stripped == "│ foo bar" || strings.HasPrefix(stripped, "│ ") && strings.Contains(stripped, "foo bar") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("no output line contained the plain content; got:\n%v", got)
+		t.Errorf("no output line contained '│ foo bar'; got:\n%v", got)
 	}
 }
 
@@ -348,6 +344,25 @@ func TestStyleLine_FenceContentMultiSegmentColumnTracking(t *testing.T) {
 	}
 	if !strings.Contains(rebuilt.String(), "func foo") {
 		t.Errorf("rebuilt = %q; expected to contain %q", rebuilt.String(), "func foo")
+	}
+}
+
+func TestRenderLines_FenceContentHasLeftBar(t *testing.T) {
+	r := New("monokai")
+	got := r.RenderLines("```go\nfunc X() {}\n```\n", 80)
+	// Lines: [0]=open, [1]=content, [2]=close, [3]=trailing empty
+	if len(got) < 3 {
+		t.Fatalf("got %d lines, want >= 3", len(got))
+	}
+	// Fence content line must start with "│ ".
+	contentStripped := testutil.StripANSI(got[1])
+	if !strings.HasPrefix(contentStripped, "│ ") {
+		t.Errorf("fence content line[1] does not start with '│ ': %q", contentStripped)
+	}
+	// Fence open line must also have the bar.
+	openStripped := testutil.StripANSI(got[0])
+	if !strings.HasPrefix(openStripped, "│ ") {
+		t.Errorf("fence open line[0] does not start with '│ ': %q", openStripped)
 	}
 }
 

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -823,7 +823,7 @@ func (m *planEditorModel) displayLines() []string {
 		if i < len(ctxs) {
 			ctx = ctxs[i]
 		}
-		out = append(out, m.renderer.StyleLine(srcLines[i], ctx, w)...)
+		out = append(out, m.styledScrollLines(srcLines[i], ctx, w)...)
 	}
 
 	// Sections.
@@ -871,7 +871,7 @@ func (m *planEditorModel) displayLines() []string {
 			if i < len(ctxs) {
 				ctx = ctxs[i]
 			}
-			out = append(out, m.renderer.StyleLine(srcLines[i], ctx, w)...)
+			out = append(out, m.styledScrollLines(srcLines[i], ctx, w)...)
 		}
 	}
 
@@ -901,6 +901,25 @@ func (m *planEditorModel) contentWidth() int {
 func (m *planEditorModel) displayLeftPad() int {
 	_, pad := mdrender.ContentMeasure(textareaWidth(m.width), planEditorMaxMeasure)
 	return pad
+}
+
+// styledScrollLines wraps and styles a source line for scroll-mode display,
+// applying fence-block bar prefixes that are omitted in edit mode to keep
+// mdtextarea cursor-splice math unaffected.
+func (m *planEditorModel) styledScrollLines(src string, ctx mdrender.LineCtx, width int) []string {
+	isFenceLine := ctx.Kind == mdrender.LineFenceContent || ctx.Kind == mdrender.LineFenceOpen || ctx.Kind == mdrender.LineFenceClose
+	lineWidth := width
+	if isFenceLine && width > 2 {
+		lineWidth = width - 2
+	}
+	lines := m.renderer.StyleLine(src, ctx, lineWidth)
+	if isFenceLine {
+		bar := StyleSubtle.Render("│") + " "
+		for i, l := range lines {
+			lines[i] = bar + l
+		}
+	}
+	return lines
 }
 
 // bodyHeight is the number of lines available for plan content.

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -861,6 +861,13 @@ func (m *planEditorModel) displayLines() []string {
 		// Additional wrapped heading segments (rare but possible on narrow terminals).
 		out = append(out, headingSegs[1:]...)
 
+		// Inject underline decoration for H1/H2 headings when expanded, matching
+		// what RenderLines produces so scroll-mode line counts stay in sync.
+		if !folded && headingCtx.HeadingLevel >= 1 && headingCtx.HeadingLevel <= 2 {
+			headingTextWidth := ansi.StringWidth(srcLines[s.headingLine])
+			out = append(out, m.renderer.HeadingUnderline(headingCtx.HeadingLevel, headingTextWidth, w))
+		}
+
 		if folded {
 			continue
 		}

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -20,6 +20,10 @@ import (
 // Hardcoded for now — a follow-up will plumb this through config.Settings.
 const planEditorChromaStyle = "monokai"
 
+// planEditorMaxMeasure is the maximum content column width for plan text.
+// On wider terminals the plan is centered with equal left/right margins.
+const planEditorMaxMeasure = 72
+
 // planSection represents one H1 or H2 ATX section in the plan. headingLine is
 // the 0-based source-line index of the `#`/`##` line; nextLine is the index of
 // the next sibling-or-ancestor heading (or end-of-lines). level is 1 or 2.
@@ -871,16 +875,32 @@ func (m *planEditorModel) displayLines() []string {
 		}
 	}
 
+	// Apply centering: prepend left-margin padding after all fold glyphs so
+	// the glyph stays at the content edge, not pushed into the margin.
+	if leftPad := m.displayLeftPad(); leftPad > 0 {
+		pad := strings.Repeat(" ", leftPad)
+		for i, line := range out {
+			out[i] = pad + line
+		}
+	}
+
 	m.displayCache = out
 	m.displayCacheKey = key
 	m.sectionDisplayStart = sectionStarts
 	return out
 }
 
-// contentWidth is the column width used for both wrap and styling. Match
-// textareaWidth so scroll-mode wraps line up with edit-mode wraps.
+// contentWidth returns the effective column width for wrap and styling.
+// Capped at planEditorMaxMeasure so wide terminals produce comfortable margins.
 func (m *planEditorModel) contentWidth() int {
-	return textareaWidth(m.width)
+	measure, _ := mdrender.ContentMeasure(textareaWidth(m.width), planEditorMaxMeasure)
+	return measure
+}
+
+// displayLeftPad returns the left-margin padding to center content on wide terminals.
+func (m *planEditorModel) displayLeftPad() int {
+	_, pad := mdrender.ContentMeasure(textareaWidth(m.width), planEditorMaxMeasure)
+	return pad
 }
 
 // bodyHeight is the number of lines available for plan content.

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -254,17 +254,18 @@ func TestPlanEditor_ReviseInputEmitsCritique(t *testing.T) {
 	}
 }
 
-// TestPlanEditor_ScrollAndEditModeUseSameWidth pins the wiring contract that
-// scroll-mode wrap (via mdrender.RenderLines) and edit-mode wrap (via the
-// embedded mdtextarea) operate at the same column width. Without this, the
-// `i`/`esc` mode toggle would visually reflow content — exactly the
-// regression Task 5's display-line agreement test is meant to catch.
+// TestPlanEditor_ScrollAndEditModeUseSameWidth pins that on terminals narrower
+// than planEditorMaxMeasure, scroll-mode and edit-mode wrap at the same column.
+// On wide terminals scroll-mode intentionally caps at planEditorMaxMeasure for
+// centering; edit-mode keeps the full textarea width so cursor math is unaffected.
 func TestPlanEditor_ScrollAndEditModeUseSameWidth(t *testing.T) {
 	sess, _ := newEditorTestSession(t)
 	_ = sess.WritePlan("# H\nshort\n")
-	editor := newPlanEditor(sess, "", 80, 30)
+	// textareaWidth(70) = 68, which is below planEditorMaxMeasure (72).
+	// On such terminals contentWidth() must equal textarea.Width().
+	editor := newPlanEditor(sess, "", 70, 30)
 	if got, want := editor.contentWidth(), editor.textarea.Width(); got != want {
-		t.Errorf("contentWidth=%d, textarea.Width()=%d; both modes must wrap at the same column", got, want)
+		t.Errorf("contentWidth=%d, textarea.Width()=%d; on narrow terminals both modes must wrap at the same column", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Implement comprehensive typography and layout improvements for the planning display using established TUI readability practices
- Add content measure and centering infrastructure to ensure optimal line lengths for reading comprehension
- Enhance visual hierarchy with heading underlines, checkbox task styling, and code block decorations
- Introduce subtle background tints for code spans and blocks to improve visual distinction
- Apply adaptive colors (dark/light) for inline code backgrounds to ensure contrast across themes
- Render horizontal rules as centered thin lines for cleaner sectioning
- Soften paragraph text color (#D1D5DB) to reduce eye strain on extended viewing
- Refine fence decorations: remove visual noise from delimiter lines while maintaining left bars on content
- Update test coverage to reflect fence marker and display-line accounting changes

These changes apply established typography principles—contrast, whitespace, hierarchy, and measure—to maximize readability of plan output in the terminal.

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI:
  - Render a plan with headings, code blocks, blockquotes, tasks, and horizontal rules
  - Verify heading underlines render correctly
  - Verify checkbox tasks display with styled glyphs
  - Verify code blocks have left bar on content lines only (not fence markers)
  - Verify blockquotes have left bar styling
  - Verify inline code has visible background on both dark and light terminal themes
  - Verify paragraph text appears softer without reduced clarity
  - Verify horizontal rules render as centered thin lines

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description