### PR TITLE
Redesign reviewing page with tabbed layout and full-screen diff viewer

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -451,6 +451,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.handleReviewDiff(msg)
 	case reviewVerdictMsg:
 		return a.handleReviewVerdict(msg)
+	case reviewOpenTaskDiffMsg:
+		return a.handleReviewOpenTaskDiff(msg)
 	}
 
 	// Route to the active view.
@@ -1493,6 +1495,14 @@ type reviewDiffEntry struct {
 	tasks    []agent.PlanTask
 	groups   []taskReviewGroup          // per-task + "other" commit groups
 	verdicts map[int]*taskVerdictRecord // keyed by taskIndex (0 = other)
+}
+
+// reviewOpenTaskDiffMsg is emitted by the review panel when the user presses
+// enter on a task row that has a non-empty rawDiff. App opens the full-screen
+// diff viewer scoped to that task without closing the review modal.
+type reviewOpenTaskDiffMsg struct {
+	rawDiff   string
+	taskLabel string
 }
 
 // reviewDiffMsg carries the result of an async review diff fetch.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -725,6 +725,7 @@ func (a *App) refreshAgentList() {
 	a.dashboard.cursor = a.cursor
 	a.dashboard.prDraftSessionID = a.prDraftSessionID
 	a.dashboard.prDraftRepoPath = a.prDraftRepoPath
+	a.dashboard.activeRepoName = a.activeRepoDisplayName()
 	a.dashboard.activeRepoPath = a.activeRepo
 	a.syncModalsToDashboard()
 	if a.cfg == nil {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -955,7 +955,6 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 		if _, ok := a.reviewDiffCache[cacheKey(rp, sess.ID)]; !ok {
 			return a.fetchReviewDiffCmd(sess, rp), true
 		}
-		a.modals.Review().RefreshDiffViewport(a.panelServices())
 		return nil, true
 	case focusSectionShipping:
 		a.openShipping(newShippingPanel(sess, items[idx].repoPath, a.width, a.height-1))

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4860,21 +4860,21 @@ func TestNewApp_InitsFeedbackTriage(t *testing.T) {
 	}
 }
 
-// TestReviewPanel_EnterDoesNotChangeView verifies that pressing enter or space
-// while focusReview is active does not transition to ViewDiff. The inline diff
-// is now shown inline, so the fullscreen hop is removed.
-func TestReviewPanel_EnterDoesNotChangeView(t *testing.T) {
+// TestReviewPanel_EnterOpensDiffViewer verifies that pressing enter on a task
+// with a non-empty rawDiff transitions to ViewDiff with the review modal preserved.
+func TestReviewPanel_EnterOpensDiffViewer(t *testing.T) {
 	sessR := agent.NewSessionForTest("r", "review-r")
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
 	sessR.SetOriginalPrompt("Fix auth")
 	sessR.MarkDone()
 
+	rawDiff := "diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,4 @@\n package main\n \n+// marker\n func A() {}\n"
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 1, Text: "Fix handler", Done: false}},
 		groups: []taskReviewGroup{{
 			taskIndex: 1,
 			commits:   []git.Commit{{Hash: "abc1234", Subject: "[task 1] fix handler"}},
-			rawDiff:   "diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,4 @@\n package main\n \n+// marker\n func A() {}\n",
+			rawDiff:   rawDiff,
 		}},
 		verdicts: map[int]*taskVerdictRecord{
 			1: {state: verdictPending},
@@ -4887,19 +4887,63 @@ func TestReviewPanel_EnterDoesNotChangeView(t *testing.T) {
 	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 	app.reviewDiffCache[cacheKey("", sessR.ID)] = entry
 
-	for _, key := range []string{"enter", "space"} {
-		msg := tea.KeyPressMsg{Code: tea.KeyEnter, Text: key}
-		if key == "space" {
-			msg = tea.KeyPressMsg{Code: tea.KeySpace, Text: " "}
-		}
-		model, _ := app.Update(msg)
-		updated := model.(App)
-		if updated.view != ViewDashboard {
-			t.Errorf("%s: expected view=ViewDashboard, got %v", key, updated.view)
-		}
-		if updated.dashboard.panelFocus != focusReview {
-			t.Errorf("%s: expected panelFocus=focusReview, got %v", key, updated.dashboard.panelFocus)
-		}
+	// Press enter: panel emits reviewOpenTaskDiffMsg, app handles it next tick.
+	model, cmd := app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	updated := model.(App)
+
+	// After the key press the view hasn't changed yet (cmd is pending).
+	if updated.view != ViewDashboard {
+		t.Errorf("after enter key: expected view=ViewDashboard (cmd pending), got %v", updated.view)
+	}
+	if updated.modals.Review() == nil {
+		t.Error("review modal must remain open after enter")
+	}
+
+	// Run the cmd to deliver reviewOpenTaskDiffMsg.
+	if cmd == nil {
+		t.Fatal("expected a cmd from enter press")
+	}
+	model2, _ := updated.Update(cmd())
+	updated2 := model2.(App)
+	if updated2.view != ViewDiff {
+		t.Errorf("after cmd delivery: expected ViewDiff, got %v", updated2.view)
+	}
+	// Review modal must survive the transition.
+	if updated2.modals.Review() == nil {
+		t.Error("review modal must survive the ViewDiff transition")
+	}
+}
+
+// TestReviewPanel_SpaceIsNoOp verifies that space does not open the diff viewer.
+func TestReviewPanel_SpaceIsNoOp(t *testing.T) {
+	sessR := agent.NewSessionForTest("r", "review-r")
+	sessR.SetLifecyclePhase(agent.LifecycleInReview)
+	sessR.SetOriginalPrompt("Fix auth")
+	sessR.MarkDone()
+
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Fix handler", Done: false}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "[task 1] fix handler"}},
+			rawDiff:   "diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,4 @@\n package main\n \n+// marker\n func A() {}\n",
+		}},
+		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
+	}
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
+	app.reviewDiffCache[cacheKey("", sessR.ID)] = entry
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
+	updated := model.(App)
+	if updated.view != ViewDashboard {
+		t.Errorf("space: expected view=ViewDashboard, got %v", updated.view)
+	}
+	if updated.dashboard.panelFocus != focusReview {
+		t.Errorf("space: expected panelFocus=focusReview, got %v", updated.dashboard.panelFocus)
 	}
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4903,61 +4903,6 @@ func TestReviewPanel_EnterDoesNotChangeView(t *testing.T) {
 	}
 }
 
-// TestReviewPanel_ScrollBindingsAdvanceViewport verifies that pressing pgdown
-// while focusReview is active advances the inline diff viewport's scroll position,
-// confirming the viewport is interactable via the scroll key bindings wired in the
-// focusReview key handler.
-func TestReviewPanel_ScrollBindingsAdvanceViewport(t *testing.T) {
-	// Build a diff with enough added lines to exceed the viewport height at 40 rows.
-	var sb strings.Builder
-	sb.WriteString("diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,53 @@\n package main\n \n")
-	for range 50 {
-		sb.WriteString("+// scroll-test-line\n")
-	}
-	sb.WriteString(" func A() {}\n")
-	rawDiff := sb.String()
-
-	sessR := agent.NewSessionForTest("scroll-vp", "review-scroll")
-	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	sessR.SetOriginalPrompt("Fix auth")
-	sessR.MarkDone()
-
-	entry := &reviewDiffEntry{
-		tasks: []agent.PlanTask{{Index: 1, Text: "Fix handler", Done: false}},
-		groups: []taskReviewGroup{{
-			taskIndex: 1,
-			commits:   []git.Commit{{Hash: "abc1234", Subject: "[task 1] fix handler"}},
-			rawDiff:   rawDiff,
-		}},
-		verdicts: map[int]*taskVerdictRecord{
-			1: {state: verdictPending},
-		},
-	}
-
-	app := NewApp()
-	app.width = 120
-	app.height = 40
-	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
-	app.reviewDiffCache[cacheKey("", sessR.ID)] = entry
-	// Load diff content and set viewport dimensions before sending scroll keys.
-	app.modals.Review().RefreshDiffViewport(app.panelServices())
-
-	if !app.modals.Review().diffVP.AtTop() {
-		t.Fatal("expected viewport at top before scrolling")
-	}
-
-	// pgdown must advance the viewport away from the top.
-	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
-	updated := model.(App)
-
-	if updated.modals.Review().diffVP.AtTop() {
-		t.Error("pgdown: inline diff viewport did not scroll; viewport must advance when diff content exceeds viewport height")
-	}
-	if updated.dashboard.panelFocus != focusReview {
-		t.Error("pgdown: panelFocus must remain focusReview")
-	}
-}
-
 // TestCreateResult_SkipFocusLaunch_StaysOnDashboard verifies that when
 // skipFocusLaunch is true the createResultMsg handler does not enter
 // focusLaunch, but still moves the pipeline cursor to the new session's row.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -117,6 +117,7 @@ type dashboardModel struct {
 	cursor                 FocusedCursor  // pipeline cursor mirror; synced from App on every refresh
 	prDraftSessionID       string         // session ID whose PR draft is in flight; "" when idle
 	prDraftRepoPath        string         // repo path whose PR draft is in flight; "" when idle
+	activeRepoName         string         // display name of the active repo
 	activeRepoPath         string         // canonical path of the active repo (for pipeline filtering)
 	focusLaunchAgent       *agent.Agent   // agent open in focusLaunch terminal; nil otherwise
 	focusLaunchSession     *agent.Session // session owning focusLaunchAgent; nil otherwise
@@ -1548,7 +1549,11 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		elapsedMin := int(d.sessionElapsed.Minutes())
 		timerStr = barModel.ViewAs(pct) + " " + fmt.Sprintf("%dm/%dm", elapsedMin, d.focusSessionMinutes)
 	}
-	headerLine := title + "  " + timerStr
+	headerLine := title
+	if d.activeRepoName != "" {
+		headerLine += "  " + StyleSubtle.Render(d.activeRepoName)
+	}
+	headerLine += "  " + timerStr
 	lines = append(lines, headerLine)
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
 

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -146,10 +146,7 @@ func renderReviewHeader(sess *agent.Session, width int) []string {
 // entry may be nil while diff stats are being fetched (shows loading placeholder).
 // cursor is the currently selected task row index (0-based among all task rows).
 // prDraftInFlight, when true, shows a spinner status line and disables the p hint.
-// vpView is the pre-rendered viewport.View() string for the inline diff. When
-// non-empty it is used directly; when empty (tests / no data) renderInlineDiffPane
-// is called as a fallback with scrollOffset=0.
-func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool, vpView string) string {
+func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool) string {
 	// Header (3–4 lines depending on prompt length).
 	headerLines := renderReviewHeader(sess, width)
 
@@ -164,13 +161,12 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 		bodyH = 4
 	}
 
-	// Build body lines.
+	// Build body lines: full-width stacked layout at all terminal widths.
 	var bodyLines []string
 	if entry == nil {
 		bodyLines = append(bodyLines, StyleSubtle.Render("loading diff stats…"))
-	} else if width < 80 {
-		// Narrow: stack list above detail with a divider.
-		listH := bodyH / 2
+	} else {
+		listH := bodyH * 2 / 5
 		detailH := bodyH - listH - 1
 		if listH < 2 {
 			listH = 2
@@ -178,45 +174,10 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 		if detailH < 2 {
 			detailH = 2
 		}
-		leftW := width - 2
-		bodyLines = append(bodyLines, renderTaskListPane(entry, leftW, listH, cursor)...)
+		paneW := width - 2
+		bodyLines = append(bodyLines, renderTaskListPane(entry, paneW, listH, cursor)...)
 		bodyLines = append(bodyLines, StyleSubtle.Render(strings.Repeat("─", width-2)))
-		bodyLines = append(bodyLines, renderTaskDetailPane(entry, cursor, leftW, detailH)...)
-	} else {
-		// Wide: side-by-side panes with a │ gutter.
-		leftW := width * 4 / 10
-		if leftW < 32 {
-			leftW = 32
-		}
-		// gutter: " │ " = 3 chars, but we also have 2 leading spaces on the outer,
-		// so effective layout: 2sp + leftW + " │ " + rightW
-		rightW := width - leftW - 5
-		if rightW < 20 {
-			rightW = 20
-		}
-		leftPaneLines := renderTaskListPane(entry, leftW, bodyH, cursor)
-		rightPaneLines := buildRightPane(entry, cursor, rightW, bodyH, vpView)
-
-		gutter := " " + StyleSubtle.Render("│") + " "
-		maxRows := len(leftPaneLines)
-		if len(rightPaneLines) > maxRows {
-			maxRows = len(rightPaneLines)
-		}
-		for i := 0; i < maxRows; i++ {
-			l, r := "", ""
-			if i < len(leftPaneLines) {
-				l = leftPaneLines[i]
-			}
-			if i < len(rightPaneLines) {
-				r = rightPaneLines[i]
-			}
-			// Pad left cell to leftW visible columns.
-			padW := leftW - ansi.StringWidth(l)
-			if padW < 0 {
-				padW = 0
-			}
-			bodyLines = append(bodyLines, l+strings.Repeat(" ", padW)+gutter+r)
-		}
+		bodyLines = append(bodyLines, renderTaskDetailPane(entry, cursor, paneW, detailH)...)
 	}
 
 	// Assemble full panel.
@@ -586,14 +547,6 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 	return capAndCenter(lines)
 }
 
-// renderTaskSummaryPane renders the summary portion of the right pane (verdict,
-// rationale, files, commits) capped to summaryH lines. It is the upper half of
-// the right pane in wide mode; the inline diff viewport occupies the lower half.
-// This is identical to renderTaskDetailPane but without the "enter — open task diff" hint.
-func renderTaskSummaryPane(entry *reviewDiffEntry, cursor, width, summaryH int) []string {
-	return renderTaskDetailPane(entry, cursor, width, summaryH)
-}
-
 // renderAllFilesUnified renders every file in a diffmodel.Model as unified
 // (non-side-by-side) text at the given width, with files joined by newlines.
 func renderAllFilesUnified(m *diffmodel.Model, width int) string {
@@ -606,93 +559,6 @@ func renderAllFilesUnified(m *diffmodel.Model, width int) string {
 		parts = append(parts, r.Render(width, false))
 	}
 	return strings.Join(parts, "\n")
-}
-
-// renderInlineDiffPane renders the diff body for the cursor task's rawDiff,
-// windowed by scrollOffset and capped to height. Returns a placeholder line
-// when the diff is empty.
-func renderInlineDiffPane(entry *reviewDiffEntry, cursor, width, height, scrollOffset int) []string {
-	rawDiff := ""
-	if entry != nil {
-		group := reviewTaskGroupAtCursor(entry, cursor)
-		// For the no-plan overview path (no tasks), fall back to the first group.
-		if group == nil && len(entry.groups) > 0 && len(entry.tasks) == 0 {
-			group = &entry.groups[0]
-		}
-		if group != nil {
-			rawDiff = group.rawDiff
-		}
-	}
-
-	const placeholder = "(no diff for this task)"
-	if rawDiff == "" {
-		if height <= 0 {
-			return []string{StyleSubtle.Render(placeholder)}
-		}
-		out := make([]string, height)
-		out[0] = StyleSubtle.Render(placeholder)
-		return out
-	}
-
-	m, err := diffmodel.Parse(rawDiff)
-	if err != nil || m == nil || len(m.Files) == 0 {
-		out := make([]string, max(1, height))
-		out[0] = StyleSubtle.Render(placeholder)
-		return out
-	}
-
-	content := renderAllFilesUnified(m, width)
-	allLines := strings.Split(content, "\n")
-
-	if scrollOffset < 0 {
-		scrollOffset = 0
-	}
-	if scrollOffset >= len(allLines) {
-		scrollOffset = max(0, len(allLines)-1)
-	}
-	end := scrollOffset + height
-	if end > len(allLines) {
-		end = len(allLines)
-	}
-	result := allLines[scrollOffset:end]
-	// Pad to height so the pane always occupies its allocated rows.
-	for len(result) < height {
-		result = append(result, "")
-	}
-	return result
-}
-
-// buildRightPane composes the right pane for wide mode: summary on top,
-// a horizontal rule, then the inline diff below.
-// vpView is the pre-rendered output from viewport.View(). When non-empty it is
-// used directly for the diff section (no re-parsing); when empty renderInlineDiffPane
-// is called as a fallback (used by tests that don't wire up a viewport).
-func buildRightPane(entry *reviewDiffEntry, cursor, width, bodyH int, vpView string) []string {
-	if entry == nil {
-		return []string{StyleSubtle.Render("loading…")}
-	}
-	maxSummaryH := bodyH / 3
-	if maxSummaryH < 4 {
-		maxSummaryH = 4
-	}
-	summaryLines := renderTaskSummaryPane(entry, cursor, width, maxSummaryH)
-	divider := StyleSubtle.Render(strings.Repeat("─", width))
-	diffH := bodyH - len(summaryLines) - 1
-	if diffH < 1 {
-		diffH = 1
-	}
-	var diffLines []string
-	if vpView != "" {
-		// Use the viewport's pre-rendered content (scroll already applied, no re-parse).
-		diffLines = strings.Split(vpView, "\n")
-	} else {
-		diffLines = renderInlineDiffPane(entry, cursor, width, diffH, 0)
-	}
-	result := make([]string, 0, len(summaryLines)+1+len(diffLines))
-	result = append(result, summaryLines...)
-	result = append(result, divider)
-	result = append(result, diffLines...)
-	return result
 }
 
 // capLines returns lines capped to height, with a trailing truncation note if needed.

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -10,9 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
-	"github.com/devenjarvis/refrain/internal/diffmodel"
 	"github.com/devenjarvis/refrain/internal/git"
-	"github.com/devenjarvis/refrain/internal/tui/diff"
 	"github.com/devenjarvis/refrain/internal/tui/mdrender"
 )
 
@@ -597,20 +595,6 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 	}
 
 	return capAndCenter(lines)
-}
-
-// renderAllFilesUnified renders every file in a diffmodel.Model as unified
-// (non-side-by-side) text at the given width, with files joined by newlines.
-func renderAllFilesUnified(m *diffmodel.Model, width int) string {
-	if m == nil {
-		return ""
-	}
-	parts := make([]string, 0, len(m.Files))
-	for i := range m.Files {
-		r := diff.NewRenderer(&m.Files[i])
-		parts = append(parts, r.Render(width, false))
-	}
-	return strings.Join(parts, "\n")
 }
 
 // capLines returns lines capped to height, with a trailing truncation note if needed.

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -142,6 +142,15 @@ func renderReviewHeader(sess *agent.Session, width int) []string {
 	return lines
 }
 
+// renderReviewPlaceholderTab renders a height-line placeholder body for tabs
+// that haven't been implemented yet. The label is centered on the first line.
+func renderReviewPlaceholderTab(label string, width, height int) []string {
+	lines := make([]string, height)
+	centered := StyleSubtle.Render("(" + label + ")")
+	lines[0] = centered
+	return lines
+}
+
 // renderReviewTabBar renders the 2-line tab bar for the review panel.
 // Line 0: tab labels separated by two spaces; active tab in ColorSecondary bold,
 // inactive tabs in StyleSubtle. Line 1: a subtle horizontal divider.
@@ -165,9 +174,13 @@ func renderReviewTabBar(activeTab, width int) []string {
 // entry may be nil while diff stats are being fetched (shows loading placeholder).
 // cursor is the currently selected task row index (0-based among all task rows).
 // prDraftInFlight, when true, shows a spinner status line and disables the p hint.
-func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool) string {
+// activeTab selects which tab body to render (0=Tasks, 1=Diff, 2=Checks, 3=Validate).
+func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool, activeTab int) string {
 	// Header (3–4 lines depending on prompt length).
 	headerLines := renderReviewHeader(sess, width)
+
+	// Tab bar: 2 lines (labels + divider).
+	const tabBarH = 2
 
 	// Footer: blank + divider + hints = 3 lines; +1 when draft in flight.
 	footerLineCount := 3
@@ -175,16 +188,30 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	if prDraftInFlight {
 		draftLineCount = 1
 	}
-	bodyH := height - len(headerLines) - footerLineCount - draftLineCount
+	bodyH := height - len(headerLines) - tabBarH - footerLineCount - draftLineCount
 	if bodyH < 4 {
 		bodyH = 4
 	}
 
-	// Build body lines: full-width stacked layout at all terminal widths.
+	// Build body lines based on active tab.
 	var bodyLines []string
-	if entry == nil {
+	switch {
+	case activeTab != reviewTabTasks:
+		// Non-Tasks tabs: placeholder.
+		var label string
+		switch activeTab {
+		case reviewTabDiff:
+			label = "full diff browser coming soon"
+		case reviewTabChecks:
+			label = "local checks coming soon"
+		case reviewTabValidate:
+			label = "manual validation coming soon"
+		}
+		bodyLines = renderReviewPlaceholderTab(label, width, bodyH)
+	case entry == nil:
 		bodyLines = append(bodyLines, StyleSubtle.Render("loading diff stats…"))
-	} else {
+	default:
+		// Tasks tab: full-width stacked layout.
 		listH := bodyH * 2 / 5
 		detailH := bodyH - listH - 1
 		if listH < 2 {
@@ -202,6 +229,7 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	// Assemble full panel.
 	var lines []string
 	lines = append(lines, headerLines...)
+	lines = append(lines, renderReviewTabBar(activeTab, width)...)
 	lines = append(lines, bodyLines...)
 
 	// In-flight PR draft status line.

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -142,6 +142,25 @@ func renderReviewHeader(sess *agent.Session, width int) []string {
 	return lines
 }
 
+// renderReviewTabBar renders the 2-line tab bar for the review panel.
+// Line 0: tab labels separated by two spaces; active tab in ColorSecondary bold,
+// inactive tabs in StyleSubtle. Line 1: a subtle horizontal divider.
+func renderReviewTabBar(activeTab, width int) []string {
+	labels := []string{"Tasks", "Diff", "Checks", "Validate"}
+	activeStyle := lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
+	var parts []string
+	for i, label := range labels {
+		if i == activeTab {
+			parts = append(parts, activeStyle.Render(label))
+		} else {
+			parts = append(parts, StyleSubtle.Render(label))
+		}
+	}
+	labelLine := "  " + strings.Join(parts, "  ")
+	divider := StyleSubtle.Render(strings.Repeat("─", width-2))
+	return []string{labelLine, divider}
+}
+
 // renderReviewPanel renders the fullscreen review panel for a session.
 // entry may be nil while diff stats are being fetched (shows loading placeholder).
 // cursor is the currently selected task row index (0-based among all task rows).

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -255,7 +255,7 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 		"  " + StyleActive.Render("c") + StyleSubtle.Render(" — mark complete") +
 		"  " + StyleActive.Render("e") + StyleSubtle.Render(" — open in editor") +
 		"  " + StyleActive.Render("d") + StyleSubtle.Render(" — defer") +
-		"  " + StyleActive.Render("pgdn") + StyleSubtle.Render("/") + StyleActive.Render("pgup") + StyleSubtle.Render(" — scroll diff") +
+		"  " + StyleActive.Render("enter") + StyleSubtle.Render(" — open task diff") +
 		"  " + StyleActive.Render("?") + StyleSubtle.Render(" — spec") +
 		"  " + StyleSubtle.Render("ESC — back to focus")
 	lines = append(lines, hints)

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -143,11 +143,16 @@ func renderReviewHeader(sess *agent.Session, width int) []string {
 }
 
 // renderReviewPlaceholderTab renders a height-line placeholder body for tabs
-// that haven't been implemented yet. The label is centered on the first line.
+// that haven't been implemented yet. The label is horizontally centered on
+// the first line; remaining lines are empty strings.
 func renderReviewPlaceholderTab(label string, width, height int) []string {
 	lines := make([]string, height)
-	centered := StyleSubtle.Render("(" + label + ")")
-	lines[0] = centered
+	text := StyleSubtle.Render("(" + label + ")")
+	pad := (width - ansi.StringWidth(text)) / 2
+	if pad < 0 {
+		pad = 0
+	}
+	lines[0] = strings.Repeat(" ", pad) + text
 	return lines
 }
 

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -252,7 +252,7 @@ func TestRenderReviewPanel_TwoPaneLayout(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 30, 0, false)
+	output := renderReviewPanel(sess, entry, 140, 30, 0, false, 0)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from left pane")
@@ -289,7 +289,7 @@ func TestRenderReviewPanel_FullWidthStack(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from list pane")
@@ -323,7 +323,7 @@ func TestRenderReviewPanel_NarrowWidthStacks(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 70, 30, 0, false)
+	output := renderReviewPanel(sess, entry, 70, 30, 0, false, 0)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from list pane")
@@ -353,7 +353,7 @@ func TestRenderReviewPanel_ShowsOriginalPrompt(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 213, Deletions: 34},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
 
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("review panel must show the original prompt")
@@ -368,7 +368,7 @@ func TestRenderReviewPanel_NilDiffEntry(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 
 	// nil entry — should not panic
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("must still show prompt even with nil diff entry")
 	}
@@ -392,7 +392,7 @@ func TestRenderReviewPanel_UsesThemeColors(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0)
 
 	// The pass verdict icon should carry the ColorSuccess ANSI escape.
 	expectedPrefix := StyleSuccess.Render("✓")
@@ -454,7 +454,7 @@ func TestRenderReviewPanel_NoPlanShowsOverview(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 30, Deletions: 2},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0)
 
 	if !strings.Contains(output, "Overview") {
 		t.Error("must show 'Overview' row in list pane for no-plan session")
@@ -494,7 +494,7 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
 
 	for _, want := range []string{
 		"open PR",
@@ -537,7 +537,7 @@ func TestRenderReviewPanel_TaskListShown(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("task list view must show PLAN TASKS header")
@@ -745,7 +745,7 @@ func TestRenderReviewPanel_NoDiffFoundBadge(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
 
 	if !strings.Contains(output, "Write tests") {
 		t.Error("must render a row for task 2 even though it has no commits")
@@ -954,7 +954,7 @@ func TestRenderReviewPanel_HintsIncludeSpecAndScroll(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
 
 	if !strings.Contains(output, "?") {
 		t.Error("footer must include '?' hint for spec overlay")
@@ -1024,7 +1024,7 @@ func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, true)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, true, 0)
 
 	if !strings.Contains(output, "Pushing branch and drafting PR") {
 		t.Error("in-flight state must show draft spinner line")
@@ -1069,7 +1069,7 @@ func TestRenderReviewPanel_TaskHasDiff(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
 
 	if !strings.Contains(output, "pass") {
 		t.Error("must contain verdict label 'pass'")
@@ -1104,7 +1104,7 @@ func TestReviewPanel_CursorMoveSwapsDetail(t *testing.T) {
 	}
 
 	// cursor=0 → task 1 heading in detail pane
-	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false)
+	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
 	if !strings.Contains(out0, "Task 1:") {
 		t.Errorf("cursor=0: expected 'Task 1:' in detail pane; got:\n%s", out0)
 	}
@@ -1113,7 +1113,7 @@ func TestReviewPanel_CursorMoveSwapsDetail(t *testing.T) {
 	}
 
 	// cursor=1 → task 2 heading in detail pane
-	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false)
+	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false, 0)
 	if !strings.Contains(out1, "Task 2:") {
 		t.Errorf("cursor=1: expected 'Task 2:' in detail pane; got:\n%s", out1)
 	}
@@ -1234,7 +1234,7 @@ func TestRenderReviewPanel_FooterUsesThemeStyles(t *testing.T) {
 	sess.SetOriginalPrompt("Fix auth")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
 
 	// StyleActive.Render("p") — carries ANSI codes in color mode, is "p" otherwise.
 	// In both cases the rendered footer must contain it.
@@ -1286,6 +1286,30 @@ func TestRenderTaskListPane_HeaderUsesHeadingColor(t *testing.T) {
 	}
 }
 
+// TestRenderReviewPanel_ShowsTabBar verifies that renderReviewPanel includes a
+// tab bar containing all four tab labels.
+func TestRenderReviewPanel_ShowsTabBar(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-tabs", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Add auth middleware"}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "add middleware"}},
+		}},
+		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
+	}
+
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
+
+	for _, tab := range []string{"Tasks", "Diff", "Checks", "Validate"} {
+		if !strings.Contains(ansi.Strip(output), tab) {
+			t.Errorf("panel must contain tab label %q; got:\n%s", tab, output)
+		}
+	}
+}
+
 // TestRenderReviewTabBar_HighlightsActiveTab verifies that renderReviewTabBar
 // returns 2 lines and contains all four tab labels in the first line.
 func TestRenderReviewTabBar_HighlightsActiveTab(t *testing.T) {
@@ -1332,7 +1356,7 @@ func TestRenderReviewPanel_NoDiffTask(t *testing.T) {
 	}
 
 	// Must not panic and must show the "no diff found" verdict badge.
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
 	if !strings.Contains(output, "no diff found") {
 		t.Errorf("must show 'no diff found' verdict badge; got:\n%s", output)
 	}

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -1310,6 +1310,69 @@ func TestRenderReviewPanel_ShowsTabBar(t *testing.T) {
 	}
 }
 
+// TestRenderReviewPanel_DiffTabPlaceholder verifies that when activeTab=1 (Diff)
+// the panel output contains the placeholder text and not the task list header.
+func TestRenderReviewPanel_DiffTabPlaceholder(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-difftab", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+	entry := &reviewDiffEntry{
+		tasks:    []agent.PlanTask{{Index: 1, Text: "task one"}},
+		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
+	}
+
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabDiff)
+	stripped := ansi.Strip(output)
+
+	if !strings.Contains(stripped, "full diff browser coming soon") {
+		t.Errorf("Diff tab must show placeholder; got:\n%s", stripped)
+	}
+	if strings.Contains(stripped, "PLAN TASKS") {
+		t.Errorf("Diff tab must not show task list header; got:\n%s", stripped)
+	}
+}
+
+// TestRenderReviewPanel_TasksTabStillWorks verifies that activeTab=0 (Tasks)
+// still renders the task list as a regression guard.
+func TestRenderReviewPanel_TasksTabStillWorks(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-taskstab", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+	entry := &reviewDiffEntry{
+		tasks:    []agent.PlanTask{{Index: 1, Text: "task one"}},
+		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
+	}
+
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks)
+	stripped := ansi.Strip(output)
+
+	if !strings.Contains(stripped, "PLAN TASKS") {
+		t.Errorf("Tasks tab must show task list header; got:\n%s", stripped)
+	}
+}
+
+// TestRenderReviewPanel_FooterShowsEnterHint verifies that the footer hint
+// says "enter — open task diff" instead of the old "pgdn/pgup — scroll diff".
+func TestRenderReviewPanel_FooterShowsEnterHint(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-footer", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+	entry := &reviewDiffEntry{
+		tasks:    []agent.PlanTask{{Index: 1, Text: "task one"}},
+		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
+	}
+
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks)
+	stripped := ansi.Strip(output)
+
+	if !strings.Contains(stripped, "enter") {
+		t.Errorf("footer must contain 'enter' hint; got:\n%s", stripped)
+	}
+	if strings.Contains(stripped, "pgdn") {
+		t.Errorf("footer must not contain old 'pgdn' hint; got:\n%s", stripped)
+	}
+}
+
 // TestRenderReviewPlaceholderTab verifies that renderReviewPlaceholderTab
 // returns height lines and that the first line contains the label text.
 func TestRenderReviewPlaceholderTab(t *testing.T) {

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -1390,16 +1390,24 @@ func TestRenderReviewPanel_FooterShowsEnterHint(t *testing.T) {
 }
 
 // TestRenderReviewPlaceholderTab verifies that renderReviewPlaceholderTab
-// returns height lines and that the first line contains the label text.
+// returns exactly height lines, that the first line contains the label text
+// horizontally centered, and that remaining lines are empty.
 func TestRenderReviewPlaceholderTab(t *testing.T) {
 	label := "full diff browser coming soon"
-	lines := renderReviewPlaceholderTab(label, 80, 20)
+	const width = 80
+	lines := renderReviewPlaceholderTab(label, width, 20)
 	if len(lines) != 20 {
 		t.Fatalf("expected 20 lines, got %d", len(lines))
 	}
 	stripped := ansi.Strip(lines[0])
 	if !strings.Contains(stripped, label) {
 		t.Errorf("first line must contain label %q; got: %q", label, stripped)
+	}
+	// Centered: the first line must have leading spaces pushing the label toward
+	// the middle. With width=80 and the label shorter than width, there should be
+	// at least one leading space.
+	if !strings.HasPrefix(lines[0], " ") {
+		t.Errorf("first line must be horizontally centered (leading spaces expected); got: %q", lines[0])
 	}
 	// Remaining lines are empty.
 	for i := 1; i < 20; i++ {

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -278,8 +278,11 @@ func TestRenderReviewPanel_FullWidthStack(t *testing.T) {
 	sess := agent.NewSessionForTest("sess-wide", "fix-auth")
 	sess.SetOriginalPrompt("Fix auth")
 	sess.MarkDone()
+	// Long task text that would be truncated in the old 40%-width left pane but
+	// must appear in full in the new full-width stacked layout.
+	longTaskText := "Add authentication middleware with token validation and redirect"
 	entry := &reviewDiffEntry{
-		tasks: []agent.PlanTask{{Index: 1, Text: "Add auth middleware"}},
+		tasks: []agent.PlanTask{{Index: 1, Text: longTaskText}},
 		groups: []taskReviewGroup{{
 			taskIndex: 1,
 			commits:   []git.Commit{{Hash: "abc1234", Subject: "add middleware"}},
@@ -300,9 +303,16 @@ func TestRenderReviewPanel_FullWidthStack(t *testing.T) {
 	}
 	// In stacked mode, PLAN TASKS and Task 1: are never on the same line.
 	for _, line := range strings.Split(output, "\n") {
-		if strings.Contains(line, "PLAN TASKS") && strings.Contains(line, "Task 1:") {
+		stripped := ansi.Strip(line)
+		if strings.Contains(stripped, "PLAN TASKS") && strings.Contains(stripped, "Task 1:") {
 			t.Errorf("in stacked mode panes must not be side-by-side; found both on one line: %q", line)
 		}
+	}
+	// Full-width: the long task name must not be truncated. In the old 40%-width
+	// left pane, text beyond ~48 chars was cut. At width=120 the list pane is
+	// now 118 chars wide, so the full task text must appear.
+	if !strings.Contains(ansi.Strip(output), "token validation and redirect") {
+		t.Errorf("full-width stacked layout must not truncate long task text; got:\n%s", output)
 	}
 }
 

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
 	"github.com/devenjarvis/refrain/internal/git"
@@ -1399,11 +1400,13 @@ func TestRenderReviewPlaceholderTab(t *testing.T) {
 }
 
 // TestRenderReviewTabBar_HighlightsActiveTab verifies that renderReviewTabBar
-// returns 2 lines and contains all four tab labels in the first line.
+// returns 2 lines, contains all four tab labels in the first line, and applies
+// the correct styling: active tab in ColorSecondary bold, inactive tabs in StyleSubtle.
 func TestRenderReviewTabBar_HighlightsActiveTab(t *testing.T) {
 	tabNames := []string{"Tasks", "Diff", "Checks", "Validate"}
+	activeStyle := lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
 
-	for activeIdx := range tabNames {
+	for activeIdx, activeName := range tabNames {
 		lines := renderReviewTabBar(activeIdx, 120)
 		if len(lines) != 2 {
 			t.Fatalf("activeTab=%d: expected 2 lines, got %d", activeIdx, len(lines))
@@ -1417,6 +1420,23 @@ func TestRenderReviewTabBar_HighlightsActiveTab(t *testing.T) {
 		// Second line must be a divider.
 		if !strings.Contains(ansi.Strip(lines[1]), "─") {
 			t.Errorf("activeTab=%d: line 1 must be a divider; got: %q", activeIdx, lines[1])
+		}
+
+		// Active tab must use ColorSecondary bold; inactive tabs must use StyleSubtle.
+		styledActive := activeStyle.Render(activeName)
+		if !strings.Contains(lines[0], styledActive) {
+			t.Errorf("activeTab=%d: active label %q not styled with ColorSecondary bold;\nraw line: %q",
+				activeIdx, activeName, lines[0])
+		}
+		for i, name := range tabNames {
+			if i == activeIdx {
+				continue
+			}
+			styledInactive := StyleSubtle.Render(name)
+			if !strings.Contains(lines[0], styledInactive) {
+				t.Errorf("activeTab=%d: inactive label %q not styled with StyleSubtle;\nraw line: %q",
+					activeIdx, name, lines[0])
+			}
 		}
 	}
 }

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -271,6 +271,40 @@ func TestRenderReviewPanel_TwoPaneLayout(t *testing.T) {
 	}
 }
 
+// TestRenderReviewPanel_FullWidthStack verifies that at width=120 (wide terminal)
+// the review panel uses a vertical stack — panes are never side-by-side.
+func TestRenderReviewPanel_FullWidthStack(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-wide", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "Add auth middleware"}},
+		groups: []taskReviewGroup{{
+			taskIndex: 1,
+			commits:   []git.Commit{{Hash: "abc1234", Subject: "add middleware"}},
+			stats:     &git.DiffStats{Files: 1, Insertions: 5, Deletions: 1},
+		}},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictPending},
+		},
+	}
+
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
+
+	if !strings.Contains(output, "PLAN TASKS") {
+		t.Error("must contain PLAN TASKS from list pane")
+	}
+	if !strings.Contains(output, "Task 1:") {
+		t.Error("must contain 'Task 1:' from detail pane")
+	}
+	// In stacked mode, PLAN TASKS and Task 1: are never on the same line.
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "PLAN TASKS") && strings.Contains(line, "Task 1:") {
+			t.Errorf("in stacked mode panes must not be side-by-side; found both on one line: %q", line)
+		}
+	}
+}
+
 // TestRenderReviewPanel_NarrowWidthStacks verifies that at <80 cols, panes stack
 // vertically (list above detail) rather than side by side.
 func TestRenderReviewPanel_NarrowWidthStacks(t *testing.T) {

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -1286,6 +1286,29 @@ func TestRenderTaskListPane_HeaderUsesHeadingColor(t *testing.T) {
 	}
 }
 
+// TestRenderReviewTabBar_HighlightsActiveTab verifies that renderReviewTabBar
+// returns 2 lines and contains all four tab labels in the first line.
+func TestRenderReviewTabBar_HighlightsActiveTab(t *testing.T) {
+	tabNames := []string{"Tasks", "Diff", "Checks", "Validate"}
+
+	for activeIdx := range tabNames {
+		lines := renderReviewTabBar(activeIdx, 120)
+		if len(lines) != 2 {
+			t.Fatalf("activeTab=%d: expected 2 lines, got %d", activeIdx, len(lines))
+		}
+		stripped := ansi.Strip(lines[0])
+		for _, name := range tabNames {
+			if !strings.Contains(stripped, name) {
+				t.Errorf("activeTab=%d: label line must contain %q; got: %q", activeIdx, name, stripped)
+			}
+		}
+		// Second line must be a divider.
+		if !strings.Contains(ansi.Strip(lines[1]), "─") {
+			t.Errorf("activeTab=%d: line 1 must be a divider; got: %q", activeIdx, lines[1])
+		}
+	}
+}
+
 // TestRenderReviewPanel_NoDiffTask verifies that when a task group has an
 // empty rawDiff, the panel renders without panic and shows the "no diff found"
 // verdict badge in the detail pane. There is no inline diff placeholder since

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -252,7 +252,7 @@ func TestRenderReviewPanel_TwoPaneLayout(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 30, 0, false, "")
+	output := renderReviewPanel(sess, entry, 140, 30, 0, false)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from left pane")
@@ -289,7 +289,7 @@ func TestRenderReviewPanel_NarrowWidthStacks(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 70, 30, 0, false, "")
+	output := renderReviewPanel(sess, entry, 70, 30, 0, false)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from list pane")
@@ -319,7 +319,7 @@ func TestRenderReviewPanel_ShowsOriginalPrompt(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 213, Deletions: 34},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, "")
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
 
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("review panel must show the original prompt")
@@ -334,7 +334,7 @@ func TestRenderReviewPanel_NilDiffEntry(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 
 	// nil entry — should not panic
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, "")
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("must still show prompt even with nil diff entry")
 	}
@@ -358,7 +358,7 @@ func TestRenderReviewPanel_UsesThemeColors(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false, "")
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false)
 
 	// The pass verdict icon should carry the ColorSuccess ANSI escape.
 	expectedPrefix := StyleSuccess.Render("✓")
@@ -420,7 +420,7 @@ func TestRenderReviewPanel_NoPlanShowsOverview(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 30, Deletions: 2},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false, "")
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false)
 
 	if !strings.Contains(output, "Overview") {
 		t.Error("must show 'Overview' row in list pane for no-plan session")
@@ -460,7 +460,7 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, "")
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
 
 	for _, want := range []string{
 		"open PR",
@@ -503,7 +503,7 @@ func TestRenderReviewPanel_TaskListShown(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, "")
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("task list view must show PLAN TASKS header")
@@ -711,7 +711,7 @@ func TestRenderReviewPanel_NoDiffFoundBadge(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, "")
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false)
 
 	if !strings.Contains(output, "Write tests") {
 		t.Error("must render a row for task 2 even though it has no commits")
@@ -920,7 +920,7 @@ func TestRenderReviewPanel_HintsIncludeSpecAndScroll(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, "")
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false)
 
 	if !strings.Contains(output, "?") {
 		t.Error("footer must include '?' hint for spec overlay")
@@ -990,7 +990,7 @@ func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, true, "")
+	output := renderReviewPanel(sess, nil, 120, 40, 0, true)
 
 	if !strings.Contains(output, "Pushing branch and drafting PR") {
 		t.Error("in-flight state must show draft spinner line")
@@ -1003,10 +1003,10 @@ func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {
 	}
 }
 
-// TestRenderReviewPanel_InlineDiffPresent verifies that when a task group has a
-// non-empty rawDiff, the wide-mode review panel renders an inline diff showing
-// both the verdict label and a diff hunk header.
-func TestRenderReviewPanel_InlineDiffPresent(t *testing.T) {
+// TestRenderReviewPanel_TaskHasDiff verifies that when a task group has a
+// non-empty rawDiff, the stacked review panel shows the verdict label.
+// The diff itself is no longer shown inline — enter opens the full-screen viewer.
+func TestRenderReviewPanel_TaskHasDiff(t *testing.T) {
 	rawDiff := "diff --git a/internal/auth/handler.go b/internal/auth/handler.go\n" +
 		"index 1234567..abcdefg 100644\n" +
 		"--- a/internal/auth/handler.go\n" +
@@ -1035,22 +1035,21 @@ func TestRenderReviewPanel_InlineDiffPresent(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, "")
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false)
 
 	if !strings.Contains(output, "pass") {
 		t.Error("must contain verdict label 'pass'")
 	}
-	if !strings.Contains(output, "@@") {
-		t.Errorf("inline diff must contain hunk header '@@'; got:\n%s", output)
+	// Diff hunk header should NOT appear inline — the diff is accessed via enter.
+	if strings.Contains(output, "@@") {
+		t.Errorf("inline diff must NOT appear in stacked layout; got:\n%s", output)
 	}
 }
 
-// TestReviewPanel_CursorMoveSwapsDiff verifies that moving the cursor from task 1
-// to task 2 causes the inline diff area to render task 2's diff and not task 1's.
-func TestReviewPanel_CursorMoveSwapsDiff(t *testing.T) {
-	rawDiff1 := "diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,4 @@\n package main\n \n+// task-one-marker\n func A() {}\n"
-	rawDiff2 := "diff --git a/b.go b/b.go\nindex 1234567..abcdefg 100644\n--- a/b.go\n+++ b/b.go\n@@ -1,3 +1,4 @@\n package main\n \n+// task-two-marker\n func B() {}\n"
-
+// TestReviewPanel_CursorMoveSwapsDetail verifies that moving the cursor from task 1
+// to task 2 causes the detail pane to show task 2's heading and commits.
+// Diffs are no longer shown inline — they open via enter.
+func TestReviewPanel_CursorMoveSwapsDetail(t *testing.T) {
 	sess := agent.NewSessionForTest("sess-cursor", "fix-auth")
 	sess.SetOriginalPrompt("Fix auth")
 	sess.MarkDone()
@@ -1061,8 +1060,8 @@ func TestReviewPanel_CursorMoveSwapsDiff(t *testing.T) {
 			{Index: 2, Text: "Task two", Done: false},
 		},
 		groups: []taskReviewGroup{
-			{taskIndex: 1, commits: []git.Commit{{Hash: "aaa1111"}}, rawDiff: rawDiff1},
-			{taskIndex: 2, commits: []git.Commit{{Hash: "bbb2222"}}, rawDiff: rawDiff2},
+			{taskIndex: 1, commits: []git.Commit{{Hash: "aaa1111"}}, rawDiff: ""},
+			{taskIndex: 2, commits: []git.Commit{{Hash: "bbb2222"}}, rawDiff: ""},
 		},
 		verdicts: map[int]*taskVerdictRecord{
 			1: {state: verdictPending},
@@ -1070,22 +1069,22 @@ func TestReviewPanel_CursorMoveSwapsDiff(t *testing.T) {
 		},
 	}
 
-	// cursor=0 → task 1's diff
-	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false, "")
-	if !strings.Contains(out0, "task-one-marker") {
-		t.Errorf("cursor=0: expected task-one-marker in output; got:\n%s", out0)
+	// cursor=0 → task 1 heading in detail pane
+	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false)
+	if !strings.Contains(out0, "Task 1:") {
+		t.Errorf("cursor=0: expected 'Task 1:' in detail pane; got:\n%s", out0)
 	}
-	if strings.Contains(out0, "task-two-marker") {
-		t.Errorf("cursor=0: must not contain task-two-marker; got:\n%s", out0)
+	if strings.Contains(out0, "Task 2:") {
+		t.Errorf("cursor=0: must not contain 'Task 2:'; got:\n%s", out0)
 	}
 
-	// cursor=1 → task 2's diff
-	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false, "")
-	if !strings.Contains(out1, "task-two-marker") {
-		t.Errorf("cursor=1: expected task-two-marker in output; got:\n%s", out1)
+	// cursor=1 → task 2 heading in detail pane
+	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false)
+	if !strings.Contains(out1, "Task 2:") {
+		t.Errorf("cursor=1: expected 'Task 2:' in detail pane; got:\n%s", out1)
 	}
-	if strings.Contains(out1, "task-one-marker") {
-		t.Errorf("cursor=1: must not contain task-one-marker; got:\n%s", out1)
+	if strings.Contains(out1, "Task 1:") {
+		t.Errorf("cursor=1: must not contain 'Task 1:'; got:\n%s", out1)
 	}
 }
 
@@ -1201,7 +1200,7 @@ func TestRenderReviewPanel_FooterUsesThemeStyles(t *testing.T) {
 	sess.SetOriginalPrompt("Fix auth")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, "")
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false)
 
 	// StyleActive.Render("p") — carries ANSI codes in color mode, is "p" otherwise.
 	// In both cases the rendered footer must contain it.
@@ -1253,9 +1252,11 @@ func TestRenderTaskListPane_HeaderUsesHeadingColor(t *testing.T) {
 	}
 }
 
-// TestRenderReviewPanel_NoDiffPlaceholder verifies that when a task group has an
-// empty rawDiff, the inline diff area shows the "(no diff for this task)" placeholder.
-func TestRenderReviewPanel_NoDiffPlaceholder(t *testing.T) {
+// TestRenderReviewPanel_NoDiffTask verifies that when a task group has an
+// empty rawDiff, the panel renders without panic and shows the "no diff found"
+// verdict badge in the detail pane. There is no inline diff placeholder since
+// the diff pane has been removed.
+func TestRenderReviewPanel_NoDiffTask(t *testing.T) {
 	sess := agent.NewSessionForTest("sess-nodiff", "fix-auth")
 	sess.SetOriginalPrompt("Fix auth redirect")
 	sess.MarkDone()
@@ -1273,10 +1274,10 @@ func TestRenderReviewPanel_NoDiffPlaceholder(t *testing.T) {
 		},
 	}
 
-	// Must not panic and must show the placeholder.
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, "")
-	if !strings.Contains(output, "(no diff for this task)") {
-		t.Errorf("must show '(no diff for this task)' placeholder; got:\n%s", output)
+	// Must not panic and must show the "no diff found" verdict badge.
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false)
+	if !strings.Contains(output, "no diff found") {
+		t.Errorf("must show 'no diff found' verdict badge; got:\n%s", output)
 	}
 }
 

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -1310,6 +1310,26 @@ func TestRenderReviewPanel_ShowsTabBar(t *testing.T) {
 	}
 }
 
+// TestRenderReviewPlaceholderTab verifies that renderReviewPlaceholderTab
+// returns height lines and that the first line contains the label text.
+func TestRenderReviewPlaceholderTab(t *testing.T) {
+	label := "full diff browser coming soon"
+	lines := renderReviewPlaceholderTab(label, 80, 20)
+	if len(lines) != 20 {
+		t.Fatalf("expected 20 lines, got %d", len(lines))
+	}
+	stripped := ansi.Strip(lines[0])
+	if !strings.Contains(stripped, label) {
+		t.Errorf("first line must contain label %q; got: %q", label, stripped)
+	}
+	// Remaining lines are empty.
+	for i := 1; i < 20; i++ {
+		if lines[i] != "" {
+			t.Errorf("line %d: expected empty, got %q", i, lines[i])
+		}
+	}
+}
+
 // TestRenderReviewTabBar_HighlightsActiveTab verifies that renderReviewTabBar
 // returns 2 lines and contains all four tab labels in the first line.
 func TestRenderReviewTabBar_HighlightsActiveTab(t *testing.T) {

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -937,9 +937,10 @@ func TestRenderReviewHeader_NoGoalWhenNoPlan(t *testing.T) {
 	}
 }
 
-// TestRenderReviewPanel_HintsIncludeSpecAndScroll verifies that the footer hints
-// include ? (spec) and pgdn/pgup (scroll), and no longer show "view task diff".
-func TestRenderReviewPanel_HintsIncludeSpecAndScroll(t *testing.T) {
+// TestRenderReviewPanel_HintsIncludeSpecAndEnter verifies that the footer hints
+// include ? (spec) and enter (open task diff), and no longer show "view task diff"
+// or "pgdn/pgup" (the inline diff viewport was removed).
+func TestRenderReviewPanel_HintsIncludeSpecAndEnter(t *testing.T) {
 	sess := agent.NewSessionForTest("sess-hints", "fix-auth")
 	sess.SetOriginalPrompt("Fix auth")
 	sess.MarkDone()
@@ -955,15 +956,19 @@ func TestRenderReviewPanel_HintsIncludeSpecAndScroll(t *testing.T) {
 	}
 
 	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	stripped := ansi.Strip(output)
 
-	if !strings.Contains(output, "?") {
+	if !strings.Contains(stripped, "?") {
 		t.Error("footer must include '?' hint for spec overlay")
 	}
-	if !strings.Contains(output, "pgdn") {
-		t.Error("footer must include 'pgdn' hint for scroll")
+	if !strings.Contains(stripped, "enter") {
+		t.Error("footer must include 'enter' hint for opening task diff")
+	}
+	if strings.Contains(stripped, "pgdn") {
+		t.Error("footer must not include 'pgdn' hint (inline viewport removed)")
 	}
 	if strings.Contains(output, "view task diff") {
-		t.Error("footer must not include 'view task diff' hint (removed in favor of inline diff)")
+		t.Error("footer must not include 'view task diff' hint (removed in favor of full-screen diff viewer)")
 	}
 }
 

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -153,6 +153,28 @@ func (m *reviewPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel, t
 // handleKey is the per-key dispatch extracted from app.go's monolithic
 // Update. Spec overlay intercepts all keys while active.
 func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (PanelModel, tea.Cmd) {
+	// Tab-switching keys work even while spec overlay is open.
+	switch msg.String() {
+	case "1":
+		m.activeTab = reviewTabTasks
+		return m, nil
+	case "2":
+		m.activeTab = reviewTabDiff
+		return m, nil
+	case "3":
+		m.activeTab = reviewTabChecks
+		return m, nil
+	case "4":
+		m.activeTab = reviewTabValidate
+		return m, nil
+	case "tab":
+		m.activeTab = (m.activeTab + 1) % 4
+		return m, nil
+	case "shift+tab":
+		m.activeTab = (m.activeTab + 3) % 4
+		return m, nil
+	}
+
 	if m.specOverlay {
 		switch msg.String() {
 		case "esc":
@@ -218,15 +240,17 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		reviewOpenIDECmd(m.session, m.repoPath, svc)
 		return m, nil
 	case "j", "down":
-		if entry := svc.ReviewCache(m.repoPath, m.session.ID); entry != nil {
-			maxIdx := reviewTaskCount(entry) - 1
-			if m.taskCursor < maxIdx {
-				m.taskCursor++
+		if m.activeTab == reviewTabTasks {
+			if entry := svc.ReviewCache(m.repoPath, m.session.ID); entry != nil {
+				maxIdx := reviewTaskCount(entry) - 1
+				if m.taskCursor < maxIdx {
+					m.taskCursor++
+				}
 			}
 		}
 		return m, nil
 	case "k", "up":
-		if m.taskCursor > 0 {
+		if m.activeTab == reviewTabTasks && m.taskCursor > 0 {
 			m.taskCursor--
 		}
 		return m, nil

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -330,21 +330,18 @@ func (m *reviewPanelModel) handleClick(msg tea.MouseClickMsg, svc PanelServices)
 		return
 	}
 	entry := svc.ReviewCache(m.repoPath, m.session.ID)
-	if entry == nil || m.width < 80 {
+	if entry == nil {
 		return
 	}
 	headerH := len(renderReviewHeader(m.session, m.width))
-	leftW := m.width * 4 / 10
-	if leftW < 32 {
-		leftW = 32
-	}
-	paneTop := svc.DashboardTopY + headerH
-	rowIdx := reviewListPaneRowAt(entry, msg.X, msg.Y, paneTop, 0, leftW)
+	const tabBarH = 2
+	paneTop := svc.DashboardTopY + headerH + tabBarH
+	rowIdx := reviewListPaneRowAt(entry, msg.X, msg.Y, paneTop, 0, m.width-2)
 	if rowIdx < 0 {
 		return
 	}
 	footerLines := 3
-	bodyH := m.height - svc.DashboardTopY - headerH - footerLines
+	bodyH := m.height - svc.DashboardTopY - headerH - tabBarH - footerLines
 	if bodyH < 4 {
 		bodyH = 4
 	}

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -285,7 +286,32 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		return m, func() tea.Msg {
 			return reviewReworkRequestMsg{sessionID: sessID, repoPath: repoPath, prompt: prompt}
 		}
-	case "enter", "space":
+	case "enter":
+		if m.activeTab == reviewTabTasks {
+			entry := svc.ReviewCache(m.repoPath, m.session.ID)
+			group := reviewTaskGroupAtCursor(entry, m.taskCursor)
+			if group == nil || group.rawDiff == "" {
+				return m, nil
+			}
+			// Build "[N] task text" label using same row order as the list pane.
+			label := "Other changes"
+			if entry != nil {
+				row := 0
+				for _, t := range entry.tasks {
+					if row == m.taskCursor {
+						label = fmt.Sprintf("[%d] %s", t.Index, t.Text)
+						break
+					}
+					row++
+				}
+			}
+			rawDiff := group.rawDiff
+			return m, func() tea.Msg {
+				return reviewOpenTaskDiffMsg{rawDiff: rawDiff, taskLabel: label}
+			}
+		}
+		return m, nil
+	case "space":
 		return m, nil
 	case "?":
 		if m.session.HasPlan() {

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -328,5 +328,5 @@ func (m *reviewPanelModel) View(svc PanelServices) string {
 	}
 	entry := svc.ReviewCache(m.repoPath, m.session.ID)
 	prDraftInFlight := svc.prDraftInFlightFor(m.session.ID, m.repoPath)
-	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight)
+	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.activeTab)
 }

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -9,14 +9,22 @@ import (
 	"github.com/devenjarvis/refrain/internal/agent"
 )
 
+const (
+	reviewTabTasks    = 0
+	reviewTabDiff     = 1
+	reviewTabChecks   = 2
+	reviewTabValidate = 3
+)
+
 // reviewPanelModel owns the keyboard, mouse, and view dispatch for the review
-// panel. Per-panel state (cursor, spec overlay toggle) lives here;
+// panel. Per-panel state (cursor, active tab, spec overlay toggle) lives here;
 // cross-panel state (the reviewDiffCache keyed by session ID) stays on App
 // because its lifetime exceeds a single panel session.
 type reviewPanelModel struct {
 	session           *agent.Session
 	repoPath          string
 	taskCursor        int
+	activeTab         int
 	specOverlay       bool
 	specOverlayScroll int
 

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -4,23 +4,19 @@ import (
 	"os/exec"
 	"strings"
 
-	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/devenjarvis/refrain/internal/agent"
-	"github.com/devenjarvis/refrain/internal/diffmodel"
 )
 
 // reviewPanelModel owns the keyboard, mouse, and view dispatch for the review
-// panel. Per-panel state (cursor, viewport scroll, spec overlay toggle) lives
-// here; cross-panel state (the reviewDiffCache keyed by session ID) stays on
-// App because its lifetime exceeds a single panel session.
+// panel. Per-panel state (cursor, spec overlay toggle) lives here;
+// cross-panel state (the reviewDiffCache keyed by session ID) stays on App
+// because its lifetime exceeds a single panel session.
 type reviewPanelModel struct {
 	session           *agent.Session
 	repoPath          string
 	taskCursor        int
-	diffVP            viewport.Model
-	diffCacheByTask   map[int]*diffmodel.Model
 	specOverlay       bool
 	specOverlayScroll int
 
@@ -30,16 +26,12 @@ type reviewPanelModel struct {
 // newReviewPanel constructs a review panel for sess at the given size.
 // repoPath pins which repo's manager is used for all key handlers — it must
 // match the repo the session belongs to so multi-repo ID collisions are safe.
-// The diff viewport is fresh; the caller should invoke RefreshDiffViewport
-// after the reviewDiffCache entry lands.
 func newReviewPanel(sess *agent.Session, repoPath string, width, height int) *reviewPanelModel {
 	return &reviewPanelModel{
-		session:         sess,
-		repoPath:        repoPath,
-		diffVP:          viewport.New(),
-		diffCacheByTask: make(map[int]*diffmodel.Model),
-		width:           width,
-		height:          height,
+		session:  sess,
+		repoPath: repoPath,
+		width:    width,
+		height:   height,
 	}
 }
 
@@ -70,65 +62,13 @@ func (m *reviewPanelModel) TaskCursor() int {
 	return m.taskCursor
 }
 
-// Resize updates cached layout dimensions; callers should follow with
-// RefreshDiffViewport so the inner viewport reflects the new size.
+// Resize updates cached layout dimensions.
 func (m *reviewPanelModel) Resize(w, h int) {
 	if m == nil {
 		return
 	}
 	m.width = w
 	m.height = h
-}
-
-// RefreshDiffViewport recomputes the inline diff viewport for the current
-// task. Call this whenever the task cursor moves or the cache entry changes.
-func (m *reviewPanelModel) RefreshDiffViewport(svc PanelServices) {
-	if m == nil || m.session == nil {
-		return
-	}
-	headerLines := len(renderReviewHeader(m.session, m.width))
-	footerH := 3
-	bodyH := m.height - headerLines - footerH
-	if bodyH < 4 {
-		bodyH = 4
-	}
-	maxSummaryH := bodyH / 3
-	if maxSummaryH < 4 {
-		maxSummaryH = 4
-	}
-	diffH := bodyH - maxSummaryH - 1
-	if diffH < 1 {
-		diffH = 1
-	}
-	rightW := m.width*6/10 - 5
-	if rightW < 20 {
-		rightW = 20
-	}
-	m.diffVP.SetHeight(diffH)
-	m.diffVP.SetWidth(rightW)
-	m.diffVP.GotoTop()
-	entry := svc.ReviewCache(m.repoPath, m.session.ID)
-	if entry == nil {
-		m.diffVP.SetContent("")
-		return
-	}
-	group := reviewTaskGroupAtCursor(entry, m.taskCursor)
-	if group == nil || group.rawDiff == "" {
-		m.diffVP.SetContent("(no diff for this task)")
-		return
-	}
-	idx := m.taskCursor
-	mdl, ok := m.diffCacheByTask[idx]
-	if !ok {
-		var err error
-		mdl, err = diffmodel.Parse(group.rawDiff)
-		if err != nil || mdl == nil {
-			m.diffVP.SetContent("(no diff for this task)")
-			return
-		}
-		m.diffCacheByTask[idx] = mdl
-	}
-	m.diffVP.SetContent(renderAllFilesUnified(mdl, rightW))
 }
 
 // closeReviewPanel invokes svc.ClosePanel(), which clears App's reviewPanel
@@ -192,7 +132,6 @@ func (m *reviewPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel, t
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.Resize(msg.Width, msg.Height-1)
-		m.RefreshDiffViewport(svc)
 		return m, nil
 	case tea.KeyPressMsg:
 		return m.handleKey(msg, svc)
@@ -275,14 +214,12 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 			maxIdx := reviewTaskCount(entry) - 1
 			if m.taskCursor < maxIdx {
 				m.taskCursor++
-				m.RefreshDiffViewport(svc)
 			}
 		}
 		return m, nil
 	case "k", "up":
 		if m.taskCursor > 0 {
 			m.taskCursor--
-			m.RefreshDiffViewport(svc)
 		}
 		return m, nil
 	case "f":
@@ -318,18 +255,6 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		}
 	case "enter", "space":
 		return m, nil
-	case "pgdown":
-		m.diffVP.PageDown()
-	case "pgup":
-		m.diffVP.PageUp()
-	case "ctrl+d":
-		m.diffVP.HalfPageDown()
-	case "ctrl+u":
-		m.diffVP.HalfPageUp()
-	case "g":
-		m.diffVP.GotoTop()
-	case "G":
-		m.diffVP.GotoBottom()
 	case "?":
 		if m.session.HasPlan() {
 			m.specOverlay = true
@@ -382,7 +307,6 @@ func (m *reviewPanelModel) handleClick(msg tea.MouseClickMsg, svc PanelServices)
 		}
 	}
 	m.taskCursor = offset + rowIdx
-	m.RefreshDiffViewport(svc)
 }
 
 // View renders the review panel — either the spec overlay or the main panel.
@@ -396,5 +320,5 @@ func (m *reviewPanelModel) View(svc PanelServices) string {
 	}
 	entry := svc.ReviewCache(m.repoPath, m.session.ID)
 	prDraftInFlight := svc.prDraftInFlightFor(m.session.ID, m.repoPath)
-	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.diffVP.View())
+	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight)
 }

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -447,6 +447,46 @@ func TestReviewPanelModel_SpaceIsNoOp(t *testing.T) {
 	}
 }
 
+// TestReviewPanelModel_ClickWithTabBarOffset verifies that a mouse click on the
+// task list pane accounts for the 2-line tab bar inserted between the header
+// and the pane body. Without the +2 offset the click lands 2 rows too high,
+// causing the cursor to land on the wrong task or be ignored as out-of-bounds.
+func TestReviewPanelModel_ClickWithTabBarOffset(t *testing.T) {
+	sess := agent.NewSessionForTest("s1", "fix-auth")
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+	// Panel width 120; DashboardTopY defaults to 0 in newTestSvc.
+	// renderReviewHeader returns 3 lines for this session (title+prompt+divider) → headerH=3.
+	// Tab bar adds 2 lines → paneTop should be 5.
+	// listHeaderLines=2 → first task row at Y=7.
+	panel := newReviewPanel(sess, "", 120, 40)
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{
+			{Index: 1, Text: "task one"},
+			{Index: 2, Text: "task two"},
+		},
+		verdicts: map[int]*taskVerdictRecord{
+			1: {state: verdictPending},
+			2: {state: verdictPending},
+		},
+	}
+	svc, _ := newTestSvc()
+	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
+
+	// Move cursor to row 1 first so we can verify the click brings it back to 0.
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	if panel.TaskCursor() != 1 {
+		t.Fatalf("precondition: cursor should be 1 after j, got %d", panel.TaskCursor())
+	}
+
+	// Click at the first task row: Y=7 (headerH=3 + tabBarH=2 + listHeaderLines=2).
+	click := tea.MouseClickMsg{Button: tea.MouseLeft, X: 30, Y: 7}
+	_, _ = panel.Update(click, svc)
+
+	if panel.TaskCursor() != 0 {
+		t.Errorf("click at Y=7 should move cursor to row 0, got %d (tab bar offset missing?)", panel.TaskCursor())
+	}
+}
+
 func TestReviewPanelModel_FormerScrollKeys_AreNoOp(t *testing.T) {
 	// pgdown / pgup / ctrl+d / ctrl+u are now unbound no-ops (the inline
 	// viewport was removed). g / G are still unbound. None may change the

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -68,6 +68,54 @@ type testServiceState struct {
 	killSessionCalled  bool
 }
 
+// TestReviewPanelModel_TabSwitching verifies 1–4 and tab/shift+tab change activeTab.
+func TestReviewPanelModel_TabSwitching(t *testing.T) {
+	sess := agent.NewSessionForTest("s1", "fix-auth")
+	panel := newReviewPanel(sess, "", 120, 40)
+	svc, _ := newTestSvc()
+
+	press := func(msg tea.KeyPressMsg) {
+		t.Helper()
+		_, _ = panel.Update(msg, svc)
+	}
+
+	// Numeric keys jump directly.
+	press(keyRune('2'))
+	if panel.activeTab != reviewTabDiff {
+		t.Errorf("'2': activeTab=%d, want %d (Diff)", panel.activeTab, reviewTabDiff)
+	}
+	press(keyRune('3'))
+	if panel.activeTab != reviewTabChecks {
+		t.Errorf("'3': activeTab=%d, want %d (Checks)", panel.activeTab, reviewTabChecks)
+	}
+	press(keyRune('4'))
+	if panel.activeTab != reviewTabValidate {
+		t.Errorf("'4': activeTab=%d, want %d (Validate)", panel.activeTab, reviewTabValidate)
+	}
+	press(keyRune('1'))
+	if panel.activeTab != reviewTabTasks {
+		t.Errorf("'1': activeTab=%d, want %d (Tasks)", panel.activeTab, reviewTabTasks)
+	}
+
+	// tab increments with wrap.
+	press(keyNamed(tea.KeyTab))
+	if panel.activeTab != reviewTabDiff {
+		t.Errorf("tab: activeTab=%d, want %d (Diff)", panel.activeTab, reviewTabDiff)
+	}
+	press(keyNamed(tea.KeyTab))
+	press(keyNamed(tea.KeyTab))
+	press(keyNamed(tea.KeyTab)) // wraps from Validate back to Tasks
+	if panel.activeTab != reviewTabTasks {
+		t.Errorf("tab wrap: activeTab=%d, want %d (Tasks)", panel.activeTab, reviewTabTasks)
+	}
+
+	// shift+tab decrements with wrap.
+	press(keyShiftNamed(tea.KeyTab))
+	if panel.activeTab != reviewTabValidate {
+		t.Errorf("shift+tab: activeTab=%d, want %d (Validate)", panel.activeTab, reviewTabValidate)
+	}
+}
+
 // TestReviewPanelModel_DefaultTab confirms that newReviewPanel initialises
 // activeTab to 0 (Tasks tab). Zero-value initialisation covers this, but the
 // test pins the contract so a future refactor can't silently break it.

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -418,8 +418,8 @@ func TestReviewPanelModel_EnterNoopOnEmptyDiff(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
 	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
-		tasks: []agent.PlanTask{{Index: 1, Text: "task one"}},
-		groups: []taskReviewGroup{{taskIndex: 1, rawDiff: ""}},
+		tasks:    []agent.PlanTask{{Index: 1, Text: "task one"}},
+		groups:   []taskReviewGroup{{taskIndex: 1, rawDiff: ""}},
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 	svc, _ := newTestSvc()

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -65,6 +66,27 @@ type testServiceState struct {
 	openInLaunchCalled bool
 	openInLaunchResult bool
 	killSessionCalled  bool
+}
+
+// TestReviewPanelModel_NoDiffViewport confirms that reviewPanelModel has no
+// diffVP or diffCacheByTask fields and no RefreshDiffViewport method — the
+// inline viewport was removed in favour of full-screen drill-in via enter.
+func TestReviewPanelModel_NoDiffViewport(t *testing.T) {
+	var m reviewPanelModel
+	v := reflect.TypeOf(m)
+	if _, found := v.FieldByName("diffVP"); found {
+		t.Error("reviewPanelModel must not have a diffVP field")
+	}
+	if _, found := v.FieldByName("diffCacheByTask"); found {
+		t.Error("reviewPanelModel must not have a diffCacheByTask field")
+	}
+	panel := newReviewPanel(nil, "", 80, 40)
+	type refresher interface {
+		RefreshDiffViewport(PanelServices)
+	}
+	if _, ok := any(panel).(refresher); ok {
+		t.Error("reviewPanelModel must not implement RefreshDiffViewport")
+	}
 }
 
 // TestReviewPanelModel_EscCloses verifies that pressing esc invokes
@@ -318,9 +340,10 @@ func TestReviewPanelModel_EnterAndSpace_AreNoOp(t *testing.T) {
 	}
 }
 
-func TestReviewPanelModel_DiffScrollKeys_DoNotChangeCursorOrClose(t *testing.T) {
-	// pgdown / pgup / ctrl+d / ctrl+u / g / G all act on the diff viewport.
-	// The taskCursor must stay put and the panel must stay open.
+func TestReviewPanelModel_FormerScrollKeys_AreNoOp(t *testing.T) {
+	// pgdown / pgup / ctrl+d / ctrl+u are now unbound no-ops (the inline
+	// viewport was removed). g / G are still unbound. None may change the
+	// cursor or close the panel.
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
 	panel := newReviewPanel(sess, "", 120, 40)
@@ -337,14 +360,14 @@ func TestReviewPanelModel_DiffScrollKeys_DoNotChangeCursorOrClose(t *testing.T) 
 	for _, k := range keys {
 		_, cmd := panel.Update(k, svc)
 		if cmd != nil {
-			t.Errorf("scroll key %v produced cmd %T, want nil", k, cmd())
+			t.Errorf("formerly-scroll key %v produced cmd %T, want nil", k, cmd())
 		}
 	}
 	if panel.TaskCursor() != 0 {
-		t.Errorf("taskCursor = %d after diff scrolls, want 0", panel.TaskCursor())
+		t.Errorf("taskCursor = %d after keys, want 0", panel.TaskCursor())
 	}
 	if state.closed {
-		t.Error("diff scroll keys must not close the panel")
+		t.Error("these keys must not close the panel")
 	}
 }
 

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -372,29 +372,78 @@ func TestReviewPanelModel_BKey_WithFlag_EmitsReworkMsg(t *testing.T) {
 	}
 }
 
-func TestReviewPanelModel_EnterAndSpace_AreNoOp(t *testing.T) {
-	// Pinned: reviewpanelmodel.go:315 has an explicit `case "enter", "space"`
-	// that returns nil. A future refactor that "uses" these keys should be
-	// noticed.
+// TestReviewPanelModel_EnterEmitsDiffMsg verifies that pressing enter on a task
+// with a non-empty rawDiff returns a cmd that produces reviewOpenTaskDiffMsg.
+func TestReviewPanelModel_EnterEmitsDiffMsg(t *testing.T) {
+	sess := agent.NewSessionForTest("s1", "fix-auth")
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+	panel := newReviewPanel(sess, "", 120, 40)
+	rawDiff := "diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,4 @@\n package main\n \n+// marker\n func A() {}\n"
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 3, Text: "Add tab-switching keys"}},
+		groups: []taskReviewGroup{{
+			taskIndex: 3,
+			rawDiff:   rawDiff,
+		}},
+		verdicts: map[int]*taskVerdictRecord{3: {state: verdictPending}},
+	}
+	svc, state := newTestSvc()
+	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
+
+	_, cmd := panel.Update(keyNamed(tea.KeyEnter), svc)
+
+	if cmd == nil {
+		t.Fatal("enter on task with rawDiff must return a cmd")
+	}
+	msgs := runCmdAll(t, cmd)
+	diffMsg, found := findMsg[reviewOpenTaskDiffMsg](msgs)
+	if !found {
+		t.Fatalf("expected reviewOpenTaskDiffMsg in cmd output; got: %v", msgs)
+	}
+	if diffMsg.rawDiff != rawDiff {
+		t.Errorf("rawDiff mismatch: got %q, want %q", diffMsg.rawDiff, rawDiff)
+	}
+	if diffMsg.taskLabel != "[3] Add tab-switching keys" {
+		t.Errorf("taskLabel = %q, want %q", diffMsg.taskLabel, "[3] Add tab-switching keys")
+	}
+	if state.closed {
+		t.Error("enter must not close the review panel")
+	}
+}
+
+// TestReviewPanelModel_EnterNoopOnEmptyDiff verifies that enter on a task with
+// no rawDiff produces no command.
+func TestReviewPanelModel_EnterNoopOnEmptyDiff(t *testing.T) {
+	sess := agent.NewSessionForTest("s1", "fix-auth")
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+	panel := newReviewPanel(sess, "", 120, 40)
+	entry := &reviewDiffEntry{
+		tasks: []agent.PlanTask{{Index: 1, Text: "task one"}},
+		groups: []taskReviewGroup{{taskIndex: 1, rawDiff: ""}},
+		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
+	}
+	svc, _ := newTestSvc()
+	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
+
+	_, cmd := panel.Update(keyNamed(tea.KeyEnter), svc)
+	if cmd != nil {
+		t.Errorf("enter on task with no rawDiff must be a no-op, got cmd %T", cmd())
+	}
+}
+
+// TestReviewPanelModel_SpaceIsNoOp verifies that space still produces no cmd.
+func TestReviewPanelModel_SpaceIsNoOp(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
 	panel := newReviewPanel(sess, "", 120, 40)
 	svc, state := newTestSvc()
 
-	for _, k := range []tea.KeyPressMsg{
-		{Code: tea.KeyEnter},
-		{Code: ' ', Text: " "},
-	} {
-		_, cmd := panel.Update(k, svc)
-		if cmd != nil {
-			t.Errorf("%v should be a no-op, got cmd %T", k, cmd())
-		}
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: ' ', Text: " "}, svc)
+	if cmd != nil {
+		t.Errorf("space should be a no-op, got cmd %T", cmd())
 	}
 	if state.closed {
-		t.Error("enter/space must not close the panel")
-	}
-	if sess.LifecyclePhase() != agent.LifecycleInReview {
-		t.Errorf("enter/space changed phase to %v", sess.LifecyclePhase())
+		t.Error("space must not close the panel")
 	}
 }
 

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -68,6 +68,16 @@ type testServiceState struct {
 	killSessionCalled  bool
 }
 
+// TestReviewPanelModel_DefaultTab confirms that newReviewPanel initialises
+// activeTab to 0 (Tasks tab). Zero-value initialisation covers this, but the
+// test pins the contract so a future refactor can't silently break it.
+func TestReviewPanelModel_DefaultTab(t *testing.T) {
+	panel := newReviewPanel(nil, "", 80, 40)
+	if panel.activeTab != 0 {
+		t.Errorf("activeTab = %d, want 0 (Tasks)", panel.activeTab)
+	}
+}
+
 // TestReviewPanelModel_NoDiffViewport confirms that reviewPanelModel has no
 // diffVP or diffCacheByTask fields and no RefreshDiffViewport method — the
 // inline viewport was removed in favour of full-screen drill-in via enter.

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -1173,7 +1173,6 @@ func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
 	if _, ok := a.reviewDiffCache[cacheKey(item.repoPath, sess.ID)]; !ok {
 		return a, a.fetchReviewDiffCmd(sess, item.repoPath), true
 	}
-	a.modals.Review().RefreshDiffViewport(a.panelServices())
 	return a, nil, true
 }
 

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -21,10 +21,6 @@ func (a App) handleReviewDiff(msg reviewDiffMsg) (tea.Model, tea.Cmd) {
 			repoPath = a.activeRepo
 		}
 		a.reviewDiffCache[cacheKey(repoPath, msg.sessionID)] = msg.entry
-		// Refresh the inline diff viewport when data arrives for the open session.
-		if rp := a.modals.Review(); rp != nil && rp.SessionID() == msg.sessionID && len(msg.entry.groups) > 0 {
-			rp.RefreshDiffViewport(a.panelServices())
-		}
 		// If the entry has task groups, dispatch a reviewer per group.
 		if len(msg.entry.groups) > 0 {
 			var cmds []tea.Cmd

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -10,6 +10,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/diffmodel"
 	"github.com/devenjarvis/refrain/internal/git"
 	"github.com/devenjarvis/refrain/internal/github"
 )
@@ -673,6 +674,24 @@ func (a App) reviewTaskCmd(sess *agent.Session, repoPath string, group taskRevie
 		})
 		return reviewVerdictMsg{sessionID: sessID, repoPath: repoPath, taskIndex: taskIndex, verdict: verdict, err: err}
 	}
+}
+
+// handleReviewOpenTaskDiff handles reviewOpenTaskDiffMsg by parsing the task's
+// raw diff and opening the full-screen diff viewer scoped to that task. The
+// review modal is preserved — diffCloseMsg returns to ViewDashboard where the
+// modal is still open.
+func (a App) handleReviewOpenTaskDiff(msg reviewOpenTaskDiffMsg) (tea.Model, tea.Cmd) {
+	if msg.rawDiff == "" {
+		return a, nil
+	}
+	m, err := diffmodel.Parse(msg.rawDiff)
+	if err != nil || m == nil {
+		a.setError("could not parse task diff")
+		return a, nil
+	}
+	a.view = ViewDiff
+	a.diff = newDiffModel(msg.taskLabel, m, a.width, a.height-1)
+	return a, nil
 }
 
 // ensureGitignore adds .refrain/ to .gitignore in the given path if not already present.


### PR DESCRIPTION
## Summary

- Redesigned review panel layout from side-by-side to full-width vertical stack for improved diff visibility and readability
- Added tab bar with Diff and Tasks views, replacing inline viewport
- Implemented full-screen diff viewer accessible via enter key on task rows (scoped to task's rawDiff)
- Enhanced placeholder rendering with horizontal centering for future feature expansion
- Improved keyboard navigation with tab-switching keys and drill-in behavior
- Fixed mouse click offset calculations to account for 2-line tab bar position
- Removed inline diff viewport and associated dead code

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI:
  - Open review panel and verify full-width vertical stack layout
  - Confirm Diff tab shows placeholder; Tasks tab shows task list
  - Press enter on a task row to open full-screen diff viewer with task label
  - Verify esc from diff viewer returns to review panel
  - Test tab-switching keyboard navigation
  - Verify footer hints show "enter — open task diff" instead of pgdn/pgup

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (tab rendering, placeholder rendering, layout assertions, keyboard navigation, modal integration)
- [x] No new public API surface