### PR TITLE
Apply plan editor typography to review panel

### DIFF
--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -16,6 +16,19 @@ import (
 	"github.com/devenjarvis/refrain/internal/tui/mdrender"
 )
 
+// reviewDetailMaxMeasure is the maximum content column width for the right detail
+// pane. Matches planEditorMaxMeasure so typography is consistent across panels.
+const reviewDetailMaxMeasure = 72
+
+// reviewRenderer is the markdown renderer used for rationale text in the detail pane.
+var reviewRenderer = mdrender.New(planEditorChromaStyle)
+
+// detailContentMeasure returns the effective content width and left-margin padding
+// for centering the detail pane content. Thin wrapper around mdrender.ContentMeasure.
+func detailContentMeasure(paneWidth, maxMeasure int) (measure, leftPad int) {
+	return mdrender.ContentMeasure(paneWidth, maxMeasure)
+}
+
 // spinnerFrames is the braille spinner sequence used while a verdict is running.
 var spinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 
@@ -224,19 +237,19 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	if prDraftInFlight {
 		pHint = StyleSubtle.Render("p — (in progress…)")
 	} else {
-		pHint = lipgloss.NewStyle().Foreground(lipgloss.Color("#5ab58a")).Render("p") + StyleSubtle.Render(" — create or open PR")
+		pHint = StyleActive.Render("p") + StyleSubtle.Render(" — create or open PR")
 	}
 	hints := "  " +
 		pHint +
-		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#7ec8e3")).Render("t") + StyleSubtle.Render(" — open agent terminal") +
-		"   " + lipgloss.NewStyle().Foreground(ColorWarning).Render("b") + StyleSubtle.Render(" — back to build") +
-		"   " + StyleSubtle.Render("f — flag task") +
-		"   " + StyleSubtle.Render("c — mark complete") +
-		"   " + StyleSubtle.Render("e — open in editor") +
-		"   " + StyleSubtle.Render("d — defer") +
-		"   " + StyleSubtle.Render("pgdn") + StyleSubtle.Render("/pgup") + StyleSubtle.Render(" — scroll diff") +
-		"   " + lipgloss.NewStyle().Foreground(lipgloss.Color("#f0c060")).Render("?") + StyleSubtle.Render(" — spec") +
-		"   " + StyleSubtle.Render("ESC — back to focus")
+		"  " + StyleActive.Render("t") + StyleSubtle.Render(" — open agent terminal") +
+		"  " + StyleWarning.Render("b") + StyleSubtle.Render(" — back to build") +
+		"  " + StyleActive.Render("f") + StyleSubtle.Render(" — flag task") +
+		"  " + StyleActive.Render("c") + StyleSubtle.Render(" — mark complete") +
+		"  " + StyleActive.Render("e") + StyleSubtle.Render(" — open in editor") +
+		"  " + StyleActive.Render("d") + StyleSubtle.Render(" — defer") +
+		"  " + StyleActive.Render("pgdn") + StyleSubtle.Render("/") + StyleActive.Render("pgup") + StyleSubtle.Render(" — scroll diff") +
+		"  " + StyleActive.Render("?") + StyleSubtle.Render(" — spec") +
+		"  " + StyleSubtle.Render("ESC — back to focus")
 	lines = append(lines, hints)
 
 	return strings.Join(lines, "\n")
@@ -267,7 +280,11 @@ func reviewListPaneRowAt(entry *reviewDiffEntry, mouseX, mouseY, paneTop, paneLe
 // Row format: <icon> [N] <truncated text>  +X -Y
 func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int) []string {
 	const headerLines = 2
-	header := []string{StyleSubtle.Render("PLAN TASKS"), ""}
+	planTasksStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#06B6D4")).Bold(true)
+	header := []string{
+		planTasksStyle.Render("PLAN TASKS"),
+		StyleSubtle.Render(strings.Repeat("─", ansi.StringWidth("PLAN TASKS"))),
+	}
 
 	type row struct {
 		taskIndex int
@@ -410,6 +427,23 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 		return []string{StyleSubtle.Render("loading…")}
 	}
 
+	measure, leftPad := detailContentMeasure(width, reviewDetailMaxMeasure)
+
+	// capAndCenter caps lines to height then prepends centering padding to each
+	// non-empty line. Applied at every return point in the function.
+	capAndCenter := func(lines []string) []string {
+		capped := capLines(lines, height)
+		if leftPad > 0 {
+			pad := strings.Repeat(" ", leftPad)
+			for i, l := range capped {
+				if l != "" {
+					capped[i] = pad + l
+				}
+			}
+		}
+		return capped
+	}
+
 	// No-plan overview path.
 	if len(entry.tasks) == 0 && len(entry.groups) == 0 {
 		var lines []string
@@ -429,7 +463,7 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 				top = sorted[:8]
 			}
 			for _, f := range top {
-				name := truncateVisible(f.Path, width-14)
+				name := truncateVisible(f.Path, measure-14)
 				stat := subtleGreen.Render(fmt.Sprintf("+%d", f.Insertions)) +
 					" " + subtleRed.Render(fmt.Sprintf("-%d", f.Deletions))
 				lines = append(lines, "  "+name+"  "+stat)
@@ -438,7 +472,7 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 				lines = append(lines, StyleSubtle.Render(fmt.Sprintf("  … %d more files", len(sorted)-8)))
 			}
 		}
-		return capLines(lines, height)
+		return capAndCenter(lines)
 	}
 
 	// Resolve selected task and group using same row order as renderTaskListPane.
@@ -467,9 +501,12 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 	}
 
 	var lines []string
-	maxW := width - 2
+	maxW := measure - 2
 
-	// (1) Task heading.
+	// H2 heading style: matches colHeading2 / styleH2 in mdrender.
+	headingStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#06B6D4")).Bold(true)
+
+	// (1) Task heading with H2 color and thin underline.
 	heading := ""
 	if selectedTask != nil {
 		heading = fmt.Sprintf("Task %d: %s", selectedTask.Index, selectedTask.Text)
@@ -477,7 +514,9 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 		heading = "Other changes"
 	}
 	if heading != "" {
-		lines = append(lines, wrapText(heading, maxW)...)
+		displayHeading := truncateVisible(heading, maxW)
+		lines = append(lines, headingStyle.Render(displayHeading))
+		lines = append(lines, reviewRenderer.HeadingUnderline(2, ansi.StringWidth(displayHeading), measure))
 		lines = append(lines, "")
 	}
 
@@ -491,15 +530,15 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 	icon, label, style := verdictBadge(rec)
 	lines = append(lines, style.Render(icon+" "+label))
 
-	// (3) Rationale.
+	// (3) Rationale rendered through mdrender for inline bold/italic/code styling.
 	if rec != nil && rec.state == verdictDone && rec.verdict.Rationale != "" {
 		lines = append(lines, "")
-		lines = append(lines, wrapText(rec.verdict.Rationale, maxW)...)
+		lines = append(lines, reviewRenderer.RenderLines(rec.verdict.Rationale, measure)...)
 	}
 
 	if group == nil {
 		lines = append(lines, "", StyleSubtle.Render("(no commits matched this task)"))
-		return capLines(lines, height)
+		return capAndCenter(lines)
 	}
 
 	// (4) Changed files.
@@ -544,7 +583,7 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 		}
 	}
 
-	return capLines(lines, height)
+	return capAndCenter(lines)
 }
 
 // renderTaskSummaryPane renders the summary portion of the right pane (verdict,
@@ -739,9 +778,9 @@ func renderReviewSpecOverlay(sess *agent.Session, plan string, scrollOffset, wid
 
 	// Footer hint.
 	footer := "\n" + StyleSubtle.Render(strings.Repeat("─", width-2)) + "\n" +
-		"  " + StyleSubtle.Render("pgdn/pgup") + " scroll  " +
-		StyleSubtle.Render("g/G") + " top/bottom  " +
-		lipgloss.NewStyle().Foreground(lipgloss.Color("#f0c060")).Render("esc") + StyleSubtle.Render(" — back to review")
+		"  " + StyleActive.Render("pgdn") + StyleSubtle.Render("/") + StyleActive.Render("pgup") + StyleSubtle.Render(" — scroll") +
+		"  " + StyleActive.Render("g") + StyleSubtle.Render("/") + StyleActive.Render("G") + StyleSubtle.Render(" — top/bottom") +
+		"  " + StyleActive.Render("esc") + StyleSubtle.Render(" — back to review")
 
 	return header + "\n" + body + footer
 }

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -153,10 +153,12 @@ func TestRenderTaskDetailPane_FullRationaleNoTruncation(t *testing.T) {
 		t.Error("rationale must not be truncated with …")
 	}
 
-	// No individual rendered line exceeds width-2 visible cells.
+	// No individual rendered line exceeds width visible cells.
+	// Rationale is now rendered at measure=width (when width<reviewDetailMaxMeasure),
+	// so lines may be up to width wide rather than the old width-2.
 	for i, l := range lines {
-		if vw := ansi.StringWidth(l); vw > width-2 {
-			t.Errorf("line %d visible width %d exceeds %d: %q", i, vw, width-2, l)
+		if vw := ansi.StringWidth(l); vw > width {
+			t.Errorf("line %d visible width %d exceeds %d: %q", i, vw, width, l)
 		}
 	}
 }
@@ -1083,6 +1085,170 @@ func TestReviewPanel_CursorMoveSwapsDiff(t *testing.T) {
 	}
 	if strings.Contains(out1, "task-one-marker") {
 		t.Errorf("cursor=1: must not contain task-one-marker; got:\n%s", out1)
+	}
+}
+
+// TestRenderTaskDetailPane_ContentWidthCapped asserts that on a wide pane, content
+// is capped at reviewDetailMaxMeasure rather than filling the full pane width.
+func TestRenderTaskDetailPane_ContentWidthCapped(t *testing.T) {
+	rationale := strings.Repeat("This is a long rationale that should be wrapped correctly. ", 5)
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Add auth middleware"}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "add middleware"}},
+			files:     []git.FileStat{{Path: "internal/auth.go", Insertions: 5, Deletions: 1}},
+			stats:     &git.DiffStats{Files: 1, Insertions: 5, Deletions: 1},
+		}},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictPass, Rationale: rationale}},
+		},
+	}
+
+	const width = 120
+	lines := renderTaskDetailPane(entry, 0, width, 30)
+
+	for i, l := range lines {
+		if l == "" {
+			continue
+		}
+		// Strip centering padding (leading spaces added for centering) then check
+		// that no content line exceeds the max measure.
+		stripped := strings.TrimLeft(l, " ")
+		cw := ansi.StringWidth(stripped)
+		if cw > reviewDetailMaxMeasure {
+			t.Errorf("line %d content width %d exceeds reviewDetailMaxMeasure %d: %q",
+				i, cw, reviewDetailMaxMeasure, l)
+		}
+	}
+}
+
+// TestRenderTaskDetailPane_RationaleHasANSIStyling asserts that rationale text is
+// rendered via reviewRenderer.RenderLines(measure=72) rather than wrapText(maxW=70).
+// A 72-char string that fits in measure=72 but not maxW=70 is used as the probe:
+// wrapText(70) would split "token refresh!!" across lines, while RenderLines(72)
+// keeps it on one line. This test works in no-color environments.
+func TestRenderTaskDetailPane_RationaleHasANSIStyling(t *testing.T) {
+	// Exactly 72 chars — fits in measure=72, does NOT fit in maxW=70.
+	rationale := "This implementation is correct and handles auth redirect token refresh!!"
+	if len(rationale) != 72 {
+		t.Fatalf("test string must be 72 chars, got %d", len(rationale))
+	}
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Add auth middleware"}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "add middleware"}},
+			stats:     &git.DiffStats{Files: 1, Insertions: 5, Deletions: 1},
+		}},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictPass, Rationale: rationale}},
+		},
+	}
+
+	// width=80 → measure=72 (capped), maxW=70. If wrapText(70) were used, "refresh!!"
+	// would land on its own line; RenderLines(72) keeps "token refresh!!" together.
+	lines := renderTaskDetailPane(entry, 0, 80, 30)
+	out := strings.Join(lines, "\n")
+
+	if !strings.Contains(ansi.Strip(out), "token refresh!!") {
+		t.Error("72-char rationale must not be split: 'token refresh!!' should appear on one line " +
+			"(verifies RenderLines(measure=72) is used, not wrapText(maxW=70))")
+	}
+}
+
+// TestRenderTaskDetailPane_HeadingHasUnderline asserts that the line immediately
+// following the "Task N:" heading contains the ─ underline character.
+func TestRenderTaskDetailPane_HeadingHasUnderline(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Add auth middleware"}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "add middleware"}},
+			stats:     &git.DiffStats{Files: 1, Insertions: 5, Deletions: 1},
+		}},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictDone, verdict: agent.ReviewVerdict{Kind: agent.VerdictPass}},
+		},
+	}
+
+	lines := renderTaskDetailPane(entry, 0, 80, 20)
+
+	headingIdx := -1
+	for i, l := range lines {
+		if strings.Contains(ansi.Strip(l), "Task 1:") {
+			headingIdx = i
+			break
+		}
+	}
+	if headingIdx < 0 {
+		t.Fatal("heading line 'Task 1:' not found")
+	}
+	if headingIdx+1 >= len(lines) {
+		t.Fatal("no line after heading")
+	}
+	if !strings.Contains(lines[headingIdx+1], "─") {
+		t.Errorf("line after heading must contain '─' underline; got: %q", lines[headingIdx+1])
+	}
+}
+
+// TestRenderReviewPanel_FooterUsesThemeStyles asserts that footer key names use
+// StyleActive. In environments with color output the ANSI-coded styled key must
+// appear; in no-color environments the test verifies structural completeness.
+func TestRenderReviewPanel_FooterUsesThemeStyles(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-1", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, "")
+
+	// StyleActive.Render("p") — carries ANSI codes in color mode, is "p" otherwise.
+	// In both cases the rendered footer must contain it.
+	styledP := StyleActive.Render("p")
+	if !strings.Contains(output, styledP) {
+		t.Errorf("footer must use StyleActive for 'p' key; %q not found in output", styledP)
+	}
+
+	// In color mode, verify the 't' key is also styled via StyleActive (not the old
+	// ad-hoc lighter-cyan #7ec8e3).
+	styledT := StyleActive.Render("t")
+	if !strings.Contains(output, styledT) {
+		t.Errorf("footer must use StyleActive for 't' key; %q not found in output", styledT)
+	}
+}
+
+// TestRenderTaskListPane_HeaderUsesHeadingColor asserts that "PLAN TASKS" is
+// followed by a ─ underline (structural change from the old blank-line separator).
+func TestRenderTaskListPane_HeaderUsesHeadingColor(t *testing.T) {
+	entry := &reviewDiffEntry{
+		tasks:  []agent.PlanTask{{Index: 1, Text: "Add auth middleware"}},
+		groups: []taskReviewGroup{},
+	}
+
+	lines := renderTaskListPane(entry, 40, 10, 0)
+	out := strings.Join(lines, "\n")
+
+	if !strings.Contains(out, "PLAN TASKS") {
+		t.Error("header must contain PLAN TASKS")
+	}
+
+	headerIdx := -1
+	for i, l := range lines {
+		if strings.Contains(l, "PLAN TASKS") {
+			headerIdx = i
+			break
+		}
+	}
+	if headerIdx < 0 {
+		t.Fatal("no line containing PLAN TASKS found")
+	}
+
+	// The line immediately after PLAN TASKS must be the ─ underline (not a blank line).
+	if headerIdx+1 >= len(lines) {
+		t.Fatal("no line after PLAN TASKS header")
+	}
+	if !strings.Contains(lines[headerIdx+1], "─") {
+		t.Errorf("line after PLAN TASKS must contain '─' underline; got: %q", lines[headerIdx+1])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Applies plan review redesign principles to the PR draft review page, achieving visual and typographic consistency with the plan editor
- Caps review detail pane content at 72 columns with responsive centering on wide terminals, matching the plan editor's measure
- Renders rationale text with ANSI styling (bold, italic, inline-code) through mdrender for consistent formatting across the UI
- Styles task headings and the "PLAN TASKS" section header with H2 color and thin underline borders
- Replaces ad-hoc color styling in panel and overlay footers with theme-aware `StyleActive` and `StyleSubtle` constants
- Adds five tests covering content-width capping, mdrender integration, heading underlines, footer styling, and header rendering

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] Manual TUI: Verified review panel renders at capped width with proper text wrapping; task headings display with H2 color and underlines; footer key-value pairs use consistent active/subtle styling; PLAN TASKS header renders with color and border; text formatting (bold, italic, code) displays correctly in rationale text

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (5 new tests added)
- [x] No new public API surface