### PR TITLE
Fix e2e task progress bar tests

### DIFF
--- a/internal/e2e/planning_test.go
+++ b/internal/e2e/planning_test.go
@@ -191,7 +191,7 @@ func waitForAny(s *Session, timeoutMs int, needles ...string) bool {
 func submitPlanPrompt(t *testing.T, s *Session, prompt string) {
 	t.Helper()
 	s.Press("n")
-	s.WaitForText("draft a plan", 5000)
+	s.WaitForText("draft plan", 5000)
 	s.Type(prompt)
 	s.Press("enter")
 }
@@ -480,7 +480,7 @@ func TestPlanPromptModalCancel(t *testing.T) {
 
 	// Open prompt modal.
 	s.Press("n")
-	s.WaitForText("draft a plan", 5000)
+	s.WaitForText("draft plan", 5000)
 
 	// Cancel.
 	s.Press("Escape")

--- a/internal/e2e/planning_test.go
+++ b/internal/e2e/planning_test.go
@@ -191,7 +191,7 @@ func waitForAny(s *Session, timeoutMs int, needles ...string) bool {
 func submitPlanPrompt(t *testing.T, s *Session, prompt string) {
 	t.Helper()
 	s.Press("n")
-	s.WaitForText("Planning", 5000)
+	s.WaitForText("draft a plan", 5000)
 	s.Type(prompt)
 	s.Press("enter")
 }
@@ -480,7 +480,7 @@ func TestPlanPromptModalCancel(t *testing.T) {
 
 	// Open prompt modal.
 	s.Press("n")
-	s.WaitForText("Planning", 5000)
+	s.WaitForText("draft a plan", 5000)
 
 	// Cancel.
 	s.Press("Escape")

--- a/internal/e2e/taskprogress_test.go
+++ b/internal/e2e/taskprogress_test.go
@@ -36,6 +36,27 @@ turns:
 `,
 }
 
+// taskProgressBranchNameScenario absorbs the background haiku branch-namer
+// subprocess that fires on the first UserPromptSubmit. The DefaultBranchNamePrompt
+// contains "Respond with ONLY the slug" which is unique to the haiku instruction
+// and not present in any build or draft prompt. Returning empty text causes the
+// namer to see an empty slug (ErrEmptySlug) and skip the rename, which eliminates
+// the race between "git branch -m" and "git commit" in the exec scenario.
+var taskProgressBranchNameScenario = scenarioFile{
+	name: "tp_branchname.yaml",
+	content: `name: tp_branchname
+match:
+  prompt: "Respond with ONLY the slug"
+session:
+  id: "e2e-tp-branchname"
+  model: "claude-haiku-4-5-20251001"
+turns:
+  - assistant:
+      - type: text
+        text: ""
+`,
+}
+
 var taskProgressBuildTask1 = scenarioFile{
 	name: "tp_build1.yaml",
 	content: `name: tp_build1
@@ -87,6 +108,7 @@ turns:
 func allTaskProgressScenarios() []scenarioFile {
 	return []scenarioFile{
 		taskProgressDraftScenario,
+		taskProgressBranchNameScenario,
 		taskProgressBuildTask1,
 		taskProgressBuildTask2,
 		taskProgressBuildTask3,
@@ -118,20 +140,37 @@ func TestTaskProgressBarUpdates(t *testing.T) {
 		t.Fatalf("session did not transition to BUILDING after approve\nScreen:\n%s", s.Screenshot())
 	}
 
+	// Open the agent terminal and send the build prompt to trigger task 1.
+	// scrim starts in interactive mode and waits for prompts via stdin.
+	s.Press("enter")
+	s.WaitForText("back", 10000)
+	s.Type("execute the plan\n")
+	s.WaitForText("Completed task 1", 15000)
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
+
 	if !waitForProgress(s, 1, 3, 30000) {
 		t.Fatalf("progress bar never showed 1/3 tasks\nScreen:\n%s", s.Screenshot())
 	}
 
+	// Send task 2, escape back to dashboard to observe 2/3 progress.
 	s.Press("enter")
 	s.WaitForText("back", 10000)
 	s.Type("continue task 2\n")
-	s.Type("continue task 3\n")
+	s.WaitForText("Completed task 2", 15000)
 	s.Press("Escape")
 	s.WaitForText("navigate", 10000)
 
 	if !waitForProgress(s, 2, 3, 30000) {
 		t.Errorf("progress bar never showed 2/3 tasks\nScreen:\n%s", s.Screenshot())
 	}
+
+	// Send task 3, then wait for either 3/3 tasks or auto-promotion to REVIEWING.
+	s.Press("enter")
+	s.WaitForText("back", 10000)
+	s.Type("continue task 3\n")
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
 
 	if !waitForBadgeText(s, "REVIEWING", 30000) {
 		if !waitForProgress(s, 3, 3, 5000) {
@@ -141,7 +180,7 @@ func TestTaskProgressBarUpdates(t *testing.T) {
 }
 
 func TestTaskProgressBarStaysInBuilding(t *testing.T) {
-	s := newPlanningSession(t, taskProgressDraftScenario, taskProgressBuildTask1)
+	s := newPlanningSession(t, taskProgressDraftScenario, taskProgressBranchNameScenario, taskProgressBuildTask1)
 	s.Start()
 	s.WaitForText("FOCUS", 10000)
 
@@ -152,6 +191,14 @@ func TestTaskProgressBarStaysInBuilding(t *testing.T) {
 	if !waitForBadgeText(s, "BUILDING", 15000) {
 		t.Fatalf("session did not transition to BUILDING\nScreen:\n%s", s.Screenshot())
 	}
+
+	// Open the agent terminal and trigger task 1.
+	s.Press("enter")
+	s.WaitForText("back", 10000)
+	s.Type("execute the plan\n")
+	s.WaitForText("Completed task 1", 15000)
+	s.Press("Escape")
+	s.WaitForText("navigate", 10000)
 
 	if !waitForProgress(s, 1, 3, 30000) {
 		t.Errorf("progress bar never showed 1/3 tasks\nScreen:\n%s", s.Screenshot())


### PR DESCRIPTION
## Summary

- Fix two failing e2e tests: `TestTaskProgressBarUpdates` and `TestTaskProgressBarStaysInBuilding`
- Root cause 1: scrim ignores positional args — the build agent passes its task as a positional arg (matching real claude's CLI contract), but scrim treats positional args the same as absent and enters interactive mode waiting on stdin. Tests now explicitly send prompts via the focusLaunch terminal, consistent with the pattern used by all other e2e tests.
- Root cause 2: concurrent git lock conflict — the background haiku branch-namer fires on `UserPromptSubmit` and runs `git branch -m` while the exec scenario's `git commit` writes to the same branch ref, causing exit status 128. The namer accidentally matched `tp_draft.yaml` (its instruction contains "progress test"). New `tp_branchname.yaml` intercepts the haiku instruction via the unique phrase "Respond with ONLY the slug" and returns empty text, producing `ErrEmptySlug` so no rename — and no lock conflict — is attempted.
- Root cause 3: `2/3 tasks` unreachable — tasks 2 and 3 were sent without escaping between them, so the session auto-promoted to REVIEWING after task 3 completed before `2/3 tasks` was observable on the dashboard. Fix: escape between prompts to catch each progress milestone.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` (pre-existing failures in `internal/config` and `internal/hook` on macOS are unrelated — unix socket path length and legacy migration test; confirmed present on main)
- [x] `go test -tags e2e -timeout 300s ./internal/e2e/` — all 27 tests pass
- [x] `go test -tags e2e -count=5 -run "TestTaskProgressBarUpdates|TestTaskProgressBarStaysInBuilding" ./internal/e2e/` — 10/10 passes (confirmed stable)

## Checklist

- [ ] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description