### PR TITLE
Redesign PR draft compose modal to match plan editing UX

### DIFF
--- a/changelog.d/pr-compose-full-page-editor.md
+++ b/changelog.d/pr-compose-full-page-editor.md
@@ -1,0 +1,11 @@
+### Changed
+
+- PR compose screen is now a full-page editor matching the plan editor's typography and layout, replacing the centered modal with a rounded border
+- Default mode on open is scroll: the AI-drafted title renders as styled text and the body renders through the markdown renderer with syntax highlighting and left-margin centering on wide terminals
+- Press `i` to enter edit mode; the title field (textinput) receives focus first
+- In edit mode, `tab`/`shift+tab` cycles focus between the title input and the markdown-aware body textarea
+- `esc` in edit mode returns to scroll mode preserving edits; `esc` in scroll mode cancels PR creation
+- `ctrl+enter` submits from either mode; `ctrl+d` toggles the draft flag; both work without entering edit mode
+- Header renders `PR DRAFT  ›  <session-name>` left-aligned with the draft/ready badge right-aligned
+- Footer shows mode-appropriate key hints using the same active/subtle pattern as the plan editor
+- `j`/`k`, `pgdn`/`pgup`, `g`/`G` scroll the body in scroll mode

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1005,7 +1005,7 @@ func (a App) View() tea.View {
 		if rp := a.modals.Review(); rp != nil {
 			var panelStr string
 			if a.prComposeModal.Active() {
-				panelStr = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, a.prComposeModal.View())
+				panelStr = a.prComposeModal.View()
 			} else {
 				panelStr = rp.View(a.panelServices())
 			}
@@ -1068,7 +1068,7 @@ func (a App) View() tea.View {
 		}
 		// PR compose modal overlay.
 		if a.prComposeModal.Active() {
-			body = lipgloss.Place(a.width, a.height-1, lipgloss.Center, lipgloss.Center, a.prComposeModal.View())
+			body = a.prComposeModal.View()
 		}
 		// Agent-limit modal overlay: replace body with centered modal when active.
 		if a.sessionLimitModalActive {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2076,7 +2076,7 @@ func TestReviewPanel_ComposeModalRendersOverPanel(t *testing.T) {
 	app.dashboard.height = 39
 	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 	app.prComposeModal.SetSize(120, 39)
-	_ = app.prComposeModal.Open("My PR Title", "My PR Body", false, "")
+	_ = app.prComposeModal.Open("My PR Title", "My PR Body", false, "ship-it")
 
 	v := app.View()
 	if !strings.Contains(v.Content, "My PR Title") {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2076,14 +2076,14 @@ func TestReviewPanel_ComposeModalRendersOverPanel(t *testing.T) {
 	app.dashboard.height = 39
 	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 	app.prComposeModal.SetSize(120, 39)
-	_ = app.prComposeModal.Open("My PR Title", "My PR Body", false)
+	_ = app.prComposeModal.Open("My PR Title", "My PR Body", false, "")
 
 	v := app.View()
 	if !strings.Contains(v.Content, "My PR Title") {
 		t.Errorf("expected view to contain %q, got content: %q", "My PR Title", v.Content)
 	}
-	if !strings.Contains(v.Content, "CREATE PR") {
-		t.Errorf("expected view to contain %q, got content: %q", "CREATE PR", v.Content)
+	if !strings.Contains(v.Content, "PR DRAFT") {
+		t.Errorf("expected view to contain %q, got content: %q", "PR DRAFT", v.Content)
 	}
 }
 

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -76,8 +76,9 @@ func (m *prComposeModal) Open(title, body string, draft bool, sessName string) t
 	m.focused = 0
 	m.titleInput.SetValue(title)
 	m.bodyArea.SetValue(body)
+	m.titleInput.Blur()
 	m.bodyArea.Blur()
-	return m.titleInput.Focus()
+	return nil
 }
 
 // Close hides the view and blurs both fields.
@@ -101,76 +102,104 @@ func (m *prComposeModal) SetSize(w, h int) {
 	m.clampScroll()
 }
 
-// Update routes a tea.Msg. Submit, cancel, draft toggle, and field focus are
-// handled flat for now; scroll/edit mode dispatch is introduced in a later task.
-// Scroll keybindings (j/k/pgdn/pgup/g/G) adjust scrollOff in all modes.
+// Update routes a tea.Msg to updateScroll or updateEdit based on mode.
 func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 	if !m.active {
 		return nil
 	}
-	if key, ok := msg.(tea.KeyPressMsg); ok {
-		switch key.String() {
-		case "esc":
-			m.Close()
-			return func() tea.Msg { return prComposeCancelMsg{} }
-		case "ctrl+enter":
-			title := strings.TrimSpace(m.titleInput.Value())
-			if title == "" {
-				return nil
-			}
-			body := strings.TrimSpace(m.bodyArea.Value())
-			draft := m.draft
-			m.Close()
-			return func() tea.Msg {
-				return prComposeSubmitMsg{title: title, body: body, draft: draft}
-			}
-		case "tab", "shift+tab":
-			if m.focused == 0 {
-				m.focused = 1
-				m.titleInput.Blur()
-				return m.bodyArea.Focus()
-			}
-			m.focused = 0
-			m.bodyArea.Blur()
-			return m.titleInput.Focus()
-		case "ctrl+d":
-			m.draft = !m.draft
-			return nil
-		// Scroll keybindings mirror the plan editor.
-		case "j":
-			m.scrollOff++
-			m.clampScroll()
-			return nil
-		case "k":
-			if m.scrollOff > 0 {
-				m.scrollOff--
-			}
-			return nil
-		case "pgdown":
-			m.scrollOff += m.scrollBodyHeight() / 2
-			m.clampScroll()
-			return nil
-		case "pgup":
-			m.scrollOff -= m.scrollBodyHeight() / 2
-			if m.scrollOff < 0 {
-				m.scrollOff = 0
-			}
-			return nil
-		case "g":
-			m.scrollOff = 0
-			return nil
-		case "G":
-			m.scrollOff = 9999
-			m.clampScroll()
+	switch m.mode {
+	case prComposeModeEdit:
+		return m.updateEdit(msg)
+	default:
+		return m.updateScroll(msg)
+	}
+}
+
+func (m *prComposeModal) updateScroll(msg tea.Msg) tea.Cmd {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return nil
+	}
+	switch key.String() {
+	case "esc":
+		m.Close()
+		return func() tea.Msg { return prComposeCancelMsg{} }
+	case "ctrl+enter":
+		title := strings.TrimSpace(m.titleInput.Value())
+		if title == "" {
 			return nil
 		}
+		body := strings.TrimSpace(m.bodyArea.Value())
+		draft := m.draft
+		m.Close()
+		return func() tea.Msg {
+			return prComposeSubmitMsg{title: title, body: body, draft: draft}
+		}
+	case "ctrl+d":
+		m.draft = !m.draft
+	case "i":
+		m.mode = prComposeModeEdit
+		m.focused = 0
+		return m.titleInput.Focus()
+	case "j":
+		m.scrollOff++
+		m.clampScroll()
+	case "k":
+		if m.scrollOff > 0 {
+			m.scrollOff--
+		}
+	case "pgdown":
+		m.scrollOff += m.scrollBodyHeight() / 2
+		m.clampScroll()
+	case "pgup":
+		m.scrollOff -= m.scrollBodyHeight() / 2
+		if m.scrollOff < 0 {
+			m.scrollOff = 0
+		}
+	case "g":
+		m.scrollOff = 0
+	case "G":
+		m.scrollOff = 9999
+		m.clampScroll()
+	}
+	return nil
+}
+
+func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		if m.focused == 0 {
+			var cmd tea.Cmd
+			m.titleInput, cmd = m.titleInput.Update(msg)
+			return cmd
+		}
+		var cmd tea.Cmd
+		m.bodyArea, cmd = m.bodyArea.Update(msg)
+		return cmd
+	}
+	switch key.String() {
+	case "esc":
+		m.titleInput.Blur()
+		m.bodyArea.Blur()
+		m.mode = prComposeModeScroll
+		return nil
+	case "tab", "shift+tab":
+		if m.focused == 0 {
+			m.focused = 1
+			m.titleInput.Blur()
+			return m.bodyArea.Focus()
+		}
+		m.focused = 0
+		m.bodyArea.Blur()
+		return m.titleInput.Focus()
+	}
+	if m.focused == 0 {
+		var cmd tea.Cmd
+		m.titleInput, cmd = m.titleInput.Update(msg)
+		return cmd
 	}
 	var cmd tea.Cmd
-	if m.focused == 0 {
-		m.titleInput, cmd = m.titleInput.Update(msg)
-	} else {
-		m.bodyArea, cmd = m.bodyArea.Update(msg)
-	}
+	m.bodyArea, cmd = m.bodyArea.Update(msg)
 	return cmd
 }
 

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -101,9 +101,9 @@ func (m *prComposeModal) SetSize(w, h int) {
 	m.clampScroll()
 }
 
-// Update routes a tea.Msg. Focus toggle, submit, cancel, and draft toggle
-// work the same as the old modal; scroll/edit mode dispatch is added in a
-// later task.
+// Update routes a tea.Msg. Submit, cancel, draft toggle, and field focus are
+// handled flat for now; scroll/edit mode dispatch is introduced in a later task.
+// Scroll keybindings (j/k/pgdn/pgup/g/G) adjust scrollOff in all modes.
 func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 	if !m.active {
 		return nil
@@ -136,6 +136,33 @@ func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 		case "ctrl+d":
 			m.draft = !m.draft
 			return nil
+		// Scroll keybindings mirror the plan editor.
+		case "j":
+			m.scrollOff++
+			m.clampScroll()
+			return nil
+		case "k":
+			if m.scrollOff > 0 {
+				m.scrollOff--
+			}
+			return nil
+		case "pgdown":
+			m.scrollOff += m.scrollBodyHeight() / 2
+			m.clampScroll()
+			return nil
+		case "pgup":
+			m.scrollOff -= m.scrollBodyHeight() / 2
+			if m.scrollOff < 0 {
+				m.scrollOff = 0
+			}
+			return nil
+		case "g":
+			m.scrollOff = 0
+			return nil
+		case "G":
+			m.scrollOff = 9999
+			m.clampScroll()
+			return nil
 		}
 	}
 	var cmd tea.Cmd
@@ -147,26 +174,65 @@ func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
-// View renders a basic full-page header with title/body content. Scroll and
-// edit mode views are fleshed out in later tasks.
+// View renders the full-page PR compose. Only call when Active() is true.
+// Scroll mode shows rendered body text; edit mode (added in a later task)
+// shows the interactive input fields.
 func (m *prComposeModal) View() string {
-	header := m.renderHeader()
-	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2)))
+	var lines []string
+	lines = append(lines, m.renderHeader())
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2))))
+	lines = append(lines, m.renderScrollBody())
+	lines = append(lines, m.renderFooter())
+	return strings.Join(lines, "\n")
+}
 
-	titleLabel := StyleSubtle.Render("Title")
-	bodyLabel := StyleSubtle.Render("Body")
-	if m.focused == 0 {
-		titleLabel = StyleTitle.Render("Title")
+func (m *prComposeModal) renderScrollBody() string {
+	pad := strings.Repeat(" ", m.displayLeftPad())
+
+	titleVal := m.titleInput.Value()
+	if titleVal == "" {
+		titleVal = StyleSubtle.Render("(no title)")
+	}
+	titleLine := pad + StyleTitle.Render("Title: ") + titleVal
+
+	bodyVal := m.bodyArea.Value()
+	var bodyContent string
+	if bodyVal == "" {
+		bodyContent = pad + StyleSubtle.Render("(no body)")
 	} else {
-		bodyLabel = StyleTitle.Render("Body")
+		rendered := m.renderer.RenderLines(bodyVal, m.contentWidth())
+		bh := m.scrollBodyHeight()
+		start := m.scrollOff
+		if start > len(rendered) {
+			start = len(rendered)
+		}
+		end := start + bh
+		if end > len(rendered) {
+			end = len(rendered)
+		}
+		paddedLines := make([]string, len(rendered[start:end]))
+		for i, l := range rendered[start:end] {
+			paddedLines[i] = pad + l
+		}
+		bodyContent = strings.Join(paddedLines, "\n")
 	}
 
 	return strings.Join([]string{
-		header, divider,
-		titleLabel, m.titleInput.Value(),
-		"", bodyLabel, m.bodyArea.Value(),
-		divider, "",
+		titleLine,
+		"",
+		pad + StyleSubtle.Render("Body"),
+		bodyContent,
 	}, "\n")
+}
+
+func (m *prComposeModal) renderFooter() string {
+	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2)))
+	hints := StyleActive.Render("j/k") + StyleSubtle.Render(" scroll  ") +
+		StyleActive.Render("i") + StyleSubtle.Render(" edit  ") +
+		StyleActive.Render("ctrl+↵") + StyleSubtle.Render(" create  ") +
+		StyleActive.Render("ctrl+d") + StyleSubtle.Render(" toggle draft  ") +
+		StyleActive.Render("esc") + StyleSubtle.Render(" cancel")
+	return divider + "\n" + hints
 }
 
 func (m *prComposeModal) renderHeader() string {

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -218,15 +218,38 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 }
 
 // View renders the full-page PR compose. Only call when Active() is true.
-// Scroll mode shows rendered body text; edit mode (added in a later task)
-// shows the interactive input fields.
 func (m *prComposeModal) View() string {
 	var lines []string
 	lines = append(lines, m.renderHeader())
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2))))
-	lines = append(lines, m.renderScrollBody())
+	switch m.mode {
+	case prComposeModeEdit:
+		lines = append(lines, m.renderEditBody())
+	default:
+		lines = append(lines, m.renderScrollBody())
+	}
 	lines = append(lines, m.renderFooter())
 	return strings.Join(lines, "\n")
+}
+
+func (m *prComposeModal) renderEditBody() string {
+	pad := strings.Repeat(" ", m.displayLeftPad())
+
+	titleLabel := StyleSubtle.Render("Title")
+	bodyLabel := StyleSubtle.Render("Body")
+	if m.focused == 0 {
+		titleLabel = StyleTitle.Render("Title")
+	} else {
+		bodyLabel = StyleTitle.Render("Body")
+	}
+
+	return strings.Join([]string{
+		pad + titleLabel,
+		m.titleInput.View(),
+		"",
+		pad + bodyLabel,
+		m.bodyArea.View(),
+	}, "\n")
 }
 
 func (m *prComposeModal) renderScrollBody() string {
@@ -270,11 +293,20 @@ func (m *prComposeModal) renderScrollBody() string {
 
 func (m *prComposeModal) renderFooter() string {
 	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2)))
-	hints := StyleActive.Render("j/k") + StyleSubtle.Render(" scroll  ") +
-		StyleActive.Render("i") + StyleSubtle.Render(" edit  ") +
-		StyleActive.Render("ctrl+↵") + StyleSubtle.Render(" create  ") +
-		StyleActive.Render("ctrl+d") + StyleSubtle.Render(" toggle draft  ") +
-		StyleActive.Render("esc") + StyleSubtle.Render(" cancel")
+	var hints string
+	switch m.mode {
+	case prComposeModeEdit:
+		hints = StyleActive.Render("tab") + StyleSubtle.Render(" switch  ") +
+			StyleActive.Render("ctrl+↵") + StyleSubtle.Render(" create  ") +
+			StyleActive.Render("ctrl+d") + StyleSubtle.Render(" toggle draft  ") +
+			StyleActive.Render("esc") + StyleSubtle.Render(" back")
+	default:
+		hints = StyleActive.Render("j/k") + StyleSubtle.Render(" scroll  ") +
+			StyleActive.Render("i") + StyleSubtle.Render(" edit  ") +
+			StyleActive.Render("ctrl+↵") + StyleSubtle.Render(" create  ") +
+			StyleActive.Render("ctrl+d") + StyleSubtle.Render(" toggle draft  ") +
+			StyleActive.Render("esc") + StyleSubtle.Render(" cancel")
+	}
 	return divider + "\n" + hints
 }
 

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -26,7 +26,6 @@ type prComposeModal struct {
 	bodyArea   mdtextarea.Model
 	renderer   *mdrender.Renderer
 	mode       prComposeMode
-	focused    int // 0=title, 1=body (meaningful in edit mode)
 	draft      bool
 	width      int
 	height     int
@@ -73,7 +72,6 @@ func (m *prComposeModal) Open(title, body string, draft bool, sessName string) t
 	m.mode = prComposeModeScroll
 	m.scrollOff = 0
 	m.sessName = sessName
-	m.focused = 0
 	m.titleInput.SetValue(title)
 	m.bodyArea.SetValue(body)
 	m.titleInput.Blur()
@@ -110,7 +108,7 @@ func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 	}
 	if paste, ok := msg.(tea.PasteMsg); ok {
 		if m.mode == prComposeModeEdit {
-			if m.focused == 0 {
+			if m.titleInput.Focused() {
 				var cmd tea.Cmd
 				m.titleInput, cmd = m.titleInput.Update(paste)
 				return cmd
@@ -153,7 +151,6 @@ func (m *prComposeModal) updateScroll(msg tea.Msg) tea.Cmd {
 		m.draft = !m.draft
 	case "i":
 		m.mode = prComposeModeEdit
-		m.focused = 0
 		return m.titleInput.Focus()
 	case "j":
 		m.scrollOff++
@@ -182,7 +179,7 @@ func (m *prComposeModal) updateScroll(msg tea.Msg) tea.Cmd {
 func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 	key, ok := msg.(tea.KeyPressMsg)
 	if !ok {
-		if m.focused == 0 {
+		if m.titleInput.Focused() {
 			var cmd tea.Cmd
 			m.titleInput, cmd = m.titleInput.Update(msg)
 			return cmd
@@ -212,16 +209,14 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 		m.draft = !m.draft
 		return nil
 	case "tab", "shift+tab":
-		if m.focused == 0 {
-			m.focused = 1
+		if m.titleInput.Focused() {
 			m.titleInput.Blur()
 			return m.bodyArea.Focus()
 		}
-		m.focused = 0
 		m.bodyArea.Blur()
 		return m.titleInput.Focus()
 	}
-	if m.focused == 0 {
+	if m.titleInput.Focused() {
 		var cmd tea.Cmd
 		m.titleInput, cmd = m.titleInput.Update(msg)
 		return cmd
@@ -251,7 +246,7 @@ func (m *prComposeModal) renderEditBody() string {
 
 	titleLabel := StyleSubtle.Render("Title")
 	bodyLabel := StyleSubtle.Render("Body")
-	if m.focused == 0 {
+	if m.titleInput.Focused() {
 		titleLabel = StyleTitle.Render("Title")
 	} else {
 		bodyLabel = StyleTitle.Render("Body")

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -183,6 +183,20 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 		m.bodyArea.Blur()
 		m.mode = prComposeModeScroll
 		return nil
+	case "ctrl+enter":
+		title := strings.TrimSpace(m.titleInput.Value())
+		if title == "" {
+			return nil
+		}
+		body := strings.TrimSpace(m.bodyArea.Value())
+		draft := m.draft
+		m.Close()
+		return func() tea.Msg {
+			return prComposeSubmitMsg{title: title, body: body, draft: draft}
+		}
+	case "ctrl+d":
+		m.draft = !m.draft
+		return nil
 	case "tab", "shift+tab":
 		if m.focused == 0 {
 			m.focused = 1

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -103,8 +103,22 @@ func (m *prComposeModal) SetSize(w, h int) {
 }
 
 // Update routes a tea.Msg to updateScroll or updateEdit based on mode.
+// PasteMsg in edit mode is forwarded to the focused field before mode dispatch.
 func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 	if !m.active {
+		return nil
+	}
+	if paste, ok := msg.(tea.PasteMsg); ok {
+		if m.mode == prComposeModeEdit {
+			if m.focused == 0 {
+				var cmd tea.Cmd
+				m.titleInput, cmd = m.titleInput.Update(paste)
+				return cmd
+			}
+			var cmd tea.Cmd
+			m.bodyArea, cmd = m.bodyArea.Update(paste)
+			return cmd
+		}
 		return nil
 	}
 	switch m.mode {

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -1,26 +1,37 @@
 package tui
 
 import (
-	"fmt"
 	"strings"
 
-	"charm.land/bubbles/v2/textarea"
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	xlipgloss "charm.land/lipgloss/v2"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/devenjarvis/refrain/internal/tui/mdrender"
+	"github.com/devenjarvis/refrain/internal/tui/mdtextarea"
 )
 
-// prComposeModal is a centered overlay for reviewing and editing an AI-drafted
-// PR title and body before creation. The user can tab between fields, toggle
-// draft mode, confirm, or cancel.
+type prComposeMode int
+
+const (
+	prComposeModeScroll prComposeMode = iota
+	prComposeModeEdit
+)
+
+// prComposeModal is a full-page view for reviewing and editing an AI-drafted
+// PR title and body before creation. Opens in scroll mode; press i to edit.
 type prComposeModal struct {
-	active    bool
-	titleArea textarea.Model
-	bodyArea  textarea.Model
-	focused   int // 0 = title field, 1 = body field
-	draft     bool
-	width     int
-	height    int
+	active     bool
+	titleInput textinput.Model
+	bodyArea   mdtextarea.Model
+	renderer   *mdrender.Renderer
+	mode       prComposeMode
+	focused    int // 0=title, 1=body (meaningful in edit mode)
+	draft      bool
+	width      int
+	height     int
+	scrollOff  int
+	sessName   string
 }
 
 // prComposeSubmitMsg fires when the user confirms the PR draft.
@@ -33,67 +44,66 @@ type prComposeSubmitMsg struct {
 // prComposeCancelMsg fires when the user presses esc.
 type prComposeCancelMsg struct{}
 
-const (
-	prModalMaxWidth  = 90
-	prModalMinWidth  = 50
-	prModalTitleRows = 1
-	prModalBodyRows  = 10
-	prModalCharLimit = 65536
-)
-
 func newPRComposeModal() prComposeModal {
-	ta := newPRTextArea(prModalTitleRows)
-	ba := newPRTextArea(prModalBodyRows)
-	return prComposeModal{titleArea: ta, bodyArea: ba, draft: true}
-}
+	ti := textinput.New()
+	ti.Placeholder = "Pull request title"
+	ti.CharLimit = 255
 
-func newPRTextArea(rows int) textarea.Model {
-	ta := textarea.New()
+	ta := mdtextarea.New()
 	ta.Prompt = ""
 	ta.ShowLineNumbers = false
-	ta.CharLimit = prModalCharLimit
-	ta.SetHeight(rows)
-	styles := ta.Styles()
-	styles.Focused.CursorLine = xlipgloss.NewStyle()
-	styles.Cursor.Color = ColorPrimary
-	ta.SetStyles(styles)
-	return ta
+
+	renderer := mdrender.New(planEditorChromaStyle)
+	ta.SetMarkdownRenderer(renderer)
+
+	return prComposeModal{
+		titleInput: ti,
+		bodyArea:   ta,
+		renderer:   renderer,
+		draft:      true,
+		mode:       prComposeModeScroll,
+	}
 }
 
-// Open shows the modal pre-filled with the AI-drafted title and body.
-// The title field receives focus. Returns the Cmd to focus the textarea.
-func (m *prComposeModal) Open(title, body string, draft bool) tea.Cmd {
+// Open shows the full-page PR compose view pre-filled with the AI-drafted
+// title and body. Opens in scroll mode so the user can review before editing.
+func (m *prComposeModal) Open(title, body string, draft bool, sessName string) tea.Cmd {
 	m.active = true
 	m.draft = draft
+	m.mode = prComposeModeScroll
+	m.scrollOff = 0
+	m.sessName = sessName
 	m.focused = 0
-	m.titleArea.SetValue(title)
+	m.titleInput.SetValue(title)
 	m.bodyArea.SetValue(body)
-	m.titleArea.SetWidth(prModalWidth(m.width) - 4)
-	m.bodyArea.SetWidth(prModalWidth(m.width) - 4)
 	m.bodyArea.Blur()
-	return m.titleArea.Focus()
+	return m.titleInput.Focus()
 }
 
-// Close hides the modal and blurs both fields.
+// Close hides the view and blurs both fields.
 func (m *prComposeModal) Close() {
 	m.active = false
-	m.titleArea.Blur()
+	m.titleInput.Blur()
 	m.bodyArea.Blur()
+	m.mode = prComposeModeScroll
 }
 
-// Active reports whether the modal is currently visible.
+// Active reports whether the view is currently visible.
 func (m *prComposeModal) Active() bool { return m.active }
 
-// SetSize updates the modal's viewport dimensions.
+// SetSize updates the viewport dimensions.
 func (m *prComposeModal) SetSize(w, h int) {
 	m.width = w
 	m.height = h
-	inner := prModalWidth(w) - 4
-	m.titleArea.SetWidth(inner)
-	m.bodyArea.SetWidth(inner)
+	m.titleInput.SetWidth(w - 4)
+	m.bodyArea.SetWidth(textareaWidth(w))
+	m.bodyArea.SetHeight(m.editBodyHeight())
+	m.clampScroll()
 }
 
-// Update routes a tea.Msg to the active modal. Returns the Cmd to run.
+// Update routes a tea.Msg. Focus toggle, submit, cancel, and draft toggle
+// work the same as the old modal; scroll/edit mode dispatch is added in a
+// later task.
 func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 	if !m.active {
 		return nil
@@ -104,12 +114,12 @@ func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 			m.Close()
 			return func() tea.Msg { return prComposeCancelMsg{} }
 		case "ctrl+enter":
-			title := strings.TrimSpace(m.titleArea.Value())
+			title := strings.TrimSpace(m.titleInput.Value())
 			if title == "" {
 				return nil
 			}
 			body := strings.TrimSpace(m.bodyArea.Value())
-			draft := m.draft // snapshot before Close() resets state
+			draft := m.draft
 			m.Close()
 			return func() tea.Msg {
 				return prComposeSubmitMsg{title: title, body: body, draft: draft}
@@ -117,12 +127,12 @@ func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 		case "tab", "shift+tab":
 			if m.focused == 0 {
 				m.focused = 1
-				m.titleArea.Blur()
+				m.titleInput.Blur()
 				return m.bodyArea.Focus()
 			}
 			m.focused = 0
 			m.bodyArea.Blur()
-			return m.titleArea.Focus()
+			return m.titleInput.Focus()
 		case "ctrl+d":
 			m.draft = !m.draft
 			return nil
@@ -130,17 +140,18 @@ func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 	}
 	var cmd tea.Cmd
 	if m.focused == 0 {
-		m.titleArea, cmd = m.titleArea.Update(msg)
+		m.titleInput, cmd = m.titleInput.Update(msg)
 	} else {
 		m.bodyArea, cmd = m.bodyArea.Update(msg)
 	}
 	return cmd
 }
 
-// View renders the modal. Callers should invoke only when Active() is true.
+// View renders a basic full-page header with title/body content. Scroll and
+// edit mode views are fleshed out in later tasks.
 func (m *prComposeModal) View() string {
-	w := prModalWidth(m.width)
-	innerW := w - 4
+	header := m.renderHeader()
+	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2)))
 
 	titleLabel := StyleSubtle.Render("Title")
 	bodyLabel := StyleSubtle.Render("Body")
@@ -150,69 +161,72 @@ func (m *prComposeModal) View() string {
 		bodyLabel = StyleTitle.Render("Body")
 	}
 
+	return strings.Join([]string{
+		header, divider,
+		titleLabel, m.titleInput.Value(),
+		"", bodyLabel, m.bodyArea.Value(),
+		divider, "",
+	}, "\n")
+}
+
+func (m *prComposeModal) renderHeader() string {
+	title := lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true).Render("PR DRAFT")
+	left := title
+	if m.sessName != "" {
+		left = title + "  " + StyleSubtle.Render("›") + "  " + m.sessName
+	}
 	var draftLabel string
 	if m.draft {
 		draftLabel = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Bold(true).Render("● draft")
 	} else {
 		draftLabel = lipgloss.NewStyle().Foreground(lipgloss.Color("#10B981")).Bold(true).Render("● ready")
 	}
-
-	header := prComposeHeader(innerW, draftLabel)
-	footer := prComposeFooter()
-
-	body := lipgloss.JoinVertical(
-		lipgloss.Left,
-		header,
-		"",
-		titleLabel,
-		m.titleArea.View(),
-		"",
-		bodyLabel,
-		m.bodyArea.View(),
-		"",
-		footer,
-	)
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ColorPrimary).
-		Padding(0, 1).
-		Width(w).
-		Render(body)
-}
-
-func prComposeHeader(innerW int, draftLabel string) string {
-	left := StyleSubtle.Render("CREATE PR")
-	right := draftLabel
-	gap := innerW - lipgloss.Width(left) - lipgloss.Width(right)
+	gap := m.width - ansi.StringWidth(left) - ansi.StringWidth(draftLabel) - 4
 	if gap < 1 {
 		gap = 1
 	}
-	return lipgloss.JoinHorizontal(lipgloss.Left, left, strings.Repeat(" ", gap), right)
+	return left + strings.Repeat(" ", gap) + draftLabel
 }
 
-func prComposeFooter() string {
-	chip := func(key string) string { return StyleTitle.Render(key) }
-	desc := func(s string) string { return StyleSubtle.Render(s) }
-	line1 := fmt.Sprintf(
-		"%s %s   %s %s   %s %s   %s %s",
-		chip("ctrl+↵"), desc("create"),
-		chip("⇥"), desc("switch field"),
-		chip("ctrl+d"), desc("toggle draft"),
-		chip("esc"), desc("cancel"),
-	)
-	return line1
-}
-
-func prModalWidth(viewportW int) int {
-	w := viewportW * 2 / 3
-	if w > prModalMaxWidth {
-		w = prModalMaxWidth
-	}
-	if w < prModalMinWidth {
-		w = prModalMinWidth
-	}
-	if viewportW > 0 && w > viewportW-2 {
-		w = viewportW - 2
-	}
+func (m *prComposeModal) contentWidth() int {
+	w, _ := mdrender.ContentMeasure(m.width, planEditorMaxMeasure)
 	return w
+}
+
+func (m *prComposeModal) displayLeftPad() int {
+	_, pad := mdrender.ContentMeasure(m.width, planEditorMaxMeasure)
+	return pad
+}
+
+func (m *prComposeModal) scrollBodyHeight() int {
+	h := m.height - 7
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func (m *prComposeModal) editBodyHeight() int {
+	h := m.height - 8
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func (m *prComposeModal) clampScroll() {
+	if m.width == 0 || m.renderer == nil {
+		return
+	}
+	rendered := m.renderer.RenderLines(m.bodyArea.Value(), m.contentWidth())
+	maxOff := len(rendered) - m.scrollBodyHeight()
+	if maxOff < 0 {
+		maxOff = 0
+	}
+	if m.scrollOff > maxOff {
+		m.scrollOff = maxOff
+	}
+	if m.scrollOff < 0 {
+		m.scrollOff = 0
+	}
 }

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -160,10 +160,10 @@ func (m *prComposeModal) updateScroll(msg tea.Msg) tea.Cmd {
 			m.scrollOff--
 		}
 	case "pgdown":
-		m.scrollOff += m.scrollBodyHeight() / 2
+		m.scrollOff += m.bodyHeight() / 2
 		m.clampScroll()
 	case "pgup":
-		m.scrollOff -= m.scrollBodyHeight() / 2
+		m.scrollOff -= m.bodyHeight() / 2
 		if m.scrollOff < 0 {
 			m.scrollOff = 0
 		}
@@ -276,7 +276,7 @@ func (m *prComposeModal) renderScrollBody() string {
 		bodyContent = pad + StyleSubtle.Render("(no body)")
 	} else {
 		rendered := m.renderer.RenderLines(bodyVal, m.contentWidth())
-		bh := m.scrollBodyHeight()
+		bh := m.bodyHeight()
 		start := m.scrollOff
 		if start > len(rendered) {
 			start = len(rendered)
@@ -348,7 +348,7 @@ func (m *prComposeModal) displayLeftPad() int {
 	return pad
 }
 
-func (m *prComposeModal) scrollBodyHeight() int {
+func (m *prComposeModal) bodyHeight() int {
 	h := m.height - 7
 	if h < 1 {
 		h = 1
@@ -369,7 +369,7 @@ func (m *prComposeModal) clampScroll() {
 		return
 	}
 	rendered := m.renderer.RenderLines(m.bodyArea.Value(), m.contentWidth())
-	maxOff := len(rendered) - m.scrollBodyHeight()
+	maxOff := len(rendered) - m.bodyHeight()
 	if maxOff < 0 {
 		maxOff = 0
 	}

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -109,6 +109,8 @@ func TestPRCompose_ScrollKeyG_GoesToTop(t *testing.T) {
 	}
 }
 
+// --- Task 4: scroll mode submit, cancel, and draft toggle ---
+
 func TestPRCompose_EscCancels(t *testing.T) {
 	m := makePRComposeForTest(t)
 	cmd := m.Update(keyNamed(tea.KeyEscape))
@@ -159,6 +161,28 @@ func TestPRCompose_CtrlEnter_EmptyTitle_NoOp(t *testing.T) {
 	}
 	if !m.Active() {
 		t.Error("modal should stay open when title is empty")
+	}
+}
+
+func TestPRCompose_CtrlD_ScrollMode_TogglesAndDraftReflectedOnSubmit(t *testing.T) {
+	m := makePRComposeForTest(t)
+	if !m.draft {
+		t.Fatal("prereq: draft should start true")
+	}
+	m.Update(keyCtrlRune('d')) // toggle to ready
+	if m.draft {
+		t.Fatal("ctrl+d did not toggle draft off in scroll mode")
+	}
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("expected submit cmd")
+	}
+	got, ok := cmd().(prComposeSubmitMsg)
+	if !ok {
+		t.Fatalf("got %T, want prComposeSubmitMsg", cmd())
+	}
+	if got.draft {
+		t.Error("submitted draft flag should be false after ctrl+d toggle")
 	}
 }
 

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -275,6 +275,46 @@ func TestPRCompose_CtrlD_TogglesDraftInEditMode(t *testing.T) {
 	}
 }
 
+// --- Task 6: PasteMsg routing ---
+
+func TestPRCompose_PasteInEditMode_TitleFocused_UpdatesTitle(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.Update(keyRune('i')) // enter edit mode, title focused
+	if m.focused != 0 {
+		t.Fatalf("prereq: focused=%d, want 0 (title)", m.focused)
+	}
+	cmd := m.Update(tea.PasteMsg{Content: "pasted-title"})
+	if cmd != nil {
+		cmd()
+	}
+	if got := m.titleInput.Value(); !strings.Contains(got, "pasted-title") {
+		t.Errorf("title = %q, want it to contain pasted content", got)
+	}
+}
+
+func TestPRCompose_PasteInEditMode_BodyFocused_UpdatesBody(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.Update(keyRune('i'))         // enter edit mode
+	m.Update(keyNamed(tea.KeyTab)) // switch to body
+	if m.focused != 1 {
+		t.Fatalf("prereq: focused=%d, want 1 (body)", m.focused)
+	}
+	bodyBefore := m.bodyArea.Value()
+	m.Update(tea.PasteMsg{Content: "pasted-body"})
+	if got := m.bodyArea.Value(); got == bodyBefore {
+		t.Error("paste in body-focused edit mode did not update body")
+	}
+}
+
+func TestPRCompose_PasteInScrollMode_IsNoOp(t *testing.T) {
+	m := makePRComposeForTest(t)
+	titleBefore := m.titleInput.Value()
+	m.Update(tea.PasteMsg{Content: "should-be-ignored"})
+	if m.titleInput.Value() != titleBefore {
+		t.Error("paste in scroll mode should not modify title")
+	}
+}
+
 func TestPRCompose_PrintableKey_AppendsToTitleInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i')) // enter edit mode (title focused)

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -245,8 +245,13 @@ func TestPRCompose_ViewEditMode_ContainsHeaderAndTitle(t *testing.T) {
 	if !strings.Contains(v, "PR DRAFT") {
 		t.Errorf("edit view missing 'PR DRAFT', got: %q", v)
 	}
+	// titleInput.View() must appear: value set in makePRComposeForTest.
 	if !strings.Contains(v, "Initial title") {
-		t.Errorf("edit view missing title value, got: %q", v)
+		t.Errorf("edit view missing titleInput.View() output, got: %q", v)
+	}
+	// bodyArea.View() must appear: value set in makePRComposeForTest.
+	if !strings.Contains(v, "Initial body line 1") {
+		t.Errorf("edit view missing bodyArea.View() output, got: %q", v)
 	}
 }
 

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -236,27 +236,6 @@ func TestPRCompose_CtrlD_TogglesDraft(t *testing.T) {
 	}
 }
 
-// --- Task 5: edit-mode View ---
-
-func TestPRCompose_ViewEditMode_ContainsHeaderAndTitle(t *testing.T) {
-	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode
-	v := m.View()
-	if !strings.Contains(v, "PR DRAFT") {
-		t.Errorf("edit view missing 'PR DRAFT', got: %q", v)
-	}
-	// titleInput.View() must appear: value set in makePRComposeForTest.
-	if !strings.Contains(v, "Initial title") {
-		t.Errorf("edit view missing titleInput.View() output, got: %q", v)
-	}
-	// bodyArea.View() must appear: value set in makePRComposeForTest.
-	if !strings.Contains(v, "Initial body line 1") {
-		t.Errorf("edit view missing bodyArea.View() output, got: %q", v)
-	}
-}
-
-// --- Task 4: submit, cancel, draft toggle across modes ---
-
 func TestPRCompose_CtrlEnterInEditMode_Submits(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i')) // enter edit mode
@@ -281,6 +260,38 @@ func TestPRCompose_CtrlD_TogglesDraftInEditMode(t *testing.T) {
 	m.Update(keyCtrlRune('d'))
 	if m.draft {
 		t.Error("ctrl+d in edit mode did not toggle draft off")
+	}
+}
+
+func TestPRCompose_CtrlEnter_EmptyTitle_NoOp_EditMode(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.Update(keyRune('i')) // enter edit mode
+	m.titleInput.SetValue("   ")
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+	if cmd != nil {
+		t.Fatalf("empty title in edit mode should be a no-op; got cmd %T", cmd())
+	}
+	if !m.Active() {
+		t.Error("modal should stay open when title is empty in edit mode")
+	}
+}
+
+// --- Task 5: edit-mode View ---
+
+func TestPRCompose_ViewEditMode_ContainsHeaderAndTitle(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.Update(keyRune('i')) // enter edit mode
+	v := m.View()
+	if !strings.Contains(v, "PR DRAFT") {
+		t.Errorf("edit view missing 'PR DRAFT', got: %q", v)
+	}
+	// titleInput.View() must appear: value set in makePRComposeForTest.
+	if !strings.Contains(v, "Initial title") {
+		t.Errorf("edit view missing titleInput.View() output, got: %q", v)
+	}
+	// bodyArea.View() must appear: value set in makePRComposeForTest.
+	if !strings.Contains(v, "Initial body line 1") {
+		t.Errorf("edit view missing bodyArea.View() output, got: %q", v)
 	}
 }
 

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -232,6 +232,35 @@ func TestPRCompose_CtrlD_TogglesDraft(t *testing.T) {
 	}
 }
 
+// --- Task 4: submit, cancel, draft toggle across modes ---
+
+func TestPRCompose_CtrlEnterInEditMode_Submits(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.Update(keyRune('i')) // enter edit mode
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("expected submit cmd from ctrl+enter in edit mode")
+	}
+	if _, ok := cmd().(prComposeSubmitMsg); !ok {
+		t.Fatalf("got %T, want prComposeSubmitMsg", cmd())
+	}
+	if m.Active() {
+		t.Error("modal should close on submit from edit mode")
+	}
+}
+
+func TestPRCompose_CtrlD_TogglesDraftInEditMode(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.Update(keyRune('i')) // enter edit mode
+	if !m.draft {
+		t.Fatal("prereq: draft should be true")
+	}
+	m.Update(keyCtrlRune('d'))
+	if m.draft {
+		t.Error("ctrl+d in edit mode did not toggle draft off")
+	}
+}
+
 func TestPRCompose_PrintableKey_AppendsToTitleInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i')) // enter edit mode (title focused)

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -158,29 +158,59 @@ func TestPRCompose_CtrlEnter_EmptyTitle_NoOp(t *testing.T) {
 	}
 }
 
-func TestPRCompose_Tab_SwitchesFocusToBody(t *testing.T) {
+// --- Task 3: edit-mode transitions ---
+
+func TestPRCompose_I_EntersEditModeAndFocusesTitle(t *testing.T) {
 	m := makePRComposeForTest(t)
-	if m.focused != 0 {
-		t.Fatalf("test prereq: focused=%d, want 0", m.focused)
+	if m.mode != prComposeModeScroll {
+		t.Fatalf("prereq: mode=%v, want scroll", m.mode)
 	}
-	cmd := m.Update(keyNamed(tea.KeyTab))
-	// Update returns a focus cmd; we only verify state here.
-	_ = cmd
-	if m.focused != 1 {
-		t.Errorf("after tab focused = %d, want 1 (body)", m.focused)
+	m.Update(keyRune('i'))
+	if m.mode != prComposeModeEdit {
+		t.Errorf("after i: mode=%v, want prComposeModeEdit", m.mode)
 	}
-	// Another tab should swing back to title (it cycles 1→0).
-	m.Update(keyNamed(tea.KeyTab))
 	if m.focused != 0 {
-		t.Errorf("after second tab focused = %d, want 0 (title)", m.focused)
+		t.Errorf("after i: focused=%d, want 0 (title)", m.focused)
 	}
 }
 
-func TestPRCompose_ShiftTab_SwitchesFocus(t *testing.T) {
+func TestPRCompose_EscInEditMode_ReturnsToScroll(t *testing.T) {
 	m := makePRComposeForTest(t)
+	m.Update(keyRune('i'))
+	if m.mode != prComposeModeEdit {
+		t.Fatalf("prereq: expected edit mode")
+	}
+	m.Update(keyNamed(tea.KeyEscape))
+	if m.mode != prComposeModeScroll {
+		t.Errorf("esc in edit mode did not return to scroll: mode=%v", m.mode)
+	}
+	if !m.Active() {
+		t.Error("esc in edit mode should not close the view")
+	}
+}
+
+func TestPRCompose_Tab_SwitchesFocusToBodyInEditMode(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.Update(keyRune('i')) // enter edit mode; focused=0 (title)
+	if m.focused != 0 {
+		t.Fatalf("prereq: focused=%d, want 0 after i", m.focused)
+	}
+	m.Update(keyNamed(tea.KeyTab))
+	if m.focused != 1 {
+		t.Errorf("after tab: focused=%d, want 1 (body)", m.focused)
+	}
+	m.Update(keyNamed(tea.KeyTab))
+	if m.focused != 0 {
+		t.Errorf("after second tab: focused=%d, want 0 (title)", m.focused)
+	}
+}
+
+func TestPRCompose_ShiftTab_SwitchesFocusInEditMode(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.Update(keyRune('i')) // enter edit mode
 	m.Update(keyShiftNamed(tea.KeyTab))
 	if m.focused != 1 {
-		t.Errorf("after shift+tab focused = %d, want 1", m.focused)
+		t.Errorf("after shift+tab: focused=%d, want 1", m.focused)
 	}
 }
 
@@ -202,44 +232,30 @@ func TestPRCompose_CtrlD_TogglesDraft(t *testing.T) {
 	}
 }
 
-func TestPRCompose_PrintableKey_AppendsToFocusedField(t *testing.T) {
+func TestPRCompose_PrintableKey_AppendsToTitleInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.titleInput.SetValue("hi")
-	// Move cursor to end. bubbles textarea handles this on Focus, but be safe.
+	m.Update(keyRune('i')) // enter edit mode (title focused)
 	m.titleInput.SetValue("hi")
 	m.Update(keyRune('!'))
 	if got := m.titleInput.Value(); !strings.Contains(got, "!") {
-		t.Errorf("title = %q, want it to include '!' after typing", got)
+		t.Errorf("title = %q, want it to include '!' after typing in edit mode", got)
 	}
 }
 
-func TestPRCompose_PrintableKey_RoutedToBodyWhenFocused(t *testing.T) {
+func TestPRCompose_PrintableKey_RoutedToBodyInEditModeWhenBodyFocused(t *testing.T) {
 	m := makePRComposeForTest(t)
-	// Switch focus to body field, then type.
-	m.Update(keyNamed(tea.KeyTab))
+	m.Update(keyRune('i'))         // enter edit mode (title focused)
+	m.Update(keyNamed(tea.KeyTab)) // switch to body
 	if m.focused != 1 {
 		t.Fatalf("focused = %d after tab, want 1", m.focused)
 	}
 	bodyBefore := m.bodyArea.Value()
 	m.Update(keyRune('?'))
-	bodyAfter := m.bodyArea.Value()
-	if bodyAfter == bodyBefore {
+	if m.bodyArea.Value() == bodyBefore {
 		t.Error("typing in body did not change body value")
 	}
-	// Title should be unchanged when body has focus.
 	if !strings.HasPrefix(m.titleInput.Value(), "Initial title") {
 		t.Errorf("title leaked: %q", m.titleInput.Value())
-	}
-}
-
-func TestPRCompose_PasteForwardedToFocusedField(t *testing.T) {
-	m := makePRComposeForTest(t)
-	cmd := m.Update(tea.PasteMsg{Content: "pasted-title"})
-	if cmd != nil {
-		cmd()
-	}
-	if got := m.titleInput.Value(); !strings.Contains(got, "pasted-title") {
-		t.Errorf("title = %q, want it to contain pasted content", got)
 	}
 }
 

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -51,6 +51,60 @@ func TestPRCompose_OpenSeedsFieldsAndFocusesTitle(t *testing.T) {
 	_ = cmd // Open returns nil in scroll mode; we only verify state here.
 }
 
+// --- Task 2: scroll mode View and scroll keybindings ---
+
+func TestPRCompose_ViewScrollMode_ContainsHeaderAndTitle(t *testing.T) {
+	m := newPRComposeModal()
+	m.SetSize(120, 40)
+	m.Open("My PR Title", "Some body content", true, "feature-x")
+	v := m.View()
+	if !strings.Contains(v, "PR DRAFT") {
+		t.Errorf("scroll view missing 'PR DRAFT', got: %q", v)
+	}
+	if !strings.Contains(v, "feature-x") {
+		t.Errorf("scroll view missing session name 'feature-x', got: %q", v)
+	}
+	if !strings.Contains(v, "My PR Title") {
+		t.Errorf("scroll view missing title text, got: %q", v)
+	}
+}
+
+func TestPRCompose_ScrollKeyJ_IncrementsScrollOff(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.bodyArea.SetValue(strings.Repeat("line\n", 50))
+	m.SetSize(120, 40)
+	before := m.scrollOff
+	m.Update(keyRune('j'))
+	if m.scrollOff <= before {
+		t.Errorf("j did not increment scrollOff: before=%d after=%d", before, m.scrollOff)
+	}
+}
+
+func TestPRCompose_ScrollKeyK_DecrementsScrollOff(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.bodyArea.SetValue(strings.Repeat("line\n", 50))
+	m.SetSize(120, 40)
+	m.Update(keyRune('j'))
+	m.Update(keyRune('j'))
+	after := m.scrollOff
+	m.Update(keyRune('k'))
+	if m.scrollOff >= after {
+		t.Errorf("k did not decrement scrollOff: before=%d after=%d", after, m.scrollOff)
+	}
+}
+
+func TestPRCompose_ScrollKeyG_GoesToTop(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.bodyArea.SetValue(strings.Repeat("line\n", 50))
+	m.SetSize(120, 40)
+	m.Update(keyRune('j'))
+	m.Update(keyRune('j'))
+	m.Update(keyRune('g'))
+	if m.scrollOff != 0 {
+		t.Errorf("g did not reset scrollOff to 0, got %d", m.scrollOff)
+	}
+}
+
 func TestPRCompose_EscCancels(t *testing.T) {
 	m := makePRComposeForTest(t)
 	cmd := m.Update(keyNamed(tea.KeyEscape))

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -13,19 +13,31 @@ func makePRComposeForTest(t *testing.T) *prComposeModal {
 	t.Helper()
 	m := newPRComposeModal()
 	m.SetSize(120, 40)
-	m.Open("Initial title", "Initial body line 1\nbody line 2", true)
+	m.Open("Initial title", "Initial body line 1\nbody line 2", true, "")
 	return &m
+}
+
+func TestPRCompose_OpenSetsScrollModeAndHasRenderer(t *testing.T) {
+	m := newPRComposeModal()
+	m.SetSize(120, 40)
+	m.Open("Title", "Body", true, "my-session")
+	if m.mode != prComposeModeScroll {
+		t.Errorf("mode = %v, want prComposeModeScroll", m.mode)
+	}
+	if m.bodyArea.MarkdownRenderer() == nil {
+		t.Error("bodyArea should have a MarkdownRenderer set")
+	}
 }
 
 func TestPRCompose_OpenSeedsFieldsAndFocusesTitle(t *testing.T) {
 	m := newPRComposeModal()
 	m.SetSize(120, 40)
-	cmd := m.Open("My title", "Body text", false)
+	cmd := m.Open("My title", "Body text", false, "")
 	if !m.Active() {
 		t.Fatal("modal should be Active after Open")
 	}
-	if m.titleArea.Value() != "My title" {
-		t.Errorf("title = %q, want %q", m.titleArea.Value(), "My title")
+	if m.titleInput.Value() != "My title" {
+		t.Errorf("title = %q, want %q", m.titleInput.Value(), "My title")
 	}
 	if m.bodyArea.Value() != "Body text" {
 		t.Errorf("body = %q, want %q", m.bodyArea.Value(), "Body text")
@@ -36,7 +48,7 @@ func TestPRCompose_OpenSeedsFieldsAndFocusesTitle(t *testing.T) {
 	if m.focused != 0 {
 		t.Errorf("focused = %d, want 0 (title)", m.focused)
 	}
-	_ = cmd // Focus may produce a cmd; we only verify state here.
+	_ = cmd // Open returns nil in scroll mode; we only verify state here.
 }
 
 func TestPRCompose_EscCancels(t *testing.T) {
@@ -55,7 +67,7 @@ func TestPRCompose_EscCancels(t *testing.T) {
 
 func TestPRCompose_CtrlEnterSubmitsTrimmedValues(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.titleArea.SetValue("  trimmed title  ")
+	m.titleInput.SetValue("  trimmed title  ")
 	m.bodyArea.SetValue("\nbody with leading newline\n")
 
 	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
@@ -82,7 +94,7 @@ func TestPRCompose_CtrlEnterSubmitsTrimmedValues(t *testing.T) {
 
 func TestPRCompose_CtrlEnter_EmptyTitle_NoOp(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.titleArea.SetValue("   ")
+	m.titleInput.SetValue("   ")
 	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
 	if cmd != nil {
 		t.Fatalf("empty title submit should be a no-op (no cmd); got %T", cmd())
@@ -138,11 +150,11 @@ func TestPRCompose_CtrlD_TogglesDraft(t *testing.T) {
 
 func TestPRCompose_PrintableKey_AppendsToFocusedField(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.titleArea.SetValue("hi")
+	m.titleInput.SetValue("hi")
 	// Move cursor to end. bubbles textarea handles this on Focus, but be safe.
-	m.titleArea.SetValue("hi")
+	m.titleInput.SetValue("hi")
 	m.Update(keyRune('!'))
-	if got := m.titleArea.Value(); !strings.Contains(got, "!") {
+	if got := m.titleInput.Value(); !strings.Contains(got, "!") {
 		t.Errorf("title = %q, want it to include '!' after typing", got)
 	}
 }
@@ -161,8 +173,8 @@ func TestPRCompose_PrintableKey_RoutedToBodyWhenFocused(t *testing.T) {
 		t.Error("typing in body did not change body value")
 	}
 	// Title should be unchanged when body has focus.
-	if !strings.HasPrefix(m.titleArea.Value(), "Initial title") {
-		t.Errorf("title leaked: %q", m.titleArea.Value())
+	if !strings.HasPrefix(m.titleInput.Value(), "Initial title") {
+		t.Errorf("title leaked: %q", m.titleInput.Value())
 	}
 }
 
@@ -172,7 +184,7 @@ func TestPRCompose_PasteForwardedToFocusedField(t *testing.T) {
 	if cmd != nil {
 		cmd()
 	}
-	if got := m.titleArea.Value(); !strings.Contains(got, "pasted-title") {
+	if got := m.titleInput.Value(); !strings.Contains(got, "pasted-title") {
 		t.Errorf("title = %q, want it to contain pasted content", got)
 	}
 }

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -45,8 +45,8 @@ func TestPRCompose_OpenSeedsFieldsAndFocusesTitle(t *testing.T) {
 	if m.draft {
 		t.Error("draft should be false when Open passes draft=false")
 	}
-	if m.focused != 0 {
-		t.Errorf("focused = %d, want 0 (title)", m.focused)
+	if m.titleInput.Focused() {
+		t.Error("title input should not be focused in scroll mode after Open")
 	}
 	_ = cmd // Open returns nil in scroll mode; we only verify state here.
 }
@@ -173,8 +173,8 @@ func TestPRCompose_I_EntersEditModeAndFocusesTitle(t *testing.T) {
 	if m.mode != prComposeModeEdit {
 		t.Errorf("after i: mode=%v, want prComposeModeEdit", m.mode)
 	}
-	if m.focused != 0 {
-		t.Errorf("after i: focused=%d, want 0 (title)", m.focused)
+	if !m.titleInput.Focused() {
+		t.Error("after i: title input should be focused")
 	}
 }
 
@@ -195,17 +195,17 @@ func TestPRCompose_EscInEditMode_ReturnsToScroll(t *testing.T) {
 
 func TestPRCompose_Tab_SwitchesFocusToBodyInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode; focused=0 (title)
-	if m.focused != 0 {
-		t.Fatalf("prereq: focused=%d, want 0 after i", m.focused)
+	m.Update(keyRune('i')) // enter edit mode; title focused first
+	if !m.titleInput.Focused() {
+		t.Fatal("prereq: title input should be focused after i")
 	}
 	m.Update(keyNamed(tea.KeyTab))
-	if m.focused != 1 {
-		t.Errorf("after tab: focused=%d, want 1 (body)", m.focused)
+	if !m.bodyArea.Focused() {
+		t.Error("after tab: body should be focused")
 	}
 	m.Update(keyNamed(tea.KeyTab))
-	if m.focused != 0 {
-		t.Errorf("after second tab: focused=%d, want 0 (title)", m.focused)
+	if !m.titleInput.Focused() {
+		t.Error("after second tab: title should be focused again")
 	}
 }
 
@@ -213,8 +213,8 @@ func TestPRCompose_ShiftTab_SwitchesFocusInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i')) // enter edit mode
 	m.Update(keyShiftNamed(tea.KeyTab))
-	if m.focused != 1 {
-		t.Errorf("after shift+tab: focused=%d, want 1", m.focused)
+	if !m.bodyArea.Focused() {
+		t.Error("after shift+tab: body should be focused")
 	}
 }
 
@@ -289,8 +289,8 @@ func TestPRCompose_CtrlD_TogglesDraftInEditMode(t *testing.T) {
 func TestPRCompose_PasteInEditMode_TitleFocused_UpdatesTitle(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i')) // enter edit mode, title focused
-	if m.focused != 0 {
-		t.Fatalf("prereq: focused=%d, want 0 (title)", m.focused)
+	if !m.titleInput.Focused() {
+		t.Fatal("prereq: title input should be focused after i")
 	}
 	cmd := m.Update(tea.PasteMsg{Content: "pasted-title"})
 	if cmd != nil {
@@ -305,8 +305,8 @@ func TestPRCompose_PasteInEditMode_BodyFocused_UpdatesBody(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i'))         // enter edit mode
 	m.Update(keyNamed(tea.KeyTab)) // switch to body
-	if m.focused != 1 {
-		t.Fatalf("prereq: focused=%d, want 1 (body)", m.focused)
+	if !m.bodyArea.Focused() {
+		t.Fatal("prereq: body should be focused after tab")
 	}
 	bodyBefore := m.bodyArea.Value()
 	m.Update(tea.PasteMsg{Content: "pasted-body"})
@@ -338,8 +338,8 @@ func TestPRCompose_PrintableKey_RoutedToBodyInEditModeWhenBodyFocused(t *testing
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i'))         // enter edit mode (title focused)
 	m.Update(keyNamed(tea.KeyTab)) // switch to body
-	if m.focused != 1 {
-		t.Fatalf("focused = %d after tab, want 1", m.focused)
+	if !m.bodyArea.Focused() {
+		t.Fatal("body should be focused after tab")
 	}
 	bodyBefore := m.bodyArea.Value()
 	m.Update(keyRune('?'))

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -67,6 +67,10 @@ func TestPRCompose_ViewScrollMode_ContainsHeaderAndTitle(t *testing.T) {
 	if !strings.Contains(v, "My PR Title") {
 		t.Errorf("scroll view missing title text, got: %q", v)
 	}
+	// Verify body is rendered through mdrender (content must appear in output).
+	if !strings.Contains(v, "Some body content") {
+		t.Errorf("scroll view missing body content rendered through mdrender, got: %q", v)
+	}
 }
 
 func TestPRCompose_ScrollKeyJ_IncrementsScrollOff(t *testing.T) {

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -232,6 +232,20 @@ func TestPRCompose_CtrlD_TogglesDraft(t *testing.T) {
 	}
 }
 
+// --- Task 5: edit-mode View ---
+
+func TestPRCompose_ViewEditMode_ContainsHeaderAndTitle(t *testing.T) {
+	m := makePRComposeForTest(t)
+	m.Update(keyRune('i')) // enter edit mode
+	v := m.View()
+	if !strings.Contains(v, "PR DRAFT") {
+		t.Errorf("edit view missing 'PR DRAFT', got: %q", v)
+	}
+	if !strings.Contains(v, "Initial title") {
+		t.Errorf("edit view missing title value, got: %q", v)
+	}
+}
+
 // --- Task 4: submit, cancel, draft toggle across modes ---
 
 func TestPRCompose_CtrlEnterInEditMode_Submits(t *testing.T) {

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -32,7 +32,7 @@ func (a App) handlePRDraftReady(msg prDraftReadyMsg) (tea.Model, tea.Cmd) {
 	a.prModalBase = msg.base
 	a.prModalTransitionShipping = msg.transitionShipping
 	resolved := a.resolvedCache[msg.repoPath]
-	cmd := a.prComposeModal.Open(msg.title, msg.body, resolved.PRDraftByDefault)
+	cmd := a.prComposeModal.Open(msg.title, msg.body, resolved.PRDraftByDefault, "")
 	return a, cmd
 }
 

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -32,7 +32,11 @@ func (a App) handlePRDraftReady(msg prDraftReadyMsg) (tea.Model, tea.Cmd) {
 	a.prModalBase = msg.base
 	a.prModalTransitionShipping = msg.transitionShipping
 	resolved := a.resolvedCache[msg.repoPath]
-	cmd := a.prComposeModal.Open(msg.title, msg.body, resolved.PRDraftByDefault, "")
+	var sessName string
+	if sess := a.sessionByIDInRepo(msg.repoPath, msg.sessionID); sess != nil {
+		sessName = sess.GetDisplayName()
+	}
+	cmd := a.prComposeModal.Open(msg.title, msg.body, resolved.PRDraftByDefault, sessName)
 	return a, cmd
 }
 


### PR DESCRIPTION
## Summary

- Redesigned `prComposeModal` struct to match the plan editor's component model: replaced textarea fields with `textinput.Model` (title) and `mdtextarea.Model` (body with markdown rendering)
- Implemented dual-mode interface: scroll mode for reading (j/k/pgdn/pgup/g/G navigation) and edit mode for composing (tab/shift+tab for field focus)
- Added mode transitions: `i` to enter edit mode (focuses title), `esc` to return to scroll mode
- Implemented submission workflow in edit mode: `ctrl+enter` submits trimmed title/body (rejects empty title), `ctrl+d` toggles draft flag
- Updated full-page rendering: removed centered modal box layout in favor of full-terminal composition screen with session name in header
- Removed legacy modal sizing constants and helpers; unified on plan-editor-style utilities (`contentWidth`, `displayLeftPad`, `bodyHeight`, `clampScroll`)

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI: open PR draft compose, verify scroll navigation (j/k) works, press `i` to edit, tab between title and body fields, test `ctrl+d` to toggle draft, `ctrl+enter` to submit, `esc` to cancel

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description