### PR TITLE
Center plan edit mode on wide terminals for consistent formatting

### DIFF
--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -226,7 +226,7 @@ func newPlanEditor(sess *agent.Session, repoPath string, width, height int) plan
 	ta := mdtextarea.New()
 	ta.Prompt = ""
 	ta.ShowLineNumbers = false
-	ta.SetWidth(textareaWidth(width))
+	ta.SetWidth(m.contentWidth())
 	ta.SetHeight(textareaHeight(height))
 	m.renderer = mdrender.New(planEditorChromaStyle)
 	ta.SetMarkdownRenderer(m.renderer)
@@ -256,7 +256,7 @@ func newPlanEditor(sess *agent.Session, repoPath string, width, height int) plan
 func (m *planEditorModel) SetSize(w, h int) {
 	m.width = w
 	m.height = h
-	m.textarea.SetWidth(textareaWidth(w))
+	m.textarea.SetWidth(m.contentWidth())
 	m.textarea.SetHeight(textareaHeight(h))
 	m.reviseInput.SetWidth(w - 4)
 	m.questionInput.SetWidth(w - 4)
@@ -892,6 +892,21 @@ func (m *planEditorModel) displayLeftPad() int {
 	return pad
 }
 
+// centeredBlock prepends displayLeftPad() spaces to each line of s, matching
+// the scroll-mode centering applied in displayLines().
+func (m *planEditorModel) centeredBlock(s string) string {
+	pad := m.displayLeftPad()
+	if pad == 0 {
+		return s
+	}
+	prefix := strings.Repeat(" ", pad)
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = prefix + l
+	}
+	return strings.Join(lines, "\n")
+}
+
 // styledScrollLines wraps and styles a source line for scroll-mode display,
 // applying fence-block bar prefixes that are omitted in edit mode to keep
 // mdtextarea cursor-splice math unaffected.
@@ -980,7 +995,7 @@ func (m *planEditorModel) View() string {
 
 	switch m.mode {
 	case planEditorModeEdit:
-		lines = append(lines, m.textarea.View())
+		lines = append(lines, m.centeredBlock(m.textarea.View()))
 	case planEditorModeReviseInput:
 		lines = append(lines, m.renderBody())
 		lines = append(lines, "")

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -269,6 +269,43 @@ func TestPlanEditor_ScrollAndEditModeUseSameWidth(t *testing.T) {
 	}
 }
 
+// TestPlanEditor_EditModeCenteredOnWideTerminal asserts that on wide terminals
+// the textarea is capped at contentWidth (72) and the edit-mode View output
+// prepends displayLeftPad() spaces, matching the scroll-mode centering.
+func TestPlanEditor_EditModeCenteredOnWideTerminal(t *testing.T) {
+	sess, _ := newEditorTestSession(t)
+	_ = sess.WritePlan("# Goal\nsome plan content here\n")
+
+	editor := newPlanEditor(sess, "", 120, 30)
+
+	// textarea.Width() must be capped at contentWidth() (72), not textareaWidth(120)=118.
+	if got, want := editor.textarea.Width(), editor.contentWidth(); got != want {
+		t.Errorf("textarea.Width()=%d, want contentWidth()=%d; edit mode must cap at planEditorMaxMeasure on wide terminals",
+			got, want)
+	}
+
+	leftPad := editor.displayLeftPad()
+	if leftPad == 0 {
+		t.Fatal("displayLeftPad() == 0 at width 120; test precondition failed")
+	}
+
+	editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
+	if editor.mode != planEditorModeEdit {
+		t.Fatalf("mode = %v after 'i', want planEditorModeEdit", editor.mode)
+	}
+
+	view := testutil.StripANSI(editor.View())
+	viewLines := strings.Split(view, "\n")
+	// viewLines[0]=header, viewLines[1]=divider, viewLines[2]=first textarea line.
+	if len(viewLines) < 3 {
+		t.Fatalf("view has only %d lines, expected header+divider+content", len(viewLines))
+	}
+	prefix := strings.Repeat(" ", leftPad)
+	if !strings.HasPrefix(viewLines[2], prefix) {
+		t.Errorf("first edit-mode content line does not start with %d-space left pad:\n%q", leftPad, viewLines[2])
+	}
+}
+
 // TestPlanEditor_DisplayLineCountAgreesWithRenderer asserts that the editor's
 // scroll-mode display lines exactly match a direct mdrender call on the same
 // content+width when no sections are folded. Folding intentionally elides

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -254,19 +254,34 @@ func TestPlanEditor_ReviseInputEmitsCritique(t *testing.T) {
 	}
 }
 
-// TestPlanEditor_ScrollAndEditModeUseSameWidth pins that on terminals narrower
-// than planEditorMaxMeasure, scroll-mode and edit-mode wrap at the same column.
-// On wide terminals scroll-mode intentionally caps at planEditorMaxMeasure for
-// centering; edit-mode keeps the full textarea width so cursor math is unaffected.
+// TestPlanEditor_ScrollAndEditModeUseSameWidth pins that contentWidth() ==
+// textarea.Width() on all terminal widths — both narrow and wide terminals now
+// produce matching widths so the visible wrap column is consistent across mode
+// switches.
 func TestPlanEditor_ScrollAndEditModeUseSameWidth(t *testing.T) {
 	sess, _ := newEditorTestSession(t)
 	_ = sess.WritePlan("# H\nshort\n")
-	// textareaWidth(70) = 68, which is below planEditorMaxMeasure (72).
-	// On such terminals contentWidth() must equal textarea.Width().
-	editor := newPlanEditor(sess, "", 70, 30)
-	if got, want := editor.contentWidth(), editor.textarea.Width(); got != want {
-		t.Errorf("contentWidth=%d, textarea.Width()=%d; on narrow terminals both modes must wrap at the same column", got, want)
-	}
+
+	t.Run("narrow", func(t *testing.T) {
+		// textareaWidth(70) = 68, which is below planEditorMaxMeasure (72).
+		// contentWidth() == 68 == textarea.Width().
+		editor := newPlanEditor(sess, "", 70, 30)
+		if got, want := editor.contentWidth(), editor.textarea.Width(); got != want {
+			t.Errorf("contentWidth=%d, textarea.Width()=%d; on narrow terminals both modes must wrap at the same column", got, want)
+		}
+	})
+
+	t.Run("wide", func(t *testing.T) {
+		// textareaWidth(120) = 118, but contentWidth() is capped at planEditorMaxMeasure (72).
+		// textarea.Width() must also be 72 so wrap columns match.
+		editor := newPlanEditor(sess, "", 120, 30)
+		if got, want := editor.contentWidth(), editor.textarea.Width(); got != want {
+			t.Errorf("contentWidth=%d, textarea.Width()=%d; on wide terminals both must equal planEditorMaxMeasure (%d)", got, want, planEditorMaxMeasure)
+		}
+		if editor.contentWidth() != planEditorMaxMeasure {
+			t.Errorf("contentWidth()=%d, want planEditorMaxMeasure=%d on wide terminal", editor.contentWidth(), planEditorMaxMeasure)
+		}
+	})
 }
 
 // TestPlanEditor_EditModeCenteredOnWideTerminal asserts that on wide terminals


### PR DESCRIPTION
## Summary

- Ensure plan editing UI uses the same width constraints and centering as plan viewing UI
- On terminals wider than 72 columns, the edit-mode textarea now wraps at the same column limit and the output is left-padded to match scroll-mode centering
- Add test coverage for edit-mode formatting on wide terminals and extend existing width-parity test to verify both modes produce matching columns across terminal widths

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI: Open plan editor on a terminal wider than 72 columns and verify textarea wraps at 72 columns with centered output matching scroll-mode display

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description