### PR TITLE
Consolidate plan and PR draft editors into reusable component

### DIFF
--- a/internal/tui/doceditor.go
+++ b/internal/tui/doceditor.go
@@ -1,0 +1,203 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/devenjarvis/refrain/internal/tui/mdrender"
+	"github.com/devenjarvis/refrain/internal/tui/mdtextarea"
+)
+
+// docEditorChromaStyle is the chroma style used by the markdown renderer.
+// Hardcoded for now — a follow-up will plumb this through config.Settings.
+const docEditorChromaStyle = "monokai"
+
+// docEditorMaxMeasure is the maximum content column width for plan/PR text.
+// On wider terminals the content is centered with equal left/right margins.
+const docEditorMaxMeasure = 72
+
+// docEditor is the shared display/edit component used by planEditorModel
+// and prComposeModal. It owns the textarea, markdown renderer, scroll
+// offset, and dimensional fields that both views formerly duplicated.
+type docEditor struct {
+	textarea  mdtextarea.Model
+	renderer  *mdrender.Renderer
+	scrollOff int
+	width     int
+	height    int
+}
+
+// newDocEditor constructs a docEditor sized to w×h.
+func newDocEditor(width, height int) docEditor {
+	r := mdrender.New(docEditorChromaStyle)
+	ta := mdtextarea.New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.SetMarkdownRenderer(r)
+	d := docEditor{
+		renderer: r,
+		width:    width,
+		height:   height,
+	}
+	ta.SetWidth(d.ContentWidth())
+	ta.SetHeight(textareaHeight(height))
+	d.textarea = ta
+	return d
+}
+
+// ContentWidth returns the effective column width for wrap and styling.
+// Capped at docEditorMaxMeasure so wide terminals produce comfortable margins.
+func (d *docEditor) ContentWidth() int {
+	measure, _ := mdrender.ContentMeasure(textareaWidth(d.width), docEditorMaxMeasure)
+	return measure
+}
+
+// DisplayLeftPad returns the left-margin padding to center content on wide terminals.
+func (d *docEditor) DisplayLeftPad() int {
+	_, pad := mdrender.ContentMeasure(textareaWidth(d.width), docEditorMaxMeasure)
+	return pad
+}
+
+// CenteredBlock prepends DisplayLeftPad() spaces to each line of s, matching
+// scroll-mode centering.
+func (d *docEditor) CenteredBlock(s string) string {
+	pad := d.DisplayLeftPad()
+	if pad == 0 {
+		return s
+	}
+	prefix := strings.Repeat(" ", pad)
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = prefix + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+// BodyHeight returns the number of lines available for content given the
+// fixed overhead rows (header, dividers, footer, etc.) for the calling view.
+func (d *docEditor) BodyHeight(overhead int) int {
+	h := d.height - overhead
+	if h < 1 {
+		return 1
+	}
+	return h
+}
+
+// ClampScroll adjusts d.scrollOff to [0, totalLines].
+func (d *docEditor) ClampScroll(totalLines int) {
+	if d.scrollOff > totalLines {
+		d.scrollOff = totalLines
+	}
+	if d.scrollOff < 0 {
+		d.scrollOff = 0
+	}
+}
+
+// ScrollWindow extracts a viewport window from lines using d.scrollOff and bodyH.
+// The local-start clamping ensures the last page fills the viewport without
+// mutating d.scrollOff, keeping the render path pure.
+func (d *docEditor) ScrollWindow(lines []string, bodyH int) string {
+	start := d.scrollOff
+	if start > len(lines)-bodyH {
+		start = len(lines) - bodyH
+	}
+	if start < 0 {
+		start = 0
+	}
+	end := start + bodyH
+	if end > len(lines) {
+		end = len(lines)
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+
+// RenderLines renders the current value into styled display lines.
+func (d *docEditor) RenderLines() []string {
+	return d.renderer.RenderLines(d.Value(), d.ContentWidth())
+}
+
+// StyledScrollLines wraps and styles a source line for scroll-mode display,
+// applying fence-block bar prefixes that are omitted in edit mode to keep
+// mdtextarea cursor-splice math unaffected.
+func (d *docEditor) StyledScrollLines(src string, ctx mdrender.LineCtx, width int) []string {
+	isFenceLine := ctx.Kind == mdrender.LineFenceContent || ctx.Kind == mdrender.LineFenceOpen || ctx.Kind == mdrender.LineFenceClose
+	lineWidth := width
+	if isFenceLine && width > 2 {
+		lineWidth = width - 2
+	}
+	lines := d.renderer.StyleLine(src, ctx, lineWidth)
+	if isFenceLine {
+		bar := StyleSubtle.Render("│") + " "
+		for i, l := range lines {
+			lines[i] = bar + l
+		}
+	}
+	return lines
+}
+
+// SetSize updates the editor dimensions and resizes the textarea.
+func (d *docEditor) SetSize(w, h int) {
+	d.width = w
+	d.height = h
+	d.textarea.SetWidth(d.ContentWidth())
+	d.textarea.SetHeight(textareaHeight(h))
+}
+
+// Focus focuses the textarea.
+func (d *docEditor) Focus() tea.Cmd {
+	return d.textarea.Focus()
+}
+
+// Blur unfocuses the textarea.
+func (d *docEditor) Blur() {
+	d.textarea.Blur()
+}
+
+// Value returns the current textarea content.
+func (d *docEditor) Value() string {
+	return d.textarea.Value()
+}
+
+// SetValue sets the textarea content.
+func (d *docEditor) SetValue(s string) {
+	d.textarea.SetValue(s)
+}
+
+// Focused reports whether the textarea is focused.
+func (d *docEditor) Focused() bool {
+	return d.textarea.Focused()
+}
+
+// UpdateTextarea forwards a message to the textarea and returns the resulting cmd.
+func (d *docEditor) UpdateTextarea(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
+	d.textarea, cmd = d.textarea.Update(msg)
+	return cmd
+}
+
+// textareaWidth/textareaHeight reserve space for the header, divider, status,
+// and footer when sizing the embedded textarea.
+func textareaWidth(w int) int {
+	if w < 8 {
+		return 8
+	}
+	return w - 2
+}
+
+func textareaHeight(h int) int {
+	if h < 6 {
+		return 1
+	}
+	return h - 5
+}
+
+func fmtSeconds(s int) string {
+	if s < 0 {
+		s = 0
+	}
+	if s < 60 {
+		return strconv.Itoa(s) + "s"
+	}
+	return strconv.Itoa(s/60) + "m" + strconv.Itoa(s%60) + "s"
+}

--- a/internal/tui/doceditor_test.go
+++ b/internal/tui/doceditor_test.go
@@ -1,0 +1,118 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/devenjarvis/refrain/internal/tui/mdrender/testutil"
+	"github.com/muesli/termenv"
+)
+
+func TestDocEditor_ContentWidth(t *testing.T) {
+	tests := []struct {
+		width       int
+		wantMeasure int
+	}{
+		// textareaWidth(60)=58 < docEditorMaxMeasure(72) → full width
+		{60, 58},
+		// textareaWidth(80)=78 > 72 → capped at 72
+		{80, 72},
+		// textareaWidth(120)=118 > 72 → capped at 72
+		{120, 72},
+	}
+	for _, tc := range tests {
+		d := newDocEditor(tc.width, 24)
+		if got := d.ContentWidth(); got != tc.wantMeasure {
+			t.Errorf("width=%d: ContentWidth()=%d, want %d", tc.width, got, tc.wantMeasure)
+		}
+	}
+}
+
+func TestDocEditor_DisplayLeftPad(t *testing.T) {
+	tests := []struct {
+		width   int
+		wantPad int
+	}{
+		// textareaWidth(60)=58: 58 <= 72, no centering
+		{60, 0},
+		// textareaWidth(80)=78: (78-72)/2 = 3
+		{80, 3},
+		// textareaWidth(120)=118: (118-72)/2 = 23
+		{120, 23},
+	}
+	for _, tc := range tests {
+		d := newDocEditor(tc.width, 24)
+		if got := d.DisplayLeftPad(); got != tc.wantPad {
+			t.Errorf("width=%d: DisplayLeftPad()=%d, want %d", tc.width, got, tc.wantPad)
+		}
+	}
+}
+
+func TestDocEditor_ClampScroll(t *testing.T) {
+	tests := []struct {
+		name       string
+		totalLines int
+		initial    int
+		want       int
+	}{
+		{"past end", 100, 200, 100},
+		{"negative", 100, -5, 0},
+		{"in range", 100, 50, 50},
+		{"at end", 100, 100, 100},
+		{"zero total", 0, 5, 0},
+	}
+	for _, tc := range tests {
+		d := newDocEditor(80, 24)
+		d.scrollOff = tc.initial
+		d.ClampScroll(tc.totalLines)
+		if d.scrollOff != tc.want {
+			t.Errorf("%s: scrollOff=%d, want %d", tc.name, d.scrollOff, tc.want)
+		}
+	}
+}
+
+func TestDocEditor_ScrollWindow(t *testing.T) {
+	lines := []string{"a", "b", "c", "d", "e"}
+	tests := []struct {
+		name      string
+		scrollOff int
+		bodyH     int
+		want      string
+	}{
+		// scrollOff=0, bodyH=3 → lines[0:3]
+		{"from start", 0, 3, "a\nb\nc"},
+		// scrollOff=2, bodyH=2 → lines[2:4]
+		{"mid scroll", 2, 2, "c\nd"},
+		// scrollOff=3, bodyH=3, len=5 → start=max(0,5-3)=2 → lines[2:5]
+		{"clamp at end", 3, 3, "c\nd\ne"},
+		// scrollOff=10, bodyH=3, len=5 → start=max(0,5-3)=2 → lines[2:5]
+		{"overflow scroll", 10, 3, "c\nd\ne"},
+		// full view
+		{"full view", 0, 5, "a\nb\nc\nd\ne"},
+	}
+	for _, tc := range tests {
+		d := newDocEditor(80, 24)
+		d.scrollOff = tc.scrollOff
+		if got := d.ScrollWindow(lines, tc.bodyH); got != tc.want {
+			t.Errorf("%s: ScrollWindow=%q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestDocEditor_RenderLines_NonEmpty(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	d := newDocEditor(80, 24)
+	d.SetValue("# Hello\n\nSome content here\n")
+	lines := d.RenderLines()
+	if len(lines) == 0 {
+		t.Fatal("RenderLines returned no lines")
+	}
+	stripped := testutil.StripANSI(strings.Join(lines, "\n"))
+	if !strings.Contains(stripped, "Hello") {
+		t.Errorf("RenderLines output did not contain 'Hello':\n%s", stripped)
+	}
+	if !strings.Contains(stripped, "Some content here") {
+		t.Errorf("RenderLines output did not contain body text:\n%s", stripped)
+	}
+}

--- a/internal/tui/doceditor_test.go
+++ b/internal/tui/doceditor_test.go
@@ -101,7 +101,9 @@ func TestDocEditor_ScrollWindow(t *testing.T) {
 }
 
 func TestDocEditor_RenderLines_NonEmpty(t *testing.T) {
+	prev := lipgloss.ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
 	d := newDocEditor(80, 24)
 	d.SetValue("# Hello\n\nSome content here\n")
 	lines := d.RenderLines()

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -88,11 +88,11 @@ type planEditorModel struct {
 
 	doc docEditor // shared textarea, renderer, dimensions, scrollOff
 
-	mode    planEditorMode
-	plan    string // last-loaded plan content; used in scroll mode
-	dirty   bool   // textarea has unsaved edits relative to file
-	saveNote  string // transient confirmation ("saved") or error
-	saveAt    time.Time
+	mode     planEditorMode
+	plan     string // last-loaded plan content; used in scroll mode
+	dirty    bool   // textarea has unsaved edits relative to file
+	saveNote string // transient confirmation ("saved") or error
+	saveAt   time.Time
 
 	reviseInput textinput.Model
 	drafting    bool // session is currently in LifecycleDrafting; show placeholder
@@ -1053,4 +1053,3 @@ func (m *planEditorModel) renderQuestionBody() string {
 	b.WriteString(StyleActive.Render("answer:") + " " + m.questionInput.View())
 	return b.String()
 }
-

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"crypto/sha256"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -15,14 +14,6 @@ import (
 	"github.com/devenjarvis/refrain/internal/tui/mdrender"
 	"github.com/devenjarvis/refrain/internal/tui/mdtextarea"
 )
-
-// planEditorChromaStyle is the chroma style used by the markdown renderer.
-// Hardcoded for now — a follow-up will plumb this through config.Settings.
-const planEditorChromaStyle = "monokai"
-
-// planEditorMaxMeasure is the maximum content column width for plan text.
-// On wider terminals the plan is centered with equal left/right margins.
-const planEditorMaxMeasure = 72
 
 // planSection represents one H1 or H2 ATX section in the plan. headingLine is
 // the 0-based source-line index of the `#`/`##` line; nextLine is the index of
@@ -228,7 +219,7 @@ func newPlanEditor(sess *agent.Session, repoPath string, width, height int) plan
 	ta.ShowLineNumbers = false
 	ta.SetWidth(m.contentWidth())
 	ta.SetHeight(textareaHeight(height))
-	m.renderer = mdrender.New(planEditorChromaStyle)
+	m.renderer = mdrender.New(docEditorChromaStyle)
 	ta.SetMarkdownRenderer(m.renderer)
 	m.textarea = ta
 
@@ -880,15 +871,15 @@ func (m *planEditorModel) displayLines() []string {
 }
 
 // contentWidth returns the effective column width for wrap and styling.
-// Capped at planEditorMaxMeasure so wide terminals produce comfortable margins.
+// Capped at docEditorMaxMeasure so wide terminals produce comfortable margins.
 func (m *planEditorModel) contentWidth() int {
-	measure, _ := mdrender.ContentMeasure(textareaWidth(m.width), planEditorMaxMeasure)
+	measure, _ := mdrender.ContentMeasure(textareaWidth(m.width), docEditorMaxMeasure)
 	return measure
 }
 
 // displayLeftPad returns the left-margin padding to center content on wide terminals.
 func (m *planEditorModel) displayLeftPad() int {
-	_, pad := mdrender.ContentMeasure(textareaWidth(m.width), planEditorMaxMeasure)
+	_, pad := mdrender.ContentMeasure(textareaWidth(m.width), docEditorMaxMeasure)
 	return pad
 }
 
@@ -1162,28 +1153,3 @@ func (m *planEditorModel) renderQuestionBody() string {
 	return b.String()
 }
 
-// textareaWidth/textareaHeight reserve space for header, divider, status,
-// and footer when sizing the embedded textarea.
-func textareaWidth(w int) int {
-	if w < 8 {
-		return 8
-	}
-	return w - 2
-}
-
-func textareaHeight(h int) int {
-	if h < 6 {
-		return 1
-	}
-	return h - 5
-}
-
-func fmtSeconds(s int) string {
-	if s < 0 {
-		s = 0
-	}
-	if s < 60 {
-		return strconv.Itoa(s) + "s"
-	}
-	return strconv.Itoa(s/60) + "m" + strconv.Itoa(s%60) + "s"
-}

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
 	"github.com/devenjarvis/refrain/internal/tui/mdrender"
-	"github.com/devenjarvis/refrain/internal/tui/mdtextarea"
 )
 
 // planSection represents one H1 or H2 ATX section in the plan. headingLine is
@@ -87,24 +86,20 @@ type planEditorModel struct {
 	sess     *agent.Session
 	repoPath string // repo this session belongs to; set at construction to avoid ambiguous cross-repo ID lookup
 
-	mode      planEditorMode
-	plan      string // last-loaded plan content; used in scroll mode
-	scrollOff int    // top line offset in scroll mode
-	dirty     bool   // textarea has unsaved edits relative to file
+	doc docEditor // shared textarea, renderer, dimensions, scrollOff
+
+	mode    planEditorMode
+	plan    string // last-loaded plan content; used in scroll mode
+	dirty   bool   // textarea has unsaved edits relative to file
 	saveNote  string // transient confirmation ("saved") or error
 	saveAt    time.Time
 
-	textarea    mdtextarea.Model
 	reviseInput textinput.Model
-	width       int
-	height      int
 	drafting    bool // session is currently in LifecycleDrafting; show placeholder
 	revising    bool // a revise call is in flight; lock i/a/ctrl+s
 	revisingFor time.Time
 	statusMsg   string // generic status line under the header (e.g. "Drafting…")
 	errMsg      string // inline error message; cleared on next interaction
-
-	renderer *mdrender.Renderer
 
 	// sections is the ordered list of H1/H2 sections parsed from the current
 	// plan. folds maps section heading name to its current fold state (true =
@@ -210,18 +205,8 @@ func newPlanEditor(sess *agent.Session, repoPath string, width, height int) plan
 		sess:     sess,
 		repoPath: repoPath,
 		mode:     planEditorModeScroll,
-		width:    width,
-		height:   height,
 	}
-
-	ta := mdtextarea.New()
-	ta.Prompt = ""
-	ta.ShowLineNumbers = false
-	ta.SetWidth(m.contentWidth())
-	ta.SetHeight(textareaHeight(height))
-	m.renderer = mdrender.New(docEditorChromaStyle)
-	ta.SetMarkdownRenderer(m.renderer)
-	m.textarea = ta
+	m.doc = newDocEditor(width, height)
 
 	ti := textinput.New()
 	ti.Placeholder = "What should change?"
@@ -245,10 +230,7 @@ func newPlanEditor(sess *agent.Session, repoPath string, width, height int) plan
 // scrollOff above its new max — keeping the clamp out of the View() path is
 // what lets renderBody stay pure.
 func (m *planEditorModel) SetSize(w, h int) {
-	m.width = w
-	m.height = h
-	m.textarea.SetWidth(m.contentWidth())
-	m.textarea.SetHeight(textareaHeight(h))
+	m.doc.SetSize(w, h)
 	m.reviseInput.SetWidth(w - 4)
 	m.questionInput.SetWidth(w - 4)
 	m.clampScroll()
@@ -310,7 +292,7 @@ func (m *planEditorModel) AskQuestion(question string, answerCh chan<- string) t
 	}
 	m.mode = planEditorModeQuestion
 	// Blur other inputs so keystrokes route to the question input only.
-	m.textarea.Blur()
+	m.doc.Blur()
 	m.reviseInput.Blur()
 	return m.questionInput.Focus()
 }
@@ -355,9 +337,9 @@ func (m *planEditorModel) reload() {
 		return
 	}
 	m.plan = plan
-	m.textarea.SetValue(plan)
+	m.doc.SetValue(plan)
 	m.dirty = false
-	m.scrollOff = 0
+	m.doc.scrollOff = 0
 	m.rebuildSections()
 }
 
@@ -369,9 +351,9 @@ func (m *planEditorModel) reload() {
 // same name (non-canonical but user-editable), they collapse/expand together —
 // accepted rather than introducing a positional disambiguator.
 func (m *planEditorModel) rebuildSections() {
-	v := m.textarea.Value()
+	v := m.doc.Value()
 	srcLines := splitPlanLines(v)
-	ctxs := m.renderer.LineContexts(v)
+	ctxs := m.doc.renderer.LineContexts(v)
 	newSections := parsePlanSections(srcLines, ctxs)
 	newFolds := make(map[string]bool, len(newSections))
 	for _, s := range newSections {
@@ -432,9 +414,7 @@ func (m *planEditorModel) Update(msg tea.Msg) tea.Cmd {
 	if !ok {
 		// Forward non-key events to whichever component is active.
 		if m.mode == planEditorModeEdit {
-			var cmd tea.Cmd
-			m.textarea, cmd = m.textarea.Update(msg)
-			return cmd
+			return m.doc.UpdateTextarea(msg)
 		}
 		if m.mode == planEditorModeReviseInput {
 			var cmd tea.Cmd
@@ -495,20 +475,20 @@ func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
 		}
 		return nil
 	case "ctrl+d", "pgdown":
-		m.scrollOff += m.bodyHeight() / 2
+		m.doc.scrollOff += m.doc.BodyHeight(5) / 2
 		m.clampScroll()
 		return nil
 	case "ctrl+u", "pgup":
-		m.scrollOff -= m.bodyHeight() / 2
-		if m.scrollOff < 0 {
-			m.scrollOff = 0
+		m.doc.scrollOff -= m.doc.BodyHeight(5) / 2
+		if m.doc.scrollOff < 0 {
+			m.doc.scrollOff = 0
 		}
 		return nil
 	case "g", "home":
-		m.scrollOff = 0
+		m.doc.scrollOff = 0
 		return nil
 	case "G", "end":
-		m.scrollOff = len(m.displayLines())
+		m.doc.scrollOff = len(m.displayLines())
 		m.clampScroll()
 		return nil
 	case "tab":
@@ -554,7 +534,7 @@ func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
 			return nil
 		}
 		m.mode = planEditorModeEdit
-		return m.textarea.Focus()
+		return m.doc.Focus()
 	case "r":
 		if m.revising {
 			return nil
@@ -592,7 +572,7 @@ func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
 		// agent reads exactly what the user saw on screen. Approve is a
 		// no-op on an empty plan; the editor surfaces an inline error and
 		// stays put.
-		val := m.textarea.Value()
+		val := m.doc.Value()
 		if strings.TrimSpace(val) == "" {
 			m.errMsg = "Plan is empty — edit or revise first."
 			return nil
@@ -616,7 +596,7 @@ func (m *planEditorModel) updateEdit(msg tea.KeyPressMsg) tea.Cmd {
 		// Preserve any in-progress edits — esc only blurs the textarea so
 		// the user can scroll and approve without losing typed content. The
 		// dirty indicator stays visible until ctrl+s or `a` writes to disk.
-		m.textarea.Blur()
+		m.doc.Blur()
 		m.rebuildSectionsPreservingFolds()
 		m.mode = planEditorModeScroll
 		return nil
@@ -624,7 +604,7 @@ func (m *planEditorModel) updateEdit(msg tea.KeyPressMsg) tea.Cmd {
 		if m.sess == nil {
 			return nil
 		}
-		val := m.textarea.Value()
+		val := m.doc.Value()
 		if err := m.sess.WritePlan(val); err != nil {
 			m.errMsg = "save plan: " + err.Error()
 			return nil
@@ -637,10 +617,9 @@ func (m *planEditorModel) updateEdit(msg tea.KeyPressMsg) tea.Cmd {
 		sessID := m.sess.ID
 		return func() tea.Msg { return planEditorSavedMsg{sessionID: sessID} }
 	}
-	prev := m.textarea.Value()
-	var cmd tea.Cmd
-	m.textarea, cmd = m.textarea.Update(msg)
-	if m.textarea.Value() != prev {
+	prev := m.doc.Value()
+	cmd := m.doc.UpdateTextarea(msg)
+	if m.doc.Value() != prev {
 		m.dirty = true
 	}
 	return cmd
@@ -755,11 +734,11 @@ func (m *planEditorModel) invalidateDisplayCache() {
 // navigation ([ and ]) and tab-fold detection can look up section positions
 // without re-scanning.
 func (m *planEditorModel) displayLines() []string {
-	v := m.textarea.Value()
+	v := m.doc.Value()
 	if v == "" {
 		return nil
 	}
-	w := m.contentWidth()
+	w := m.doc.ContentWidth()
 	key := displayCacheKey{
 		width:         w,
 		valueHash:     sha256.Sum256([]byte(v)),
@@ -772,7 +751,7 @@ func (m *planEditorModel) displayLines() []string {
 
 	// If there are no sections at all, fall back to the plain renderer path.
 	if len(m.sections) == 0 {
-		out := m.renderer.RenderLines(v, w)
+		out := m.doc.renderer.RenderLines(v, w)
 		m.displayCache = out
 		m.displayCacheKey = key
 		m.sectionDisplayStart = nil
@@ -780,7 +759,7 @@ func (m *planEditorModel) displayLines() []string {
 	}
 
 	srcLines := splitPlanLines(v)
-	ctxs := m.renderer.LineContexts(v)
+	ctxs := m.doc.renderer.LineContexts(v)
 	sectionStarts := make([]int, len(m.sections))
 
 	out := make([]string, 0, len(srcLines))
@@ -792,7 +771,7 @@ func (m *planEditorModel) displayLines() []string {
 		if i < len(ctxs) {
 			ctx = ctxs[i]
 		}
-		out = append(out, m.styledScrollLines(srcLines[i], ctx, w)...)
+		out = append(out, m.doc.StyledScrollLines(srcLines[i], ctx, w)...)
 	}
 
 	// Sections.
@@ -805,7 +784,7 @@ func (m *planEditorModel) displayLines() []string {
 		if s.headingLine < len(ctxs) {
 			headingCtx = ctxs[s.headingLine]
 		}
-		headingSegs := m.renderer.StyleLine(srcLines[s.headingLine], headingCtx, w)
+		headingSegs := m.doc.renderer.StyleLine(srcLines[s.headingLine], headingCtx, w)
 		if len(headingSegs) == 0 {
 			headingSegs = []string{""}
 		}
@@ -838,7 +817,7 @@ func (m *planEditorModel) displayLines() []string {
 		// what RenderLines produces so scroll-mode line counts stay in sync.
 		if !folded && headingCtx.HeadingLevel >= 1 && headingCtx.HeadingLevel <= 2 {
 			headingTextWidth := ansi.StringWidth(srcLines[s.headingLine])
-			out = append(out, m.renderer.HeadingUnderline(headingCtx.HeadingLevel, headingTextWidth, w))
+			out = append(out, m.doc.renderer.HeadingUnderline(headingCtx.HeadingLevel, headingTextWidth, w))
 		}
 
 		if folded {
@@ -851,13 +830,13 @@ func (m *planEditorModel) displayLines() []string {
 			if i < len(ctxs) {
 				ctx = ctxs[i]
 			}
-			out = append(out, m.styledScrollLines(srcLines[i], ctx, w)...)
+			out = append(out, m.doc.StyledScrollLines(srcLines[i], ctx, w)...)
 		}
 	}
 
 	// Apply centering: prepend left-margin padding after all fold glyphs so
 	// the glyph stays at the content edge, not pushed into the margin.
-	if leftPad := m.displayLeftPad(); leftPad > 0 {
+	if leftPad := m.doc.DisplayLeftPad(); leftPad > 0 {
 		pad := strings.Repeat(" ", leftPad)
 		for i, line := range out {
 			out[i] = pad + line
@@ -870,74 +849,8 @@ func (m *planEditorModel) displayLines() []string {
 	return out
 }
 
-// contentWidth returns the effective column width for wrap and styling.
-// Capped at docEditorMaxMeasure so wide terminals produce comfortable margins.
-func (m *planEditorModel) contentWidth() int {
-	measure, _ := mdrender.ContentMeasure(textareaWidth(m.width), docEditorMaxMeasure)
-	return measure
-}
-
-// displayLeftPad returns the left-margin padding to center content on wide terminals.
-func (m *planEditorModel) displayLeftPad() int {
-	_, pad := mdrender.ContentMeasure(textareaWidth(m.width), docEditorMaxMeasure)
-	return pad
-}
-
-// centeredBlock prepends displayLeftPad() spaces to each line of s, matching
-// the scroll-mode centering applied in displayLines().
-func (m *planEditorModel) centeredBlock(s string) string {
-	pad := m.displayLeftPad()
-	if pad == 0 {
-		return s
-	}
-	prefix := strings.Repeat(" ", pad)
-	lines := strings.Split(s, "\n")
-	for i, l := range lines {
-		lines[i] = prefix + l
-	}
-	return strings.Join(lines, "\n")
-}
-
-// styledScrollLines wraps and styles a source line for scroll-mode display,
-// applying fence-block bar prefixes that are omitted in edit mode to keep
-// mdtextarea cursor-splice math unaffected.
-func (m *planEditorModel) styledScrollLines(src string, ctx mdrender.LineCtx, width int) []string {
-	isFenceLine := ctx.Kind == mdrender.LineFenceContent || ctx.Kind == mdrender.LineFenceOpen || ctx.Kind == mdrender.LineFenceClose
-	lineWidth := width
-	if isFenceLine && width > 2 {
-		lineWidth = width - 2
-	}
-	lines := m.renderer.StyleLine(src, ctx, lineWidth)
-	if isFenceLine {
-		bar := StyleSubtle.Render("│") + " "
-		for i, l := range lines {
-			lines[i] = bar + l
-		}
-	}
-	return lines
-}
-
-// bodyHeight is the number of lines available for plan content.
-// Subtract: header (2) + status line (1) + footer hints (2) = 5.
-func (m *planEditorModel) bodyHeight() int {
-	h := m.height - 5
-	if h < 1 {
-		return 1
-	}
-	return h
-}
-
 func (m *planEditorModel) clampScroll() {
-	max := len(m.displayLines()) - m.bodyHeight()
-	if max < 0 {
-		max = 0
-	}
-	if m.scrollOff > max {
-		m.scrollOff = max
-	}
-	if m.scrollOff < 0 {
-		m.scrollOff = 0
-	}
+	m.doc.ClampScroll(len(m.displayLines()))
 }
 
 // scrollToCursor adjusts scrollOff so the heading of sectionCursor's section
@@ -951,11 +864,11 @@ func (m *planEditorModel) scrollToCursor() {
 		return
 	}
 	headingLine := m.sectionDisplayStart[m.sectionCursor]
-	body := m.bodyHeight()
-	if headingLine < m.scrollOff {
-		m.scrollOff = headingLine
-	} else if headingLine >= m.scrollOff+body {
-		m.scrollOff = headingLine - body + 1
+	body := m.doc.BodyHeight(5)
+	if headingLine < m.doc.scrollOff {
+		m.doc.scrollOff = headingLine
+	} else if headingLine >= m.doc.scrollOff+body {
+		m.doc.scrollOff = headingLine - body + 1
 	}
 	m.clampScroll()
 }
@@ -978,7 +891,7 @@ func (m *planEditorModel) clampCursor() {
 func (m *planEditorModel) View() string {
 	var lines []string
 	lines = append(lines, m.renderHeader())
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2))))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, m.doc.width-2))))
 
 	if status := m.renderStatusLine(); status != "" {
 		lines = append(lines, status)
@@ -986,7 +899,7 @@ func (m *planEditorModel) View() string {
 
 	switch m.mode {
 	case planEditorModeEdit:
-		lines = append(lines, m.centeredBlock(m.textarea.View()))
+		lines = append(lines, m.doc.CenteredBlock(m.doc.textarea.View()))
 	case planEditorModeReviseInput:
 		lines = append(lines, m.renderBody())
 		lines = append(lines, "")
@@ -1020,7 +933,7 @@ func (m *planEditorModel) renderHeader() string {
 	case m.saveNote != "" && time.Since(m.saveAt) < 3*time.Second:
 		rightLabel = StyleSuccess.Render(m.saveNote)
 	}
-	gap := m.width - ansi.StringWidth(left) - ansi.StringWidth(rightLabel) - 4
+	gap := m.doc.width - ansi.StringWidth(left) - ansi.StringWidth(rightLabel) - 4
 	if gap < 1 {
 		gap = 1
 	}
@@ -1053,11 +966,11 @@ func (m *planEditorModel) renderBody() string {
 		// is a transient state and a uniform muted body cues "this is the
 		// previous plan, not the current one".
 		all := m.planLinesPlain()
-		body := m.bodyHeight() - 1
+		body := m.doc.BodyHeight(5) - 1
 		if body < 1 {
 			body = 1
 		}
-		end := m.scrollOff + body
+		end := m.doc.scrollOff + body
 		if end > len(all) {
 			end = len(all)
 		}
@@ -1065,7 +978,7 @@ func (m *planEditorModel) renderBody() string {
 		if len(all) == 0 {
 			rendered = StyleSubtle.Render("(no plan content)")
 		} else {
-			start := m.scrollOff
+			start := m.doc.scrollOff
 			if start > len(all) {
 				start = len(all)
 			}
@@ -1080,29 +993,17 @@ func (m *planEditorModel) renderBody() string {
 	if len(all) == 0 {
 		return StyleSubtle.Render("(no plan content yet — press i to start writing or r to revise)")
 	}
-	body := m.bodyHeight()
-	// Use a local start so View() stays pure — never mutate m.scrollOff
-	// from the render path. Update()/SetSize keep m.scrollOff in range via
+	// Use a local start so View() stays pure — never mutate m.doc.scrollOff
+	// from the render path. Update()/SetSize keep m.doc.scrollOff in range via
 	// clampScroll; this local clamp guards a stale scrollOff in the render
 	// frame that races a textarea shrink (e.g. plan reload after revise).
-	start := m.scrollOff
-	if start > len(all)-body {
-		start = len(all) - body
-	}
-	if start < 0 {
-		start = 0
-	}
-	end := start + body
-	if end > len(all) {
-		end = len(all)
-	}
-	return strings.Join(all[start:end], "\n")
+	return m.doc.ScrollWindow(all, m.doc.BodyHeight(5))
 }
 
 // planLinesPlain returns the textarea's value as raw source lines. Used by
 // the revising-mode preview, which intentionally shows un-styled muted text.
 func (m *planEditorModel) planLinesPlain() []string {
-	v := m.textarea.Value()
+	v := m.doc.Value()
 	if v == "" {
 		return nil
 	}
@@ -1134,7 +1035,7 @@ func (m *planEditorModel) renderFooter() string {
 			StyleActive.Render("q") + StyleSubtle.Render(" abandon  ") +
 			StyleActive.Render("esc") + StyleSubtle.Render(" back")
 	}
-	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2)))
+	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.doc.width-2)))
 	return divider + "\n" + hints
 }
 
@@ -1147,7 +1048,7 @@ func (m *planEditorModel) renderQuestionBody() string {
 	var b strings.Builder
 	b.WriteString(StyleActive.Render("planner is asking:"))
 	b.WriteString("\n\n")
-	b.WriteString(ansi.Wrap(m.questionText, max(20, m.width-4), ""))
+	b.WriteString(ansi.Wrap(m.questionText, max(20, m.doc.width-4), ""))
 	b.WriteString("\n\n")
 	b.WriteString(StyleActive.Render("answer:") + " " + m.questionInput.View())
 	return b.String()

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -96,7 +96,7 @@ func TestPlanEditor_EditModeSavesOnCtrlS(t *testing.T) {
 	}
 
 	// Replace textarea content directly (simulate user typing).
-	editor.textarea.SetValue("rewritten\n")
+	editor.doc.textarea.SetValue("rewritten\n")
 	editor.dirty = true
 
 	cmd = editor.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl, Text: "ctrl+s"})
@@ -128,14 +128,14 @@ func TestPlanEditor_EscFromEditPreservesEdits(t *testing.T) {
 	_ = sess.WritePlan("orig\n")
 	editor := newPlanEditor(sess, "", 80, 30)
 	editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
-	editor.textarea.SetValue("typed but not saved\n")
+	editor.doc.textarea.SetValue("typed but not saved\n")
 	editor.dirty = true
 
 	editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if editor.mode != planEditorModeScroll {
 		t.Errorf("mode = %v, want scroll after esc", editor.mode)
 	}
-	if editor.textarea.Value() != "typed but not saved\n" {
+	if editor.doc.Value() != "typed but not saved\n" {
 		t.Errorf("textarea cleared on esc; want preserved edits")
 	}
 	if !editor.dirty {
@@ -164,7 +164,7 @@ func TestPlanEditor_ApprovePersistsAndEmits(t *testing.T) {
 
 	// User edits, doesn't ctrl+s, esc back, then approves.
 	editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
-	editor.textarea.SetValue("# revised\n- [ ] thing\n")
+	editor.doc.textarea.SetValue("# revised\n- [ ] thing\n")
 	editor.dirty = true
 	editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 
@@ -266,20 +266,20 @@ func TestPlanEditor_ScrollAndEditModeUseSameWidth(t *testing.T) {
 		// textareaWidth(70) = 68, which is below docEditorMaxMeasure (72).
 		// contentWidth() == 68 == textarea.Width().
 		editor := newPlanEditor(sess, "", 70, 30)
-		if got, want := editor.contentWidth(), editor.textarea.Width(); got != want {
+		if got, want := editor.doc.ContentWidth(), editor.doc.textarea.Width(); got != want {
 			t.Errorf("contentWidth=%d, textarea.Width()=%d; on narrow terminals both modes must wrap at the same column", got, want)
 		}
 	})
 
 	t.Run("wide", func(t *testing.T) {
-		// textareaWidth(120) = 118, but contentWidth() is capped at docEditorMaxMeasure (72).
+		// textareaWidth(120) = 118, but ContentWidth() is capped at docEditorMaxMeasure (72).
 		// textarea.Width() must also be 72 so wrap columns match.
 		editor := newPlanEditor(sess, "", 120, 30)
-		if got, want := editor.contentWidth(), editor.textarea.Width(); got != want {
+		if got, want := editor.doc.ContentWidth(), editor.doc.textarea.Width(); got != want {
 			t.Errorf("contentWidth=%d, textarea.Width()=%d; on wide terminals both must equal docEditorMaxMeasure (%d)", got, want, docEditorMaxMeasure)
 		}
-		if editor.contentWidth() != docEditorMaxMeasure {
-			t.Errorf("contentWidth()=%d, want docEditorMaxMeasure=%d on wide terminal", editor.contentWidth(), docEditorMaxMeasure)
+		if editor.doc.ContentWidth() != docEditorMaxMeasure {
+			t.Errorf("ContentWidth()=%d, want docEditorMaxMeasure=%d on wide terminal", editor.doc.ContentWidth(), docEditorMaxMeasure)
 		}
 	})
 }
@@ -294,12 +294,12 @@ func TestPlanEditor_EditModeCenteredOnWideTerminal(t *testing.T) {
 	editor := newPlanEditor(sess, "", 120, 30)
 
 	// textarea.Width() must be capped at contentWidth() (72), not textareaWidth(120)=118.
-	if got, want := editor.textarea.Width(), editor.contentWidth(); got != want {
-		t.Errorf("textarea.Width()=%d, want contentWidth()=%d; edit mode must cap at docEditorMaxMeasure on wide terminals",
+	if got, want := editor.doc.textarea.Width(), editor.doc.ContentWidth(); got != want {
+		t.Errorf("textarea.Width()=%d, want ContentWidth()=%d; edit mode must cap at docEditorMaxMeasure on wide terminals",
 			got, want)
 	}
 
-	leftPad := editor.displayLeftPad()
+	leftPad := editor.doc.DisplayLeftPad()
 	if leftPad == 0 {
 		t.Fatal("displayLeftPad() == 0 at width 120; test precondition failed")
 	}
@@ -351,7 +351,7 @@ func TestPlanEditor_DisplayLineCountAgreesWithRenderer(t *testing.T) {
 	editor.invalidateDisplayCache()
 
 	scrollLines := editor.displayLines()
-	directLines := mdrender.New("monokai").RenderLines(editor.textarea.Value(), editor.contentWidth())
+	directLines := mdrender.New("monokai").RenderLines(editor.doc.Value(), editor.doc.ContentWidth())
 	if len(scrollLines) != len(directLines) {
 		t.Errorf("editor.displayLines()=%d vs direct mdrender.RenderLines=%d — scroll and edit modes will desync",
 			len(scrollLines), len(directLines))
@@ -738,13 +738,13 @@ func TestPlanEditor_CtrlD_CtrlU_HalfPage(t *testing.T) {
 	}
 	editor := newPlanEditor(sess, "", 80, 20)
 	editor.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
-	if editor.scrollOff == 0 {
+	if editor.doc.scrollOff == 0 {
 		t.Errorf("ctrl+d did not scroll")
 	}
-	pre := editor.scrollOff
+	pre := editor.doc.scrollOff
 	editor.Update(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
-	if editor.scrollOff >= pre {
-		t.Errorf("ctrl+u did not reverse scroll: pre=%d post=%d", pre, editor.scrollOff)
+	if editor.doc.scrollOff >= pre {
+		t.Errorf("ctrl+u did not reverse scroll: pre=%d post=%d", pre, editor.doc.scrollOff)
 	}
 }
 
@@ -761,22 +761,22 @@ func TestPlanEditor_GHomeAndShiftGEnd_Jump(t *testing.T) {
 	editor := newPlanEditor(sess, "", 80, 20)
 	// G jumps to bottom.
 	editor.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
-	if editor.scrollOff == 0 {
+	if editor.doc.scrollOff == 0 {
 		t.Errorf("G did not move scroll")
 	}
 	// g jumps back to top.
 	editor.Update(tea.KeyPressMsg{Code: 'g', Text: "g"})
-	if editor.scrollOff != 0 {
-		t.Errorf("g did not jump to top, got %d", editor.scrollOff)
+	if editor.doc.scrollOff != 0 {
+		t.Errorf("g did not jump to top, got %d", editor.doc.scrollOff)
 	}
 	// home/end aliases.
 	editor.Update(tea.KeyPressMsg{Code: tea.KeyEnd})
-	if editor.scrollOff == 0 {
+	if editor.doc.scrollOff == 0 {
 		t.Errorf("end did not move scroll")
 	}
 	editor.Update(tea.KeyPressMsg{Code: tea.KeyHome})
-	if editor.scrollOff != 0 {
-		t.Errorf("home did not jump to top, got %d", editor.scrollOff)
+	if editor.doc.scrollOff != 0 {
+		t.Errorf("home did not jump to top, got %d", editor.doc.scrollOff)
 	}
 }
 
@@ -802,7 +802,7 @@ func TestPlanEditor_DraftingState_BlocksAllExceptEscAndQ(t *testing.T) {
 	}
 	editor := newPlanEditor(sess, "", 80, 20)
 	editor.drafting = true
-	editor.scrollOff = 0
+	editor.doc.scrollOff = 0
 
 	// Try a bunch of keys; they should all be no-ops.
 	for _, k := range []tea.KeyPressMsg{
@@ -818,8 +818,8 @@ func TestPlanEditor_DraftingState_BlocksAllExceptEscAndQ(t *testing.T) {
 	} {
 		editor.Update(k)
 	}
-	if editor.scrollOff != 0 {
-		t.Errorf("scroll changed during drafting, got %d", editor.scrollOff)
+	if editor.doc.scrollOff != 0 {
+		t.Errorf("scroll changed during drafting, got %d", editor.doc.scrollOff)
 	}
 	if editor.sectionCursor != 0 {
 		t.Errorf("sectionCursor changed during drafting, got %d", editor.sectionCursor)
@@ -884,7 +884,7 @@ func TestPlanEditor_ScrollMode_UnknownKey_NoOp(t *testing.T) {
 		mode   planEditorMode
 		err    string
 		dirty  bool
-	}{editor.scrollOff, editor.mode, editor.errMsg, editor.dirty}
+	}{editor.doc.scrollOff, editor.mode, editor.errMsg, editor.dirty}
 	cmd := editor.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
 	if cmd != nil {
 		t.Errorf("unknown key produced cmd %T, want nil", cmd())
@@ -894,7 +894,7 @@ func TestPlanEditor_ScrollMode_UnknownKey_NoOp(t *testing.T) {
 		mode   planEditorMode
 		err    string
 		dirty  bool
-	}{editor.scrollOff, editor.mode, editor.errMsg, editor.dirty}
+	}{editor.doc.scrollOff, editor.mode, editor.errMsg, editor.dirty}
 	if before != after {
 		t.Errorf("unknown key changed state: before=%+v after=%+v", before, after)
 	}
@@ -1040,10 +1040,10 @@ func TestPlanEditor_JK_MoveSectionCursor(t *testing.T) {
 	editor.displayLines()
 	cursor := editor.sectionCursor
 	headingLine := editor.sectionDisplayStart[cursor]
-	body := editor.bodyHeight()
-	if headingLine < editor.scrollOff || headingLine >= editor.scrollOff+body {
+	body := editor.doc.BodyHeight(5)
+	if headingLine < editor.doc.scrollOff || headingLine >= editor.doc.scrollOff+body {
 		t.Errorf("heading line %d not in viewport [%d, %d)",
-			headingLine, editor.scrollOff, editor.scrollOff+body)
+			headingLine, editor.doc.scrollOff, editor.doc.scrollOff+body)
 	}
 }
 

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -263,7 +263,7 @@ func TestPlanEditor_ScrollAndEditModeUseSameWidth(t *testing.T) {
 	_ = sess.WritePlan("# H\nshort\n")
 
 	t.Run("narrow", func(t *testing.T) {
-		// textareaWidth(70) = 68, which is below planEditorMaxMeasure (72).
+		// textareaWidth(70) = 68, which is below docEditorMaxMeasure (72).
 		// contentWidth() == 68 == textarea.Width().
 		editor := newPlanEditor(sess, "", 70, 30)
 		if got, want := editor.contentWidth(), editor.textarea.Width(); got != want {
@@ -272,14 +272,14 @@ func TestPlanEditor_ScrollAndEditModeUseSameWidth(t *testing.T) {
 	})
 
 	t.Run("wide", func(t *testing.T) {
-		// textareaWidth(120) = 118, but contentWidth() is capped at planEditorMaxMeasure (72).
+		// textareaWidth(120) = 118, but contentWidth() is capped at docEditorMaxMeasure (72).
 		// textarea.Width() must also be 72 so wrap columns match.
 		editor := newPlanEditor(sess, "", 120, 30)
 		if got, want := editor.contentWidth(), editor.textarea.Width(); got != want {
-			t.Errorf("contentWidth=%d, textarea.Width()=%d; on wide terminals both must equal planEditorMaxMeasure (%d)", got, want, planEditorMaxMeasure)
+			t.Errorf("contentWidth=%d, textarea.Width()=%d; on wide terminals both must equal docEditorMaxMeasure (%d)", got, want, docEditorMaxMeasure)
 		}
-		if editor.contentWidth() != planEditorMaxMeasure {
-			t.Errorf("contentWidth()=%d, want planEditorMaxMeasure=%d on wide terminal", editor.contentWidth(), planEditorMaxMeasure)
+		if editor.contentWidth() != docEditorMaxMeasure {
+			t.Errorf("contentWidth()=%d, want docEditorMaxMeasure=%d on wide terminal", editor.contentWidth(), docEditorMaxMeasure)
 		}
 	})
 }
@@ -295,7 +295,7 @@ func TestPlanEditor_EditModeCenteredOnWideTerminal(t *testing.T) {
 
 	// textarea.Width() must be capped at contentWidth() (72), not textareaWidth(120)=118.
 	if got, want := editor.textarea.Width(), editor.contentWidth(); got != want {
-		t.Errorf("textarea.Width()=%d, want contentWidth()=%d; edit mode must cap at planEditorMaxMeasure on wide terminals",
+		t.Errorf("textarea.Width()=%d, want contentWidth()=%d; edit mode must cap at docEditorMaxMeasure on wide terminals",
 			got, want)
 	}
 

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -7,8 +7,6 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/devenjarvis/refrain/internal/tui/mdrender"
-	"github.com/devenjarvis/refrain/internal/tui/mdtextarea"
 )
 
 type prComposeMode int
@@ -23,13 +21,9 @@ const (
 type prComposeModal struct {
 	active     bool
 	titleInput textinput.Model
-	bodyArea   mdtextarea.Model
-	renderer   *mdrender.Renderer
+	doc        docEditor
 	mode       prComposeMode
 	draft      bool
-	width      int
-	height     int
-	scrollOff  int
 	sessName   string
 }
 
@@ -48,17 +42,9 @@ func newPRComposeModal() prComposeModal {
 	ti.Placeholder = "Pull request title"
 	ti.CharLimit = 255
 
-	ta := mdtextarea.New()
-	ta.Prompt = ""
-	ta.ShowLineNumbers = false
-
-	renderer := mdrender.New(docEditorChromaStyle)
-	ta.SetMarkdownRenderer(renderer)
-
 	return prComposeModal{
 		titleInput: ti,
-		bodyArea:   ta,
-		renderer:   renderer,
+		doc:        newDocEditor(0, 0),
 		draft:      true,
 		mode:       prComposeModeScroll,
 	}
@@ -70,12 +56,12 @@ func (m *prComposeModal) Open(title, body string, draft bool, sessName string) t
 	m.active = true
 	m.draft = draft
 	m.mode = prComposeModeScroll
-	m.scrollOff = 0
+	m.doc.scrollOff = 0
 	m.sessName = sessName
 	m.titleInput.SetValue(title)
-	m.bodyArea.SetValue(body)
+	m.doc.SetValue(body)
 	m.titleInput.Blur()
-	m.bodyArea.Blur()
+	m.doc.Blur()
 	return nil
 }
 
@@ -83,7 +69,7 @@ func (m *prComposeModal) Open(title, body string, draft bool, sessName string) t
 func (m *prComposeModal) Close() {
 	m.active = false
 	m.titleInput.Blur()
-	m.bodyArea.Blur()
+	m.doc.Blur()
 	m.mode = prComposeModeScroll
 }
 
@@ -92,12 +78,11 @@ func (m *prComposeModal) Active() bool { return m.active }
 
 // SetSize updates the viewport dimensions.
 func (m *prComposeModal) SetSize(w, h int) {
-	m.width = w
-	m.height = h
+	m.doc.SetSize(w, h)
 	m.titleInput.SetWidth(w - 4)
-	m.bodyArea.SetWidth(textareaWidth(w))
-	m.bodyArea.SetHeight(m.editBodyHeight())
-	m.clampScroll()
+	m.doc.textarea.SetHeight(m.doc.BodyHeight(8))
+	rendered := m.doc.RenderLines()
+	m.doc.ClampScroll(len(rendered))
 }
 
 // Update routes a tea.Msg to updateScroll or updateEdit based on mode.
@@ -113,9 +98,7 @@ func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
 				m.titleInput, cmd = m.titleInput.Update(paste)
 				return cmd
 			}
-			var cmd tea.Cmd
-			m.bodyArea, cmd = m.bodyArea.Update(paste)
-			return cmd
+			return m.doc.UpdateTextarea(paste)
 		}
 		return nil
 	}
@@ -141,7 +124,7 @@ func (m *prComposeModal) updateScroll(msg tea.Msg) tea.Cmd {
 		if title == "" {
 			return nil
 		}
-		body := strings.TrimSpace(m.bodyArea.Value())
+		body := strings.TrimSpace(m.doc.Value())
 		draft := m.draft
 		m.Close()
 		return func() tea.Msg {
@@ -153,25 +136,28 @@ func (m *prComposeModal) updateScroll(msg tea.Msg) tea.Cmd {
 		m.mode = prComposeModeEdit
 		return m.titleInput.Focus()
 	case "j":
-		m.scrollOff++
-		m.clampScroll()
+		m.doc.scrollOff++
+		rendered := m.doc.RenderLines()
+		m.doc.ClampScroll(len(rendered))
 	case "k":
-		if m.scrollOff > 0 {
-			m.scrollOff--
+		if m.doc.scrollOff > 0 {
+			m.doc.scrollOff--
 		}
 	case "pgdown":
-		m.scrollOff += m.bodyHeight() / 2
-		m.clampScroll()
+		m.doc.scrollOff += m.doc.BodyHeight(7) / 2
+		rendered := m.doc.RenderLines()
+		m.doc.ClampScroll(len(rendered))
 	case "pgup":
-		m.scrollOff -= m.bodyHeight() / 2
-		if m.scrollOff < 0 {
-			m.scrollOff = 0
+		m.doc.scrollOff -= m.doc.BodyHeight(7) / 2
+		if m.doc.scrollOff < 0 {
+			m.doc.scrollOff = 0
 		}
 	case "g":
-		m.scrollOff = 0
+		m.doc.scrollOff = 0
 	case "G":
-		m.scrollOff = 9999
-		m.clampScroll()
+		m.doc.scrollOff = 9999
+		rendered := m.doc.RenderLines()
+		m.doc.ClampScroll(len(rendered))
 	}
 	return nil
 }
@@ -184,14 +170,12 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 			m.titleInput, cmd = m.titleInput.Update(msg)
 			return cmd
 		}
-		var cmd tea.Cmd
-		m.bodyArea, cmd = m.bodyArea.Update(msg)
-		return cmd
+		return m.doc.UpdateTextarea(msg)
 	}
 	switch key.String() {
 	case "esc":
 		m.titleInput.Blur()
-		m.bodyArea.Blur()
+		m.doc.Blur()
 		m.mode = prComposeModeScroll
 		return nil
 	case "ctrl+enter":
@@ -199,7 +183,7 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 		if title == "" {
 			return nil
 		}
-		body := strings.TrimSpace(m.bodyArea.Value())
+		body := strings.TrimSpace(m.doc.Value())
 		draft := m.draft
 		m.Close()
 		return func() tea.Msg {
@@ -211,9 +195,9 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 	case "tab", "shift+tab":
 		if m.titleInput.Focused() {
 			m.titleInput.Blur()
-			return m.bodyArea.Focus()
+			return m.doc.Focus()
 		}
-		m.bodyArea.Blur()
+		m.doc.Blur()
 		return m.titleInput.Focus()
 	}
 	if m.titleInput.Focused() {
@@ -221,16 +205,14 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 		m.titleInput, cmd = m.titleInput.Update(msg)
 		return cmd
 	}
-	var cmd tea.Cmd
-	m.bodyArea, cmd = m.bodyArea.Update(msg)
-	return cmd
+	return m.doc.UpdateTextarea(msg)
 }
 
 // View renders the full-page PR compose. Only call when Active() is true.
 func (m *prComposeModal) View() string {
 	var lines []string
 	lines = append(lines, m.renderHeader())
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2))))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, m.doc.width-2))))
 	switch m.mode {
 	case prComposeModeEdit:
 		lines = append(lines, m.renderEditBody())
@@ -242,7 +224,7 @@ func (m *prComposeModal) View() string {
 }
 
 func (m *prComposeModal) renderEditBody() string {
-	pad := strings.Repeat(" ", m.displayLeftPad())
+	pad := strings.Repeat(" ", m.doc.DisplayLeftPad())
 
 	titleLabel := StyleSubtle.Render("Title")
 	bodyLabel := StyleSubtle.Render("Body")
@@ -257,12 +239,12 @@ func (m *prComposeModal) renderEditBody() string {
 		m.titleInput.View(),
 		"",
 		pad + bodyLabel,
-		m.bodyArea.View(),
+		m.doc.textarea.View(),
 	}, "\n")
 }
 
 func (m *prComposeModal) renderScrollBody() string {
-	pad := strings.Repeat(" ", m.displayLeftPad())
+	pad := strings.Repeat(" ", m.doc.DisplayLeftPad())
 
 	titleVal := m.titleInput.Value()
 	if titleVal == "" {
@@ -270,26 +252,17 @@ func (m *prComposeModal) renderScrollBody() string {
 	}
 	titleLine := pad + StyleTitle.Render("Title: ") + titleVal
 
-	bodyVal := m.bodyArea.Value()
 	var bodyContent string
-	if bodyVal == "" {
+	if m.doc.Value() == "" {
 		bodyContent = pad + StyleSubtle.Render("(no body)")
 	} else {
-		rendered := m.renderer.RenderLines(bodyVal, m.contentWidth())
-		bh := m.bodyHeight()
-		start := m.scrollOff
-		if start > len(rendered) {
-			start = len(rendered)
+		rendered := m.doc.RenderLines()
+		bh := m.doc.BodyHeight(7)
+		windowed := strings.Split(m.doc.ScrollWindow(rendered, bh), "\n")
+		for i, l := range windowed {
+			windowed[i] = pad + l
 		}
-		end := start + bh
-		if end > len(rendered) {
-			end = len(rendered)
-		}
-		paddedLines := make([]string, len(rendered[start:end]))
-		for i, l := range rendered[start:end] {
-			paddedLines[i] = pad + l
-		}
-		bodyContent = strings.Join(paddedLines, "\n")
+		bodyContent = strings.Join(windowed, "\n")
 	}
 
 	return strings.Join([]string{
@@ -301,7 +274,7 @@ func (m *prComposeModal) renderScrollBody() string {
 }
 
 func (m *prComposeModal) renderFooter() string {
-	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.width-2)))
+	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.doc.width-2)))
 	var hints string
 	switch m.mode {
 	case prComposeModeEdit:
@@ -331,52 +304,9 @@ func (m *prComposeModal) renderHeader() string {
 	} else {
 		draftLabel = lipgloss.NewStyle().Foreground(lipgloss.Color("#10B981")).Bold(true).Render("● ready")
 	}
-	gap := m.width - ansi.StringWidth(left) - ansi.StringWidth(draftLabel) - 4
+	gap := m.doc.width - ansi.StringWidth(left) - ansi.StringWidth(draftLabel) - 4
 	if gap < 1 {
 		gap = 1
 	}
 	return left + strings.Repeat(" ", gap) + draftLabel
-}
-
-func (m *prComposeModal) contentWidth() int {
-	w, _ := mdrender.ContentMeasure(m.width, docEditorMaxMeasure)
-	return w
-}
-
-func (m *prComposeModal) displayLeftPad() int {
-	_, pad := mdrender.ContentMeasure(m.width, docEditorMaxMeasure)
-	return pad
-}
-
-func (m *prComposeModal) bodyHeight() int {
-	h := m.height - 7
-	if h < 1 {
-		h = 1
-	}
-	return h
-}
-
-func (m *prComposeModal) editBodyHeight() int {
-	h := m.height - 8
-	if h < 1 {
-		h = 1
-	}
-	return h
-}
-
-func (m *prComposeModal) clampScroll() {
-	if m.width == 0 || m.renderer == nil {
-		return
-	}
-	rendered := m.renderer.RenderLines(m.bodyArea.Value(), m.contentWidth())
-	maxOff := len(rendered) - m.bodyHeight()
-	if maxOff < 0 {
-		maxOff = 0
-	}
-	if m.scrollOff > maxOff {
-		m.scrollOff = maxOff
-	}
-	if m.scrollOff < 0 {
-		m.scrollOff = 0
-	}
 }

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -52,7 +52,7 @@ func newPRComposeModal() prComposeModal {
 	ta.Prompt = ""
 	ta.ShowLineNumbers = false
 
-	renderer := mdrender.New(planEditorChromaStyle)
+	renderer := mdrender.New(docEditorChromaStyle)
 	ta.SetMarkdownRenderer(renderer)
 
 	return prComposeModal{
@@ -339,12 +339,12 @@ func (m *prComposeModal) renderHeader() string {
 }
 
 func (m *prComposeModal) contentWidth() int {
-	w, _ := mdrender.ContentMeasure(m.width, planEditorMaxMeasure)
+	w, _ := mdrender.ContentMeasure(m.width, docEditorMaxMeasure)
 	return w
 }
 
 func (m *prComposeModal) displayLeftPad() int {
-	_, pad := mdrender.ContentMeasure(m.width, planEditorMaxMeasure)
+	_, pad := mdrender.ContentMeasure(m.width, docEditorMaxMeasure)
 	return pad
 }
 

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -24,7 +24,7 @@ func TestPRCompose_OpenSetsScrollModeAndHasRenderer(t *testing.T) {
 	if m.mode != prComposeModeScroll {
 		t.Errorf("mode = %v, want prComposeModeScroll", m.mode)
 	}
-	if m.bodyArea.MarkdownRenderer() == nil {
+	if m.doc.textarea.MarkdownRenderer() == nil {
 		t.Error("bodyArea should have a MarkdownRenderer set")
 	}
 }
@@ -39,8 +39,8 @@ func TestPRCompose_OpenSeedsFieldsAndFocusesTitle(t *testing.T) {
 	if m.titleInput.Value() != "My title" {
 		t.Errorf("title = %q, want %q", m.titleInput.Value(), "My title")
 	}
-	if m.bodyArea.Value() != "Body text" {
-		t.Errorf("body = %q, want %q", m.bodyArea.Value(), "Body text")
+	if m.doc.Value() != "Body text" {
+		t.Errorf("body = %q, want %q", m.doc.Value(), "Body text")
 	}
 	if m.draft {
 		t.Error("draft should be false when Open passes draft=false")
@@ -75,37 +75,37 @@ func TestPRCompose_ViewScrollMode_ContainsHeaderAndTitle(t *testing.T) {
 
 func TestPRCompose_ScrollKeyJ_IncrementsScrollOff(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.bodyArea.SetValue(strings.Repeat("line\n", 50))
+	m.doc.SetValue(strings.Repeat("line\n", 50))
 	m.SetSize(120, 40)
-	before := m.scrollOff
+	before := m.doc.scrollOff
 	m.Update(keyRune('j'))
-	if m.scrollOff <= before {
-		t.Errorf("j did not increment scrollOff: before=%d after=%d", before, m.scrollOff)
+	if m.doc.scrollOff <= before {
+		t.Errorf("j did not increment scrollOff: before=%d after=%d", before, m.doc.scrollOff)
 	}
 }
 
 func TestPRCompose_ScrollKeyK_DecrementsScrollOff(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.bodyArea.SetValue(strings.Repeat("line\n", 50))
+	m.doc.SetValue(strings.Repeat("line\n", 50))
 	m.SetSize(120, 40)
 	m.Update(keyRune('j'))
 	m.Update(keyRune('j'))
-	after := m.scrollOff
+	after := m.doc.scrollOff
 	m.Update(keyRune('k'))
-	if m.scrollOff >= after {
-		t.Errorf("k did not decrement scrollOff: before=%d after=%d", after, m.scrollOff)
+	if m.doc.scrollOff >= after {
+		t.Errorf("k did not decrement scrollOff: before=%d after=%d", after, m.doc.scrollOff)
 	}
 }
 
 func TestPRCompose_ScrollKeyG_GoesToTop(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.bodyArea.SetValue(strings.Repeat("line\n", 50))
+	m.doc.SetValue(strings.Repeat("line\n", 50))
 	m.SetSize(120, 40)
 	m.Update(keyRune('j'))
 	m.Update(keyRune('j'))
 	m.Update(keyRune('g'))
-	if m.scrollOff != 0 {
-		t.Errorf("g did not reset scrollOff to 0, got %d", m.scrollOff)
+	if m.doc.scrollOff != 0 {
+		t.Errorf("g did not reset scrollOff to 0, got %d", m.doc.scrollOff)
 	}
 }
 
@@ -128,7 +128,7 @@ func TestPRCompose_EscCancels(t *testing.T) {
 func TestPRCompose_CtrlEnterSubmitsTrimmedValues(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.titleInput.SetValue("  trimmed title  ")
-	m.bodyArea.SetValue("\nbody with leading newline\n")
+	m.doc.SetValue("\nbody with leading newline\n")
 
 	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
 	if cmd == nil {
@@ -224,7 +224,7 @@ func TestPRCompose_Tab_SwitchesFocusToBodyInEditMode(t *testing.T) {
 		t.Fatal("prereq: title input should be focused after i")
 	}
 	m.Update(keyNamed(tea.KeyTab))
-	if !m.bodyArea.Focused() {
+	if !m.doc.Focused() {
 		t.Error("after tab: body should be focused")
 	}
 	m.Update(keyNamed(tea.KeyTab))
@@ -237,7 +237,7 @@ func TestPRCompose_ShiftTab_SwitchesFocusInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i')) // enter edit mode
 	m.Update(keyShiftNamed(tea.KeyTab))
-	if !m.bodyArea.Focused() {
+	if !m.doc.Focused() {
 		t.Error("after shift+tab: body should be focused")
 	}
 }
@@ -340,12 +340,12 @@ func TestPRCompose_PasteInEditMode_BodyFocused_UpdatesBody(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i'))         // enter edit mode
 	m.Update(keyNamed(tea.KeyTab)) // switch to body
-	if !m.bodyArea.Focused() {
+	if !m.doc.Focused() {
 		t.Fatal("prereq: body should be focused after tab")
 	}
-	bodyBefore := m.bodyArea.Value()
+	bodyBefore := m.doc.Value()
 	m.Update(tea.PasteMsg{Content: "pasted-body"})
-	if got := m.bodyArea.Value(); got == bodyBefore {
+	if got := m.doc.Value(); got == bodyBefore {
 		t.Error("paste in body-focused edit mode did not update body")
 	}
 }
@@ -373,12 +373,12 @@ func TestPRCompose_PrintableKey_RoutedToBodyInEditModeWhenBodyFocused(t *testing
 	m := makePRComposeForTest(t)
 	m.Update(keyRune('i'))         // enter edit mode (title focused)
 	m.Update(keyNamed(tea.KeyTab)) // switch to body
-	if !m.bodyArea.Focused() {
+	if !m.doc.Focused() {
 		t.Fatal("body should be focused after tab")
 	}
-	bodyBefore := m.bodyArea.Value()
+	bodyBefore := m.doc.Value()
 	m.Update(keyRune('?'))
-	if m.bodyArea.Value() == bodyBefore {
+	if m.doc.Value() == bodyBefore {
 		t.Error("typing in body did not change body value")
 	}
 	if !strings.HasPrefix(m.titleInput.Value(), "Initial title") {

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -21,7 +21,7 @@ import (
 const reviewDetailMaxMeasure = 72
 
 // reviewRenderer is the markdown renderer used for rationale text in the detail pane.
-var reviewRenderer = mdrender.New(planEditorChromaStyle)
+var reviewRenderer = mdrender.New(docEditorChromaStyle)
 
 // detailContentMeasure returns the effective content width and left-margin padding
 // for centering the detail pane content. Thin wrapper around mdrender.ContentMeasure.
@@ -730,7 +730,7 @@ func renderReviewSpecOverlay(sess *agent.Session, plan string, scrollOffset, wid
 	}
 
 	sections := agent.ParsePlanSections(plan)
-	r := mdrender.New(planEditorChromaStyle)
+	r := mdrender.New(docEditorChromaStyle)
 	contentW := width - 4
 
 	type namedSection struct {

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -17,8 +17,8 @@ import (
 )
 
 // reviewDetailMaxMeasure is the maximum content column width for the right detail
-// pane. Matches planEditorMaxMeasure so typography is consistent across panels.
-const reviewDetailMaxMeasure = 72
+// pane. Matches docEditorMaxMeasure so typography is consistent across panels.
+const reviewDetailMaxMeasure = docEditorMaxMeasure
 
 // reviewRenderer is the markdown renderer used for rationale text in the detail pane.
 var reviewRenderer = mdrender.New(docEditorChromaStyle)

--- a/internal/tui/update_plan.go
+++ b/internal/tui/update_plan.go
@@ -148,7 +148,7 @@ func (a App) handlePlanEditorRevise(msg planEditorReviseMsg) (tea.Model, tea.Cmd
 	// we abort the revise — otherwise the model would revise the wrong
 	// plan and overwrite the user's edits with the result.
 	if a.modals.PlanEditor() != nil && a.modals.PlanEditor().dirty && a.modals.PlanEditor().sess != nil {
-		val := a.modals.PlanEditor().textarea.Value()
+		val := a.modals.PlanEditor().doc.Value()
 		if err := a.modals.PlanEditor().sess.WritePlan(val); err != nil {
 			a.modals.PlanEditor().SetError("save plan: " + err.Error())
 			return a, nil


### PR DESCRIPTION
## Summary

- Extracted duplicated editor logic (textarea, renderer, scrolling) into a shared `docEditor` component
- Refactored `planEditorModel` and `prComposeModal` to embed and use `docEditor`, eliminating five duplicate receiver methods in each
- Moved shared constants (`docEditorMaxMeasure`, etc.) and helpers to a single source of truth in `doceditor.go`
- Fixes a width-off-by-2 bug in `prComposeModal.contentWidth()` that was using `m.width` instead of `textareaWidth(m.width)`
- Reduces code duplication and makes future editor changes maintainable in one place

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI:
  - [ ] Plan editor: verify text input, scrolling, rendering, and centered layout work correctly
  - [ ] PR compose modal: verify body text editor input, scrolling, rendering, and width constraints work correctly

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description