### PR TITLE
Add validation checks feature with parallel runner and Checks tab

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -153,6 +153,13 @@ type GlobalSettings struct {
 	MergeMethod *string `json:"merge_method,omitempty"`
 }
 
+// ValidationCheck defines a named shell command to run against the session's
+// worktree during the Checks tab of the review panel.
+type ValidationCheck struct {
+	Name    string `json:"name"`
+	Command string `json:"command"`
+}
+
 // RepoSettings holds per-repo overrides stored at <repo>/.refrain/config.json.
 // Fields here override the corresponding GlobalSettings value.
 type RepoSettings struct {
@@ -174,6 +181,9 @@ type RepoSettings struct {
 	PRDraftByDefault    *bool   `json:"pr_draft_by_default,omitempty"`
 	AutoOpenPRInBrowser *bool   `json:"auto_open_pr_in_browser,omitempty"`
 	MergeMethod         *string `json:"merge_method,omitempty"`
+
+	// ValidationChecks are shell commands run against the worktree during review.
+	ValidationChecks []ValidationCheck `json:"validation_checks,omitempty"`
 }
 
 // ResolvedSettings is the fully merged configuration with no nil pointers.
@@ -220,6 +230,10 @@ type ResolvedSettings struct {
 	// MergeMethod is how PRs are merged from the shipping panel.
 	// "squash" | "merge" | "rebase" — defaults to "squash".
 	MergeMethod string
+
+	// ValidationChecks are the shell commands to run during the Checks tab.
+	// Sourced from per-repo settings only; empty slice means no checks configured.
+	ValidationChecks []ValidationCheck
 }
 
 // Resolve merges global and repo settings over built-in defaults.
@@ -361,6 +375,9 @@ func Resolve(global *GlobalSettings, repo *RepoSettings) ResolvedSettings {
 		}
 		if repo.MergeMethod != nil {
 			r.MergeMethod = *repo.MergeMethod
+		}
+		if repo.ValidationChecks != nil {
+			r.ValidationChecks = repo.ValidationChecks
 		}
 	}
 

--- a/internal/config/settings_prop_helpers_test.go
+++ b/internal/config/settings_prop_helpers_test.go
@@ -166,6 +166,17 @@ func genRepoSettings(t *rapid.T) *config.RepoSettings {
 		v := genMergeMethod(t)
 		r.MergeMethod = &v
 	}
+	if rapid.Bool().Draw(t, "r_validation_checks") {
+		n := rapid.IntRange(0, 4).Draw(t, "r_validation_checks_n")
+		checks := make([]config.ValidationCheck, n)
+		for i := range checks {
+			checks[i] = config.ValidationCheck{
+				Name:    rapid.String().Draw(t, fmt.Sprintf("r_check_name_%d", i)),
+				Command: rapid.String().Draw(t, fmt.Sprintf("r_check_cmd_%d", i)),
+			}
+		}
+		r.ValidationChecks = checks
+	}
 	return r
 }
 

--- a/internal/config/settings_prop_test.go
+++ b/internal/config/settings_prop_test.go
@@ -31,6 +31,9 @@ func TestResolve_DefaultsProperty(t *testing.T) {
 		{"PRDraftByDefault", r.PRDraftByDefault, config.DefaultPRDraftByDefault},
 		{"AutoOpenPRInBrowser", r.AutoOpenPRInBrowser, config.DefaultAutoOpenPRInBrowser},
 	}
+	if len(r.ValidationChecks) != 0 {
+		t.Errorf("ValidationChecks = %v, want empty slice", r.ValidationChecks)
+	}
 	for _, c := range checks {
 		if c.got != c.want {
 			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -667,3 +667,29 @@ func TestResolve_MergeMethod_NormalizesAndValidates(t *testing.T) {
 		}
 	}
 }
+
+func TestResolve_ValidationChecks_RepoOverridesEmpty(t *testing.T) {
+	repo := &config.RepoSettings{
+		ValidationChecks: []config.ValidationCheck{
+			{Name: "Tests", Command: "go test ./..."},
+			{Name: "Vet", Command: "go vet ./..."},
+		},
+	}
+	r := config.Resolve(nil, repo)
+	if len(r.ValidationChecks) != 2 {
+		t.Fatalf("ValidationChecks: got %d entries, want 2", len(r.ValidationChecks))
+	}
+	if r.ValidationChecks[0].Name != "Tests" {
+		t.Errorf("ValidationChecks[0].Name = %q, want Tests", r.ValidationChecks[0].Name)
+	}
+	if r.ValidationChecks[1].Name != "Vet" {
+		t.Errorf("ValidationChecks[1].Name = %q, want Vet", r.ValidationChecks[1].Name)
+	}
+}
+
+func TestResolve_ValidationChecks_DefaultEmpty(t *testing.T) {
+	r := config.Resolve(nil, nil)
+	if len(r.ValidationChecks) != 0 {
+		t.Errorf("ValidationChecks: got %d entries, want 0", len(r.ValidationChecks))
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -689,6 +689,12 @@ func (a *App) panelServices() PanelServices {
 		prDraftInFlightFor: func(sessionID, repoPath string) bool {
 			return a.prDraftInFlight && a.prDraftSessionID == sessionID && a.prDraftRepoPath == repoPath
 		},
+		ValidationRuns: func(sessID string) *validationRunState {
+			return a.validationRuns[sessID]
+		},
+		TriggerValidationRerun: func(sessID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd {
+			return triggerValidationRun(a, sessID, repoPath, worktreePath, checks)
+		},
 		FeedbackTriage: func(repoPath, sessionID string) map[string]*feedbackTriageEntry {
 			return a.feedbackTriage[cacheKey(repoPath, sessionID)]
 		},

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -198,9 +198,9 @@ type App struct {
 	// openConfig / openLaunch / closeModal helpers (which keep the dashboard
 	// mirror fields in sync).
 	modals          Modals
-	reviewDiffCache  map[string]*reviewDiffEntry                // keyed by cacheKey(repoPath, sessionID); lifetime exceeds panel
-	validationRuns   map[string]*validationRunState            // keyed by sessionID; lifetime exceeds panel
-	feedbackTriage   map[string]map[string]*feedbackTriageEntry // keyed by cacheKey(repoPath, sessionID) → itemKey
+	reviewDiffCache map[string]*reviewDiffEntry                // keyed by cacheKey(repoPath, sessionID); lifetime exceeds panel
+	validationRuns  map[string]*validationRunState             // keyed by sessionID; lifetime exceeds panel
+	feedbackTriage  map[string]map[string]*feedbackTriageEntry // keyed by cacheKey(repoPath, sessionID) → itemKey
 	promptModal     promptModalModel                           // overlay for plan-first new-session prompt
 
 	// closingAgents and closingSessions track in-flight kill requests so the

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -198,8 +198,9 @@ type App struct {
 	// openConfig / openLaunch / closeModal helpers (which keep the dashboard
 	// mirror fields in sync).
 	modals          Modals
-	reviewDiffCache map[string]*reviewDiffEntry                // keyed by cacheKey(repoPath, sessionID); lifetime exceeds panel
-	feedbackTriage  map[string]map[string]*feedbackTriageEntry // keyed by cacheKey(repoPath, sessionID) → itemKey
+	reviewDiffCache  map[string]*reviewDiffEntry                // keyed by cacheKey(repoPath, sessionID); lifetime exceeds panel
+	validationRuns   map[string]*validationRunState            // keyed by sessionID; lifetime exceeds panel
+	feedbackTriage   map[string]map[string]*feedbackTriageEntry // keyed by cacheKey(repoPath, sessionID) → itemKey
 	promptModal     promptModalModel                           // overlay for plan-first new-session prompt
 
 	// closingAgents and closingSessions track in-flight kill requests so the
@@ -314,6 +315,7 @@ func NewApp() App {
 		lastKnownStatus: make(map[string]agent.Status),
 		diffStatsCache:  make(map[string]*diffStatsEntry),
 		reviewDiffCache: make(map[string]*reviewDiffEntry),
+		validationRuns:  make(map[string]*validationRunState),
 		prCache:         make(map[string]*prCacheEntry),
 		prPollStates:    make(map[string]*prSessionState),
 		closingAgents:   make(map[string]bool),
@@ -1465,6 +1467,46 @@ const (
 	verdictErr                         // reviewer subprocess errored
 	verdictNoDiff                      // task has no matching commits — nothing to review
 )
+
+// validationCheckState tracks the lifecycle of one validation check run.
+type validationCheckState int
+
+const (
+	checkPending validationCheckState = iota
+	checkRunning
+	checkPassed
+	checkFailed
+	checkError
+)
+
+// validationCheckResult holds the result of one completed (or pending) check.
+type validationCheckResult struct {
+	state    validationCheckState
+	output   string
+	exitCode int
+	duration time.Duration
+	err      error
+}
+
+// validationCheckResultMsg is emitted by a check goroutine when it finishes.
+type validationCheckResultMsg struct {
+	sessionID  string
+	repoPath   string
+	checkIndex int
+	runID      int
+	state      validationCheckState
+	output     string
+	exitCode   int
+	duration   time.Duration
+	err        error
+}
+
+// validationRunState holds the current run of validation checks for a session.
+type validationRunState struct {
+	checks  []config.ValidationCheck
+	results []validationCheckResult
+	runID   int
+}
 
 // taskVerdictRecord holds the verdict state for one task row.
 type taskVerdictRecord struct {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -455,6 +455,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.handleReviewVerdict(msg)
 	case reviewOpenTaskDiffMsg:
 		return a.handleReviewOpenTaskDiff(msg)
+	case validationCheckResultMsg:
+		a.handleValidationCheckResult(msg)
+		return a, nil
 	}
 
 	// Route to the active view.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -5488,3 +5488,97 @@ func TestCleanStaleCaches_ScopesByRepo(t *testing.T) {
 		t.Error("repoB's dead cache entry survived cleanup (it should be evicted)")
 	}
 }
+
+// TestAutoPromoteToReview_TriggersValidation verifies that auto-promoting a
+// session to LifecycleReadyForReview initialises a validationRunState when the
+// repo has ValidationChecks configured.
+func TestAutoPromoteToReview_TriggersValidation(t *testing.T) {
+	dir, mgr := setupAutoPromoteRepo(t)
+
+	sess, err := mgr.CreateSessionForPlanning(agent.Config{Rows: 24, Cols: 80, AgentProgram: "bash"})
+	if err != nil {
+		t.Fatalf("CreateSessionForPlanning: %v", err)
+	}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("ag-idle-val-1", false, agent.StatusIdle)
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.resolvedCache[dir] = config.ResolvedSettings{
+		ValidationChecks: []config.ValidationCheck{
+			{Name: "Tests", Command: "echo test"},
+			{Name: "Vet", Command: "echo vet"},
+		},
+	}
+
+	app.Update(agentEventMsg{ //nolint:errcheck
+		event: agent.Event{
+			Type:      agent.EventStatusChanged,
+			AgentID:   ag.ID,
+			SessionID: sess.ID,
+			Status:    agent.StatusIdle,
+		},
+		repoPath: dir,
+	})
+
+	run := app.validationRuns[sess.ID]
+	if run == nil {
+		t.Fatal("validationRuns[sess.ID] is nil — validation was not triggered")
+	}
+	if len(run.results) != 2 {
+		t.Errorf("len(results) = %d, want 2", len(run.results))
+	}
+	for i, r := range run.results {
+		if r.state != checkRunning {
+			t.Errorf("results[%d].state = %v, want checkRunning", i, r.state)
+		}
+	}
+}
+
+// TestManualMarkReady_TriggersValidation verifies that pressing 'm' on a
+// finished Building session with configured checks starts a validation run.
+func TestManualMarkReady_TriggersValidation(t *testing.T) {
+	dir, mgr := setupAutoPromoteRepo(t)
+
+	sess, err := mgr.CreateSessionForPlanning(agent.Config{Rows: 24, Cols: 80, AgentProgram: "bash"})
+	if err != nil {
+		t.Fatalf("CreateSessionForPlanning: %v", err)
+	}
+	sess.SetLifecyclePhase(agent.LifecycleInProgress)
+	ag := sess.AddTestAgent("ag-idle-m-1", false, agent.StatusIdle)
+	_ = ag
+	sess.MarkDone()
+
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.managers[dir] = mgr
+	app.activeRepo = dir
+	app.resolvedCache[dir] = config.ResolvedSettings{
+		ValidationChecks: []config.ValidationCheck{
+			{Name: "Lint", Command: "echo lint"},
+		},
+	}
+	// Populate the dashboard so the m-key handler can find the session.
+	app.refreshAgentList()
+	// Move cursor to the Building section.
+	app.cursor.SetSection(focusSectionBuilding)
+	app.cursor.SetIndex(focusSectionBuilding, 0)
+
+	app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"}) //nolint:errcheck
+
+	run := app.validationRuns[sess.ID]
+	if run == nil {
+		t.Fatal("validationRuns[sess.ID] is nil — validation was not triggered on manual m")
+	}
+	if len(run.results) != 1 {
+		t.Errorf("len(results) = %d, want 1", len(run.results))
+	}
+}

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -70,6 +70,16 @@ type PanelServices struct {
 	// this to render the "Drafting PR…" footer hint.
 	prDraftInFlightFor func(sessionID, repoPath string) bool
 
+	// ValidationRuns returns the live validation run state for a session, or
+	// nil when no run has been started. The Checks tab uses this to render
+	// check rows and output; it is keyed by session ID (run state lives on App
+	// so results survive panel close/reopen).
+	ValidationRuns func(sessID string) *validationRunState
+	// TriggerValidationRerun starts a new validation run for sessID, resetting
+	// all results to checkRunning and returning a batched tea.Cmd that fires
+	// one runValidationCheckCmd per check.
+	TriggerValidationRerun func(sessID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd
+
 	// Shipping-panel feedback triage state. Reads return the live map (or
 	// nil); the setters lazily allocate and apply the same cleanup rules as
 	// the original App methods (neutral+empty -> delete entry). Keyed by

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -107,7 +107,7 @@ func renderChecksTab(cs *checksTabState, width, height int) []string {
 
 	// Build list pane.
 	header := lipgloss.NewStyle().Foreground(lipgloss.Color("#06B6D4")).Bold(true).Render("CHECKS")
-	var listLines []string
+	listLines := make([]string, 0, len(cs.checks)+1)
 	listLines = append(listLines, header)
 	for i, ch := range cs.checks {
 		var result validationCheckResult

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -173,12 +173,31 @@ func renderReviewTabBar(activeTab, width int) []string {
 	return []string{labelLine, divider}
 }
 
+// checksTabState carries the data needed to render the Checks tab body.
+// checks and results are sourced from App-level validationRunState; cursor
+// and scroll are panel-local since they don't need to survive panel close.
+type checksTabState struct {
+	checks  []validationCheck
+	results []validationCheckResult
+	cursor  int
+	scroll  int
+}
+
+// validationCheck mirrors config.ValidationCheck, defined here so the render
+// layer doesn't import config (config is imported by the App layer).
+type validationCheck struct {
+	Name    string
+	Command string
+}
+
 // renderReviewPanel renders the fullscreen review panel for a session.
 // entry may be nil while diff stats are being fetched (shows loading placeholder).
 // cursor is the currently selected task row index (0-based among all task rows).
 // prDraftInFlight, when true, shows a spinner status line and disables the p hint.
-// activeTab selects which tab body to render (0=Tasks, 1=Diff, 2=Checks, 3=Validate).
-func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool, activeTab int) string {
+// activeTab selects which tab body to render (0=Tasks, 1=Diff, 2=Checks).
+// checkState is non-nil when validation checks are configured and their results
+// are available; nil when no checks are configured or the run state is absent.
+func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool, activeTab int, checkState *checksTabState) string {
 	// Header (3–4 lines depending on prompt length).
 	headerLines := renderReviewHeader(sess, width)
 
@@ -242,17 +261,28 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	} else {
 		pHint = StyleActive.Render("p") + StyleSubtle.Render(" — create or open PR")
 	}
-	hints := "  " +
-		pHint +
-		"  " + StyleActive.Render("t") + StyleSubtle.Render(" — open agent terminal") +
-		"  " + StyleWarning.Render("b") + StyleSubtle.Render(" — back to build") +
-		"  " + StyleActive.Render("f") + StyleSubtle.Render(" — flag task") +
-		"  " + StyleActive.Render("c") + StyleSubtle.Render(" — mark complete") +
-		"  " + StyleActive.Render("e") + StyleSubtle.Render(" — open in editor") +
-		"  " + StyleActive.Render("d") + StyleSubtle.Render(" — defer") +
-		"  " + StyleActive.Render("enter") + StyleSubtle.Render(" — open task diff") +
-		"  " + StyleActive.Render("?") + StyleSubtle.Render(" — spec") +
-		"  " + StyleSubtle.Render("ESC — back to focus")
+	var hints string
+	if activeTab == reviewTabChecks {
+		hints = "  " +
+			pHint +
+			"  " + StyleActive.Render("t") + StyleSubtle.Render(" — open agent terminal") +
+			"  " + StyleActive.Render("r") + StyleSubtle.Render(" — run checks") +
+			"  " + StyleActive.Render("pgdn/pgup") + StyleSubtle.Render(" — scroll output") +
+			"  " + StyleActive.Render("j/k") + StyleSubtle.Render(" — select check") +
+			"  " + StyleSubtle.Render("ESC — back to focus")
+	} else {
+		hints = "  " +
+			pHint +
+			"  " + StyleActive.Render("t") + StyleSubtle.Render(" — open agent terminal") +
+			"  " + StyleWarning.Render("b") + StyleSubtle.Render(" — back to build") +
+			"  " + StyleActive.Render("f") + StyleSubtle.Render(" — flag task") +
+			"  " + StyleActive.Render("c") + StyleSubtle.Render(" — mark complete") +
+			"  " + StyleActive.Render("e") + StyleSubtle.Render(" — open in editor") +
+			"  " + StyleActive.Render("d") + StyleSubtle.Render(" — defer") +
+			"  " + StyleActive.Render("enter") + StyleSubtle.Render(" — open task diff") +
+			"  " + StyleActive.Render("?") + StyleSubtle.Render(" — spec") +
+			"  " + StyleSubtle.Render("ESC — back to focus")
+	}
 	lines = append(lines, hints)
 
 	return strings.Join(lines, "\n")

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -158,7 +158,7 @@ func renderReviewPlaceholderTab(label string, width, height int) []string {
 // Line 0: tab labels separated by two spaces; active tab in ColorSecondary bold,
 // inactive tabs in StyleSubtle. Line 1: a subtle horizontal divider.
 func renderReviewTabBar(activeTab, width int) []string {
-	labels := []string{"Tasks", "Diff", "Checks", "Validate"}
+	labels := []string{"Tasks", "Diff", "Checks"}
 	activeStyle := lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
 	var parts []string
 	for i, label := range labels {
@@ -199,18 +199,10 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	// Build body lines based on active tab.
 	var bodyLines []string
 	switch {
-	case activeTab != reviewTabTasks:
-		// Non-Tasks tabs: placeholder.
-		var label string
-		switch activeTab {
-		case reviewTabDiff:
-			label = "full diff browser coming soon"
-		case reviewTabChecks:
-			label = "local checks coming soon"
-		case reviewTabValidate:
-			label = "manual validation coming soon"
-		}
-		bodyLines = renderReviewPlaceholderTab(label, width, bodyH)
+	case activeTab == reviewTabDiff:
+		bodyLines = renderReviewPlaceholderTab("full diff browser coming soon", width, bodyH)
+	case activeTab == reviewTabChecks:
+		bodyLines = renderReviewPlaceholderTab("No validation checks configured — add them in .refrain/config.json", width, bodyH)
 	case entry == nil:
 		bodyLines = append(bodyLines, StyleSubtle.Render("loading diff stats…"))
 	default:

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
 	"github.com/devenjarvis/refrain/internal/git"
 	"github.com/devenjarvis/refrain/internal/tui/mdrender"
 )
@@ -68,6 +69,108 @@ func verdictBadge(rec *taskVerdictRecord) (icon, label string, style lipgloss.St
 		return "⊘", "no diff found", StyleSubtle
 	}
 	return "⋯", "Pending", StyleSubtle
+}
+
+// checkBadge returns the icon and lipgloss style for a validation check result.
+// Modeled on verdictBadge to keep icon/style language consistent.
+func checkBadge(result validationCheckResult) (icon string, style lipgloss.Style) {
+	switch result.state {
+	case checkPending:
+		return "⋯", StyleSubtle
+	case checkRunning:
+		return reviewSpinnerFrame(), lipgloss.NewStyle().Foreground(ColorPrimary)
+	case checkPassed:
+		return "✓", StyleSuccess
+	case checkFailed:
+		return "✗", StyleError
+	case checkError:
+		return "✗", StyleError
+	}
+	return "⋯", StyleSubtle
+}
+
+// renderChecksTab renders the Checks tab body: a compact check list on top and
+// the selected check's combined output below. cs must not be nil.
+func renderChecksTab(cs *checksTabState, width, height int) []string {
+	if height < 4 {
+		height = 4
+	}
+
+	listH := height * 2 / 5
+	if listH < 2 {
+		listH = 2
+	}
+	outputH := height - listH - 1
+	if outputH < 2 {
+		outputH = 2
+	}
+
+	// Build list pane.
+	header := lipgloss.NewStyle().Foreground(lipgloss.Color("#06B6D4")).Bold(true).Render("CHECKS")
+	var listLines []string
+	listLines = append(listLines, header)
+	for i, ch := range cs.checks {
+		var result validationCheckResult
+		if i < len(cs.results) {
+			result = cs.results[i]
+		}
+		icon, iconStyle := checkBadge(result)
+		iconStr := iconStyle.Render(icon)
+
+		duration := ""
+		if result.state == checkPassed || result.state == checkFailed || result.state == checkError {
+			if result.duration > 0 {
+				duration = "  " + StyleSubtle.Render(result.duration.Round(time.Millisecond).String())
+			}
+		}
+
+		cursor := " "
+		nameStyle := StyleSubtle
+		if i == cs.cursor {
+			cursor = "›"
+			nameStyle = lipgloss.NewStyle()
+		}
+
+		line := fmt.Sprintf("  %s %s %s%s%s",
+			cursor,
+			iconStr,
+			nameStyle.Render(ch.Name),
+			duration,
+			"",
+		)
+		listLines = append(listLines, line)
+	}
+	listLines = capLines(listLines, listH)
+
+	// Build output pane.
+	var outputLines []string
+	outputLines = append(outputLines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	if cs.cursor < len(cs.results) {
+		result := cs.results[cs.cursor]
+		out := result.output
+		if result.err != nil {
+			out += "\n" + result.err.Error()
+		}
+		if out == "" {
+			if result.state == checkRunning {
+				out = "(running…)"
+			} else {
+				out = "(no output)"
+			}
+		}
+		outLines := strings.Split(out, "\n")
+		// Apply scroll offset.
+		if cs.scroll > 0 && cs.scroll < len(outLines) {
+			outLines = outLines[cs.scroll:]
+		}
+		outputLines = append(outputLines, capLines(outLines, outputH-1)...)
+	}
+	outputLines = capLines(outputLines, outputH)
+
+	var lines []string
+	lines = append(lines, listLines...)
+	lines = append(lines, outputLines...)
+	return lines
 }
 
 // renderReviewHeader returns the 4-line collapsed header:
@@ -177,17 +280,10 @@ func renderReviewTabBar(activeTab, width int) []string {
 // checks and results are sourced from App-level validationRunState; cursor
 // and scroll are panel-local since they don't need to survive panel close.
 type checksTabState struct {
-	checks  []validationCheck
+	checks  []config.ValidationCheck
 	results []validationCheckResult
 	cursor  int
 	scroll  int
-}
-
-// validationCheck mirrors config.ValidationCheck, defined here so the render
-// layer doesn't import config (config is imported by the App layer).
-type validationCheck struct {
-	Name    string
-	Command string
 }
 
 // renderReviewPanel renders the fullscreen review panel for a session.
@@ -221,7 +317,11 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 	case activeTab == reviewTabDiff:
 		bodyLines = renderReviewPlaceholderTab("full diff browser coming soon", width, bodyH)
 	case activeTab == reviewTabChecks:
-		bodyLines = renderReviewPlaceholderTab("No validation checks configured — add them in .refrain/config.json", width, bodyH)
+		if checkState != nil {
+			bodyLines = renderChecksTab(checkState, width, bodyH)
+		} else {
+			bodyLines = renderReviewPlaceholderTab("No validation checks configured — add them in .refrain/config.json", width, bodyH)
+		}
 	case entry == nil:
 		bodyLines = append(bodyLines, StyleSubtle.Render("loading diff stats…"))
 	default:

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -131,7 +131,8 @@ func renderChecksTab(cs *checksTabState, width, height int) []string {
 			nameStyle = lipgloss.NewStyle()
 		}
 
-		line := fmt.Sprintf("  %s %s %s%s%s",
+		line := fmt.Sprintf(
+			"  %s %s %s%s%s",
 			cursor,
 			iconStr,
 			nameStyle.Render(ch.Name),

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -1303,7 +1303,7 @@ func TestRenderTaskListPane_HeaderUsesHeadingColor(t *testing.T) {
 }
 
 // TestRenderReviewPanel_ShowsTabBar verifies that renderReviewPanel includes a
-// tab bar containing all four tab labels.
+// tab bar containing all three tab labels.
 func TestRenderReviewPanel_ShowsTabBar(t *testing.T) {
 	sess := agent.NewSessionForTest("sess-tabs", "fix-auth")
 	sess.SetOriginalPrompt("Fix auth")
@@ -1319,7 +1319,7 @@ func TestRenderReviewPanel_ShowsTabBar(t *testing.T) {
 
 	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
 
-	for _, tab := range []string{"Tasks", "Diff", "Checks", "Validate"} {
+	for _, tab := range []string{"Tasks", "Diff", "Checks"} {
 		if !strings.Contains(ansi.Strip(output), tab) {
 			t.Errorf("panel must contain tab label %q; got:\n%s", tab, output)
 		}
@@ -1418,10 +1418,10 @@ func TestRenderReviewPlaceholderTab(t *testing.T) {
 }
 
 // TestRenderReviewTabBar_HighlightsActiveTab verifies that renderReviewTabBar
-// returns 2 lines, contains all four tab labels in the first line, and applies
+// returns 2 lines, contains all three tab labels in the first line, and applies
 // the correct styling: active tab in ColorSecondary bold, inactive tabs in StyleSubtle.
 func TestRenderReviewTabBar_HighlightsActiveTab(t *testing.T) {
-	tabNames := []string{"Tasks", "Diff", "Checks", "Validate"}
+	tabNames := []string{"Tasks", "Diff", "Checks"}
 	activeStyle := lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
 
 	for activeIdx, activeName := range tabNames {

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -253,7 +253,7 @@ func TestRenderReviewPanel_TwoPaneLayout(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 30, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 140, 30, 0, false, 0, nil)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from left pane")
@@ -293,7 +293,7 @@ func TestRenderReviewPanel_FullWidthStack(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from list pane")
@@ -334,7 +334,7 @@ func TestRenderReviewPanel_NarrowWidthStacks(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 70, 30, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 70, 30, 0, false, 0, nil)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from list pane")
@@ -364,7 +364,7 @@ func TestRenderReviewPanel_ShowsOriginalPrompt(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 213, Deletions: 34},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
 
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("review panel must show the original prompt")
@@ -379,7 +379,7 @@ func TestRenderReviewPanel_NilDiffEntry(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 
 	// nil entry — should not panic
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0, nil)
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("must still show prompt even with nil diff entry")
 	}
@@ -403,7 +403,7 @@ func TestRenderReviewPanel_UsesThemeColors(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0, nil)
 
 	// The pass verdict icon should carry the ColorSuccess ANSI escape.
 	expectedPrefix := StyleSuccess.Render("✓")
@@ -465,7 +465,7 @@ func TestRenderReviewPanel_NoPlanShowsOverview(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 30, Deletions: 2},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0, nil)
 
 	if !strings.Contains(output, "Overview") {
 		t.Error("must show 'Overview' row in list pane for no-plan session")
@@ -505,7 +505,7 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0, nil)
 
 	for _, want := range []string{
 		"open PR",
@@ -518,6 +518,24 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Errorf("footer must advertise %q; got:\n%s", want, output)
 		}
+	}
+}
+
+// TestRenderReviewPanel_ChecksTabFooter verifies that when activeTab is Checks,
+// the footer shows the r-run hint and does not contain the flag-task hint.
+func TestRenderReviewPanel_ChecksTabFooter(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-1", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, reviewTabChecks, nil)
+	stripped := ansi.Strip(output)
+
+	if !strings.Contains(stripped, "run checks") {
+		t.Errorf("Checks tab footer must contain 'run checks'; got:\n%s", stripped)
+	}
+	if strings.Contains(stripped, "flag task") {
+		t.Errorf("Checks tab footer must not contain 'flag task'; got:\n%s", stripped)
 	}
 }
 
@@ -548,7 +566,7 @@ func TestRenderReviewPanel_TaskListShown(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("task list view must show PLAN TASKS header")
@@ -756,7 +774,7 @@ func TestRenderReviewPanel_NoDiffFoundBadge(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
 
 	if !strings.Contains(output, "Write tests") {
 		t.Error("must render a row for task 2 even though it has no commits")
@@ -966,7 +984,7 @@ func TestRenderReviewPanel_HintsIncludeSpecAndEnter(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil)
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "?") {
@@ -1040,7 +1058,7 @@ func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, true, 0)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, true, 0, nil)
 
 	if !strings.Contains(output, "Pushing branch and drafting PR") {
 		t.Error("in-flight state must show draft spinner line")
@@ -1085,7 +1103,7 @@ func TestRenderReviewPanel_TaskHasDiff(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil)
 
 	if !strings.Contains(output, "pass") {
 		t.Error("must contain verdict label 'pass'")
@@ -1120,7 +1138,7 @@ func TestReviewPanel_CursorMoveSwapsDetail(t *testing.T) {
 	}
 
 	// cursor=0 → task 1 heading in detail pane
-	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil)
 	if !strings.Contains(out0, "Task 1:") {
 		t.Errorf("cursor=0: expected 'Task 1:' in detail pane; got:\n%s", out0)
 	}
@@ -1129,7 +1147,7 @@ func TestReviewPanel_CursorMoveSwapsDetail(t *testing.T) {
 	}
 
 	// cursor=1 → task 2 heading in detail pane
-	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false, 0)
+	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false, 0, nil)
 	if !strings.Contains(out1, "Task 2:") {
 		t.Errorf("cursor=1: expected 'Task 2:' in detail pane; got:\n%s", out1)
 	}
@@ -1250,7 +1268,7 @@ func TestRenderReviewPanel_FooterUsesThemeStyles(t *testing.T) {
 	sess.SetOriginalPrompt("Fix auth")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0, nil)
 
 	// StyleActive.Render("p") — carries ANSI codes in color mode, is "p" otherwise.
 	// In both cases the rendered footer must contain it.
@@ -1317,7 +1335,7 @@ func TestRenderReviewPanel_ShowsTabBar(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
 
 	for _, tab := range []string{"Tasks", "Diff", "Checks"} {
 		if !strings.Contains(ansi.Strip(output), tab) {
@@ -1337,7 +1355,7 @@ func TestRenderReviewPanel_DiffTabPlaceholder(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabDiff)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabDiff, nil)
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "full diff browser coming soon") {
@@ -1359,7 +1377,7 @@ func TestRenderReviewPanel_TasksTabStillWorks(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks, nil)
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "PLAN TASKS") {
@@ -1378,7 +1396,7 @@ func TestRenderReviewPanel_FooterShowsEnterHint(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks, nil)
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "enter") {
@@ -1482,7 +1500,7 @@ func TestRenderReviewPanel_NoDiffTask(t *testing.T) {
 	}
 
 	// Must not panic and must show the "no diff found" verdict badge.
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil)
 	if !strings.Contains(output, "no diff found") {
 		t.Errorf("must show 'no diff found' verdict badge; got:\n%s", output)
 	}

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
 	"github.com/devenjarvis/refrain/internal/git"
 )
 
@@ -1575,5 +1576,72 @@ func TestReviewTaskCmd_PassesTaskDetail(t *testing.T) {
 	}
 	if !foundTest {
 		t.Errorf("ChangedFiles must include internal/widget_test.go, got: %v", req.ChangedFiles)
+	}
+}
+
+// TestRenderChecksTab_ShowsCheckNames verifies the check list renders names and spinner.
+func TestRenderChecksTab_ShowsCheckNames(t *testing.T) {
+	cs := &checksTabState{
+		checks: []config.ValidationCheck{
+			{Name: "Tests", Command: "go test ./..."},
+			{Name: "Lint", Command: "golangci-lint run"},
+		},
+		results: []validationCheckResult{
+			{state: checkRunning},
+			{state: checkRunning},
+		},
+	}
+	lines := renderChecksTab(cs, 80, 20)
+	out := strings.Join(lines, "\n")
+	stripped := ansi.Strip(out)
+
+	if !strings.Contains(stripped, "Tests") {
+		t.Error("must contain check name 'Tests'")
+	}
+	if !strings.Contains(stripped, "Lint") {
+		t.Error("must contain check name 'Lint'")
+	}
+}
+
+// TestRenderChecksTab_PassedCheck verifies a passed check shows the ✓ icon.
+func TestRenderChecksTab_PassedCheck(t *testing.T) {
+	cs := &checksTabState{
+		checks:  []config.ValidationCheck{{Name: "Tests", Command: "go test ./..."}},
+		results: []validationCheckResult{{state: checkPassed, exitCode: 0}},
+	}
+	lines := renderChecksTab(cs, 80, 20)
+	out := ansi.Strip(strings.Join(lines, "\n"))
+
+	if !strings.Contains(out, "✓") {
+		t.Errorf("passed check must show ✓; got:\n%s", out)
+	}
+}
+
+// TestRenderChecksTab_OutputPane verifies the selected check's output appears in the pane.
+func TestRenderChecksTab_OutputPane(t *testing.T) {
+	cs := &checksTabState{
+		checks:  []config.ValidationCheck{{Name: "Tests", Command: "go test ./..."}},
+		results: []validationCheckResult{{state: checkPassed, output: "PASS: all 42 tests"}},
+		cursor:  0,
+	}
+	lines := renderChecksTab(cs, 80, 20)
+	out := ansi.Strip(strings.Join(lines, "\n"))
+
+	if !strings.Contains(out, "PASS: all 42 tests") {
+		t.Errorf("output pane must contain check output; got:\n%s", out)
+	}
+}
+
+// TestRenderChecksTab_NilState_ShowsPlaceholder verifies the no-checks placeholder.
+func TestRenderChecksTab_NilState_ShowsPlaceholder(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-1", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, reviewTabChecks, nil)
+	stripped := ansi.Strip(output)
+
+	if !strings.Contains(stripped, "No validation checks configured") {
+		t.Errorf("must show no-checks placeholder; got:\n%s", stripped)
 	}
 }

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -1645,3 +1645,27 @@ func TestRenderChecksTab_NilState_ShowsPlaceholder(t *testing.T) {
 		t.Errorf("must show no-checks placeholder; got:\n%s", stripped)
 	}
 }
+
+// TestRenderReviewPanel_ChecksTabWithState verifies that renderReviewPanel routes
+// to renderChecksTab when checkState is non-nil, showing check names in the body.
+func TestRenderReviewPanel_ChecksTabWithState(t *testing.T) {
+	sess := agent.NewSessionForTest("sess-1", "fix-auth")
+	sess.SetOriginalPrompt("Fix auth")
+	sess.MarkDone()
+
+	cs := &checksTabState{
+		checks: []config.ValidationCheck{
+			{Name: "Tests", Command: "go test ./..."},
+		},
+		results: []validationCheckResult{{state: checkPassed}},
+	}
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, reviewTabChecks, cs)
+	stripped := ansi.Strip(output)
+
+	if !strings.Contains(stripped, "Tests") {
+		t.Errorf("renderReviewPanel with non-nil checkState must show check names; got:\n%s", stripped)
+	}
+	if strings.Contains(stripped, "No validation checks configured") {
+		t.Error("must not show placeholder when checkState is non-nil")
+	}
+}

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -373,5 +373,5 @@ func (m *reviewPanelModel) View(svc PanelServices) string {
 	}
 	entry := svc.ReviewCache(m.repoPath, m.session.ID)
 	prDraftInFlight := svc.prDraftInFlightFor(m.session.ID, m.repoPath)
-	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.activeTab)
+	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.activeTab, nil)
 }

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -240,14 +240,15 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		reviewOpenIDECmd(m.session, m.repoPath, svc)
 		return m, nil
 	case "j", "down":
-		if m.activeTab == reviewTabTasks {
+		switch m.activeTab {
+		case reviewTabTasks:
 			if entry := svc.ReviewCache(m.repoPath, m.session.ID); entry != nil {
 				maxIdx := reviewTaskCount(entry) - 1
 				if m.taskCursor < maxIdx {
 					m.taskCursor++
 				}
 			}
-		} else if m.activeTab == reviewTabChecks {
+		case reviewTabChecks:
 			if svc.ValidationRuns != nil {
 				if run := svc.ValidationRuns(m.session.ID); run != nil {
 					maxIdx := len(run.results) - 1
@@ -259,10 +260,15 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		}
 		return m, nil
 	case "k", "up":
-		if m.activeTab == reviewTabTasks && m.taskCursor > 0 {
-			m.taskCursor--
-		} else if m.activeTab == reviewTabChecks && m.checksCursor > 0 {
-			m.checksCursor--
+		switch m.activeTab {
+		case reviewTabTasks:
+			if m.taskCursor > 0 {
+				m.taskCursor--
+			}
+		case reviewTabChecks:
+			if m.checksCursor > 0 {
+				m.checksCursor--
+			}
 		}
 		return m, nil
 	case "r":

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -11,10 +11,9 @@ import (
 )
 
 const (
-	reviewTabTasks    = 0
-	reviewTabDiff     = 1
-	reviewTabChecks   = 2
-	reviewTabValidate = 3
+	reviewTabTasks  = 0
+	reviewTabDiff   = 1
+	reviewTabChecks = 2
 )
 
 // reviewPanelModel owns the keyboard, mouse, and view dispatch for the review
@@ -165,14 +164,11 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 	case "3":
 		m.activeTab = reviewTabChecks
 		return m, nil
-	case "4":
-		m.activeTab = reviewTabValidate
-		return m, nil
 	case "tab":
-		m.activeTab = (m.activeTab + 1) % 4
+		m.activeTab = (m.activeTab + 1) % 3
 		return m, nil
 	case "shift+tab":
-		m.activeTab = (m.activeTab + 3) % 4
+		m.activeTab = (m.activeTab + 2) % 3
 		return m, nil
 	}
 

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -27,6 +27,8 @@ type reviewPanelModel struct {
 	activeTab         int
 	specOverlay       bool
 	specOverlayScroll int
+	checksCursor      int // cursor position in the Checks tab list
+	checksScroll      int // scroll offset for the Checks tab output pane
 
 	width, height int
 }

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -246,11 +246,51 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 					m.taskCursor++
 				}
 			}
+		} else if m.activeTab == reviewTabChecks {
+			if svc.ValidationRuns != nil {
+				if run := svc.ValidationRuns(m.session.ID); run != nil {
+					maxIdx := len(run.results) - 1
+					if m.checksCursor < maxIdx {
+						m.checksCursor++
+					}
+				}
+			}
 		}
 		return m, nil
 	case "k", "up":
 		if m.activeTab == reviewTabTasks && m.taskCursor > 0 {
 			m.taskCursor--
+		} else if m.activeTab == reviewTabChecks && m.checksCursor > 0 {
+			m.checksCursor--
+		}
+		return m, nil
+	case "r":
+		if m.activeTab == reviewTabChecks && svc.TriggerValidationRerun != nil {
+			var run *validationRunState
+			if svc.ValidationRuns != nil {
+				run = svc.ValidationRuns(m.session.ID)
+			}
+			if run == nil {
+				return m, nil
+			}
+			var worktreePath string
+			if m.session.Worktree != nil {
+				worktreePath = m.session.Worktree.Path
+			}
+			return m, svc.TriggerValidationRerun(m.session.ID, m.repoPath, worktreePath, run.checks)
+		}
+		return m, nil
+	case "pgdown":
+		if m.activeTab == reviewTabChecks {
+			m.checksScroll += m.height - 4
+		}
+		return m, nil
+	case "pgup":
+		if m.activeTab == reviewTabChecks {
+			m.checksScroll -= m.height - 4
+			if m.checksScroll < 0 {
+				m.checksScroll = 0
+			}
 		}
 		return m, nil
 	case "f":
@@ -373,5 +413,16 @@ func (m *reviewPanelModel) View(svc PanelServices) string {
 	}
 	entry := svc.ReviewCache(m.repoPath, m.session.ID)
 	prDraftInFlight := svc.prDraftInFlightFor(m.session.ID, m.repoPath)
-	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.activeTab, nil)
+	var checkState *checksTabState
+	if svc.ValidationRuns != nil {
+		if run := svc.ValidationRuns(m.session.ID); run != nil {
+			checkState = &checksTabState{
+				checks:  run.checks,
+				results: run.results,
+				cursor:  m.checksCursor,
+				scroll:  m.checksScroll,
+			}
+		}
+	}
+	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.activeTab, checkState)
 }

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
 )
 
 const (
@@ -270,14 +271,20 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 			if svc.ValidationRuns != nil {
 				run = svc.ValidationRuns(m.session.ID)
 			}
-			if run == nil {
+			var checks []config.ValidationCheck
+			if run != nil {
+				checks = run.checks
+			} else if svc.Resolved != nil {
+				checks = svc.Resolved(m.repoPath).ValidationChecks
+			}
+			if len(checks) == 0 {
 				return m, nil
 			}
 			var worktreePath string
 			if m.session.Worktree != nil {
 				worktreePath = m.session.Worktree.Path
 			}
-			return m, svc.TriggerValidationRerun(m.session.ID, m.repoPath, worktreePath, run.checks)
+			return m, svc.TriggerValidationRerun(m.session.ID, m.repoPath, worktreePath, checks)
 		}
 		return m, nil
 	case "pgdown":

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -56,6 +56,10 @@ func newTestSvc() (PanelServices, *testServiceState) {
 		SetFeedbackVerdict: func(string, string, string, feedbackVerdict) {},
 		SetFeedbackNote:    func(string, string, string, string) {},
 		prDraftInFlightFor: func(string, string) bool { return false },
+		ValidationRuns:     func(string) *validationRunState { return nil },
+		TriggerValidationRerun: func(string, string, string, []config.ValidationCheck) tea.Cmd {
+			return nil
+		},
 	}
 	return svc, state
 }
@@ -108,6 +112,100 @@ func TestReviewPanelModel_TabSwitching(t *testing.T) {
 	press(keyShiftNamed(tea.KeyTab))
 	if panel.activeTab != reviewTabChecks {
 		t.Errorf("shift+tab from Tasks: activeTab=%d, want %d (Checks)", panel.activeTab, reviewTabChecks)
+	}
+}
+
+// TestReviewPanelModel_ChecksTab_JKMovesCursor verifies j/k navigate the checks list.
+func TestReviewPanelModel_ChecksTab_JKMovesCursor(t *testing.T) {
+	sess := agent.NewSessionForTest("s1", "fix-auth")
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+	panel := newReviewPanel(sess, "", 120, 40)
+	svc, _ := newTestSvc()
+
+	app := NewApp()
+	app.validationRuns[sess.ID] = &validationRunState{
+		runID: 1,
+		checks: []config.ValidationCheck{
+			{Name: "A", Command: "echo a"},
+			{Name: "B", Command: "echo b"},
+			{Name: "C", Command: "echo c"},
+		},
+		results: []validationCheckResult{
+			{state: checkRunning},
+			{state: checkRunning},
+			{state: checkRunning},
+		},
+	}
+	svc.ValidationRuns = func(sessID string) *validationRunState {
+		return app.validationRuns[sessID]
+	}
+
+	// Switch to Checks tab.
+	_, _ = panel.Update(tea.KeyPressMsg{Code: '3', Text: "3"}, svc)
+
+	// Press j twice.
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	if panel.checksCursor != 1 {
+		t.Errorf("after j: checksCursor = %d, want 1", panel.checksCursor)
+	}
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	if panel.checksCursor != 2 {
+		t.Errorf("after j j: checksCursor = %d, want 2", panel.checksCursor)
+	}
+	// Press k.
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"}, svc)
+	if panel.checksCursor != 1 {
+		t.Errorf("after k: checksCursor = %d, want 1", panel.checksCursor)
+	}
+}
+
+// TestReviewPanelModel_ChecksTab_RKeyTriggersRerun verifies r starts a new run.
+func TestReviewPanelModel_ChecksTab_RKeyTriggersRerun(t *testing.T) {
+	sess := agent.NewSessionForTest("s1", "fix-auth")
+	sess.SetLifecyclePhase(agent.LifecycleInReview)
+	panel := newReviewPanel(sess, "/repo", 120, 40)
+	svc, _ := newTestSvc()
+
+	app := NewApp()
+	app.resolvedCache["/repo"] = config.ResolvedSettings{
+		ValidationChecks: []config.ValidationCheck{
+			{Name: "Tests", Command: "echo test"},
+		},
+	}
+	if sess.Worktree == nil {
+		// Set up a mock worktree path so triggerValidationRun can find it.
+	}
+	app.validationRuns[sess.ID] = &validationRunState{
+		runID:   1,
+		checks:  []config.ValidationCheck{{Name: "Tests", Command: "echo test"}},
+		results: []validationCheckResult{{state: checkPassed}},
+	}
+	svc.ValidationRuns = func(sessID string) *validationRunState {
+		return app.validationRuns[sessID]
+	}
+	svc.TriggerValidationRerun = func(sessID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd {
+		run := app.validationRuns[sessID]
+		if run != nil {
+			run.runID++
+			for i := range run.results {
+				run.results[i] = validationCheckResult{state: checkRunning}
+			}
+		}
+		return func() tea.Msg { return nil }
+	}
+
+	// Switch to Checks tab.
+	_, _ = panel.Update(tea.KeyPressMsg{Code: '3', Text: "3"}, svc)
+
+	priorRunID := app.validationRuns[sess.ID].runID
+
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'r', Text: "r"}, svc)
+	if cmd == nil {
+		t.Fatal("r on Checks tab must return a non-nil cmd")
+	}
+
+	if app.validationRuns[sess.ID].runID <= priorRunID {
+		t.Errorf("runID should have incremented; got %d, prior %d", app.validationRuns[sess.ID].runID, priorRunID)
 	}
 }
 

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -111,6 +111,19 @@ func TestReviewPanelModel_TabSwitching(t *testing.T) {
 	}
 }
 
+// TestReviewPanelModel_ChecksFieldsZeroValue confirms that newReviewPanel
+// initialises checksCursor and checksScroll to 0.
+func TestReviewPanelModel_ChecksFieldsZeroValue(t *testing.T) {
+	sess := agent.NewSessionForTest("s1", "fix-auth")
+	panel := newReviewPanel(sess, "", 120, 40)
+	if panel.checksCursor != 0 {
+		t.Errorf("checksCursor = %d, want 0", panel.checksCursor)
+	}
+	if panel.checksScroll != 0 {
+		t.Errorf("checksScroll = %d, want 0", panel.checksScroll)
+	}
+}
+
 // TestReviewPanelModel_DefaultTab confirms that newReviewPanel initialises
 // activeTab to 0 (Tasks tab). Zero-value initialisation covers this, but the
 // test pins the contract so a future refactor can't silently break it.

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -172,9 +172,6 @@ func TestReviewPanelModel_ChecksTab_RKeyTriggersRerun(t *testing.T) {
 			{Name: "Tests", Command: "echo test"},
 		},
 	}
-	if sess.Worktree == nil {
-		// Set up a mock worktree path so triggerValidationRun can find it.
-	}
 	app.validationRuns[sess.ID] = &validationRunState{
 		runID:   1,
 		checks:  []config.ValidationCheck{{Name: "Tests", Command: "echo test"}},

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -68,7 +68,7 @@ type testServiceState struct {
 	killSessionCalled  bool
 }
 
-// TestReviewPanelModel_TabSwitching verifies 1–4 and tab/shift+tab change activeTab.
+// TestReviewPanelModel_TabSwitching verifies 1–3 and tab/shift+tab change activeTab.
 func TestReviewPanelModel_TabSwitching(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	panel := newReviewPanel(sess, "", 120, 40)
@@ -88,10 +88,6 @@ func TestReviewPanelModel_TabSwitching(t *testing.T) {
 	if panel.activeTab != reviewTabChecks {
 		t.Errorf("'3': activeTab=%d, want %d (Checks)", panel.activeTab, reviewTabChecks)
 	}
-	press(keyRune('4'))
-	if panel.activeTab != reviewTabValidate {
-		t.Errorf("'4': activeTab=%d, want %d (Validate)", panel.activeTab, reviewTabValidate)
-	}
 	press(keyRune('1'))
 	if panel.activeTab != reviewTabTasks {
 		t.Errorf("'1': activeTab=%d, want %d (Tasks)", panel.activeTab, reviewTabTasks)
@@ -103,16 +99,15 @@ func TestReviewPanelModel_TabSwitching(t *testing.T) {
 		t.Errorf("tab: activeTab=%d, want %d (Diff)", panel.activeTab, reviewTabDiff)
 	}
 	press(keyNamed(tea.KeyTab))
-	press(keyNamed(tea.KeyTab))
-	press(keyNamed(tea.KeyTab)) // wraps from Validate back to Tasks
+	press(keyNamed(tea.KeyTab)) // wraps from Checks back to Tasks
 	if panel.activeTab != reviewTabTasks {
 		t.Errorf("tab wrap: activeTab=%d, want %d (Tasks)", panel.activeTab, reviewTabTasks)
 	}
 
-	// shift+tab decrements with wrap.
+	// shift+tab decrements with wrap (from Tasks wraps to Checks).
 	press(keyShiftNamed(tea.KeyTab))
-	if panel.activeTab != reviewTabValidate {
-		t.Errorf("shift+tab: activeTab=%d, want %d (Validate)", panel.activeTab, reviewTabValidate)
+	if panel.activeTab != reviewTabChecks {
+		t.Errorf("shift+tab from Tasks: activeTab=%d, want %d (Checks)", panel.activeTab, reviewTabChecks)
 	}
 }
 

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -111,6 +111,67 @@ func TestReviewPanelModel_TabSwitching(t *testing.T) {
 	}
 }
 
+// TestHandleValidationResult_MatchingRunID verifies that a result message with
+// the correct runID updates the matching check result without touching others.
+func TestHandleValidationResult_MatchingRunID(t *testing.T) {
+	app := NewApp()
+	app.validationRuns["s1"] = &validationRunState{
+		runID: 1,
+		checks: []config.ValidationCheck{
+			{Name: "A", Command: "echo a"},
+			{Name: "B", Command: "echo b"},
+		},
+		results: []validationCheckResult{
+			{state: checkRunning},
+			{state: checkRunning},
+		},
+	}
+
+	msg := validationCheckResultMsg{
+		sessionID:  "s1",
+		checkIndex: 0,
+		runID:      1,
+		state:      checkPassed,
+		output:     "ok",
+		exitCode:   0,
+	}
+	app.handleValidationCheckResult(msg)
+
+	run := app.validationRuns["s1"]
+	if run.results[0].state != checkPassed {
+		t.Errorf("results[0].state = %v, want checkPassed", run.results[0].state)
+	}
+	if run.results[1].state != checkRunning {
+		t.Errorf("results[1].state = %v, want checkRunning (independent)", run.results[1].state)
+	}
+}
+
+// TestHandleValidationResult_StaleRunID verifies that a result with a stale
+// runID is silently discarded.
+func TestHandleValidationResult_StaleRunID(t *testing.T) {
+	app := NewApp()
+	app.validationRuns["s1"] = &validationRunState{
+		runID: 2,
+		checks: []config.ValidationCheck{{Name: "A", Command: "echo a"}},
+		results: []validationCheckResult{
+			{state: checkRunning},
+		},
+	}
+
+	msg := validationCheckResultMsg{
+		sessionID:  "s1",
+		checkIndex: 0,
+		runID:      1, // stale
+		state:      checkPassed,
+	}
+	app.handleValidationCheckResult(msg)
+
+	run := app.validationRuns["s1"]
+	if run.results[0].state != checkRunning {
+		t.Errorf("stale result should be discarded; results[0].state = %v, want checkRunning", run.results[0].state)
+	}
+}
+
 // TestReviewPanelModel_ChecksFieldsZeroValue confirms that newReviewPanel
 // initialises checksCursor and checksScroll to 0.
 func TestReviewPanelModel_ChecksFieldsZeroValue(t *testing.T) {

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -246,7 +246,7 @@ func TestHandleValidationResult_MatchingRunID(t *testing.T) {
 func TestHandleValidationResult_StaleRunID(t *testing.T) {
 	app := NewApp()
 	app.validationRuns["s1"] = &validationRunState{
-		runID: 2,
+		runID:  2,
 		checks: []config.ValidationCheck{{Name: "A", Command: "echo a"}},
 		results: []validationCheckResult{
 			{state: checkRunning},

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -1151,7 +1151,10 @@ func (a App) handlePipelineMarkReady() (App, tea.Cmd, bool) {
 	}
 	sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
 	a.cursor.SetIndex(focusSectionReview, 0)
-	return a, a.fetchReviewDiffCmd(sess, repoPath), true
+	return a, tea.Batch(
+		a.fetchReviewDiffCmd(sess, repoPath),
+		a.startValidationChecksCmd(sess, repoPath),
+	), true
 }
 
 // handlePipelineOpenReview opens the review panel on the cursor-selected
@@ -1171,7 +1174,14 @@ func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
 	a.openReview(newReviewPanel(sess, item.repoPath, a.width, a.height))
 	if _, ok := a.reviewDiffCache[cacheKey(item.repoPath, sess.ID)]; !ok {
-		return a, a.fetchReviewDiffCmd(sess, item.repoPath), true
+		return a, tea.Batch(
+			a.fetchReviewDiffCmd(sess, item.repoPath),
+			a.startValidationChecksCmd(sess, item.repoPath),
+		), true
+	}
+	// Diff already cached; start validation if not already running.
+	if a.validationRuns[sess.ID] == nil {
+		return a, a.startValidationChecksCmd(sess, item.repoPath), true
 	}
 	return a, nil, true
 }

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -400,7 +400,10 @@ func (a App) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd) {
 						}
 						if promote {
 							sess.SetLifecyclePhase(agent.LifecycleReadyForReview)
-							autoPromoteCmd = a.fetchReviewDiffCmd(sess, msg.repoPath)
+							autoPromoteCmd = tea.Batch(
+								a.fetchReviewDiffCmd(sess, msg.repoPath),
+								a.startValidationChecksCmd(sess, msg.repoPath),
+							)
 						}
 					}
 					// Mark session done when all non-shell agents have exited.

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -77,6 +77,26 @@ func (a App) handleReviewVerdict(msg reviewVerdictMsg) (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
+// handleValidationCheckResult processes a validationCheckResultMsg. It looks
+// up the validationRunState by sessionID, verifies the runID matches (dropping
+// stale results), then updates the result at checkIndex.
+func (a *App) handleValidationCheckResult(msg validationCheckResultMsg) {
+	run := a.validationRuns[msg.sessionID]
+	if run == nil || run.runID != msg.runID {
+		return
+	}
+	if msg.checkIndex < 0 || msg.checkIndex >= len(run.results) {
+		return
+	}
+	run.results[msg.checkIndex] = validationCheckResult{
+		state:    msg.state,
+		output:   msg.output,
+		exitCode: msg.exitCode,
+		duration: msg.duration,
+		err:      msg.err,
+	}
+}
+
 func reviewTaskGroupAtCursor(entry *reviewDiffEntry, cursor int) *taskReviewGroup {
 	if entry == nil {
 		return nil

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -696,6 +696,22 @@ func (a App) handleReviewOpenTaskDiff(msg reviewOpenTaskDiffMsg) (tea.Model, tea
 	return a, nil
 }
 
+// startValidationChecksCmd resolves ValidationChecks from settings and, when
+// non-empty, calls triggerValidationRun to initialise the run state and return
+// a batched tea.Cmd. Returns nil when no checks are configured or the session
+// has no worktree.
+func (a App) startValidationChecksCmd(sess *agent.Session, repoPath string) tea.Cmd {
+	resolved := a.resolvedCache[repoPath]
+	if len(resolved.ValidationChecks) == 0 {
+		return nil
+	}
+	worktreePath := ""
+	if sess.Worktree != nil {
+		worktreePath = sess.Worktree.Path
+	}
+	return triggerValidationRun(&a, sess.ID, repoPath, worktreePath, resolved.ValidationChecks)
+}
+
 // runValidationCheckCmd returns a tea.Cmd that executes one validation check
 // via `sh -c <command>` with Dir set to worktreePath, with a 5-minute timeout.
 // The result is a validationCheckResultMsg carrying the exit code, combined

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
 	"sort"
 	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
 	"github.com/devenjarvis/refrain/internal/diffmodel"
 	"github.com/devenjarvis/refrain/internal/git"
 	"github.com/devenjarvis/refrain/internal/github"
@@ -692,6 +694,97 @@ func (a App) handleReviewOpenTaskDiff(msg reviewOpenTaskDiffMsg) (tea.Model, tea
 	a.view = ViewDiff
 	a.diff = newDiffModel(msg.taskLabel, m, a.width, a.height-1)
 	return a, nil
+}
+
+// runValidationCheckCmd returns a tea.Cmd that executes one validation check
+// via `sh -c <command>` with Dir set to worktreePath, with a 5-minute timeout.
+// The result is a validationCheckResultMsg carrying the exit code, combined
+// output, and final state. runID is forwarded so stale results can be discarded.
+func runValidationCheckCmd(sessionID, repoPath, worktreePath string, checkIndex, runID int, command string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		start := time.Now()
+		cmd := exec.CommandContext(ctx, "sh", "-c", command)
+		cmd.Dir = worktreePath
+
+		out, err := cmd.CombinedOutput()
+		dur := time.Since(start)
+		output := string(out)
+
+		if err == nil {
+			return validationCheckResultMsg{
+				sessionID:  sessionID,
+				repoPath:   repoPath,
+				checkIndex: checkIndex,
+				runID:      runID,
+				state:      checkPassed,
+				output:     output,
+				exitCode:   0,
+				duration:   dur,
+			}
+		}
+
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return validationCheckResultMsg{
+				sessionID:  sessionID,
+				repoPath:   repoPath,
+				checkIndex: checkIndex,
+				runID:      runID,
+				state:      checkFailed,
+				output:     output,
+				exitCode:   exitErr.ExitCode(),
+				duration:   dur,
+			}
+		}
+
+		// Command not found, timeout, or other execution error.
+		return validationCheckResultMsg{
+			sessionID:  sessionID,
+			repoPath:   repoPath,
+			checkIndex: checkIndex,
+			runID:      runID,
+			state:      checkError,
+			output:     output,
+			exitCode:   -1,
+			duration:   dur,
+			err:        err,
+		}
+	}
+}
+
+// triggerValidationRun creates or replaces the validationRuns entry for
+// sessionID, increments the runID, sets all results to checkRunning, and
+// returns a batched tea.Cmd with one runValidationCheckCmd per check.
+func triggerValidationRun(a *App, sessionID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd {
+	if len(checks) == 0 {
+		return nil
+	}
+
+	prior := a.validationRuns[sessionID]
+	runID := 1
+	if prior != nil {
+		runID = prior.runID + 1
+	}
+
+	results := make([]validationCheckResult, len(checks))
+	for i := range results {
+		results[i] = validationCheckResult{state: checkRunning}
+	}
+
+	a.validationRuns[sessionID] = &validationRunState{
+		checks:  checks,
+		results: results,
+		runID:   runID,
+	}
+
+	cmds := make([]tea.Cmd, len(checks))
+	for i, ch := range checks {
+		cmds[i] = runValidationCheckCmd(sessionID, repoPath, worktreePath, i, runID, ch.Command)
+	}
+	return tea.Batch(cmds...)
 }
 
 // ensureGitignore adds .refrain/ to .gitignore in the given path if not already present.

--- a/internal/tui/update_review_test.go
+++ b/internal/tui/update_review_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -29,8 +30,8 @@ func TestRunValidationCheckCmd_PassingCommand(t *testing.T) {
 	if msg.exitCode != 0 {
 		t.Errorf("exitCode = %d, want 0", msg.exitCode)
 	}
-	if msg.output == "" {
-		t.Error("output should contain 'hello'")
+	if !strings.Contains(msg.output, "hello") {
+		t.Errorf("output = %q, want it to contain 'hello'", msg.output)
 	}
 }
 

--- a/internal/tui/update_review_test.go
+++ b/internal/tui/update_review_test.go
@@ -1,0 +1,56 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestRunValidationCheckCmd_PassingCommand(t *testing.T) {
+	worktreeDir := t.TempDir()
+	cmd := runValidationCheckCmd("s1", "/repo", worktreeDir, 0, 1, "echo hello")
+	if cmd == nil {
+		t.Fatal("runValidationCheckCmd returned nil cmd")
+	}
+	msg, ok := cmd().(validationCheckResultMsg)
+	if !ok {
+		t.Fatalf("cmd() returned %T, want validationCheckResultMsg", cmd())
+	}
+	if msg.runID != 1 {
+		t.Errorf("runID = %d, want 1", msg.runID)
+	}
+	if msg.sessionID != "s1" {
+		t.Errorf("sessionID = %q, want s1", msg.sessionID)
+	}
+	if msg.checkIndex != 0 {
+		t.Errorf("checkIndex = %d, want 0", msg.checkIndex)
+	}
+	if msg.state != checkPassed {
+		t.Errorf("state = %v, want checkPassed", msg.state)
+	}
+	if msg.exitCode != 0 {
+		t.Errorf("exitCode = %d, want 0", msg.exitCode)
+	}
+	if msg.output == "" {
+		t.Error("output should contain 'hello'")
+	}
+}
+
+func TestRunValidationCheckCmd_FailingCommand(t *testing.T) {
+	worktreeDir := t.TempDir()
+	cmd := runValidationCheckCmd("s1", "/repo", worktreeDir, 1, 2, "exit 42")
+	if cmd == nil {
+		t.Fatal("runValidationCheckCmd returned nil cmd")
+	}
+	msg, ok := cmd().(validationCheckResultMsg)
+	if !ok {
+		t.Fatalf("cmd() returned %T, want validationCheckResultMsg", cmd())
+	}
+	if msg.runID != 2 {
+		t.Errorf("runID = %d, want 2", msg.runID)
+	}
+	if msg.state != checkFailed {
+		t.Errorf("state = %v, want checkFailed", msg.state)
+	}
+	if msg.exitCode != 42 {
+		t.Errorf("exitCode = %d, want 42", msg.exitCode)
+	}
+}


### PR DESCRIPTION
## Summary

- Introduce ValidationCheck type and configuration system for pre-submission validation
- Add validation state types and app-level state management for tracking check results
- Implement parallel validation check runner for concurrent execution
- Auto-trigger validation when PR transitions to ReadyForReview status
- Collapse tab layout from 4 to 3 tabs (Tasks, Diff, Checks)
- Render Checks tab with check list and output viewer pane
- Support keyboard shortcuts for manual rerun and output navigation
- Fix output assertion and r-key edge case for checks without prior runs

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofumpt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI: Navigate to Checks tab, verify checks auto-run on ReadyForReview transition, verify manual rerun with r-key, verify output viewer displays check results

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [ ] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [ ] No new public API surface without a note in the PR description