### PR TITLE
Migrate internal/tui to CONVENTIONS.md view purity + async (Phase 1)

### DIFF
--- a/changelog.d/fix-tui-view-purity-and-async-ide-launch.md
+++ b/changelog.d/fix-tui-view-purity-and-async-ide-launch.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- TUI rendering is now side-effect free and IDE launches surface failures. Every `View()`/render helper in `internal/tui` is now pure: the dashboard no longer reads env vars or writes files during render (the E2E debug-dump path is read once at startup and written from the tick path), and all render-time clock reads (the plan editor's revising counter and save-note window, the dashboard's idle/elapsed/done-ago timers, and the review panel's age strings and verdict/check spinner) now read a tick-refreshed timestamp stored on the model instead of calling `time.Now`/`time.Since` while rendering. The two fire-and-forget IDE-launch goroutines are replaced by a shared `tea.Cmd` so a failed launch shows a transient error instead of failing silently.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -148,12 +148,18 @@ type App struct {
 	// managers is keyed by repo path. The value satisfies the narrow
 	// SessionManager interface (see manager_iface.go); production uses
 	// *agent.Manager but tests can inject a deterministic fake.
-	managers     map[string]SessionManager
-	activeRepo   string
-	cfg          *config.Config
-	repoBrowser  fileBrowserModel
-	branchPicker branchPickerModel
-	repoPicker   repoPickerModel
+	managers   map[string]SessionManager
+	activeRepo string
+	cfg        *config.Config
+
+	// debugDumpPath, when non-empty, names a file that the latest composed
+	// dashboard frame is written to on every tick. Set once at startup from
+	// REFRAIN_E2E_DEBUG_DUMP so the env read stays out of the render loop;
+	// the e2e harness (TestArtifactsOnPlanReview) reads the frame from here.
+	debugDumpPath string
+	repoBrowser   fileBrowserModel
+	branchPicker  branchPickerModel
+	repoPicker    repoPickerModel
 
 	// repoPickerPending is set when the file browser was opened from the repo
 	// picker. After the browser emits a select or cancel, control returns to
@@ -328,6 +334,7 @@ func (a *App) closeModal() {
 func NewApp() App {
 	return App{
 		view:            ViewDashboard,
+		debugDumpPath:   os.Getenv("REFRAIN_E2E_DEBUG_DUMP"),
 		dashboard:       newDashboardModel(),
 		cursor:          NewFocusedCursor(),
 		keys:            DefaultKeyMap(),
@@ -438,6 +445,13 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// File-saved confirmation lives inside the editor itself; nothing to
 		// do at the App level beyond not propagating the message further.
 		_ = msg
+		return a, nil
+	case ideOpenedMsg:
+		// IDE launch is the only side effect; surface a failure transiently
+		// (§8) and stop. Success is silent — the editor window appears.
+		if msg.err != nil {
+			a.setError("open IDE: " + msg.err.Error())
+		}
 		return a, nil
 	case planEditorAbandonMsg:
 		return a.handlePlanEditorAbandon(msg)

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"image/color"
 	"math"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -142,6 +141,11 @@ type dashboardModel struct {
 	// tickers tracks marquee scroll state for session names that overflow the sidebar.
 	tickers map[string]*sessionTicker
 
+	// now is the render clock, refreshed from the app tick. View derives the
+	// "idle Nm" / "done Nm ago" / elapsed strings and the review spinner from
+	// it so rendering stays pure (§5: no clock read at render time).
+	now time.Time
+
 	// Repo config form shown in the right panel when focusConfig is active.
 	repoConfigForm *configForm
 	configRepoPath string // path of the repo being configured
@@ -168,7 +172,7 @@ type selection struct {
 }
 
 func newDashboardModel() dashboardModel {
-	return dashboardModel{tickers: make(map[string]*sessionTicker)}
+	return dashboardModel{tickers: make(map[string]*sessionTicker), now: time.Now()}
 }
 
 // advanceTickers steps the marquee scroll state for all sessions whose names
@@ -281,9 +285,6 @@ func (d dashboardModel) View() string {
 		out = d.renderRepoChecksOverlay(d.width, d.height)
 	default:
 		out = d.renderFullscreenFocus(d.width, d.height)
-	}
-	if path := os.Getenv("REFRAIN_E2E_DEBUG_DUMP"); path != "" {
-		_ = os.WriteFile(path, []byte(out), 0o644)
 	}
 	return out
 }
@@ -834,10 +835,10 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	case waitingReason != "":
 		detailStr = waitingReason
 	case anyAgent && allIdle && !sess.LastOutputTime().IsZero():
-		detailStr = fmt.Sprintf("idle %dm", int(time.Since(sess.LastOutputTime()).Minutes()))
+		detailStr = fmt.Sprintf("idle %dm", int(d.now.Sub(sess.LastOutputTime()).Minutes()))
 	}
 
-	totalMins := int(sess.Elapsed().Minutes())
+	totalMins := int(d.now.Sub(sess.CreatedAt).Minutes())
 	var elapsedStr string
 	if totalMins >= 60 {
 		elapsedStr = fmt.Sprintf("%dh %dm", totalMins/60, totalMins%60)
@@ -1675,7 +1676,7 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName, repoPath s
 	name := sess.GetDisplayName()
 	age := ""
 	if !sess.DoneAt().IsZero() {
-		mins := int(time.Since(sess.DoneAt()).Minutes())
+		mins := int(d.now.Sub(sess.DoneAt()).Minutes())
 		age = fmt.Sprintf("done %dm ago", mins)
 	}
 	var cardStyle lipgloss.Style
@@ -1714,7 +1715,7 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName, repoPath s
 
 	var taskDisplay string
 	if d.prDraftSessionID != "" && sess.ID == d.prDraftSessionID && repoPath == d.prDraftRepoPath {
-		taskDisplay = lipgloss.NewStyle().Foreground(ColorWarning).Render(reviewSpinnerFrame() + " drafting PR…")
+		taskDisplay = lipgloss.NewStyle().Foreground(ColorWarning).Render(reviewSpinnerFrame(d.now) + " drafting PR…")
 	} else {
 		origPrompt := sess.OriginalPrompt()
 		switch {

--- a/internal/tui/idecommand.go
+++ b/internal/tui/idecommand.go
@@ -2,11 +2,34 @@ package tui
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 	"unicode"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/devenjarvis/refrain/internal/editor"
 )
+
+// ideOpenedMsg reports the outcome of launching the configured IDE. A non-nil
+// err surfaces as a transient error in the UI (§8).
+type ideOpenedMsg struct{ err error }
+
+// openIDECmd launches the IDE executable detached from refrain and reports the
+// result as an ideOpenedMsg. Running the exec inside the tea.Cmd — rather than
+// a fire-and-forget goroutine — keeps the side effect on the Bubble Tea command
+// path so a launch failure can surface to the user (§4: goroutines produce
+// messages, they don't silently mutate or drop work the UI depends on).
+func openIDECmd(exe string, args []string, dir string) tea.Cmd {
+	return func() tea.Msg {
+		cmd := exec.Command(exe, args...)
+		cmd.Dir = dir
+		if err := cmd.Start(); err != nil {
+			return ideOpenedMsg{err: err}
+		}
+		return ideOpenedMsg{}
+	}
+}
 
 const (
 	editorFieldLabel        = "Editor"

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -88,18 +88,20 @@ type planEditorModel struct {
 
 	doc docEditor // shared textarea, renderer, dimensions, scrollOff
 
-	mode     planEditorMode
-	plan     string // last-loaded plan content; used in scroll mode
-	dirty    bool   // textarea has unsaved edits relative to file
-	saveNote string // transient confirmation ("saved") or error
-	saveAt   time.Time
+	mode            planEditorMode
+	plan            string // last-loaded plan content; used in scroll mode
+	dirty           bool   // textarea has unsaved edits relative to file
+	saveNote        string // transient confirmation ("saved") or error
+	saveAt          time.Time
+	saveNoteVisible bool // saveNote still within its 3s display window; refreshed on tick
 
-	reviseInput textinput.Model
-	drafting    bool // session is currently in LifecycleDrafting; show placeholder
-	revising    bool // a revise call is in flight; lock i/a/ctrl+s
-	revisingFor time.Time
-	statusMsg   string // generic status line under the header (e.g. "Drafting…")
-	errMsg      string // inline error message; cleared on next interaction
+	reviseInput     textinput.Model
+	drafting        bool // session is currently in LifecycleDrafting; show placeholder
+	revising        bool // a revise call is in flight; lock i/a/ctrl+s
+	revisingFor     time.Time
+	revisingElapsed int    // whole seconds since revisingFor; refreshed on tick
+	statusMsg       string // generic status line under the header (e.g. "Drafting…")
+	errMsg          string // inline error message; cleared on next interaction
 
 	// sections is the ordered list of H1/H2 sections parsed from the current
 	// plan. folds maps section heading name to its current fold state (true =
@@ -260,10 +262,22 @@ func (m *planEditorModel) SetRevising(v bool) {
 	m.revising = v
 	if v {
 		m.revisingFor = time.Now()
+		m.revisingElapsed = 0
 		m.statusMsg = "Revising…"
 	} else if m.statusMsg == "Revising…" {
 		m.statusMsg = ""
 	}
+}
+
+// refreshDerived recomputes time-based display values (the revising-elapsed
+// counter and the save-note visibility window) from the editor's timestamps.
+// Driven by the app tick so View()/renderHeader stay pure (§5): they read the
+// stored fields instead of calling time.Since at render time.
+func (m *planEditorModel) refreshDerived(now time.Time) {
+	if m.revising {
+		m.revisingElapsed = int(now.Sub(m.revisingFor).Seconds())
+	}
+	m.saveNoteVisible = m.saveNote != "" && now.Sub(m.saveAt) < 3*time.Second
 }
 
 // SetError sets a one-shot error message rendered below the header until
@@ -613,6 +627,7 @@ func (m *planEditorModel) updateEdit(msg tea.KeyPressMsg) tea.Cmd {
 		m.dirty = false
 		m.saveNote = "saved"
 		m.saveAt = time.Now()
+		m.saveNoteVisible = true
 		m.rebuildSectionsPreservingFolds()
 		sessID := m.sess.ID
 		return func() tea.Msg { return planEditorSavedMsg{sessionID: sessID} }
@@ -926,11 +941,10 @@ func (m *planEditorModel) renderHeader() string {
 	case m.drafting:
 		rightLabel = StyleActive.Render("drafting…")
 	case m.revising:
-		secs := int(time.Since(m.revisingFor).Seconds())
-		rightLabel = StyleActive.Render("revising… (" + fmtSeconds(secs) + ")")
+		rightLabel = StyleActive.Render("revising… (" + fmtSeconds(m.revisingElapsed) + ")")
 	case m.dirty:
 		rightLabel = StyleWarning.Render("● unsaved")
-	case m.saveNote != "" && time.Since(m.saveAt) < 3*time.Second:
+	case m.saveNoteVisible:
 		rightLabel = StyleSuccess.Render(m.saveNote)
 	}
 	gap := m.doc.width - ansi.StringWidth(left) - ansi.StringWidth(rightLabel) - 4

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -31,16 +31,17 @@ func detailContentMeasure(paneWidth, maxMeasure int) (measure, leftPad int) {
 // spinnerFrames is the braille spinner sequence used while a verdict is running.
 var spinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 
-// reviewSpinnerFrame returns the current spinner character based on wall time.
-// Using time.Now() keeps all running rows in sync without needing a tick counter.
-func reviewSpinnerFrame() string {
-	frame := int(time.Now().UnixMilli()/100) % len(spinnerFrames)
+// reviewSpinnerFrame returns the spinner character for the given render clock.
+// now is the model's tick-refreshed timestamp (§5: no clock read at render
+// time); deriving the frame from it keeps all running rows in sync.
+func reviewSpinnerFrame(now time.Time) string {
+	frame := int(now.UnixMilli()/100) % len(spinnerFrames)
 	return spinnerFrames[frame]
 }
 
 // verdictBadge returns the icon, label, and lipgloss style for a task verdict record.
-// rec may be nil (treated as verdictPending).
-func verdictBadge(rec *taskVerdictRecord) (icon, label string, style lipgloss.Style) {
+// rec may be nil (treated as verdictPending). now drives the running-state spinner.
+func verdictBadge(rec *taskVerdictRecord, now time.Time) (icon, label string, style lipgloss.Style) {
 	if rec == nil {
 		return "⋯", "Pending", StyleSubtle
 	}
@@ -53,7 +54,7 @@ func verdictBadge(rec *taskVerdictRecord) (icon, label string, style lipgloss.St
 	case verdictPending:
 		return "⋯", "Pending", StyleSubtle
 	case verdictRunning:
-		return reviewSpinnerFrame(), "Reviewing…", lipgloss.NewStyle().Foreground(ColorPrimary)
+		return reviewSpinnerFrame(now), "Reviewing…", lipgloss.NewStyle().Foreground(ColorPrimary)
 	case verdictDone:
 		switch rec.verdict.Kind {
 		case agent.VerdictPass:
@@ -72,13 +73,14 @@ func verdictBadge(rec *taskVerdictRecord) (icon, label string, style lipgloss.St
 }
 
 // checkBadge returns the icon and lipgloss style for a validation check result.
-// Modeled on verdictBadge to keep icon/style language consistent.
-func checkBadge(result validationCheckResult) (icon string, style lipgloss.Style) {
+// Modeled on verdictBadge to keep icon/style language consistent. now drives
+// the running-state spinner.
+func checkBadge(result validationCheckResult, now time.Time) (icon string, style lipgloss.Style) {
 	switch result.state {
 	case checkPending:
 		return "⋯", StyleSubtle
 	case checkRunning:
-		return reviewSpinnerFrame(), lipgloss.NewStyle().Foreground(ColorPrimary)
+		return reviewSpinnerFrame(now), lipgloss.NewStyle().Foreground(ColorPrimary)
 	case checkPassed:
 		return "✓", StyleSuccess
 	case checkFailed:
@@ -91,7 +93,7 @@ func checkBadge(result validationCheckResult) (icon string, style lipgloss.Style
 
 // renderChecksTab renders the Checks tab body: a compact check list on top and
 // the selected check's combined output below. cs must not be nil.
-func renderChecksTab(cs *checksTabState, width, height int) []string {
+func renderChecksTab(cs *checksTabState, width, height int, now time.Time) []string {
 	if height < 4 {
 		height = 4
 	}
@@ -114,7 +116,7 @@ func renderChecksTab(cs *checksTabState, width, height int) []string {
 		if i < len(cs.results) {
 			result = cs.results[i]
 		}
-		icon, iconStyle := checkBadge(result)
+		icon, iconStyle := checkBadge(result, now)
 		iconStr := iconStyle.Render(icon)
 
 		duration := ""
@@ -177,10 +179,10 @@ func renderChecksTab(cs *checksTabState, width, height int) []string {
 // renderReviewHeader returns the 4-line collapsed header:
 // [0] REVIEW › <name> [age], [1] prompt line 1, [2] prompt line 2 (with …), [3] divider.
 // For short prompts that fit in one line, returns 3 lines: [0] title, [1] prompt, [2] divider.
-func renderReviewHeader(sess *agent.Session, width int) []string {
+func renderReviewHeader(sess *agent.Session, width int, now time.Time) []string {
 	age := ""
 	if !sess.DoneAt().IsZero() {
-		mins := int(time.Since(sess.DoneAt()).Minutes())
+		mins := int(now.Sub(sess.DoneAt()).Minutes())
 		age = fmt.Sprintf("done %dm ago", mins)
 	}
 	headerLeft := lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true).Render("REVIEW") +
@@ -294,9 +296,9 @@ type checksTabState struct {
 // activeTab selects which tab body to render (0=Tasks, 1=Diff, 2=Checks).
 // checkState is non-nil when validation checks are configured and their results
 // are available; nil when no checks are configured or the run state is absent.
-func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool, activeTab int, checkState *checksTabState) string {
+func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, height, cursor int, prDraftInFlight bool, activeTab int, checkState *checksTabState, now time.Time) string {
 	// Header (3–4 lines depending on prompt length).
-	headerLines := renderReviewHeader(sess, width)
+	headerLines := renderReviewHeader(sess, width, now)
 
 	// Tab bar: 2 lines (labels + divider).
 	const tabBarH = 2
@@ -319,7 +321,7 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 		bodyLines = renderReviewPlaceholderTab("full diff browser coming soon", width, bodyH)
 	case activeTab == reviewTabChecks:
 		if checkState != nil {
-			bodyLines = renderChecksTab(checkState, width, bodyH)
+			bodyLines = renderChecksTab(checkState, width, bodyH, now)
 		} else {
 			bodyLines = renderReviewPlaceholderTab("No validation checks configured — add them in .refrain/config.json", width, bodyH)
 		}
@@ -336,9 +338,9 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 			detailH = 2
 		}
 		paneW := width - 2
-		bodyLines = append(bodyLines, renderTaskListPane(entry, paneW, listH, cursor)...)
+		bodyLines = append(bodyLines, renderTaskListPane(entry, paneW, listH, cursor, now)...)
 		bodyLines = append(bodyLines, StyleSubtle.Render(strings.Repeat("─", width-2)))
-		bodyLines = append(bodyLines, renderTaskDetailPane(entry, cursor, paneW, detailH)...)
+		bodyLines = append(bodyLines, renderTaskDetailPane(entry, cursor, paneW, detailH, now)...)
 	}
 
 	// Assemble full panel.
@@ -349,7 +351,7 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 
 	// In-flight PR draft status line.
 	if prDraftInFlight {
-		draftStatus := lipgloss.NewStyle().Foreground(ColorWarning).Render(reviewSpinnerFrame() + " Pushing branch and drafting PR…")
+		draftStatus := lipgloss.NewStyle().Foreground(ColorWarning).Render(reviewSpinnerFrame(now) + " Pushing branch and drafting PR…")
 		lines = append(lines, draftStatus)
 	}
 
@@ -412,7 +414,7 @@ func reviewListPaneRowAt(entry *reviewDiffEntry, mouseX, mouseY, paneTop, paneLe
 
 // renderTaskListPane renders the left-pane compact task list with icon, index, text, stat.
 // Row format: <icon> [N] <truncated text>  +X -Y
-func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int) []string {
+func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int, now time.Time) []string {
 	const headerLines = 2
 	planTasksStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#06B6D4")).Bold(true)
 	header := []string{
@@ -485,7 +487,7 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int) []str
 		if entry.verdicts != nil {
 			rec = entry.verdicts[r.taskIndex]
 		}
-		icon, _, style := verdictBadge(rec)
+		icon, _, style := verdictBadge(rec, now)
 		// For the synthetic overview row, use a dot.
 		if r.taskIndex == -1 {
 			icon = "·"
@@ -505,7 +507,7 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int) []str
 		// Stat string — for verdictNoDiff, show the label as the stat.
 		statStr := ""
 		if rec != nil && rec.state == verdictNoDiff {
-			_, lbl, sty := verdictBadge(rec)
+			_, lbl, sty := verdictBadge(rec, now)
 			statStr = sty.Render(lbl)
 		} else if r.group != nil && r.group.stats != nil {
 			st := r.group.stats
@@ -556,7 +558,7 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int) []str
 
 // renderTaskDetailPane renders the right-pane detail for the cursor-selected task.
 // Sections: task heading, verdict badge, rationale, changed files, commits.
-func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []string {
+func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int, now time.Time) []string {
 	if entry == nil {
 		return []string{StyleSubtle.Render("loading…")}
 	}
@@ -661,7 +663,7 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int) []s
 	} else if entry.verdicts != nil && group != nil {
 		rec = entry.verdicts[group.taskIndex]
 	}
-	icon, label, style := verdictBadge(rec)
+	icon, label, style := verdictBadge(rec, now)
 	lines = append(lines, style.Render(icon+" "+label))
 
 	// (3) Rationale rendered through mdrender for inline bold/italic/code styling.

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
@@ -23,7 +24,7 @@ func TestRenderReviewHeader_TwoLineIntentCap(t *testing.T) {
 	sess.SetOriginalPrompt(longPrompt)
 	sess.MarkDone()
 
-	lines := renderReviewHeader(sess, width)
+	lines := renderReviewHeader(sess, width, time.Now())
 
 	// Expect: title row + exactly 2 intent rows (2nd ending with …) + divider = 4 total.
 	if len(lines) != 4 {
@@ -80,7 +81,7 @@ func TestRenderTaskListPane_RowFormat(t *testing.T) {
 	}
 
 	const width, height, cursor = 40, 10, 0
-	lines := renderTaskListPane(entry, width, height, cursor)
+	lines := renderTaskListPane(entry, width, height, cursor, time.Now())
 	out := strings.Join(lines, "\n")
 
 	if !strings.Contains(out, "PLAN TASKS") {
@@ -141,7 +142,7 @@ func TestRenderTaskDetailPane_FullRationaleNoTruncation(t *testing.T) {
 	}
 
 	const width, height, cursor = 60, 20, 0
-	lines := renderTaskDetailPane(entry, cursor, width, height)
+	lines := renderTaskDetailPane(entry, cursor, width, height, time.Now())
 	out := strings.Join(lines, "\n")
 
 	// Full rationale must appear — check a phrase that fits within one wrapped line.
@@ -189,7 +190,7 @@ func TestRenderTaskDetailPane_VerdictStatesRender(t *testing.T) {
 				groups:   []taskReviewGroup{{taskIndex: 1, commits: []git.Commit{{Hash: "abc1234"}}}},
 				verdicts: map[int]*taskVerdictRecord{1: tt.rec},
 			}
-			lines := renderTaskDetailPane(entry, 0, 80, 20)
+			lines := renderTaskDetailPane(entry, 0, 80, 20, time.Now())
 			out := strings.Join(lines, "\n")
 			if !strings.Contains(out, tt.wantLabel) {
 				t.Errorf("verdict state %s: want label %q in output; got:\n%s", tt.name, tt.wantLabel, out)
@@ -220,7 +221,7 @@ func TestRenderTaskDetailPane_ShowsFilesAndCommits(t *testing.T) {
 		},
 	}
 
-	lines := renderTaskDetailPane(entry, 0, 80, 30)
+	lines := renderTaskDetailPane(entry, 0, 80, 30, time.Now())
 	out := strings.Join(lines, "\n")
 
 	for _, want := range []string{
@@ -254,7 +255,7 @@ func TestRenderReviewPanel_TwoPaneLayout(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 30, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 140, 30, 0, false, 0, nil, time.Now())
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from left pane")
@@ -294,7 +295,7 @@ func TestRenderReviewPanel_FullWidthStack(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil, time.Now())
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from list pane")
@@ -335,7 +336,7 @@ func TestRenderReviewPanel_NarrowWidthStacks(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 70, 30, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 70, 30, 0, false, 0, nil, time.Now())
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("must contain PLAN TASKS from list pane")
@@ -365,7 +366,7 @@ func TestRenderReviewPanel_ShowsOriginalPrompt(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 213, Deletions: 34},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil, time.Now())
 
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("review panel must show the original prompt")
@@ -380,7 +381,7 @@ func TestRenderReviewPanel_NilDiffEntry(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 
 	// nil entry — should not panic
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0, nil, time.Now())
 	if !strings.Contains(output, "Fix the auth bug") {
 		t.Error("must still show prompt even with nil diff entry")
 	}
@@ -404,7 +405,7 @@ func TestRenderReviewPanel_UsesThemeColors(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0, nil, time.Now())
 
 	// The pass verdict icon should carry the ColorSuccess ANSI escape.
 	expectedPrefix := StyleSuccess.Render("✓")
@@ -466,7 +467,7 @@ func TestRenderReviewPanel_NoPlanShowsOverview(t *testing.T) {
 		aggregate: &git.DiffStats{Files: 2, Insertions: 30, Deletions: 2},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 120, 30, 0, false, 0, nil, time.Now())
 
 	if !strings.Contains(output, "Overview") {
 		t.Error("must show 'Overview' row in list pane for no-plan session")
@@ -506,7 +507,7 @@ func TestRenderReviewPanel_FooterAdvertisesAllActions(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0, nil, time.Now())
 
 	for _, want := range []string{
 		"open PR",
@@ -529,7 +530,7 @@ func TestRenderReviewPanel_ChecksTabFooter(t *testing.T) {
 	sess.SetOriginalPrompt("Fix auth")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, reviewTabChecks, nil)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, reviewTabChecks, nil, time.Now())
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "run checks") {
@@ -567,7 +568,7 @@ func TestRenderReviewPanel_TaskListShown(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil, time.Now())
 
 	if !strings.Contains(output, "PLAN TASKS") {
 		t.Error("task list view must show PLAN TASKS header")
@@ -775,7 +776,7 @@ func TestRenderReviewPanel_NoDiffFoundBadge(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil, time.Now())
 
 	if !strings.Contains(output, "Write tests") {
 		t.Error("must render a row for task 2 even though it has no commits")
@@ -907,7 +908,7 @@ func TestVerdictBadge(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			icon, label, _ := verdictBadge(tt.rec)
+			icon, label, _ := verdictBadge(tt.rec, time.Now())
 			if !tt.wantIcon(icon) {
 				t.Errorf("verdictBadge icon = %q, unexpected for %s", icon, tt.name)
 			}
@@ -931,7 +932,7 @@ func TestRenderReviewHeader_GoalLineFromPlan(t *testing.T) {
 		t.Fatalf("WritePlan: %v", err)
 	}
 
-	lines := renderReviewHeader(sess, 120)
+	lines := renderReviewHeader(sess, 120, time.Now())
 	out := strings.Join(lines, "\n")
 
 	foundGoalLine := false
@@ -957,7 +958,7 @@ func TestRenderReviewHeader_NoGoalWhenNoPlan(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth redirect bug")
 	sess.MarkDone()
 
-	lines := renderReviewHeader(sess, 120)
+	lines := renderReviewHeader(sess, 120, time.Now())
 	out := strings.Join(lines, "\n")
 
 	for _, l := range lines {
@@ -985,7 +986,7 @@ func TestRenderReviewPanel_HintsIncludeSpecAndEnter(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil, time.Now())
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "?") {
@@ -1059,7 +1060,7 @@ func TestRenderReviewPanel_PRDraftInFlight(t *testing.T) {
 	sess.SetOriginalPrompt("Fix the auth bug")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, true, 0, nil)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, true, 0, nil, time.Now())
 
 	if !strings.Contains(output, "Pushing branch and drafting PR") {
 		t.Error("in-flight state must show draft spinner line")
@@ -1104,7 +1105,7 @@ func TestRenderReviewPanel_TaskHasDiff(t *testing.T) {
 		},
 	}
 
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil, time.Now())
 
 	if !strings.Contains(output, "pass") {
 		t.Error("must contain verdict label 'pass'")
@@ -1139,7 +1140,7 @@ func TestReviewPanel_CursorMoveSwapsDetail(t *testing.T) {
 	}
 
 	// cursor=0 → task 1 heading in detail pane
-	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil)
+	out0 := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil, time.Now())
 	if !strings.Contains(out0, "Task 1:") {
 		t.Errorf("cursor=0: expected 'Task 1:' in detail pane; got:\n%s", out0)
 	}
@@ -1148,7 +1149,7 @@ func TestReviewPanel_CursorMoveSwapsDetail(t *testing.T) {
 	}
 
 	// cursor=1 → task 2 heading in detail pane
-	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false, 0, nil)
+	out1 := renderReviewPanel(sess, entry, 140, 40, 1, false, 0, nil, time.Now())
 	if !strings.Contains(out1, "Task 2:") {
 		t.Errorf("cursor=1: expected 'Task 2:' in detail pane; got:\n%s", out1)
 	}
@@ -1175,7 +1176,7 @@ func TestRenderTaskDetailPane_ContentWidthCapped(t *testing.T) {
 	}
 
 	const width = 120
-	lines := renderTaskDetailPane(entry, 0, width, 30)
+	lines := renderTaskDetailPane(entry, 0, width, 30, time.Now())
 
 	for i, l := range lines {
 		if l == "" {
@@ -1217,7 +1218,7 @@ func TestRenderTaskDetailPane_RationaleHasANSIStyling(t *testing.T) {
 
 	// width=80 → measure=72 (capped), maxW=70. If wrapText(70) were used, "refresh!!"
 	// would land on its own line; RenderLines(72) keeps "token refresh!!" together.
-	lines := renderTaskDetailPane(entry, 0, 80, 30)
+	lines := renderTaskDetailPane(entry, 0, 80, 30, time.Now())
 	out := strings.Join(lines, "\n")
 
 	if !strings.Contains(ansi.Strip(out), "token refresh!!") {
@@ -1241,7 +1242,7 @@ func TestRenderTaskDetailPane_HeadingHasUnderline(t *testing.T) {
 		},
 	}
 
-	lines := renderTaskDetailPane(entry, 0, 80, 20)
+	lines := renderTaskDetailPane(entry, 0, 80, 20, time.Now())
 
 	headingIdx := -1
 	for i, l := range lines {
@@ -1269,7 +1270,7 @@ func TestRenderReviewPanel_FooterUsesThemeStyles(t *testing.T) {
 	sess.SetOriginalPrompt("Fix auth")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, 0, nil, time.Now())
 
 	// StyleActive.Render("p") — carries ANSI codes in color mode, is "p" otherwise.
 	// In both cases the rendered footer must contain it.
@@ -1294,7 +1295,7 @@ func TestRenderTaskListPane_HeaderUsesHeadingColor(t *testing.T) {
 		groups: []taskReviewGroup{},
 	}
 
-	lines := renderTaskListPane(entry, 40, 10, 0)
+	lines := renderTaskListPane(entry, 40, 10, 0, time.Now())
 	out := strings.Join(lines, "\n")
 
 	if !strings.Contains(out, "PLAN TASKS") {
@@ -1336,7 +1337,7 @@ func TestRenderReviewPanel_ShowsTabBar(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, 0, nil, time.Now())
 
 	for _, tab := range []string{"Tasks", "Diff", "Checks"} {
 		if !strings.Contains(ansi.Strip(output), tab) {
@@ -1356,7 +1357,7 @@ func TestRenderReviewPanel_DiffTabPlaceholder(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabDiff, nil)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabDiff, nil, time.Now())
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "full diff browser coming soon") {
@@ -1378,7 +1379,7 @@ func TestRenderReviewPanel_TasksTabStillWorks(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks, nil)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks, nil, time.Now())
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "PLAN TASKS") {
@@ -1397,7 +1398,7 @@ func TestRenderReviewPanel_FooterShowsEnterHint(t *testing.T) {
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
 
-	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks, nil)
+	output := renderReviewPanel(sess, entry, 120, 40, 0, false, reviewTabTasks, nil, time.Now())
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "enter") {
@@ -1501,7 +1502,7 @@ func TestRenderReviewPanel_NoDiffTask(t *testing.T) {
 	}
 
 	// Must not panic and must show the "no diff found" verdict badge.
-	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil)
+	output := renderReviewPanel(sess, entry, 140, 40, 0, false, 0, nil, time.Now())
 	if !strings.Contains(output, "no diff found") {
 		t.Errorf("must show 'no diff found' verdict badge; got:\n%s", output)
 	}
@@ -1591,7 +1592,7 @@ func TestRenderChecksTab_ShowsCheckNames(t *testing.T) {
 			{state: checkRunning},
 		},
 	}
-	lines := renderChecksTab(cs, 80, 20)
+	lines := renderChecksTab(cs, 80, 20, time.Now())
 	out := strings.Join(lines, "\n")
 	stripped := ansi.Strip(out)
 
@@ -1609,7 +1610,7 @@ func TestRenderChecksTab_PassedCheck(t *testing.T) {
 		checks:  []config.ValidationCheck{{Name: "Tests", Command: "go test ./..."}},
 		results: []validationCheckResult{{state: checkPassed, exitCode: 0}},
 	}
-	lines := renderChecksTab(cs, 80, 20)
+	lines := renderChecksTab(cs, 80, 20, time.Now())
 	out := ansi.Strip(strings.Join(lines, "\n"))
 
 	if !strings.Contains(out, "✓") {
@@ -1624,7 +1625,7 @@ func TestRenderChecksTab_OutputPane(t *testing.T) {
 		results: []validationCheckResult{{state: checkPassed, output: "PASS: all 42 tests"}},
 		cursor:  0,
 	}
-	lines := renderChecksTab(cs, 80, 20)
+	lines := renderChecksTab(cs, 80, 20, time.Now())
 	out := ansi.Strip(strings.Join(lines, "\n"))
 
 	if !strings.Contains(out, "PASS: all 42 tests") {
@@ -1638,7 +1639,7 @@ func TestRenderChecksTab_NilState_ShowsPlaceholder(t *testing.T) {
 	sess.SetOriginalPrompt("Fix auth")
 	sess.MarkDone()
 
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, reviewTabChecks, nil)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, reviewTabChecks, nil, time.Now())
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "No validation checks configured") {
@@ -1659,7 +1660,7 @@ func TestRenderReviewPanel_ChecksTabWithState(t *testing.T) {
 		},
 		results: []validationCheckResult{{state: checkPassed}},
 	}
-	output := renderReviewPanel(sess, nil, 120, 40, 0, false, reviewTabChecks, cs)
+	output := renderReviewPanel(sess, nil, 120, 40, 0, false, reviewTabChecks, cs, time.Now())
 	stripped := ansi.Strip(output)
 
 	if !strings.Contains(stripped, "Tests") {

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -2,8 +2,8 @@ package tui
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -31,6 +31,11 @@ type reviewPanelModel struct {
 	checksCursor      int // cursor position in the Checks tab list
 	checksScroll      int // scroll offset for the Checks tab output pane
 
+	// now is the render clock, refreshed from the app tick via SetNow. View
+	// derives elapsed/age strings and the verdict spinner from it so rendering
+	// stays pure (§5: no clock read at render time).
+	now time.Time
+
 	width, height int
 }
 
@@ -43,7 +48,17 @@ func newReviewPanel(sess *agent.Session, repoPath string, width, height int) *re
 		repoPath: repoPath,
 		width:    width,
 		height:   height,
+		now:      time.Now(),
 	}
+}
+
+// SetNow updates the render clock. Called from the app tick so View can derive
+// time-based display values without reading the clock itself (§5).
+func (m *reviewPanelModel) SetNow(now time.Time) {
+	if m == nil {
+		return
+	}
+	m.now = now
 }
 
 // SessionID returns the ID of the session this panel is open for, or "" when
@@ -104,32 +119,30 @@ type reviewReworkRequestMsg struct {
 
 // reviewOpenIDECmd opens the configured IDE on the session's worktree.
 // Mirrors the inline 'i' / 'e' key handler shape: silent if the worktree is
-// missing, errors via svc.SetError when the IDE command isn't set.
-func reviewOpenIDECmd(sess *agent.Session, repoPath string, svc PanelServices) {
+// missing, errors via svc.SetError when the IDE command isn't set. Returns the
+// launch tea.Cmd (or nil) so the caller routes it onto the command path; the
+// launch result surfaces as ideOpenedMsg.
+func reviewOpenIDECmd(sess *agent.Session, repoPath string, svc PanelServices) tea.Cmd {
 	if sess == nil || sess.Worktree == nil {
-		return
+		return nil
 	}
 	if repoPath == "" {
-		return
+		return nil
 	}
 	ideCmd := strings.TrimSpace(svc.Resolved(repoPath).IDECommand)
 	if ideCmd == "" {
 		svc.SetError("No IDE configured (set 'IDE Command' in settings)")
-		return
+		return nil
 	}
 	parts := splitIDECommand(ideCmd)
 	if len(parts) == 0 {
 		svc.SetError("No IDE configured (set 'IDE Command' in settings)")
-		return
+		return nil
 	}
 	worktreePath := sess.Worktree.Path
 	exe := parts[0]
 	args := append(parts[1:], worktreePath)
-	go func() {
-		cmd := exec.Command(exe, args...)
-		cmd.Dir = worktreePath
-		_ = cmd.Start()
-	}()
+	return openIDECmd(exe, args, worktreePath)
 }
 
 // Update dispatches the review panel's key handling. Returns the (possibly
@@ -237,8 +250,7 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		}
 		return m, tea.Batch(closeReviewPanel(svc), svc.KillSessionCmd(sess, m.repoPath))
 	case "e":
-		reviewOpenIDECmd(m.session, m.repoPath, svc)
-		return m, nil
+		return m, reviewOpenIDECmd(m.session, m.repoPath, svc)
 	case "j", "down":
 		switch m.activeTab {
 		case reviewTabTasks:
@@ -384,7 +396,7 @@ func (m *reviewPanelModel) handleClick(msg tea.MouseClickMsg, svc PanelServices)
 	if entry == nil {
 		return
 	}
-	headerH := len(renderReviewHeader(m.session, m.width))
+	headerH := len(renderReviewHeader(m.session, m.width, m.now))
 	const tabBarH = 2
 	paneTop := svc.DashboardTopY + headerH + tabBarH
 	rowIdx := reviewListPaneRowAt(entry, msg.X, msg.Y, paneTop, 0, m.width-2)
@@ -437,5 +449,5 @@ func (m *reviewPanelModel) View(svc PanelServices) string {
 			}
 		}
 	}
-	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.activeTab, checkState)
+	return renderReviewPanel(m.session, entry, m.width, m.height, m.taskCursor, prDraftInFlight, m.activeTab, checkState, m.now)
 }

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -584,12 +583,7 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 		worktreePath := sess.Worktree.Path
 		exe := parts[0]
 		args := append(parts[1:], worktreePath)
-		go func() {
-			cmd := exec.Command(exe, args...)
-			cmd.Dir = worktreePath
-			_ = cmd.Start()
-		}()
-		return a, nil, true
+		return a, openIDECmd(exe, args, worktreePath), true
 
 	case "a":
 		// Open file browser to add a new repo.

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -254,6 +254,16 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	a.refreshAgentList()
+	// Refresh every component's render clock from a single tick timestamp so
+	// their View()/render helpers stay pure (§5: no clock read at render time).
+	renderNow := time.Now()
+	a.dashboard.now = renderNow
+	if pe := a.modals.PlanEditor(); pe != nil {
+		pe.refreshDerived(renderNow)
+	}
+	if rp := a.modals.Review(); rp != nil {
+		rp.SetNow(renderNow)
+	}
 	// Detect Active->Idle transitions for diff-stats refresh. Chime
 	// notifications are fired in the EventStatusChanged handler below,
 	// which reacts the instant Claude's Stop hook arrives.
@@ -322,8 +332,17 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 			diffCmd = a.refreshDiffStatsCmd()
 		}
 	}
-	// Advance sidebar marquee tickers for overflowing session names.
-	a.dashboard.advanceTickers(time.Now())
+	// Advance sidebar marquee tickers for overflowing session names. Reuse
+	// renderNow so all of the dashboard's time-derived state (now field +
+	// ticker advance) is coherent from a single per-tick timestamp.
+	a.dashboard.advanceTickers(renderNow)
+	// E2E debug-dump: write the latest composed dashboard frame to the file
+	// named by REFRAIN_E2E_DEBUG_DUMP (read once at startup). Kept out of any
+	// View()/render helper so rendering stays pure (§5); dashboard.View() is
+	// itself pure, so calling it here from the Update path is side-effect free.
+	if a.debugDumpPath != "" {
+		_ = os.WriteFile(a.debugDumpPath, []byte(a.dashboard.View()), 0o644)
+	}
 	// Adaptive per-session PR polling.
 	var prCmds []tea.Cmd
 	if a.ghClient != nil {


### PR DESCRIPTION
## Summary

Phase 1 of the CONVENTIONS.md migration. No behavior/product change — pure §4 (async) / §5 (view purity) correctness so every `View()`/render helper in `internal/tui` is deterministic from model state and no goroutine fires a side effect the UI depends on without returning a `Msg`.

- **`dashboard.View()` no longer does file I/O (§5).** `REFRAIN_E2E_DEBUG_DUMP` is read once at startup into `App.debugDumpPath`; the debug-dump write moved out of the render loop into the tick path (which calls the now-pure `dashboard.View()`). Keeps the env read and the write out of any `View`.
- **`planeditor` render path no longer reads the clock (§5).** The "revising… (Ns)" counter and the 3s save-note window are now stored fields (`revisingElapsed`, `saveNoteVisible`) refreshed in `Update` via `refreshDerived`, instead of `renderHeader` calling `time.Since`.
- **Dashboard + review-panel render-time clock reads removed (§5).** Idle/elapsed/done-ago timers and the review panel's age strings + verdict/check spinner now read a tick-refreshed `now` snapshot stored on `dashboardModel`/`reviewPanelModel` and threaded through the render helpers, rather than calling `time.Now`/`time.Since`/`sess.Elapsed()` at render time. Spinner cadence is preserved (100ms tick = one frame).
- **IDE launch goes through a `Cmd` (§4).** The two fire-and-forget `go func(){ exec.Command(...).Start() }()` sites (review panel + dashboard `e` key) are replaced by a shared `openIDECmd(...) tea.Cmd` that returns `ideOpenedMsg{err}`; a launch failure now surfaces as a transient error instead of failing silently.

This is the first of a phased migration; later phases (style/layout registries, mirror-field removal, the `Component` contract, thinning `App`, file splits) ship as separate PRs.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] `go test -tags e2e -count=1 ./internal/e2e/ -run TestArtifactsOnPlanReview`
- [ ] Manual TUI: open the IDE via `e` from the dashboard and from the review panel; confirm it launches, and that an intentionally-bad IDE command shows a transient error rather than failing silently.

## Checklist

- [x] Updated changelog (`changelog.d/fix-tui-view-purity-and-async-ide-launch.md`)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md` (existing render/e2e tests cover purity; IDE-launch failure path is the manual step above)
- [x] No new public API surface without a note in the PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)