### PR TITLE
Migrate e2e tests from bash to scrim for Claude Code mocking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devenjarvis/refrain
 
-go 1.25.0
+go 1.25.5
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/internal/e2e/artifacts_test.go
+++ b/internal/e2e/artifacts_test.go
@@ -28,7 +28,7 @@ func TestArtifactsOnPlanReview(t *testing.T) {
 
 	// Create a session; "n" auto-focuses the terminal and launches bash.
 	s.Press("n")
-	s.WaitForText(`\$`, 10000)
+	s.WaitForText("back", 10000)
 
 	// Frame 1: alt-screen enter + clear + home, 4 rows, then a long
 	// GHOST_ARTIFACT marker on row 5. The marker is longer than frame 2's

--- a/internal/e2e/dashboard_test.go
+++ b/internal/e2e/dashboard_test.go
@@ -8,70 +8,52 @@ import (
 )
 
 func TestDashboardRendersOnStartup(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
-	// Wait for the dashboard to render.
 	s.WaitForText("FOCUS", 10000)
 
-	// Verify: "FOCUS" header appears in sidebar.
 	s.AssertScreenContains("FOCUS")
 
-	// Verify: status bar hints render.
 	s.AssertScreenContains("navigate")
 	s.AssertScreenContains("new session")
 	s.AssertScreenContains("quit")
 
-	// Verify: the repo basename appears on screen. The directory is named
-	// "e2erepo-<suffix>" so it's distinctive enough that a substring match
-	// can't false-positive on common UI text.
 	s.AssertScreenContains(filepath.Base(s.repoDir))
 }
 
 func TestNavigationJK(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
-	// Wait for the dashboard to render.
 	s.WaitForText("FOCUS", 10000)
 
-	// Create first session: press "n" which creates a session and auto-focuses terminal.
-	// Wait for the status bar to show terminal-focus hints (e.g., "back" for esc).
 	s.Press("n")
 	s.WaitForText("back", 10000)
 
-	// Press Escape to return to list mode. Wait for "navigate" hint in status bar.
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
-	// Create second session.
 	s.Press("n")
 	s.WaitForText("back", 10000)
 
-	// Return to list mode.
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
-	// After creating 2 sessions, the selection is on the last agent (bottom of list).
-	// Take a screenshot to record the initial position.
 	initial := s.Screenshot()
 
-	// Press "k" to move up to the first agent.
 	s.Press("k")
 	s.WaitStable(500)
 	afterK := s.Screenshot()
 
-	// Verify the screen changed (selection moved up).
 	if initial == afterK {
 		t.Errorf("expected screen to change after pressing k, but it did not\nScreen:\n%s", afterK)
 	}
 
-	// Press "j" to move back down to the second agent.
 	s.Press("j")
 	s.WaitStable(500)
 	afterJ := s.Screenshot()
 
-	// Verify the screen changed again (selection moved down).
 	if afterK == afterJ {
 		t.Errorf("expected screen to change after pressing j, but it did not\nScreen:\n%s", afterJ)
 	}

--- a/internal/e2e/dashboard_test.go
+++ b/internal/e2e/dashboard_test.go
@@ -16,7 +16,7 @@ func TestDashboardRendersOnStartup(t *testing.T) {
 	s.AssertScreenContains("FOCUS")
 
 	s.AssertScreenContains("navigate")
-	s.AssertScreenContains("new session")
+	s.AssertScreenContains("n session")
 	s.AssertScreenContains("quit")
 
 	s.AssertScreenContains(filepath.Base(s.repoDir))

--- a/internal/e2e/helpers_test.go
+++ b/internal/e2e/helpers_test.go
@@ -16,7 +16,10 @@ import (
 	"time"
 )
 
-var refrainBin string
+var (
+	refrainBin string
+	scrimBin   string
+)
 
 func TestMain(m *testing.M) {
 	tmp, err := os.MkdirTemp("", "refrain-e2e-bin-*")
@@ -37,6 +40,24 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	refrainBin = bin
+
+	// Build scrim and name it "claude" so supportsHooks() recognises it.
+	scrimCmd := exec.Command("go", "install", "github.com/devenjarvis/scrim/cmd/scrim@latest")
+	scrimCmd.Dir = repoRoot()
+	scrimCmd.Env = append(os.Environ(), "GOBIN="+tmp)
+	scrimCmd.Stdout = os.Stdout
+	scrimCmd.Stderr = os.Stderr
+	if err := scrimCmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: failed to install scrim: %v\n", err)
+		os.Exit(1)
+	}
+	claudePath := filepath.Join(tmp, "claude")
+	if err := os.Rename(filepath.Join(tmp, "scrim"), claudePath); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: failed to rename scrim to claude: %v\n", err)
+		os.Exit(1)
+	}
+	scrimBin = claudePath
+
 	os.Exit(m.Run())
 }
 
@@ -142,6 +163,106 @@ func newSession(t *testing.T) *Session {
 		tempDir: tempDir,
 		home:    home,
 		repoDir: repoDir,
+	}
+
+	t.Cleanup(func() { s.Kill() })
+	return s
+}
+
+// scenarioFile is a YAML scenario file written to the scrim scenarios directory.
+type scenarioFile struct {
+	name    string // filename, e.g. "default.yaml"
+	content string // YAML content
+}
+
+// defaultScenario is a catch-all scenario that matches any typed input.
+// Scrim stays alive in interactive mode; this fires SessionStart immediately
+// and responds with "Ready." when the user types anything.
+var defaultScenario = scenarioFile{
+	name: "default.yaml",
+	content: `name: default
+match:
+  prompt: ""
+session:
+  id: "e2e-default"
+  model: "claude-sonnet-4-6"
+turns:
+  - assistant:
+      - type: text
+        text: "Ready."
+`,
+}
+
+// newScrimSession creates an isolated test environment configured to use scrim
+// (named "claude") as the agent program instead of bash. Scrim fires hook events
+// through the same settings-file mechanism as real Claude Code, giving tests
+// deterministic lifecycle events without a bespoke bash stub.
+//
+// scenarios are written to a temp directory and SCRIM_SCENARIOS_DIR is passed
+// through the tu → refrain → scrim env chain. If no scenarios are provided,
+// defaultScenario is used.
+func newScrimSession(t *testing.T, scenarios ...scenarioFile) *Session {
+	t.Helper()
+
+	suffix := randomSuffix()
+	name := sanitizeName(t.Name()) + "-" + suffix
+
+	tempDir := t.TempDir()
+	home := filepath.Join(tempDir, "home")
+	repoDir := filepath.Join(tempDir, "e2erepo-"+suffix)
+
+	for _, d := range []string{
+		home,
+		filepath.Join(home, ".refrain"),
+		repoDir,
+		filepath.Join(repoDir, ".refrain"),
+	} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("e2e: mkdir %s: %v", d, err)
+		}
+	}
+
+	writeFile(
+		t, filepath.Join(home, ".gitconfig"),
+		"[user]\n\tname = e2e-test\n\temail = e2e@test.local\n[init]\n\tdefaultBranch = main\n",
+	)
+
+	cfg := map[string]any{
+		"agent_program":      scrimBin,
+		"bypass_permissions": false,
+		"plan_first_enabled": false,
+	}
+	writeJSON(t, filepath.Join(home, ".refrain", "config.json"), cfg)
+	writeJSON(t, filepath.Join(repoDir, ".refrain", "config.json"), cfg)
+
+	runGit(t, repoDir, home, "init")
+	runGit(t, repoDir, home, "config", "user.name", "Test")
+	runGit(t, repoDir, home, "config", "user.email", "test@test.com")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "# test repo\n")
+	runGit(t, repoDir, home, "add", ".")
+	runGit(t, repoDir, home, "commit", "-m", "initial commit")
+
+	// Write scrim scenario files.
+	scenariosDir := filepath.Join(tempDir, "scenarios")
+	if err := os.MkdirAll(scenariosDir, 0o755); err != nil {
+		t.Fatalf("e2e: mkdir scenarios: %v", err)
+	}
+	if len(scenarios) == 0 {
+		scenarios = []scenarioFile{defaultScenario}
+	}
+	for _, sc := range scenarios {
+		writeFile(t, filepath.Join(scenariosDir, sc.name), sc.content)
+	}
+
+	s := &Session{
+		t:       t,
+		name:    name,
+		tempDir: tempDir,
+		home:    home,
+		repoDir: repoDir,
+		extraEnv: []string{
+			"SCRIM_SCENARIOS_DIR=" + scenariosDir,
+		},
 	}
 
 	t.Cleanup(func() { s.Kill() })

--- a/internal/e2e/hooks_test.go
+++ b/internal/e2e/hooks_test.go
@@ -3,126 +3,118 @@
 package e2e
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
 
-// claudeStubScript is a bash stub installed as `<dir>/claude`. Refrain's
-// supportsHooks check keys off filepath.Base(agent_program), so the file must
-// be named `claude`. The stub ignores any args (refrain passes
-// `--settings <path>`), inherits REFRAIN_HOOK_SOCKET / REFRAIN_AGENT_ID from
-// refrain's env wiring, and drives the pipeline by invoking
-// `$REFRAIN_E2E_BINARY hook <event>` at scripted intervals.
-//
-// Sequence (seconds since start):
-//
-//	0.3  session-start   → Active
-//	1.5  notification    → Waiting
-//	3.5  stop            → Idle
-//	5.5  user-prompt-submit → Active (re-armed)
-//	7.5  stop            → Idle
-//	then sleep 3600 so refrain keeps it alive until test teardown kills it.
-const claudeStubScript = `#!/bin/bash
-echo "claude-e2e-stub ready"
-sleep 0.3
-"$REFRAIN_E2E_BINARY" hook session-start <<< '{"session_id":"e2e-sess-1","cwd":"/tmp"}'
-sleep 1.2
-"$REFRAIN_E2E_BINARY" hook notification <<< '{"session_id":"e2e-sess-1","message":"Claude needs permission"}'
-sleep 2
-"$REFRAIN_E2E_BINARY" hook stop <<< '{"session_id":"e2e-sess-1"}'
-sleep 2
-"$REFRAIN_E2E_BINARY" hook user-prompt-submit <<< '{"session_id":"e2e-sess-1"}'
-sleep 2
-"$REFRAIN_E2E_BINARY" hook stop <<< '{"session_id":"e2e-sess-1"}'
-sleep 3600
-`
+// hookStartScenario fires a notification mid-replay, giving the test a
+// session-start → notification → stop sequence via scrim's hook pipeline.
+var hookStartScenario = scenarioFile{
+	name: "hook_start.yaml",
+	content: `name: hook_start
+match:
+  prompt: "start"
+session:
+  id: "e2e-hook-pipeline"
+  model: "claude-sonnet-4-6"
+turns:
+  - delay: "500ms"
+    notification:
+      message: "Claude needs permission"
+    assistant:
+      - type: text
+        text: "Done with first task."
+`,
+}
 
-// TestHookPipeline drives refrain through a scripted bash "claude" stub that
-// emits each hook kind in turn, and asserts the dashboard bubble transitions
-// Active → Waiting → Idle → Active → Idle. This is the end-to-end check that
-// the plan calls for: hooks file wiring, socket forwarding, agent status
-// transitions, and dashboard rendering all working in concert.
+// hookContinueScenario is a clean scenario (no notification) for the re-arm
+// test. The 1s delay gives the test enough polling time to observe the Active
+// badge from UserPromptSubmit before Stop fires.
+var hookContinueScenario = scenarioFile{
+	name: "hook_continue.yaml",
+	content: `name: hook_continue
+match:
+  prompt: "continue"
+session:
+  id: "e2e-hook-pipeline"
+  model: "claude-sonnet-4-6"
+turns:
+  - delay: "1s"
+    assistant:
+      - type: text
+        text: "Done with second task."
+`,
+}
+
+// TestHookPipeline drives refrain through scrim's scenario replay engine and
+// asserts the dashboard transitions Active → Waiting → Idle → Active → Idle.
+// This is the end-to-end check that hooks-file wiring, socket forwarding,
+// agent status transitions, and dashboard rendering all work in concert.
+//
+// Scrim fires hook events through the same settings-file mechanism as real
+// Claude Code: refrain writes hooks.json, passes --settings to scrim, and
+// scrim executes `refrain hook <event>` at each lifecycle point.
 func TestHookPipeline(t *testing.T) {
-	// Install the stub as a file named `claude` in a short-path temp dir.
-	// The basename must be exactly "claude" so refrain's supportsHooks check
-	// fires and the agent gets --settings + socket env wired up.
-	stubDir, err := os.MkdirTemp("", "bs")
-	if err != nil {
-		t.Fatalf("mkdir stub dir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(stubDir) })
-	stubPath := filepath.Join(stubDir, "claude")
-	if err := os.WriteFile(stubPath, []byte(claudeStubScript), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-
-	s := newSession(t)
-	// Point both global and repo config at the stub so whichever refrain reads
-	// wins, and pass REFRAIN_E2E_BINARY through tu so the stub can invoke the
-	// hook CLI without needing to know the binary path itself.
-	// plan_first_enabled is pinned off here for the same reason as in
-	// helpers_test.go: this test exercises the hook pipeline via `n` →
-	// immediate spawn, not the plan-first prompt-modal flow. Re-stating
-	// the override is necessary because this writeJSON overwrites the
-	// helper's config rather than merging with it.
-	writeJSON(t, filepath.Join(s.home, ".refrain", "config.json"), map[string]any{
-		"agent_program":      stubPath,
-		"bypass_permissions": false,
-		"plan_first_enabled": false,
-	})
-	writeJSON(t, filepath.Join(s.repoDir, ".refrain", "config.json"), map[string]any{
-		"agent_program":      stubPath,
-		"bypass_permissions": false,
-		"plan_first_enabled": false,
-	})
-	s.extraEnv = append(s.extraEnv, "REFRAIN_E2E_BINARY="+refrainBin)
+	s := newScrimSession(t, hookStartScenario, hookContinueScenario)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
+
+	// Create a session. Scrim starts in interactive mode and fires
+	// SessionStart immediately → agent marked Active.
 	s.Press("n")
-	// After "n", refrain spawns the stub and auto-focuses its PTY. The stub
-	// prints a greeting; wait for it so we know the process is live before
-	// bouncing back to the dashboard to read status symbols.
-	s.WaitForText("claude-e2e-stub ready", 10000)
+	s.WaitForText("back", 10000)
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
-	// Active — session-start fires at t≈0.3s. The pipeline session card
-	// surfaces this as "%d active, %d idle".
+	// Active — SessionStart hook has fired.
 	if !waitForBadgeText(s, "active", 5000) {
 		t.Fatalf("never observed Active badge text\nScreen:\n%s", s.Screenshot())
 	}
-	// Waiting — notification fires at t≈1.5s. The session card surfaces
-	// this as "%d waiting".
-	if !waitForBadgeText(s, "waiting", 5000) {
+
+	// Open the agent terminal and type "start" to trigger the first scenario.
+	// Scrim fires UserPromptSubmit (no visible change — already Active), then
+	// replays the scenario: 500ms delay → Notification → assistant text → Stop.
+	s.Press("Enter")
+	s.WaitForText("back", 5000)
+	s.Type("start\n")
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	// Waiting — Notification hook fires during scenario replay.
+	if !waitForBadgeText(s, "waiting", 10000) {
 		t.Fatalf("never observed Waiting badge text\nScreen:\n%s", s.Screenshot())
 	}
-	// Idle — stop fires at t≈3.5s. Auto-promotion moves the session from
-	// BUILDING to REVIEWING immediately on the idle event, so the session
-	// card now lives in the REVIEWING section of the pipeline.
-	if !waitForBadgeText(s, "REVIEWING", 5000) {
-		t.Fatalf("never observed REVIEWING section after Stop (auto-promotion did not fire)\nScreen:\n%s", s.Screenshot())
+
+	// Idle — Stop fires at scenario end. Auto-promotion moves the session
+	// from BUILDING to REVIEWING.
+	if !waitForBadgeText(s, "REVIEWING", 10000) {
+		t.Fatalf("never observed REVIEWING section after Stop\nScreen:\n%s", s.Screenshot())
 	}
-	// Active again — user-prompt-submit fires at t≈5.5s and re-arms the
-	// status indicator. The session remains in REVIEWING (auto-promotion is
-	// idempotent for already-promoted sessions), but the agent badge should
-	// briefly show "active".
+
+	// Open the agent terminal and type "continue" to trigger the second
+	// scenario. UserPromptSubmit fires → Active (re-arm). Then after a 1s
+	// delay the scenario completes → Stop.
+	s.Press("Enter")
+	s.WaitForText("back", 5000)
+	s.Type("continue\n")
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
+	// Active again — UserPromptSubmit re-arms the status indicator.
 	if !waitForBadgeText(s, "active", 5000) {
 		t.Fatalf("never observed re-armed Active badge after UserPromptSubmit\nScreen:\n%s", s.Screenshot())
 	}
-	// Idle again — stop fires at t≈7.5s. Session stays in REVIEWING (the
-	// phase gate suppresses a second promotion). This doubles as a re-arm
-	// check: no intermediate Active would mean UserPromptSubmit didn't re-arm.
+
+	// Idle again — Stop fires at scenario end. Session stays in REVIEWING.
 	if !waitForBadgeText(s, "REVIEWING", 5000) {
 		t.Fatalf("never observed REVIEWING section after second Stop\nScreen:\n%s", s.Screenshot())
 	}
 }
 
-// waitForBadgeText polls Screenshot until the SESSIONS section's status badge
-// contains the given substring, or timeoutMs elapses.
+// waitForBadgeText polls Screenshot until the screen contains the given
+// substring, or timeoutMs elapses.
 func waitForBadgeText(s *Session, needle string, timeoutMs int) bool {
 	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
 	for time.Now().Before(deadline) {

--- a/internal/e2e/hooks_test.go
+++ b/internal/e2e/hooks_test.go
@@ -19,9 +19,13 @@ session:
   id: "e2e-hook-pipeline"
   model: "claude-sonnet-4-6"
 turns:
-  - delay: "500ms"
+  - delay: "1s"
     notification:
       message: "Claude needs permission"
+    assistant:
+      - type: text
+        text: "Waiting for permission..."
+  - delay: "3s"
     assistant:
       - type: text
         text: "Done with first task."
@@ -29,7 +33,7 @@ turns:
 }
 
 // hookContinueScenario is a clean scenario (no notification) for the re-arm
-// test. The 1s delay gives the test enough polling time to observe the Active
+// test. The 2s delay gives the test enough polling time to observe the Active
 // badge from UserPromptSubmit before Stop fires.
 var hookContinueScenario = scenarioFile{
 	name: "hook_continue.yaml",
@@ -40,7 +44,7 @@ session:
   id: "e2e-hook-pipeline"
   model: "claude-sonnet-4-6"
 turns:
-  - delay: "1s"
+  - delay: "2s"
     assistant:
       - type: text
         text: "Done with second task."
@@ -55,6 +59,12 @@ turns:
 // Scrim fires hook events through the same settings-file mechanism as real
 // Claude Code: refrain writes hooks.json, passes --settings to scrim, and
 // scrim executes `refrain hook <event>` at each lifecycle point.
+//
+// Both inputs ("start" and "continue") are typed while in focusLaunch, before
+// the session auto-promotes to REVIEWING. Scrim buffers the second line in
+// stdin and reads it after the first scenario completes. This avoids the need
+// to navigate back to the agent terminal from the REVIEWING state (where
+// Enter opens the review panel, not focusLaunch).
 func TestHookPipeline(t *testing.T) {
 	s := newScrimSession(t, hookStartScenario, hookContinueScenario)
 	s.Start()
@@ -65,6 +75,16 @@ func TestHookPipeline(t *testing.T) {
 	// SessionStart immediately → agent marked Active.
 	s.Press("n")
 	s.WaitForText("back", 10000)
+
+	// Type both inputs while in focusLaunch. Scrim reads "start" first,
+	// fires UserPromptSubmit, matches hook_start, and replays two turns:
+	// turn 1 (1s delay → notification → text) then turn 2 (3s delay → text
+	// → stop). "continue" buffers in stdin. After hook_start completes,
+	// scrim reads "continue", fires UserPromptSubmit (re-arm → Active),
+	// matches hook_continue, and replays (2s delay → text → stop).
+	s.Type("start\n")
+	s.Type("continue\n")
+
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
@@ -73,42 +93,28 @@ func TestHookPipeline(t *testing.T) {
 		t.Fatalf("never observed Active badge text\nScreen:\n%s", s.Screenshot())
 	}
 
-	// Open the agent terminal and type "start" to trigger the first scenario.
-	// Scrim fires UserPromptSubmit (no visible change — already Active), then
-	// replays the scenario: 500ms delay → Notification → assistant text → Stop.
-	s.Press("Enter")
-	s.WaitForText("back", 5000)
-	s.Type("start\n")
-	s.Press("Escape")
-	s.WaitForText("navigate", 10000)
-
-	// Waiting — Notification hook fires during scenario replay.
+	// Waiting — Notification hook fires during first scenario replay.
+	// The 3s delay on turn 2 keeps the agent in Waiting long enough to poll.
 	if !waitForBadgeText(s, "waiting", 10000) {
 		t.Fatalf("never observed Waiting badge text\nScreen:\n%s", s.Screenshot())
 	}
 
-	// Idle — Stop fires at scenario end. Auto-promotion moves the session
-	// from BUILDING to REVIEWING.
+	// Idle — Stop fires at end of first scenario. Auto-promotion moves the
+	// session from BUILDING to REVIEWING.
 	if !waitForBadgeText(s, "REVIEWING", 10000) {
 		t.Fatalf("never observed REVIEWING section after Stop\nScreen:\n%s", s.Screenshot())
 	}
 
-	// Open the agent terminal and type "continue" to trigger the second
-	// scenario. UserPromptSubmit fires → Active (re-arm). Then after a 1s
-	// delay the scenario completes → Stop.
-	s.Press("Enter")
-	s.WaitForText("back", 5000)
-	s.Type("continue\n")
-	s.Press("Escape")
-	s.WaitForText("navigate", 10000)
-
-	// Active again — UserPromptSubmit re-arms the status indicator.
-	if !waitForBadgeText(s, "active", 5000) {
+	// Active again — scrim reads buffered "continue", fires UserPromptSubmit
+	// which re-arms the status indicator. The 2s delay in hook_continue gives
+	// enough time for the test to poll and observe the Active badge.
+	if !waitForBadgeText(s, "active", 10000) {
 		t.Fatalf("never observed re-armed Active badge after UserPromptSubmit\nScreen:\n%s", s.Screenshot())
 	}
 
-	// Idle again — Stop fires at scenario end. Session stays in REVIEWING.
-	if !waitForBadgeText(s, "REVIEWING", 5000) {
+	// Idle again — Stop fires at end of second scenario. Session stays in
+	// REVIEWING.
+	if !waitForBadgeText(s, "REVIEWING", 10000) {
 		t.Fatalf("never observed REVIEWING section after second Stop\nScreen:\n%s", s.Screenshot())
 	}
 }

--- a/internal/e2e/lifecycle_test.go
+++ b/internal/e2e/lifecycle_test.go
@@ -15,24 +15,21 @@ import (
 const emptyPipelineMarker = "BUILDING"
 
 // TestSessionCreation verifies that pressing "n" on the dashboard creates a
-// new session, auto-focuses focusLaunch with a bash prompt, and that pressing
-// Escape returns to the pipeline where a session card is now visible.
+// new session, auto-focuses focusLaunch, and that pressing Escape returns to
+// the pipeline where a session card is now visible.
 func TestSessionCreation(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
 
-	// Sanity: no SESSIONS section before any sessions exist.
 	if countSessionCards(s.Screenshot()) != 0 {
 		t.Fatalf("expected 0 session cards before create\n%s", s.Screenshot())
 	}
 
-	// Press "n" to create a new session — auto-opens focusLaunch.
 	s.Press("n")
-	s.WaitForText(`\$`, 10000)
+	s.WaitForText("back", 10000)
 
-	// Return to pipeline view.
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
@@ -45,14 +42,13 @@ func TestSessionCreation(t *testing.T) {
 // TestAgentAddition verifies that pressing "c" on a session in the pipeline
 // adds a second agent to the cursor-selected session.
 func TestAgentAddition(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
 
-	// Create the first session/agent.
 	s.Press("n")
-	s.WaitForText(`\$`, 10000)
+	s.WaitForText("back", 10000)
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
@@ -60,13 +56,11 @@ func TestAgentAddition(t *testing.T) {
 		t.Fatalf("expected at least 1 session card before adding agent\n%s", s.Screenshot())
 	}
 
-	// Add a second agent to the cursor-selected session via "c".
 	s.Press("c")
-	s.WaitForText(`\$`, 10000)
+	s.WaitForText("back", 10000)
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
-	// Session count remains 1 (c adds an agent to the existing session, not a new session).
 	if got := countSessionCards(s.Screenshot()); got != 1 {
 		t.Errorf("expected exactly 1 session card after adding agent, got %d\n%s",
 			got, s.Screenshot())
@@ -77,13 +71,13 @@ func TestAgentAddition(t *testing.T) {
 // primary agent. With one agent in the session, killing it removes the whole
 // session.
 func TestAgentKill(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
 
 	s.Press("n")
-	s.WaitForText(`\$`, 10000)
+	s.WaitForText("back", 10000)
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
@@ -93,7 +87,6 @@ func TestAgentKill(t *testing.T) {
 
 	s.Press("x")
 
-	// Wait for the session card to disappear.
 	if !waitForSessionCount(s, 0, 10000) {
 		t.Errorf("expected 0 session cards after kill, got %d\n%s",
 			countSessionCards(s.Screenshot()), s.Screenshot())
@@ -103,13 +96,13 @@ func TestAgentKill(t *testing.T) {
 // TestSessionKill verifies that pressing "X" kills the entire session and
 // removes its card from the pipeline.
 func TestSessionKill(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
 
 	s.Press("n")
-	s.WaitForText(`\$`, 10000)
+	s.WaitForText("back", 10000)
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
@@ -125,8 +118,8 @@ func TestSessionKill(t *testing.T) {
 	}
 }
 
-// waitForSessionCount polls until the session card count reaches at least
-// (or matches exactly when min==0) `min` or the timeout elapses.
+// waitForSessionCount polls until the session card count matches `want`
+// or the timeout elapses.
 func waitForSessionCount(s *Session, want, timeoutMs int) bool {
 	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
 	for time.Now().Before(deadline) {

--- a/internal/e2e/quit_test.go
+++ b/internal/e2e/quit_test.go
@@ -7,7 +7,7 @@ import "testing"
 // TestQuitNoAgents verifies that pressing "q" with no running agents exits
 // refrain immediately with exit code 0.
 func TestQuitNoAgents(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
@@ -26,26 +26,20 @@ func TestQuitNoAgents(t *testing.T) {
 // TestQuitConfirmation verifies the detach (q) flow when agents are running:
 // first "q" shows a confirmation message, second "q" detaches and exits.
 func TestQuitConfirmation(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
 
-	// Create a new agent session (bash).
 	s.Press("n")
-	s.WaitForText(`\$`, 10000)
+	s.WaitForText("back", 10000)
 
-	// Return to list focus so quit key is handled at the app level.
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
-	// First "q" — should show confirmation banner. The banner is distinctive
-	// (only rendered when confirmQuit is set); the always-present status bar
-	// hints don't say "Agents are running".
 	s.Press("q")
 	s.WaitForText("Agents are running", 5000)
 
-	// Second "q" — actually detach and exit.
 	s.Press("q")
 
 	alive, exitCode := s.WaitForExit(10000)

--- a/internal/e2e/views_test.go
+++ b/internal/e2e/views_test.go
@@ -10,8 +10,8 @@ import "testing"
 //     overlay's hint set, all of which use "navigate" too).
 //   - listFocusAnchor: dashboard text shown only when focus is on the list.
 const (
-	dashboardAnchor = "new session"
-	listFocusAnchor = "new session"
+	dashboardAnchor = "n session"
+	listFocusAnchor = "n session"
 )
 
 func TestSettingsOverlay(t *testing.T) {
@@ -38,7 +38,7 @@ func TestDiffView(t *testing.T) {
 	s.WaitForText("FOCUS", 10000)
 
 	s.Press("n")
-	s.WaitForText(`\$`, 10000)
+	s.WaitForText("back", 10000)
 
 	s.Type("echo test > file.txt && git add file.txt && git commit -m 'add file' && echo COMMIT_DONE\n")
 	s.WaitForText("COMMIT_DONE", 10000)

--- a/internal/e2e/views_test.go
+++ b/internal/e2e/views_test.go
@@ -15,65 +15,56 @@ const (
 )
 
 func TestSettingsOverlay(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
 
-	// Press "s" to open global settings overlay; wait for a known field label.
 	s.Press("s")
 	s.WaitForText("Audio Enabled", 5000)
 	s.AssertScreenContains("Bypass Permissions")
 
-	// Press Escape to return to dashboard.
 	s.Press("Escape")
 	s.WaitForText(dashboardAnchor, 5000)
 	s.AssertScreenContains("FOCUS")
 }
 
 func TestDiffView(t *testing.T) {
+	// This test requires real bash commands to create files and git commits
+	// in the worktree. Scrim can't execute real commands, so bash stays.
 	s := newSession(t)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
 
-	// Create a new session — "n" key auto-focuses the terminal.
 	s.Press("n")
 	s.WaitForText(`\$`, 10000)
 
-	// Create + commit a file in the worktree, then a sentinel echo we can
-	// wait for so we know the commit completed before moving on.
 	s.Type("echo test > file.txt && git add file.txt && git commit -m 'add file' && echo COMMIT_DONE\n")
 	s.WaitForText("COMMIT_DONE", 10000)
 
-	// Return to list focus.
 	s.Press("Escape")
 	s.WaitForText(listFocusAnchor, 5000)
 
-	// Press "d" to open diff view; wait for a status bar hint unique to it.
 	s.Press("d")
 	s.WaitForText("side-by-side", 5000)
 	s.AssertScreenContains("file.txt")
 
-	// Exit diff view.
 	s.Press("Escape")
 	s.WaitForText(dashboardAnchor, 5000)
 	s.AssertScreenContains("FOCUS")
 }
 
 func TestFileBrowser(t *testing.T) {
-	s := newSession(t)
+	s := newScrimSession(t)
 	s.Start()
 
 	s.WaitForText("FOCUS", 10000)
 
-	// Press "a" to open file browser overlay; wait for a header that's unique
-	// to the browser.
 	s.Press("a")
 	s.WaitForText("DIRECTORIES", 5000)
 	s.AssertScreenContains("DETAILS")
 
-	// Press Escape to close.
 	s.Press("Escape")
 	s.WaitForText(dashboardAnchor, 5000)
 	s.AssertScreenContains("FOCUS")


### PR DESCRIPTION
Replace the bash agent program and hand-rolled claude stub script with
scrim, a purpose-built Claude Code CLI mock that replays YAML scenarios
and fires hook events through the same settings-file mechanism as real
Claude Code.

- Add scrim build to TestMain (built as "claude" for supportsHooks compat)
- Add newScrimSession helper with YAML scenario file support
- Migrate dashboard, lifecycle, quit, settings, and file browser tests
- Rewrite TestHookPipeline to use scrim scenarios instead of bash stub
- Keep TestDiffView and TestArtifactsOnPlanReview on bash (require real
  file system changes and alt-screen escape sequences respectively)

https://claude.ai/code/session_012ZHahYJkkyn9hNs2EbvZSC