### PR TITLE
Add validation checks editor to repo settings overlay

### DIFF
--- a/changelog.d/add-validation-checks-editor.md
+++ b/changelog.d/add-validation-checks-editor.md
@@ -1,0 +1,3 @@
+### Added
+
+- In-app editor for per-repo validation checks. The repo settings overlay now exposes a "Validation Checks" row that opens a list editor for the shell commands run during the review panel's Checks tab — previously the only way to configure these was hand-editing `.refrain/config.json`. Keys: `a` add, `e`/`enter` edit, `d` delete, `ctrl+s` save, `esc` cancel; in row-edit mode, `tab` switches between Name and Command. Blank rows are filtered on save.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -170,6 +170,12 @@ type App struct {
 	repoSettings   map[string]*config.RepoSettings    // keyed by repo path
 	resolvedCache  map[string]config.ResolvedSettings // keyed by repo path
 
+	// pendingChecks buffers the validation-checks list while the repo settings
+	// form is open. Seeded by initRepoConfigForm, mutated by the repoChecks
+	// sub-editor, and consumed by extractRepoSettings on save. nil between
+	// form sessions.
+	pendingChecks []config.ValidationCheck
+
 	view         ViewMode
 	dashboard    dashboardModel
 	diff         diffModel
@@ -257,6 +263,8 @@ func (a *App) syncModalsToDashboard() {
 	a.dashboard.panelFocus = a.modals.Current()
 	a.dashboard.repoConfigForm = a.modals.Config()
 	a.dashboard.configRepoPath = a.modals.ConfigRepoPath()
+	a.dashboard.repoChecksEditor = a.modals.RepoChecks()
+	a.dashboard.repoChecksRepoPath = a.modals.RepoChecksRepoPath()
 	a.dashboard.focusLaunchAgent = a.modals.LaunchAgent()
 	a.dashboard.focusLaunchSession = a.modals.LaunchSession()
 }
@@ -284,6 +292,21 @@ func (a *App) openPlanEditorPanel(pe *planEditorModel) {
 // openConfigForm opens the per-repo config form for repoPath and syncs.
 func (a *App) openConfigForm(form *configForm, repoPath string) {
 	a.modals.OpenConfig(form, repoPath)
+	a.syncModalsToDashboard()
+}
+
+// openRepoChecksEditor switches focus from the repo config form to the
+// validation-checks sub-editor for the same repo. The parent config form is
+// preserved in modals so the user returns to it on save/cancel.
+func (a *App) openRepoChecksEditor(editor *repoChecksModel, repoPath string) {
+	a.modals.OpenRepoChecks(editor, repoPath)
+	a.syncModalsToDashboard()
+}
+
+// closeRepoChecksEditor pops the checks sub-editor without disturbing the
+// parent config form.
+func (a *App) closeRepoChecksEditor() {
+	a.modals.CloseRepoChecks()
 	a.syncModalsToDashboard()
 }
 
@@ -1044,6 +1067,8 @@ func (a App) View() tea.View {
 		switch a.dashboard.panelFocus {
 		case focusConfig:
 			hints = repoConfigHints
+		case focusRepoChecks:
+			hints = repoChecksHints
 		case focusLaunch:
 			hints = focusLaunchHints
 		}
@@ -1437,6 +1462,10 @@ func panelFocusName(f panelFocus) string {
 		return "launch"
 	case focusPlanEditor:
 		return "plan-editor"
+	case focusRepoChecks:
+		return "repo-checks"
+	case focusShipping:
+		return "shipping"
 	default:
 		return fmt.Sprintf("unknown(%d)", int(f))
 	}

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -15,6 +15,7 @@ const (
 	fieldToggle fieldKind = iota
 	fieldText
 	fieldSelect
+	fieldAction
 )
 
 // formField is a single field in a config form.
@@ -26,6 +27,7 @@ type formField struct {
 	editing     bool            // true when text field has cursor active
 	options     []string        // for fieldSelect
 	selected    int             // for fieldSelect
+	actionHint  string          // for fieldAction: right-aligned summary text
 }
 
 // configForm composes toggle and text input fields into a navigable form.
@@ -40,6 +42,11 @@ type configFormSaveMsg struct{}
 
 // configFormCancelMsg is emitted when the user cancels (esc with no text editing).
 type configFormCancelMsg struct{}
+
+// configFormActionMsg is emitted when the user presses enter on a fieldAction
+// row. Routed by label so a single form can carry multiple sub-editor entry
+// points without cross-wiring the model layer.
+type configFormActionMsg struct{ Label string }
 
 // newConfigForm creates a form with the given fields. Width controls text input sizing.
 func newConfigForm(fields []formField, width int) configForm {
@@ -73,6 +80,18 @@ func addSelect(fields []formField, label string, options []string, selected int)
 		kind:     fieldSelect,
 		options:  options,
 		selected: selected,
+	})
+}
+
+// addAction appends a non-editable action row. Pressing enter on it emits a
+// configFormActionMsg{Label: label}, intended to launch a sub-editor for
+// values that don't fit a scalar widget (e.g. a list of structs). The hint
+// renders right-aligned and may carry a summary like "3 configured  ↵ edit".
+func addAction(fields []formField, label, hint string) []formField {
+	return append(fields, formField{
+		label:      label,
+		kind:       fieldAction,
+		actionHint: hint,
 	})
 }
 
@@ -167,6 +186,9 @@ func (f *configForm) Update(msg tea.Msg) tea.Cmd {
 				if len(field.options) > 0 {
 					field.selected = (field.selected + 1) % len(field.options)
 				}
+			case fieldAction:
+				label := field.label
+				return func() tea.Msg { return configFormActionMsg{Label: label} }
 			}
 			return nil
 		case "ctrl+s":
@@ -221,6 +243,8 @@ func (f configForm) View() string {
 				opt = field.options[field.selected]
 			}
 			value = chevronStyle.Render("< ") + opt + chevronStyle.Render(" >")
+		case fieldAction:
+			value = StyleSubtle.Render(field.actionHint)
 		}
 
 		rows = append(rows, cursor+label+" "+value)

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -129,6 +129,11 @@ type dashboardModel struct {
 	repoConfigForm *configForm
 	configRepoPath string // path of the repo being configured
 
+	// Validation-checks sub-editor, mirrored from Modals when focusRepoChecks
+	// is active. nil at all other times.
+	repoChecksEditor   *repoChecksModel
+	repoChecksRepoPath string
+
 	// Mouse text selection state in VT-cell coordinates, bound to a specific
 	// agent so a sidebar selection change clears it cleanly.
 	selection selection
@@ -227,6 +232,10 @@ func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 			cmd := d.repoConfigForm.Update(msg)
 			return d, cmd
 		}
+		if d.panelFocus == focusRepoChecks && d.repoChecksEditor != nil {
+			cmd := d.repoChecksEditor.Update(msg)
+			return d, cmd
+		}
 	}
 	return d, nil
 }
@@ -251,6 +260,8 @@ func (d dashboardModel) View() string {
 		out = d.renderFocusLaunchView(d.width, d.height)
 	case d.panelFocus == focusConfig && d.repoConfigForm != nil:
 		out = d.renderRepoConfigOverlay(d.width, d.height)
+	case d.panelFocus == focusRepoChecks && d.repoChecksEditor != nil:
+		out = d.renderRepoChecksOverlay(d.width, d.height)
 	default:
 		out = d.renderFullscreenFocus(d.width, d.height)
 	}
@@ -317,6 +328,37 @@ func (d dashboardModel) renderRepoConfigOverlay(width, height int) string {
 		pathLine, "",
 		d.repoConfigForm.View(), "",
 		hint,
+	)
+
+	box := boxStyle.Render(content)
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box)
+}
+
+// renderRepoChecksOverlay renders the validation-checks list editor as a
+// centered modal box, styled to match renderRepoConfigOverlay so the user
+// perceives it as a sub-form of the repo settings overlay.
+func (d dashboardModel) renderRepoChecksOverlay(width, height int) string {
+	if d.repoChecksEditor == nil {
+		return d.emptyView()
+	}
+
+	repoName := d.repoChecksEditor.repoName
+	if repoName == "" {
+		repoName = d.repoChecksRepoPath
+	}
+
+	boxWidth := 72
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorPrimary).
+		Padding(1, 2).
+		Width(boxWidth)
+
+	title := StyleTitle.Render(repoName + " · Validation Checks")
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		title, "",
+		d.repoChecksEditor.View(),
 	)
 
 	box := boxStyle.Render(content)

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -87,6 +87,7 @@ type panelFocus int
 const (
 	focusList       panelFocus = iota // pipeline: j/k navigate sessions
 	focusConfig                       // overlay: per-repo config form
+	focusRepoChecks                   // overlay: validation checks editor (sub-form of focusConfig)
 	focusReview                       // overlay: review panel
 	focusLaunch                       // overlay: fullscreen agent terminal
 	focusPlanEditor                   // overlay: full-page plan editor (.claude/plan.md)

--- a/internal/tui/modals.go
+++ b/internal/tui/modals.go
@@ -14,13 +14,15 @@ import "github.com/devenjarvis/refrain/internal/agent"
 type Modals struct {
 	current panelFocus
 
-	review      *reviewPanelModel
-	shipping    *shippingPanelModel
-	planEditor  *planEditorModel
-	config      *configForm
-	configRepo  string
-	launchAgent *agent.Agent
-	launchSess  *agent.Session
+	review         *reviewPanelModel
+	shipping       *shippingPanelModel
+	planEditor     *planEditorModel
+	config         *configForm
+	configRepo     string
+	repoChecks     *repoChecksModel
+	repoChecksRepo string
+	launchAgent    *agent.Agent
+	launchSess     *agent.Session
 	// launchRepoPath is the repo that owns launchSess. Stored so the
 	// focusLaunch key handlers (ctrl+t shell, ctrl+n agent, ctrl+w kill)
 	// route to the right manager without a first-match session lookup, which
@@ -46,6 +48,8 @@ func (m *Modals) Close() {
 	m.planEditor = nil
 	m.config = nil
 	m.configRepo = ""
+	m.repoChecks = nil
+	m.repoChecksRepo = ""
 	m.launchAgent = nil
 	m.launchSess = nil
 	m.launchRepoPath = ""
@@ -78,6 +82,31 @@ func (m *Modals) OpenConfig(form *configForm, repoPath string) {
 	m.current = focusConfig
 	m.config = form
 	m.configRepo = repoPath
+}
+
+// OpenRepoChecks opens the validation-checks sub-editor without disturbing
+// the parent config form — the config form is preserved so the user returns
+// to it on save/cancel. The caller must hold focusConfig as a precondition,
+// otherwise the call is a no-op.
+func (m *Modals) OpenRepoChecks(editor *repoChecksModel, repoPath string) {
+	if m.current != focusConfig {
+		return
+	}
+	m.current = focusRepoChecks
+	m.repoChecks = editor
+	m.repoChecksRepo = repoPath
+}
+
+// CloseRepoChecks pops the checks editor and returns focus to the underlying
+// repo config form. The parent form pointer was retained across the open, so
+// it's still valid here.
+func (m *Modals) CloseRepoChecks() {
+	if m.current != focusRepoChecks {
+		return
+	}
+	m.repoChecks = nil
+	m.repoChecksRepo = ""
+	m.current = focusConfig
 }
 
 // OpenLaunch opens the fullscreen agent terminal focused on ag (owned by sess
@@ -129,6 +158,24 @@ func (m *Modals) Config() *configForm {
 func (m *Modals) ConfigRepoPath() string {
 	if m.current == focusConfig {
 		return m.configRepo
+	}
+	return ""
+}
+
+// RepoChecks returns the validation-checks editor if focusRepoChecks is
+// current; otherwise nil.
+func (m *Modals) RepoChecks() *repoChecksModel {
+	if m.current == focusRepoChecks {
+		return m.repoChecks
+	}
+	return nil
+}
+
+// RepoChecksRepoPath returns the repo path whose checks are being edited, or
+// "" when focusRepoChecks is not current.
+func (m *Modals) RepoChecksRepoPath() string {
+	if m.current == focusRepoChecks {
+		return m.repoChecksRepo
 	}
 	return ""
 }

--- a/internal/tui/repochecks_integration_test.go
+++ b/internal/tui/repochecks_integration_test.go
@@ -1,0 +1,183 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/devenjarvis/refrain/internal/config"
+)
+
+// TestRepoChecks_RoundTrip_FormToEditorToDisk exercises the full path from
+// the repo settings form's action row through the checks sub-editor and back
+// to a configFormSaveMsg, then verifies the new check is persisted to
+// .refrain/config.json.
+func TestRepoChecks_RoundTrip_FormToEditorToDisk(t *testing.T) {
+	dir := t.TempDir()
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir, Name: "myrepo"}}}
+	app.activeRepo = dir
+	app.repoSettings[dir] = &config.RepoSettings{}
+	app.globalSettings = &config.GlobalSettings{}
+	app.resolvedCache[dir] = config.Resolve(app.globalSettings, app.repoSettings[dir])
+
+	// Open the repo settings form.
+	app.initRepoConfigForm(dir)
+	if !app.modals.Is(focusConfig) {
+		t.Fatalf("expected focusConfig after initRepoConfigForm, got %v", app.modals.Current())
+	}
+
+	// Emit the action message that the form would emit on enter on the
+	// "Validation Checks" row.
+	model, _ := app.Update(configFormActionMsg{Label: "Validation Checks"})
+	app = model.(App)
+	if !app.modals.Is(focusRepoChecks) {
+		t.Fatalf("expected focusRepoChecks after action, got %v", app.modals.Current())
+	}
+	editor := app.modals.RepoChecks()
+	if editor == nil {
+		t.Fatal("expected non-nil RepoChecks editor after open")
+	}
+
+	// Add a check via the editor and commit it.
+	editor.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	editor.nameInput.SetValue("Smoke")
+	editor.cmdInput.SetValue("true")
+	editor.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	saveCmd := editor.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	if saveCmd == nil {
+		t.Fatal("expected non-nil cmd from ctrl+s in editor")
+	}
+
+	// Dispatch the save msg through the app — should return focus to the
+	// config form and copy the editor's list into pendingChecks.
+	model, _ = app.Update(saveCmd())
+	app = model.(App)
+	if !app.modals.Is(focusConfig) {
+		t.Fatalf("expected focusConfig after editor save, got %v", app.modals.Current())
+	}
+	if len(app.pendingChecks) != 1 || app.pendingChecks[0].Name != "Smoke" {
+		t.Fatalf("pendingChecks = %+v, want one Smoke entry", app.pendingChecks)
+	}
+
+	// Now save the repo config form. This should write .refrain/config.json
+	// with the new check included.
+	model, _ = app.Update(configFormSaveMsg{})
+	app = model.(App)
+	if app.modals.Current() != focusList {
+		t.Errorf("expected focusList after form save, got %v", app.modals.Current())
+	}
+	if app.pendingChecks != nil {
+		t.Errorf("expected pendingChecks cleared after form close, got %+v", app.pendingChecks)
+	}
+
+	// Re-read from disk and assert the persisted shape.
+	settingsPath := filepath.Join(dir, ".refrain", "config.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", settingsPath, err)
+	}
+	body := string(data)
+	if !strings.Contains(body, `"validation_checks"`) {
+		t.Errorf("expected validation_checks key in saved config, got:\n%s", body)
+	}
+	if !strings.Contains(body, `"Smoke"`) || !strings.Contains(body, `"true"`) {
+		t.Errorf("expected Smoke/true entry in saved config, got:\n%s", body)
+	}
+
+	// And via the typed loader.
+	loaded, err := config.LoadRepoSettings(dir)
+	if err != nil {
+		t.Fatalf("LoadRepoSettings: %v", err)
+	}
+	if len(loaded.ValidationChecks) != 1 {
+		t.Fatalf("loaded len = %d, want 1", len(loaded.ValidationChecks))
+	}
+	if loaded.ValidationChecks[0].Name != "Smoke" || loaded.ValidationChecks[0].Command != "true" {
+		t.Errorf("loaded[0] = %+v, want {Smoke true}", loaded.ValidationChecks[0])
+	}
+}
+
+// TestRepoChecks_CancelDiscardsPending verifies that pressing esc in the
+// checks editor leaves the buffer unchanged from the value seeded by the
+// parent form.
+func TestRepoChecks_CancelDiscardsPending(t *testing.T) {
+	dir := t.TempDir()
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir, Name: "r"}}}
+	app.activeRepo = dir
+	app.repoSettings[dir] = &config.RepoSettings{
+		ValidationChecks: []config.ValidationCheck{{Name: "Original", Command: "echo hi"}},
+	}
+	app.globalSettings = &config.GlobalSettings{}
+	app.resolvedCache[dir] = config.Resolve(app.globalSettings, app.repoSettings[dir])
+
+	app.initRepoConfigForm(dir)
+	if len(app.pendingChecks) != 1 || app.pendingChecks[0].Name != "Original" {
+		t.Fatalf("pendingChecks seed = %+v, want one Original entry", app.pendingChecks)
+	}
+
+	// Open the editor, replace the list entirely, then cancel.
+	model, _ := app.Update(configFormActionMsg{Label: "Validation Checks"})
+	app = model.(App)
+	editor := app.modals.RepoChecks()
+	editor.checks = []config.ValidationCheck{{Name: "Replaced", Command: "false"}}
+	cancelCmd := editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cancelCmd == nil {
+		t.Fatal("esc should produce a cancel cmd")
+	}
+
+	model, _ = app.Update(cancelCmd())
+	app = model.(App)
+	if !app.modals.Is(focusConfig) {
+		t.Errorf("expected focusConfig after editor cancel, got %v", app.modals.Current())
+	}
+	if len(app.pendingChecks) != 1 || app.pendingChecks[0].Name != "Original" {
+		t.Errorf("cancel should not mutate pendingChecks, got %+v", app.pendingChecks)
+	}
+}
+
+// TestRepoChecks_BlankEntryFilteredOnFormSave verifies that a row left blank
+// in the editor never reaches disk.
+func TestRepoChecks_BlankEntryFilteredOnFormSave(t *testing.T) {
+	dir := t.TempDir()
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	app.dashboard.width = 120
+	app.dashboard.height = 39
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir, Name: "r"}}}
+	app.activeRepo = dir
+	app.repoSettings[dir] = &config.RepoSettings{}
+	app.globalSettings = &config.GlobalSettings{}
+	app.resolvedCache[dir] = config.Resolve(app.globalSettings, app.repoSettings[dir])
+
+	app.initRepoConfigForm(dir)
+	// Inject directly into pendingChecks; this mimics what would be on the
+	// wire if save somehow leaked an incomplete row through the editor's
+	// own filter.
+	app.pendingChecks = []config.ValidationCheck{
+		{Name: "OK", Command: "true"},
+		{Name: "", Command: "false"},
+	}
+	model, _ := app.Update(configFormSaveMsg{})
+	app = model.(App)
+
+	loaded, err := config.LoadRepoSettings(dir)
+	if err != nil {
+		t.Fatalf("LoadRepoSettings: %v", err)
+	}
+	if len(loaded.ValidationChecks) != 1 || loaded.ValidationChecks[0].Name != "OK" {
+		t.Errorf("expected only OK entry persisted, got %+v", loaded.ValidationChecks)
+	}
+}

--- a/internal/tui/repochecksmodel.go
+++ b/internal/tui/repochecksmodel.go
@@ -1,0 +1,271 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/devenjarvis/refrain/internal/config"
+)
+
+// repoChecksSaveMsg is emitted when the user accepts their changes to the
+// validation checks list (ctrl+s from list mode). The receiver is responsible
+// for copying Checks into the pending buffer that the parent repo settings
+// form will later persist.
+type repoChecksSaveMsg struct {
+	Checks []config.ValidationCheck
+}
+
+// repoChecksCancelMsg is emitted when the user discards their changes (esc
+// from list mode).
+type repoChecksCancelMsg struct{}
+
+// repoChecksInput identifies which of the two text inputs has focus while a
+// row is in edit mode.
+type repoChecksInput int
+
+const (
+	repoChecksInputName repoChecksInput = iota
+	repoChecksInputCommand
+)
+
+// repoChecksModel is the list editor for a repo's validation checks. It owns
+// only the in-memory edit buffer; persistence is performed by the parent repo
+// settings form after the user saves both layers (`ctrl+s` in this view, then
+// `ctrl+s` in the repo settings form).
+type repoChecksModel struct {
+	repoName    string
+	checks      []config.ValidationCheck
+	cursor      int
+	editing     bool
+	editIdx     int
+	activeInput repoChecksInput
+	nameInput   textinput.Model
+	cmdInput    textinput.Model
+}
+
+// newRepoChecksModel seeds the editor from an existing checks list. The
+// caller must pass a fresh copy if it wants edits to be discardable on cancel.
+func newRepoChecksModel(repoName string, checks []config.ValidationCheck) *repoChecksModel {
+	cp := make([]config.ValidationCheck, len(checks))
+	copy(cp, checks)
+	return &repoChecksModel{
+		repoName: repoName,
+		checks:   cp,
+	}
+}
+
+// Update handles a key event for the editor.
+func (m *repoChecksModel) Update(msg tea.Msg) tea.Cmd {
+	key, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return nil
+	}
+
+	if m.editing {
+		return m.updateEditing(key)
+	}
+	return m.updateList(key)
+}
+
+func (m *repoChecksModel) updateList(msg tea.KeyPressMsg) tea.Cmd {
+	switch msg.String() {
+	case "j", "down":
+		if len(m.checks) > 0 && m.cursor < len(m.checks)-1 {
+			m.cursor++
+		}
+		return nil
+	case "k", "up":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		return nil
+	case "a":
+		m.checks = append(m.checks, config.ValidationCheck{})
+		m.cursor = len(m.checks) - 1
+		m.beginEdit(m.cursor)
+		return nil
+	case "e", "enter":
+		if len(m.checks) > 0 {
+			m.beginEdit(m.cursor)
+		}
+		return nil
+	case "d":
+		if len(m.checks) > 0 {
+			m.checks = append(m.checks[:m.cursor], m.checks[m.cursor+1:]...)
+			if m.cursor >= len(m.checks) {
+				m.cursor = len(m.checks) - 1
+			}
+			if m.cursor < 0 {
+				m.cursor = 0
+			}
+		}
+		return nil
+	case "ctrl+s":
+		out := make([]config.ValidationCheck, len(m.checks))
+		copy(out, m.checks)
+		return func() tea.Msg { return repoChecksSaveMsg{Checks: out} }
+	case "esc":
+		return func() tea.Msg { return repoChecksCancelMsg{} }
+	}
+	return nil
+}
+
+func (m *repoChecksModel) updateEditing(msg tea.KeyPressMsg) tea.Cmd {
+	switch msg.String() {
+	case "tab":
+		m.switchInput(repoChecksInputCommand)
+		return nil
+	case "shift+tab":
+		m.switchInput(repoChecksInputName)
+		return nil
+	case "esc":
+		// Abandon this row's in-flight edits; if it's a freshly-appended
+		// blank row drop it so the user isn't left with an empty entry.
+		if m.checks[m.editIdx].Name == "" && m.checks[m.editIdx].Command == "" {
+			m.checks = append(m.checks[:m.editIdx], m.checks[m.editIdx+1:]...)
+			if m.cursor >= len(m.checks) {
+				m.cursor = len(m.checks) - 1
+			}
+			if m.cursor < 0 {
+				m.cursor = 0
+			}
+		}
+		m.endEdit()
+		return nil
+	case "enter", "ctrl+s":
+		m.commitEdit()
+		m.endEdit()
+		return nil
+	}
+	var cmd tea.Cmd
+	if m.activeInput == repoChecksInputName {
+		m.nameInput, cmd = m.nameInput.Update(msg)
+	} else {
+		m.cmdInput, cmd = m.cmdInput.Update(msg)
+	}
+	return cmd
+}
+
+func (m *repoChecksModel) beginEdit(idx int) {
+	m.editing = true
+	m.editIdx = idx
+	m.activeInput = repoChecksInputName
+
+	m.nameInput = textinput.New()
+	m.nameInput.CharLimit = 64
+	m.nameInput.SetWidth(40)
+	m.nameInput.SetValue(m.checks[idx].Name)
+	m.nameInput.Focus()
+
+	m.cmdInput = textinput.New()
+	m.cmdInput.CharLimit = 512
+	m.cmdInput.SetWidth(40)
+	m.cmdInput.SetValue(m.checks[idx].Command)
+}
+
+func (m *repoChecksModel) endEdit() {
+	m.editing = false
+	m.nameInput.Blur()
+	m.cmdInput.Blur()
+}
+
+func (m *repoChecksModel) switchInput(target repoChecksInput) {
+	m.activeInput = target
+	if target == repoChecksInputName {
+		m.nameInput.Focus()
+		m.cmdInput.Blur()
+	} else {
+		m.cmdInput.Focus()
+		m.nameInput.Blur()
+	}
+}
+
+func (m *repoChecksModel) commitEdit() {
+	m.checks[m.editIdx].Name = strings.TrimSpace(m.nameInput.Value())
+	m.checks[m.editIdx].Command = strings.TrimSpace(m.cmdInput.Value())
+}
+
+// View renders the editor body (no surrounding border — that's the overlay's
+// job).
+func (m *repoChecksModel) View() string {
+	subtitle := StyleSubtle.Render("Commands run with sh -c against the worktree during the review panel's Checks tab.")
+	var body string
+	if len(m.checks) == 0 {
+		body = StyleSubtle.Render("No checks yet — press a to add the first one.")
+	} else {
+		rows := make([]string, 0, len(m.checks)*3)
+		for i, c := range m.checks {
+			cursor := "  "
+			nameStyle := lipgloss.NewStyle().Foreground(ColorText)
+			cmdStyle := StyleSubtle
+			if i == m.cursor && !m.editing {
+				cursor = StyleActive.Render("› ")
+				nameStyle = nameStyle.Bold(true)
+			}
+
+			if m.editing && i == m.editIdx {
+				nameLabel := StyleSubtle.Render("Name    ")
+				cmdLabel := StyleSubtle.Render("Command ")
+				if m.activeInput == repoChecksInputName {
+					nameLabel = StyleActive.Render("Name    ")
+				} else {
+					cmdLabel = StyleActive.Render("Command ")
+				}
+				rows = append(rows,
+					StyleActive.Render("› ")+fmt.Sprintf("%d.", i+1),
+					"    "+nameLabel+m.nameInput.View(),
+					"    "+cmdLabel+m.cmdInput.View(),
+				)
+				continue
+			}
+
+			name := c.Name
+			if name == "" {
+				name = StyleSubtle.Italic(true).Render("(unnamed)")
+			} else {
+				name = nameStyle.Render(name)
+			}
+			cmd := c.Command
+			if cmd == "" {
+				cmd = StyleSubtle.Italic(true).Render("(no command)")
+			} else {
+				cmd = cmdStyle.Render(cmd)
+			}
+			rows = append(rows,
+				cursor+fmt.Sprintf("%d. ", i+1)+name,
+				"    "+cmd,
+			)
+		}
+		body = strings.Join(rows, "\n")
+	}
+
+	// Row-edit mode has its own hint (statusbar shows list-mode keys).
+	if m.editing {
+		hint := StyleSubtle.Render("tab switch field  enter save row  esc cancel row")
+		return strings.Join([]string{subtitle, "", body, "", hint}, "\n")
+	}
+	return strings.Join([]string{subtitle, "", body}, "\n")
+}
+
+// Checks returns a copy of the current in-memory list.
+func (m *repoChecksModel) Checks() []config.ValidationCheck {
+	out := make([]config.ValidationCheck, len(m.checks))
+	copy(out, m.checks)
+	return out
+}
+
+// repoChecksHint returns the right-aligned summary text rendered next to the
+// "Validation Checks" action row in the repo settings form.
+func repoChecksHint(checks []config.ValidationCheck) string {
+	switch len(checks) {
+	case 0:
+		return "none configured  ↵ edit"
+	case 1:
+		return "1 configured  ↵ edit"
+	default:
+		return fmt.Sprintf("%d configured  ↵ edit", len(checks))
+	}
+}

--- a/internal/tui/repochecksmodel.go
+++ b/internal/tui/repochecksmodel.go
@@ -214,7 +214,8 @@ func (m *repoChecksModel) View() string {
 				} else {
 					cmdLabel = StyleActive.Render("Command ")
 				}
-				rows = append(rows,
+				rows = append(
+					rows,
 					StyleActive.Render("› ")+fmt.Sprintf("%d.", i+1),
 					"    "+nameLabel+m.nameInput.View(),
 					"    "+cmdLabel+m.cmdInput.View(),
@@ -234,7 +235,8 @@ func (m *repoChecksModel) View() string {
 			} else {
 				cmd = cmdStyle.Render(cmd)
 			}
-			rows = append(rows,
+			rows = append(
+				rows,
 				cursor+fmt.Sprintf("%d. ", i+1)+name,
 				"    "+cmd,
 			)

--- a/internal/tui/repochecksmodel_test.go
+++ b/internal/tui/repochecksmodel_test.go
@@ -1,0 +1,216 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/devenjarvis/refrain/internal/config"
+)
+
+func sampleChecks() []config.ValidationCheck {
+	return []config.ValidationCheck{
+		{Name: "Tests", Command: "go test ./..."},
+		{Name: "Lint", Command: "golangci-lint run"},
+	}
+}
+
+func TestRepoChecks_NewSeedsCopy(t *testing.T) {
+	seed := sampleChecks()
+	m := newRepoChecksModel("myrepo", seed)
+	if len(m.checks) != 2 {
+		t.Fatalf("checks len = %d, want 2", len(m.checks))
+	}
+	seed[0].Name = "MUTATED"
+	if m.checks[0].Name != "Tests" {
+		t.Error("model checks should be independent of caller's slice")
+	}
+}
+
+func TestRepoChecks_DownClampsAtLast(t *testing.T) {
+	m := newRepoChecksModel("r", sampleChecks())
+	for range 5 {
+		m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	}
+	if m.cursor != 1 {
+		t.Errorf("cursor = %d, want 1", m.cursor)
+	}
+}
+
+func TestRepoChecks_UpClampsAtZero(t *testing.T) {
+	m := newRepoChecksModel("r", sampleChecks())
+	m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0", m.cursor)
+	}
+}
+
+func TestRepoChecks_AddBeginsEditOnNewRow(t *testing.T) {
+	m := newRepoChecksModel("r", nil)
+	m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if !m.editing {
+		t.Fatal("expected editing=true after 'a'")
+	}
+	if len(m.checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1 after 'a'", len(m.checks))
+	}
+	if m.editIdx != 0 || m.cursor != 0 {
+		t.Errorf("editIdx=%d cursor=%d, want both 0", m.editIdx, m.cursor)
+	}
+}
+
+func TestRepoChecks_EditCommitsValuesAndExitsEditMode(t *testing.T) {
+	m := newRepoChecksModel("r", nil)
+	m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	m.nameInput.SetValue("Smoke")
+	m.cmdInput.SetValue("./smoke.sh")
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if m.editing {
+		t.Error("editing should be false after committing")
+	}
+	if m.checks[0].Name != "Smoke" || m.checks[0].Command != "./smoke.sh" {
+		t.Errorf("checks[0] = %+v, want {Smoke ./smoke.sh}", m.checks[0])
+	}
+}
+
+func TestRepoChecks_EditEscDiscardsBlankRow(t *testing.T) {
+	m := newRepoChecksModel("r", sampleChecks())
+	m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if len(m.checks) != 3 {
+		t.Fatalf("setup: len = %d, want 3", len(m.checks))
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	if m.editing {
+		t.Error("editing should be false after esc")
+	}
+	if len(m.checks) != 2 {
+		t.Errorf("blank row should be dropped, got len = %d", len(m.checks))
+	}
+}
+
+func TestRepoChecks_EditEscPreservesNonBlankRow(t *testing.T) {
+	m := newRepoChecksModel("r", sampleChecks())
+	m.beginEdit(0)
+	m.nameInput.SetValue("Edited but cancelled")
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	if m.checks[0].Name != "Tests" {
+		t.Errorf("esc should not commit, got %q", m.checks[0].Name)
+	}
+	if len(m.checks) != 2 {
+		t.Errorf("non-blank row should be preserved, len = %d", len(m.checks))
+	}
+}
+
+func TestRepoChecks_DeleteRemovesAndClampsCursor(t *testing.T) {
+	m := newRepoChecksModel("r", sampleChecks())
+	m.cursor = 1
+	m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if len(m.checks) != 1 {
+		t.Errorf("after delete, len = %d, want 1", len(m.checks))
+	}
+	if m.cursor != 0 {
+		t.Errorf("cursor should clamp to last row, got %d", m.cursor)
+	}
+	// Delete the last remaining row -> cursor clamps to 0 with empty slice.
+	m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if len(m.checks) != 0 {
+		t.Errorf("after second delete, len = %d, want 0", len(m.checks))
+	}
+	if m.cursor != 0 {
+		t.Errorf("cursor on empty list should be 0, got %d", m.cursor)
+	}
+}
+
+func TestRepoChecks_DeleteOnEmptyIsNoOp(t *testing.T) {
+	m := newRepoChecksModel("r", nil)
+	m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if len(m.checks) != 0 {
+		t.Errorf("delete on empty should keep len 0, got %d", len(m.checks))
+	}
+}
+
+func TestRepoChecks_CtrlSEmitsSaveMsgWithCurrentList(t *testing.T) {
+	m := newRepoChecksModel("r", sampleChecks())
+	cmd := m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("ctrl+s should return a non-nil cmd")
+	}
+	msg := cmd()
+	save, ok := msg.(repoChecksSaveMsg)
+	if !ok {
+		t.Fatalf("expected repoChecksSaveMsg, got %T", msg)
+	}
+	if len(save.Checks) != 2 || save.Checks[0].Name != "Tests" {
+		t.Errorf("save payload = %+v, want sample list", save.Checks)
+	}
+}
+
+func TestRepoChecks_EscEmitsCancelMsg(t *testing.T) {
+	m := newRepoChecksModel("r", sampleChecks())
+	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("esc should return a non-nil cmd")
+	}
+	if _, ok := cmd().(repoChecksCancelMsg); !ok {
+		t.Errorf("expected repoChecksCancelMsg, got %T", cmd())
+	}
+}
+
+func TestRepoChecks_TabSwitchesInputFocus(t *testing.T) {
+	m := newRepoChecksModel("r", sampleChecks())
+	m.beginEdit(0)
+	if m.activeInput != repoChecksInputName {
+		t.Fatalf("initial activeInput = %v, want name", m.activeInput)
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.activeInput != repoChecksInputCommand {
+		t.Errorf("after tab, activeInput = %v, want command", m.activeInput)
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	if m.activeInput != repoChecksInputName {
+		t.Errorf("after shift+tab, activeInput = %v, want name", m.activeInput)
+	}
+}
+
+func TestRepoChecks_ViewEmptyStateMentionsAdd(t *testing.T) {
+	m := newRepoChecksModel("r", nil)
+	view := m.View()
+	if !strings.Contains(view, "No checks yet") {
+		t.Errorf("empty view should hint that none are configured, got:\n%s", view)
+	}
+}
+
+func TestRepoChecks_HintFormatsCount(t *testing.T) {
+	if got := repoChecksHint(nil); !strings.Contains(got, "none configured") {
+		t.Errorf("nil list hint = %q, want to contain 'none configured'", got)
+	}
+	if got := repoChecksHint([]config.ValidationCheck{{Name: "x", Command: "y"}}); !strings.Contains(got, "1 configured") {
+		t.Errorf("single hint = %q, want to contain '1 configured'", got)
+	}
+	if got := repoChecksHint(sampleChecks()); !strings.Contains(got, "2 configured") {
+		t.Errorf("two hint = %q, want to contain '2 configured'", got)
+	}
+}
+
+func TestFilterValidationChecks_DropsBlankRows(t *testing.T) {
+	in := []config.ValidationCheck{
+		{Name: "  Tests  ", Command: "go test ./..."},
+		{Name: "", Command: "ignored"},
+		{Name: "ignored", Command: ""},
+		{Name: "   ", Command: "   "},
+		{Name: "Lint", Command: "  golangci-lint run  "},
+	}
+	out := filterValidationChecks(in)
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2 (blanks dropped)", len(out))
+	}
+	if out[0].Name != "Tests" || out[0].Command != "go test ./..." {
+		t.Errorf("out[0] = %+v, want trimmed Tests row", out[0])
+	}
+	if out[1].Name != "Lint" || out[1].Command != "golangci-lint run" {
+		t.Errorf("out[1] = %+v, want trimmed Lint row", out[1])
+	}
+}

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -60,6 +60,15 @@ var (
 		{"esc", "back"},
 	}
 
+	repoChecksHints = []keyHint{
+		{"j/k", "navigate"},
+		{"a", "add"},
+		{"e", "edit"},
+		{"d", "delete"},
+		{"ctrl+s", "save"},
+		{"esc", "back"},
+	}
+
 	branchPickerHints = []keyHint{
 		{"j/k", "navigate"},
 		{"enter", "select"},

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -25,6 +25,12 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Repo config form cancelled.
 		return a.returnFromConfigForm()
 
+	case configFormActionMsg:
+		return a.handleConfigFormAction(msg)
+
+	case repoChecksSaveMsg, repoChecksCancelMsg:
+		return a.updateRepoChecks(msg)
+
 	case tea.PasteMsg:
 		return a.handleDashboardPaste(msg)
 
@@ -47,6 +53,13 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// When the config panel has focus, skip all app-level bindings.
 		if a.modals.Is(focusConfig) {
+			a.confirmQuit = false
+			break
+		}
+
+		// Same treatment for the validation-checks sub-editor: forward
+		// everything to the dashboard, which routes to the editor model.
+		if a.modals.Is(focusRepoChecks) {
 			a.confirmQuit = false
 			break
 		}
@@ -1184,6 +1197,19 @@ func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
 		return a, a.startValidationChecksCmd(sess, item.repoPath), true
 	}
 	return a, nil, true
+}
+
+// handleConfigFormAction dispatches a configFormActionMsg emitted from a
+// fieldAction row to the appropriate sub-editor. Today the only action row
+// is "Validation Checks"; other labels are ignored (forward-compatible).
+func (a App) handleConfigFormAction(msg configFormActionMsg) (tea.Model, tea.Cmd) {
+	if msg.Label == "Validation Checks" && a.modals.Is(focusConfig) {
+		repoPath := a.modals.ConfigRepoPath()
+		if repoPath != "" {
+			a.initRepoChecksEditor(repoPath)
+		}
+	}
+	return a, nil
 }
 
 // handleConfigFormSave persists the in-flight repo config form. On success

--- a/internal/tui/update_views.go
+++ b/internal/tui/update_views.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"strings"
+
 	tea "charm.land/bubbletea/v2"
 	"github.com/devenjarvis/refrain/internal/config"
 )
@@ -16,10 +18,12 @@ func (a App) returnFromConfigForm() (tea.Model, tea.Cmd) {
 		}
 		a.repoPicker.setRepos(a.cfg.Repos, counts, a.modals.ConfigRepoPath())
 		a.closeModal()
+		a.pendingChecks = nil
 		a.view = ViewRepoPicker
 		return a, nil
 	}
 	a.closeModal()
+	a.pendingChecks = nil
 	return a, nil
 }
 
@@ -93,6 +97,12 @@ func (a *App) initRepoConfigForm(repoPath string) {
 	fields = addEditorFields(fields, ideCommand)
 	fields = addTextInput(fields, "Worktree Directory", worktreeDir, config.DefaultWorktreeDir, inputWidth)
 
+	// Seed the validation-checks buffer from the loaded settings and append
+	// the action row that opens the sub-editor. The buffer is the source of
+	// truth while the form is open; extractRepoSettings reads from it on save.
+	a.pendingChecks = append([]config.ValidationCheck(nil), rs.ValidationChecks...)
+	fields = addAction(fields, "Validation Checks", repoChecksHint(a.pendingChecks))
+
 	form := newConfigForm(fields, a.dashboard.fixedTermWidth())
 	a.openConfigForm(&form, repoPath)
 }
@@ -129,7 +139,83 @@ func (a App) extractRepoSettings() *config.RepoSettings {
 	if v := form.textValue("Worktree Directory"); v != "" {
 		s.WorktreeDir = &v
 	}
+	if checks := filterValidationChecks(a.pendingChecks); len(checks) > 0 {
+		s.ValidationChecks = checks
+	}
 	return s
+}
+
+// filterValidationChecks drops rows whose Name or Command is empty after
+// trimming. Empty rows arise when a user pressed `a` to add a check and then
+// abandoned it; treating them as "never added" is friendlier than refusing to
+// save the form.
+func filterValidationChecks(in []config.ValidationCheck) []config.ValidationCheck {
+	out := make([]config.ValidationCheck, 0, len(in))
+	for _, c := range in {
+		name := strings.TrimSpace(c.Name)
+		cmd := strings.TrimSpace(c.Command)
+		if name == "" || cmd == "" {
+			continue
+		}
+		out = append(out, config.ValidationCheck{Name: name, Command: cmd})
+	}
+	return out
+}
+
+// initRepoChecksEditor switches the panel from the repo config form to the
+// validation-checks sub-editor. The current pendingChecks list is handed to
+// the editor as its working buffer; on save it's copied back, on cancel it's
+// discarded.
+func (a *App) initRepoChecksEditor(repoPath string) {
+	repoName := repoPath
+	for _, r := range a.cfg.Repos {
+		if r.Path == repoPath {
+			if r.Alias != "" {
+				repoName = r.Alias
+			}
+			break
+		}
+	}
+	editor := newRepoChecksModel(repoName, a.pendingChecks)
+	a.openRepoChecksEditor(editor, repoPath)
+}
+
+// updateRepoChecks handles save and cancel messages from the checks
+// sub-editor. On save the new list is copied back into pendingChecks and the
+// repo config form's action-row hint is refreshed; on cancel the list is
+// preserved as it was before the editor opened.
+func (a App) updateRepoChecks(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case repoChecksSaveMsg:
+		a.pendingChecks = append([]config.ValidationCheck(nil), m.Checks...)
+		refreshChecksActionHint(a.modals.Config(), a.pendingChecks)
+		a.closeRepoChecksEditor()
+		return a, nil
+	case repoChecksCancelMsg:
+		a.closeRepoChecksEditor()
+		return a, nil
+	case tea.KeyPressMsg:
+		var cmd tea.Cmd
+		a.dashboard, cmd = a.dashboard.Update(msg)
+		return a, cmd
+	}
+	return a, nil
+}
+
+// refreshChecksActionHint walks the form's fields and updates the "Validation
+// Checks" action row's right-aligned hint so it reflects the current count.
+// A no-op when the form is nil or doesn't contain that row.
+func refreshChecksActionHint(form *configForm, checks []config.ValidationCheck) {
+	if form == nil {
+		return
+	}
+	hint := repoChecksHint(filterValidationChecks(checks))
+	for i := range form.fields {
+		if form.fields[i].kind == fieldAction && form.fields[i].label == "Validation Checks" {
+			form.fields[i].actionHint = hint
+			return
+		}
+	}
 }
 
 func (a App) updateGlobalConfig(msg tea.Msg) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
The review panel already ran per-repo validation checks via the Checks tab,
but the only way to configure them was hand-editing .refrain/config.json.
Adds a sub-editor reached from a new "Validation Checks" row on the repo
settings overlay: a add, e/enter edit, d delete, ctrl+s save, esc cancel.
Blank rows are dropped on form save.

https://claude.ai/code/session_019FTe4svRQK2xg7uMhtsQJQ