### PR TITLE
Optimize unit tests: reduce redundant setup, remove sleeps, cap iterations

### DIFF
--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 )
 
-// TestCheckHookPipeline exercises the doctor self-check: it builds the refrain
-// binary, invokes checkHookPipeline against it, and asserts the socket round
-// trip succeeds. Uses buildRefrain from hook_test.go.
+// TestCheckHookPipeline exercises the doctor self-check: it invokes
+// checkHookPipeline against the binary built in TestMain and asserts the socket
+// round trip succeeds.
 func TestCheckHookPipeline(t *testing.T) {
-	bin := buildRefrain(t)
+	bin := testBin
 	if err := checkHookPipeline(bin); err != nil {
 		t.Fatalf("checkHookPipeline: %v", err)
 	}

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -27,25 +26,11 @@ outer:
 	return filtered
 }
 
-// buildRefrain builds the refrain binary into a temp dir and returns the path.
-func buildRefrain(t *testing.T) string {
-	t.Helper()
-	_, thisFile, _, _ := runtime.Caller(0)
-	repoRoot := filepath.Dir(filepath.Dir(thisFile))
-	bin := filepath.Join(t.TempDir(), "refrain")
-	build := exec.Command("go", "build", "-o", bin, ".")
-	build.Dir = repoRoot
-	if out, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("building refrain: %v\n%s", err, out)
-	}
-	return bin
-}
-
 // TestHookSubcommandForwards runs the built refrain binary with each supported
 // subcommand and asserts the server receives the event with the right kind,
 // AgentID, and parsed payload fields.
 func TestHookSubcommandForwards(t *testing.T) {
-	bin := buildRefrain(t)
+	bin := testBin
 
 	cases := []struct {
 		name        string
@@ -182,7 +167,7 @@ func TestHookSubcommandForwards(t *testing.T) {
 // REFRAIN_HOOK_SOCKET and REFRAIN_AGENT_ID aren't set — this is the case for a
 // user running `claude` outside of refrain.
 func TestHookSubcommandNoEnv(t *testing.T) {
-	bin := buildRefrain(t)
+	bin := testBin
 
 	cmd := exec.Command(bin, "hook", "stop")
 	// Deliberately no REFRAIN_* env vars — if refrain itself was launched inside
@@ -200,7 +185,7 @@ func TestHookSubcommandNoEnv(t *testing.T) {
 
 // TestHookSubcommandUnknownEvent ensures unknown event names exit 0 silently.
 func TestHookSubcommandUnknownEvent(t *testing.T) {
-	bin := buildRefrain(t)
+	bin := testBin
 
 	cmd := exec.Command(bin, "hook", "made-up-event")
 	cmd.Stdin = strings.NewReader(`{}`)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// testBin is the path to the refrain binary built once for the entire test run.
+var testBin string
+
+func TestMain(m *testing.M) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	dir, err := os.MkdirTemp("", "refrain-cmd-test-*")
+	if err != nil {
+		panic("creating temp dir: " + err.Error())
+	}
+	defer os.RemoveAll(dir)
+
+	bin := filepath.Join(dir, "refrain")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		panic("building refrain: " + err.Error() + "\n" + string(out))
+	}
+	testBin = bin
+
+	os.Exit(m.Run())
+}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic("creating temp dir: " + err.Error())
 	}
-	defer os.RemoveAll(dir)
+	defer func() { _ = os.RemoveAll(dir) }()
 
 	bin := filepath.Join(dir, "refrain")
 	build := exec.Command("go", "build", "-o", bin, ".")

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -227,10 +227,11 @@ func TestIdleSuppressedWhileTyping(t *testing.T) {
 		t.Fatalf("expected Active after output, got %s", s)
 	}
 
-	// Simulate user typing every 500ms for 5 seconds (well past the 3s idle timeout).
-	for i := 0; i < 10; i++ {
+	// Simulate user typing to confirm idle is suppressed while input is received.
+	// Hook-driven idle detection means no background timer; a few iterations suffice.
+	for i := 0; i < 3; i++ {
 		a.SendText("x")
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	// Agent should still be Active because user input keeps it non-idle.
@@ -260,7 +261,8 @@ func TestIdleDrivenByStopHook(t *testing.T) {
 	}
 
 	// With no hook, Active MUST NOT flip to Idle on its own.
-	time.Sleep(4 * time.Second)
+	// Hook-driven idle detection means there is no background timer; 50ms is sufficient.
+	time.Sleep(50 * time.Millisecond)
 	if s := a.Status(); s != StatusActive {
 		t.Errorf("expected Active without hook event, got %s", s)
 	}
@@ -357,10 +359,10 @@ func TestNewShellAgent(t *testing.T) {
 		t.Errorf("expected render to contain 'hello', got: %q", render)
 	}
 
-	// Shell agents should NOT transition to Idle (no statusLoop).
-	time.Sleep(4 * time.Second)
+	// Shell agents should NOT transition to Idle (hook-driven idle detection, no background timer).
+	time.Sleep(50 * time.Millisecond)
 	if s := a.Status(); s == StatusIdle {
-		t.Error("shell agent should not transition to Idle (no statusLoop)")
+		t.Error("shell agent should not transition to Idle (hook-driven idle detection)")
 	}
 }
 

--- a/internal/agent/session_repo_prop_test.go
+++ b/internal/agent/session_repo_prop_test.go
@@ -30,7 +30,7 @@ func setRapidChecks(t *testing.T, n int) {
 func TestSessionRepoProp_WorktreeAlwaysUnderRepo(t *testing.T) {
 	setRapidChecks(t, 20)
 	repo := setupTestRepoForProp()
-	t.Cleanup(func() { os.RemoveAll(repo) })
+	t.Cleanup(func() { _ = os.RemoveAll(repo) })
 
 	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())
@@ -76,7 +76,7 @@ func TestSessionRepoProp_AgentWorktreePathMatchesSession(t *testing.T) {
 func TestSessionRepoProp_PlanPathsUnderWorktree(t *testing.T) {
 	setRapidChecks(t, 20)
 	repo := setupTestRepoForProp()
-	t.Cleanup(func() { os.RemoveAll(repo) })
+	t.Cleanup(func() { _ = os.RemoveAll(repo) })
 
 	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())
@@ -118,7 +118,7 @@ func TestSessionRepoProp_PlanPathsUnderWorktree(t *testing.T) {
 func TestSessionRepoProp_LifecycleTransitionsPreserveWorktreePath(t *testing.T) {
 	setRapidChecks(t, 20)
 	repo := setupTestRepoForProp()
-	t.Cleanup(func() { os.RemoveAll(repo) })
+	t.Cleanup(func() { _ = os.RemoveAll(repo) })
 
 	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())
@@ -207,7 +207,7 @@ func TestSessionRepoProp_ReviseCwdMatchesWorktreePath(t *testing.T) {
 func TestSessionRepoProp_MultipleSessionsDistinctWorktreesSameRepo(t *testing.T) {
 	setRapidChecks(t, 20)
 	repo := setupTestRepoForProp()
-	t.Cleanup(func() { os.RemoveAll(repo) })
+	t.Cleanup(func() { _ = os.RemoveAll(repo) })
 
 	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())
@@ -415,7 +415,7 @@ func TestSessionRepoProp_PlanningSessionWorktreeUnderRepo(t *testing.T) {
 func TestSessionRepoProp_WorktreePathsNeverNested(t *testing.T) {
 	setRapidChecks(t, 20)
 	repo := setupTestRepoForProp()
-	t.Cleanup(func() { os.RemoveAll(repo) })
+	t.Cleanup(func() { _ = os.RemoveAll(repo) })
 
 	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())

--- a/internal/agent/session_repo_prop_test.go
+++ b/internal/agent/session_repo_prop_test.go
@@ -74,10 +74,11 @@ func TestSessionRepoProp_AgentWorktreePathMatchesSession(t *testing.T) {
 
 // PlanPath and PrevPlanPath are always under the session's worktree.
 func TestSessionRepoProp_PlanPathsUnderWorktree(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		repo := setupTestRepoForProp()
-		defer func() { _ = os.RemoveAll(repo) }()
+	setRapidChecks(t, 20)
+	repo := setupTestRepoForProp()
+	t.Cleanup(func() { os.RemoveAll(repo) })
 
+	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())
 		defer mgr.Shutdown()
 

--- a/internal/agent/session_repo_prop_test.go
+++ b/internal/agent/session_repo_prop_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"flag"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,18 +14,31 @@ import (
 	"pgregory.net/rapid"
 )
 
+// setRapidChecks sets -rapid.checks to n for the duration of the current test
+// and restores the previous value via t.Cleanup. rapid v1.3.0 has no per-call
+// option API; the flag binding is the only runtime-safe override.
+func setRapidChecks(t *testing.T, n int) {
+	t.Helper()
+	prev := flag.Lookup("rapid.checks").Value.String()
+	if err := flag.Set("rapid.checks", fmt.Sprintf("%d", n)); err != nil {
+		t.Fatalf("setRapidChecks: %v", err)
+	}
+	t.Cleanup(func() { _ = flag.Set("rapid.checks", prev) })
+}
+
 // Every session's worktree path is a subdirectory of its manager's repoPath.
 func TestSessionRepoProp_WorktreeAlwaysUnderRepo(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		repo := setupTestRepoForProp()
-		defer func() { _ = os.RemoveAll(repo) }()
+	setRapidChecks(t, 20)
+	repo := setupTestRepoForProp()
+	t.Cleanup(func() { os.RemoveAll(repo) })
 
+	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())
 		defer mgr.Shutdown()
 
 		n := rapid.IntRange(1, 3).Draw(t, "session_count")
 		for i := 0; i < n; i++ {
-			sess, _ := createTestSession(t, mgr)
+			sess := createTestSessionPlanOnly(t, mgr)
 			assertWorktreeUnderRepo(t, repo, sess)
 		}
 	})
@@ -100,14 +115,15 @@ func TestSessionRepoProp_PlanPathsUnderWorktree(t *testing.T) {
 // Walking through any sequence of lifecycle phase transitions never changes
 // the session's worktree path.
 func TestSessionRepoProp_LifecycleTransitionsPreserveWorktreePath(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		repo := setupTestRepoForProp()
-		defer func() { _ = os.RemoveAll(repo) }()
+	setRapidChecks(t, 20)
+	repo := setupTestRepoForProp()
+	t.Cleanup(func() { os.RemoveAll(repo) })
 
+	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())
 		defer mgr.Shutdown()
 
-		sess, _ := createTestSession(t, mgr)
+		sess := createTestSessionPlanOnly(t, mgr)
 		originalPath := sess.Worktree.Path
 		originalBranch := sess.Worktree.BaseBranch
 
@@ -188,17 +204,18 @@ func TestSessionRepoProp_ReviseCwdMatchesWorktreePath(t *testing.T) {
 // Multiple sessions on the same manager all have worktrees under the same repo
 // and all worktree paths are mutually distinct.
 func TestSessionRepoProp_MultipleSessionsDistinctWorktreesSameRepo(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		repo := setupTestRepoForProp()
-		defer func() { _ = os.RemoveAll(repo) }()
+	setRapidChecks(t, 20)
+	repo := setupTestRepoForProp()
+	t.Cleanup(func() { os.RemoveAll(repo) })
 
+	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())
 		defer mgr.Shutdown()
 
 		n := rapid.IntRange(2, 4).Draw(t, "session_count")
 		sessions := make([]*Session, n)
 		for i := 0; i < n; i++ {
-			sessions[i], _ = createTestSession(t, mgr)
+			sessions[i] = createTestSessionPlanOnly(t, mgr)
 		}
 
 		paths := make(map[string]bool)
@@ -395,17 +412,18 @@ func TestSessionRepoProp_PlanningSessionWorktreeUnderRepo(t *testing.T) {
 // The worktree path never shares a prefix with any other session's worktree
 // path (they are peers under .refrain/worktrees/, not nested).
 func TestSessionRepoProp_WorktreePathsNeverNested(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		repo := setupTestRepoForProp()
-		defer func() { _ = os.RemoveAll(repo) }()
+	setRapidChecks(t, 20)
+	repo := setupTestRepoForProp()
+	t.Cleanup(func() { os.RemoveAll(repo) })
 
+	rapid.Check(t, func(t *rapid.T) {
 		mgr := NewManager(repo, defaultTestSettings())
 		defer mgr.Shutdown()
 
 		n := rapid.IntRange(2, 4).Draw(t, "count")
 		sessions := make([]*Session, n)
 		for i := 0; i < n; i++ {
-			sessions[i], _ = createTestSession(t, mgr)
+			sessions[i] = createTestSessionPlanOnly(t, mgr)
 		}
 
 		for i := 0; i < n; i++ {


### PR DESCRIPTION
## Summary

- Build refrain binary once per cmd test run instead of repeatedly
- Remove stale idle-detection sleeps that added unnecessary delays to agent tests
- Switch structural prop tests from full `createTestSession` to lightweight `createTestSessionPlanOnly` (no PTY/bash overhead)
- Move expensive setup operations (`setupTestRepoForProp`) outside property test closures so git init runs once per test instead of per iteration (was running 100x per test)
- Cap rapid property test iterations at 20 via `flag.Set("rapid.checks", "20")` to reduce iteration count from 100 to 20 while maintaining coverage
- Apply the same optimization to `TestSessionRepoProp_PlanPathsUnderWorktree` which was missed in the initial pass

These changes directly address the root cause of slow unit tests: redundant resource allocation and excessive iteration counts in property-based tests. Expected improvement: ~10-15x faster test suite.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI:

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description