### PR TITLE
Remove redundant dashboard repo list from FOCUS header

### DIFF
--- a/changelog.d/remove-focus-header-repo-summary.md
+++ b/changelog.d/remove-focus-header-repo-summary.md
@@ -1,0 +1,2 @@
+### Removed
+- Cross-repo summary line from the FOCUS header (`repo: <name>` and `repoA(N●) | repoB(N⏸)`). The pipeline widget one line below already surfaces per-phase session counts, making the header summary redundant.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -723,7 +723,6 @@ func (a *App) refreshAgentList() {
 	a.dashboard.cursor = a.cursor
 	a.dashboard.prDraftSessionID = a.prDraftSessionID
 	a.dashboard.prDraftRepoPath = a.prDraftRepoPath
-	a.dashboard.activeRepoName = a.activeRepoDisplayName()
 	a.dashboard.activeRepoPath = a.activeRepo
 	a.syncModalsToDashboard()
 	if a.cfg == nil {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -1550,56 +1550,6 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		timerStr = barModel.ViewAs(pct) + " " + fmt.Sprintf("%dm/%dm", elapsedMin, d.focusSessionMinutes)
 	}
 	headerLine := title + "  " + timerStr
-	if d.activeRepoName != "" {
-		headerLine += "  " + StyleSubtle.Render("repo: "+d.activeRepoName)
-	}
-	// Cross-repo summary: collect repo names and per-repo agent status counts.
-	type repoStat struct {
-		name    string
-		path    string
-		active  int
-		waiting int
-	}
-	var repoOrder []string
-	repoStats := make(map[string]*repoStat)
-	for _, item := range d.items {
-		if item.kind == listItemRepo {
-			if _, ok := repoStats[item.repoPath]; !ok {
-				repoOrder = append(repoOrder, item.repoPath)
-				repoStats[item.repoPath] = &repoStat{name: item.repoName, path: item.repoPath}
-			}
-		} else if item.kind == listItemAgent && item.agent != nil && !item.agent.IsShell {
-			if rs, ok := repoStats[item.repoPath]; ok {
-				switch item.agent.Status() {
-				case agent.StatusActive:
-					rs.active++
-				case agent.StatusWaiting:
-					rs.waiting++
-				}
-			}
-		}
-	}
-	if len(repoOrder) > 1 {
-		var parts []string
-		for _, path := range repoOrder {
-			rs := repoStats[path]
-			var sym string
-			if rs.active > 0 {
-				sym = fmt.Sprintf("%d●", rs.active)
-			} else if rs.waiting > 0 {
-				sym = fmt.Sprintf("%d⏸", rs.waiting)
-			} else {
-				sym = "0"
-			}
-			entry := rs.name + "(" + sym + ")"
-			if path == d.activeRepoPath {
-				parts = append(parts, StyleActive.Render(entry))
-			} else {
-				parts = append(parts, StyleSubtle.Render(entry))
-			}
-		}
-		headerLine += "  " + strings.Join(parts, StyleSubtle.Render(" | "))
-	}
 	lines = append(lines, headerLine)
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -117,7 +117,6 @@ type dashboardModel struct {
 	cursor                 FocusedCursor  // pipeline cursor mirror; synced from App on every refresh
 	prDraftSessionID       string         // session ID whose PR draft is in flight; "" when idle
 	prDraftRepoPath        string         // repo path whose PR draft is in flight; "" when idle
-	activeRepoName         string         // display name of the active repo
 	activeRepoPath         string         // canonical path of the active repo (for pipeline filtering)
 	focusLaunchAgent       *agent.Agent   // agent open in focusLaunch terminal; nil otherwise
 	focusLaunchSession     *agent.Session // session owning focusLaunchAgent; nil otherwise

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -1190,7 +1190,6 @@ func TestHeaderOmitsCrossRepoSummary(t *testing.T) {
 	d := newDashboardModel()
 	d.width = 120
 	d.height = 39
-	d.activeRepoName = "myrepo"
 	d.items = []listItem{
 		{kind: listItemRepo, repoPath: "/a", repoName: "repoA"},
 		{kind: listItemSession, repoPath: "/a", repoName: "repoA", session: sessA},

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -1178,6 +1178,42 @@ func TestRenderFocusSessionCard_StaleTodosLineLine3UsesPlan(t *testing.T) {
 	}
 }
 
+// TestHeaderOmitsCrossRepoSummary verifies that renderFullscreenFocus never
+// emits a "repo: " label or a "|" cross-repo separator on the header line,
+// even when activeRepoName is set and multiple repo items are present.
+func TestHeaderOmitsCrossRepoSummary(t *testing.T) {
+	sessA := agent.NewSessionForTest("s-a", "add-dark-mode")
+	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
+	sessB := agent.NewSessionForTest("s-b", "fix-login")
+	sessB.SetLifecyclePhase(agent.LifecycleInProgress)
+
+	d := newDashboardModel()
+	d.width = 120
+	d.height = 39
+	d.activeRepoName = "myrepo"
+	d.items = []listItem{
+		{kind: listItemRepo, repoPath: "/a", repoName: "repoA"},
+		{kind: listItemSession, repoPath: "/a", repoName: "repoA", session: sessA},
+		{kind: listItemRepo, repoPath: "/b", repoName: "repoB"},
+		{kind: listItemSession, repoPath: "/b", repoName: "repoB", session: sessB},
+	}
+
+	out := d.renderFullscreenFocus(120, 39)
+
+	lines := strings.Split(out, "\n")
+	if len(lines) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+	headerLine := ansi.Strip(lines[0])
+
+	if strings.Contains(headerLine, "repo: ") {
+		t.Errorf("header must not contain \"repo: \", got %q", headerLine)
+	}
+	if strings.Contains(headerLine, " | ") {
+		t.Errorf("header must not contain cross-repo separator \" | \", got %q", headerLine)
+	}
+}
+
 // TestSessionFocusStatus_BuildingProgressCombinesPlanAndCommits verifies that
 // the building card badge uses max(planDone, commitDone) / max(planTotal, commitMax).
 func TestSessionFocusStatus_BuildingProgressCombinesPlanAndCommits(t *testing.T) {

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -1180,7 +1180,7 @@ func TestRenderFocusSessionCard_StaleTodosLineLine3UsesPlan(t *testing.T) {
 
 // TestHeaderOmitsCrossRepoSummary verifies that renderFullscreenFocus never
 // emits a "repo: " label or a "|" cross-repo separator on the header line,
-// even when activeRepoName is set and multiple repo items are present.
+// even when multiple repo items are present in d.items.
 func TestHeaderOmitsCrossRepoSummary(t *testing.T) {
 	sessA := agent.NewSessionForTest("s-a", "add-dark-mode")
 	sessA.SetLifecyclePhase(agent.LifecycleInProgress)


### PR DESCRIPTION
## Summary

- Removed the cross-repo summary and `repo:` label from the FOCUS header, which was redundant pixel spend — the pipeline widget directly below already surfaces per-phase session counts
- Deleted the `activeRepoName` field from `dashboardModel` as it was only consumed by the removed header block; compiler enforces no remaining callers
- Updated CHANGELOG.md and fixed related test comment

This frees screen space on the dashboard for higher-value information displays.

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI: Verify FOCUS header displays without repo summary, pipeline widget still shows per-phase counts

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] No new tests needed (cleanup of redundant UI, no behavior change)
- [x] No new public API surface