### PR TITLE
Include task details and file changes in review requests

### DIFF
--- a/internal/agent/reviewer.go
+++ b/internal/agent/reviewer.go
@@ -37,6 +37,8 @@ type ReviewRequest struct {
 	TaskText       string
 	TaskDiff       string
 	OriginalPrompt string
+	TaskDetail     string   // plan sub-bullets for this task; empty when no plan or freeform plan
+	ChangedFiles   []string // paths of files modified in this task's commits; empty when unknown
 }
 
 // ReviewerAgent reviews a single task's diff and returns a verdict.
@@ -61,29 +63,6 @@ type defaultReviewerAgent struct {
 	model string
 }
 
-// reviewPromptTemplate is sent to the reviewer subprocess on stdin.
-// The concrete task fields are interpolated by buildReviewPrompt.
-const reviewPromptTemplate = `You are a code reviewer checking whether a code diff fulfills a specific task.
-
-ORIGINAL INTENT:
-%s
-
-TASK #%d:
-%s
-
-DIFF:
-%s
-
-Review the diff and decide:
-- "pass" — the diff clearly fulfills this task
-- "concerns" — the diff addresses this task but has notable gaps, risks, or incomplete work
-- "fail" — the diff does not fulfill this task or introduces clear regressions
-
-Respond with EXACTLY this format (no other text):
-VERDICT: <pass|concerns|fail>
-RATIONALE: <one or two sentences explaining your verdict>
-`
-
 func buildReviewPrompt(req ReviewRequest) string {
 	prompt := strings.TrimSpace(req.OriginalPrompt)
 	if prompt == "" {
@@ -93,7 +72,38 @@ func buildReviewPrompt(req ReviewRequest) string {
 	if diff == "" {
 		diff = "(no diff — task may have no committed changes)"
 	}
-	return fmt.Sprintf(reviewPromptTemplate, prompt, req.TaskIndex, req.TaskText, diff)
+
+	var b strings.Builder
+	b.WriteString("You are a code reviewer checking whether a code diff fulfills a specific task.\n\n")
+	fmt.Fprintf(&b, "ORIGINAL INTENT:\n%s\n\n", prompt)
+	fmt.Fprintf(&b, "TASK #%d:\n%s\n\n", req.TaskIndex, req.TaskText)
+
+	if req.TaskDetail != "" {
+		fmt.Fprintf(&b, "TASK DETAIL:\n%s\n\n", req.TaskDetail)
+	}
+
+	if len(req.ChangedFiles) > 0 {
+		b.WriteString("CHANGED FILES:\n")
+		for _, f := range req.ChangedFiles {
+			fmt.Fprintf(&b, "- %s\n", f)
+		}
+		b.WriteString("\n")
+	}
+
+	fmt.Fprintf(&b, "DIFF:\n%s\n\n", diff)
+
+	b.WriteString("Review the diff and decide:\n")
+	b.WriteString("- \"pass\" — the diff clearly fulfills this task\n")
+	b.WriteString("- \"concerns\" — the diff addresses this task but has notable gaps, risks, or incomplete work\n")
+	b.WriteString("- \"fail\" — the diff does not fulfill this task or introduces clear regressions\n\n")
+	if req.TaskDetail != "" || len(req.ChangedFiles) > 0 {
+		b.WriteString("Check that the diff touches the files and implements the behavior described in TASK DETAIL.\n\n")
+	}
+	b.WriteString("Respond with EXACTLY this format (no other text):\n")
+	b.WriteString("VERDICT: <pass|concerns|fail>\n")
+	b.WriteString("RATIONALE: <one or two sentences explaining your verdict>\n")
+
+	return b.String()
 }
 
 // buildReviewerArgs returns the argv (excluding the binary path) for the

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -220,12 +220,12 @@ func TestBuildReviewPrompt(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		req               ReviewRequest
-		wantTaskDetail    bool
-		wantChangedFiles  bool
-		detailSnippet     string
-		filesSnippet      string
+		name             string
+		req              ReviewRequest
+		wantTaskDetail   bool
+		wantChangedFiles bool
+		detailSnippet    string
+		filesSnippet     string
 	}{
 		{
 			name: "all fields populated",

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/devenjarvis/refrain/internal/git"
@@ -94,6 +95,60 @@ func TestParsePlanTasks_NoTasksHeadingFallback(t *testing.T) {
 	tasks := ParsePlanTasks(plan)
 	if len(tasks) != 2 {
 		t.Fatalf("freeform plan: want 2 tasks, got %d", len(tasks))
+	}
+}
+
+// TestParsePlanTasks_WithSubBullets verifies that sub-bullet lines following
+// each checkbox are collected into Body, and the checkbox line itself is not
+// included in Body.
+func TestParsePlanTasks_WithSubBullets(t *testing.T) {
+	plan := `# Goal
+Test sub-bullets.
+
+## Tasks
+- [ ] First task
+  - Files: internal/agent/session.go
+  - Implement: add the field
+- [ ] Second task
+  - Test first: write TestFoo
+  - Implement: do the thing
+  - Verify: go test ./...
+
+## Not in scope
+Nothing.
+`
+	tasks := ParsePlanTasks(plan)
+	if len(tasks) != 2 {
+		t.Fatalf("want 2 tasks, got %d", len(tasks))
+	}
+
+	if tasks[0].Body == "" {
+		t.Error("tasks[0].Body is empty, want sub-bullet content")
+	}
+	if !strings.Contains(tasks[0].Body, "Files: internal/agent/session.go") {
+		t.Errorf("tasks[0].Body missing Files line, got: %q", tasks[0].Body)
+	}
+	if !strings.Contains(tasks[0].Body, "Implement: add the field") {
+		t.Errorf("tasks[0].Body missing Implement line, got: %q", tasks[0].Body)
+	}
+	if strings.Contains(tasks[0].Body, "- [ ]") || strings.Contains(tasks[0].Body, "First task") {
+		t.Errorf("tasks[0].Body must not include the checkbox line, got: %q", tasks[0].Body)
+	}
+
+	if tasks[1].Body == "" {
+		t.Error("tasks[1].Body is empty, want sub-bullet content")
+	}
+	if !strings.Contains(tasks[1].Body, "Test first: write TestFoo") {
+		t.Errorf("tasks[1].Body missing Test first line, got: %q", tasks[1].Body)
+	}
+	if !strings.Contains(tasks[1].Body, "Implement: do the thing") {
+		t.Errorf("tasks[1].Body missing Implement line, got: %q", tasks[1].Body)
+	}
+	if !strings.Contains(tasks[1].Body, "Verify: go test ./...") {
+		t.Errorf("tasks[1].Body missing Verify line, got: %q", tasks[1].Body)
+	}
+	if strings.Contains(tasks[1].Body, "- [ ]") || strings.Contains(tasks[1].Body, "Second task") {
+		t.Errorf("tasks[1].Body must not include the checkbox line, got: %q", tasks[1].Body)
 	}
 }
 

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -209,6 +209,116 @@ func TestGroupCommitsByTask_NoOtherBucket(t *testing.T) {
 	}
 }
 
+// TestBuildReviewPrompt verifies the reviewer prompt is assembled correctly
+// depending on which optional fields are populated.
+func TestBuildReviewPrompt(t *testing.T) {
+	base := ReviewRequest{
+		TaskIndex:      2,
+		TaskText:       "Add widget",
+		TaskDiff:       "diff --git a/widget.go\n+func NewWidget() {}",
+		OriginalPrompt: "Build a widget system",
+	}
+
+	tests := []struct {
+		name              string
+		req               ReviewRequest
+		wantTaskDetail    bool
+		wantChangedFiles  bool
+		detailSnippet     string
+		filesSnippet      string
+	}{
+		{
+			name: "all fields populated",
+			req: func() ReviewRequest {
+				r := base
+				r.TaskDetail = "  - Files: internal/widget.go\n  - Implement: add NewWidget"
+				r.ChangedFiles = []string{"internal/widget.go", "internal/widget_test.go"}
+				return r
+			}(),
+			wantTaskDetail:   true,
+			wantChangedFiles: true,
+			detailSnippet:    "Files: internal/widget.go",
+			filesSnippet:     "internal/widget_test.go",
+		},
+		{
+			name: "empty TaskDetail omits section",
+			req: func() ReviewRequest {
+				r := base
+				r.TaskDetail = ""
+				r.ChangedFiles = []string{"internal/widget.go"}
+				return r
+			}(),
+			wantTaskDetail:   false,
+			wantChangedFiles: true,
+			filesSnippet:     "internal/widget.go",
+		},
+		{
+			name: "empty ChangedFiles omits section",
+			req: func() ReviewRequest {
+				r := base
+				r.TaskDetail = "  - Files: internal/widget.go"
+				r.ChangedFiles = nil
+				return r
+			}(),
+			wantTaskDetail:   true,
+			wantChangedFiles: false,
+			detailSnippet:    "Files: internal/widget.go",
+		},
+		{
+			name:             "both empty - plain format",
+			req:              base,
+			wantTaskDetail:   false,
+			wantChangedFiles: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildReviewPrompt(tt.req)
+
+			if tt.wantTaskDetail {
+				if !strings.Contains(got, "TASK DETAIL:") {
+					t.Error("expected TASK DETAIL section, not found")
+				}
+				if tt.detailSnippet != "" && !strings.Contains(got, tt.detailSnippet) {
+					t.Errorf("expected detail snippet %q in prompt, got:\n%s", tt.detailSnippet, got)
+				}
+			} else {
+				if strings.Contains(got, "TASK DETAIL:") {
+					t.Error("TASK DETAIL section must be absent when TaskDetail is empty")
+				}
+			}
+
+			if tt.wantChangedFiles {
+				if !strings.Contains(got, "CHANGED FILES:") {
+					t.Error("expected CHANGED FILES section, not found")
+				}
+				if tt.filesSnippet != "" && !strings.Contains(got, tt.filesSnippet) {
+					t.Errorf("expected files snippet %q in prompt, got:\n%s", tt.filesSnippet, got)
+				}
+			} else {
+				if strings.Contains(got, "CHANGED FILES:") {
+					t.Error("CHANGED FILES section must be absent when ChangedFiles is empty")
+				}
+			}
+
+			// Core sections always present.
+			if !strings.Contains(got, "ORIGINAL INTENT:") {
+				t.Error("ORIGINAL INTENT section missing")
+			}
+			if !strings.Contains(got, "TASK #2:") {
+				t.Error("TASK #N section missing")
+			}
+			if !strings.Contains(got, "Add widget") {
+				t.Error("task text missing")
+			}
+			if !strings.Contains(got, "DIFF:") {
+				t.Error("DIFF section missing")
+			}
+		})
+	}
+}
+
 // TestBuildReviewerArgs_NoBare verifies --bare is absent without an API key.
 func TestBuildReviewerArgs_NoBare(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -884,6 +884,7 @@ type PlanTask struct {
 	Index int    // 1-based, counting all "- [ ]" and "- [x]" lines top-to-bottom
 	Text  string // task description without the leading "- [ ] " or "- [x] "
 	Done  bool   // true if marked [x] or [X]
+	Body  string // raw sub-bullet lines that follow the checkbox, preserving indentation
 }
 
 // ParsePlanTasks extracts ordered task items from plan markdown using the same
@@ -899,17 +900,22 @@ func ParsePlanTasks(plan string) []PlanTask {
 	idx := 0
 	for _, raw := range ScanTaskLines(plan) {
 		line := strings.TrimLeft(raw, " \t")
-		if !strings.HasPrefix(line, "- [") {
-			continue
+		isCheckbox := strings.HasPrefix(line, "- [") && len(line) >= 6 && line[4] == ']'
+		if isCheckbox {
+			if len(tasks) > 0 {
+				tasks[len(tasks)-1].Body = strings.TrimRight(tasks[len(tasks)-1].Body, " \t\n")
+			}
+			idx++
+			marker := line[3]
+			done := marker == 'x' || marker == 'X'
+			text := strings.TrimSpace(line[5:])
+			tasks = append(tasks, PlanTask{Index: idx, Text: text, Done: done})
+		} else if len(tasks) > 0 {
+			tasks[len(tasks)-1].Body += raw + "\n"
 		}
-		if len(line) < 6 || line[4] != ']' {
-			continue
-		}
-		idx++
-		marker := line[3]
-		done := marker == 'x' || marker == 'X'
-		text := strings.TrimSpace(line[5:])
-		tasks = append(tasks, PlanTask{Index: idx, Text: text, Done: done})
+	}
+	if len(tasks) > 0 {
+		tasks[len(tasks)-1].Body = strings.TrimRight(tasks[len(tasks)-1].Body, " \t\n")
 	}
 	return tasks
 }

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -1110,5 +1111,77 @@ func TestRenderReviewPanel_NoDiffPlaceholder(t *testing.T) {
 	output := renderReviewPanel(sess, entry, 140, 40, 0, false, "")
 	if !strings.Contains(output, "(no diff for this task)") {
 		t.Errorf("must show '(no diff for this task)' placeholder; got:\n%s", output)
+	}
+}
+
+// capturingReviewer captures the ReviewRequest passed to Review for assertion.
+type capturingReviewer struct {
+	captured agent.ReviewRequest
+}
+
+func (c *capturingReviewer) Review(_ context.Context, req agent.ReviewRequest) (agent.ReviewVerdict, error) {
+	c.captured = req
+	return agent.ReviewVerdict{Kind: agent.VerdictPass, Rationale: "stub"}, nil
+}
+
+// TestReviewTaskCmd_PassesTaskDetail verifies that reviewTaskCmd populates
+// TaskDetail from PlanTask.Body and ChangedFiles from the group's file list.
+func TestReviewTaskCmd_PassesTaskDetail(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-1", "add-widget")
+
+	app := NewApp()
+	const repoPath = "/test/repo"
+	const taskIndex = 2
+
+	// Pre-populate the cache with tasks that have Body set.
+	app.reviewDiffCache[cacheKey(repoPath, sess.ID)] = &reviewDiffEntry{
+		tasks: []agent.PlanTask{
+			{Index: 1, Text: "First task", Body: "  - Files: internal/other.go"},
+			{Index: 2, Text: "Add widget", Body: "  - Files: internal/widget.go\n  - Implement: add NewWidget"},
+		},
+	}
+
+	group := taskReviewGroup{
+		taskIndex: taskIndex,
+		rawDiff:   "diff --git a/widget.go b/widget.go\n+func NewWidget() {}",
+		files: []git.FileStat{
+			{Path: "internal/widget.go", Insertions: 10, Deletions: 0},
+			{Path: "internal/widget_test.go", Insertions: 20, Deletions: 0},
+		},
+	}
+
+	reviewer := &capturingReviewer{}
+	cmd := app.reviewTaskCmd(sess, repoPath, group, reviewer)
+	cmd() // execute synchronously; reviewer.Review is called inline
+
+	req := reviewer.captured
+	if req.TaskDetail == "" {
+		t.Error("TaskDetail must be populated from PlanTask.Body, got empty")
+	}
+	if !strings.Contains(req.TaskDetail, "Files: internal/widget.go") {
+		t.Errorf("TaskDetail must contain Files sub-bullet, got: %q", req.TaskDetail)
+	}
+	if !strings.Contains(req.TaskDetail, "Implement: add NewWidget") {
+		t.Errorf("TaskDetail must contain Implement sub-bullet, got: %q", req.TaskDetail)
+	}
+
+	if len(req.ChangedFiles) != 2 {
+		t.Fatalf("ChangedFiles must have 2 entries, got %d: %v", len(req.ChangedFiles), req.ChangedFiles)
+	}
+	foundWidget := false
+	foundTest := false
+	for _, f := range req.ChangedFiles {
+		if f == "internal/widget.go" {
+			foundWidget = true
+		}
+		if f == "internal/widget_test.go" {
+			foundTest = true
+		}
+	}
+	if !foundWidget {
+		t.Errorf("ChangedFiles must include internal/widget.go, got: %v", req.ChangedFiles)
+	}
+	if !foundTest {
+		t.Errorf("ChangedFiles must include internal/widget_test.go, got: %v", req.ChangedFiles)
 	}
 }

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -644,17 +644,24 @@ func (a App) reviewTaskCmd(sess *agent.Session, repoPath string, group taskRevie
 	taskIndex := group.taskIndex
 	rawDiff := group.rawDiff
 
-	// Find task text from the entry if available.
+	// Find task text and sub-bullet body from the entry if available.
 	taskText := fmt.Sprintf("Task %d", taskIndex)
+	var taskDetail string
 	if taskIndex == 0 {
 		taskText = "Other changes"
 	} else if entry := a.reviewDiffCache[cacheKey(repoPath, sessID)]; entry != nil {
 		for _, t := range entry.tasks {
 			if t.Index == taskIndex {
 				taskText = t.Text
+				taskDetail = t.Body
 				break
 			}
 		}
+	}
+
+	changedFiles := make([]string, 0, len(group.files))
+	for _, f := range group.files {
+		changedFiles = append(changedFiles, f.Path)
 	}
 
 	return func() tea.Msg {
@@ -665,6 +672,8 @@ func (a App) reviewTaskCmd(sess *agent.Session, repoPath string, group taskRevie
 			TaskText:       taskText,
 			TaskDiff:       rawDiff,
 			OriginalPrompt: originalPrompt,
+			TaskDetail:     taskDetail,
+			ChangedFiles:   changedFiles,
 		})
 		return reviewVerdictMsg{sessionID: sessID, repoPath: repoPath, taskIndex: taskIndex, verdict: verdict, err: err}
 	}


### PR DESCRIPTION
## Summary

- Added `Body` field to `PlanTask` to capture detailed task descriptions from plan sub-bullet lines, enabling richer context for task verification
- Extended `ReviewRequest` with `TaskDetail` and `ChangedFiles` fields to pass plan context and affected files to the reviewer
- Updated `buildReviewPrompt` to conditionally insert TASK DETAIL and CHANGED FILES sections in the prompt when available, improving the quality of feedback from Haiku
- Wired `TaskDetail` and `ChangedFiles` extraction into `reviewTaskCmd` to automatically populate these fields from the plan and file group metadata
- When task details or file changes are absent, the prompt output maintains backward compatibility with the prior format

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI: Run `review task` command with a plan containing task sub-bullets and verify TASK DETAIL section appears in the review prompt

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description