### PR TITLE
Phase 2 — Foundations: style registry, layout helpers, cmd wiring

### DIFF
--- a/changelog.d/tui-foundations-registry-layout-wiring.md
+++ b/changelog.d/tui-foundations-registry-layout-wiring.md
@@ -1,0 +1,10 @@
+### Changed
+
+- Consolidated the `internal/tui` foundations toward CONVENTIONS.md: semantic
+  colors and styles now live in a single theme registry (no inline
+  `lipgloss.NewStyle()` for semantic styling), width/height arithmetic is
+  centralized in `layout.go` (one source for border/sidebar/modal math, with a
+  shared two-column split helper), and concrete dependency wiring (config,
+  per-repo managers, GitHub client) moved into `cmd/` behind an injected
+  manager factory. The new-session sidebar is unified to 30 columns to match
+  the dashboard. No behavioral change beyond the sidebar width.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,9 +65,11 @@ func buildAppDeps() (tui.AppDeps, error) {
 	// launch. On failure we proceed with nil (config.Resolve tolerates it),
 	// matching the prior in-TUI behavior. The one-time bypass migration runs
 	// only when settings loaded cleanly.
+	var initWarning string
 	globalSettings, gerr := config.LoadGlobalSettings()
 	if gerr != nil {
 		globalSettings = nil
+		initWarning = gerr.Error()
 	} else {
 		_ = config.MigrateBypassPermissions(cfg)
 	}
@@ -95,6 +97,7 @@ func buildAppDeps() (tui.AppDeps, error) {
 		Managers:       managers,
 		GHClient:       ghClient,
 		Factory:        factory,
+		InitWarning:    initWarning,
 	}, nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/devenjarvis/refrain/internal/config"
+	"github.com/devenjarvis/refrain/internal/github"
 	"github.com/devenjarvis/refrain/internal/migrate"
 	"github.com/devenjarvis/refrain/internal/tui"
 	"github.com/spf13/cobra"
@@ -28,12 +30,72 @@ var rootCmd = &cobra.Command{
 		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		p := tea.NewProgram(tui.NewApp())
+		deps, err := buildAppDeps()
+		if err != nil {
+			return err
+		}
+		p := tea.NewProgram(tui.NewAppFromDeps(deps))
 		if _, err := p.Run(); err != nil {
 			return fmt.Errorf("error running TUI: %w", err)
 		}
 		return nil
 	},
+}
+
+// buildAppDeps wires the concrete dependencies the TUI needs. Per
+// CONVENTIONS.md §2, cmd/ is the only place these concretes are constructed:
+// config, per-repo settings, a manager per repo, and the GitHub client are all
+// built here and injected via tui.AppDeps.
+func buildAppDeps() (tui.AppDeps, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return tui.AppDeps{}, fmt.Errorf("cmd: load config: %w", err)
+	}
+	if len(cfg.Repos) == 0 {
+		// Auto-register the current working directory on first run.
+		if err := config.AddRepo(cfg, "."); err != nil {
+			return tui.AppDeps{}, fmt.Errorf("cmd: bootstrap repo: %w", err)
+		}
+		if err := config.Save(cfg); err != nil {
+			return tui.AppDeps{}, fmt.Errorf("cmd: save config: %w", err)
+		}
+	}
+
+	// Global settings are best-effort: a malformed file should not block
+	// launch. On failure we proceed with nil (config.Resolve tolerates it),
+	// matching the prior in-TUI behavior. The one-time bypass migration runs
+	// only when settings loaded cleanly.
+	globalSettings, gerr := config.LoadGlobalSettings()
+	if gerr != nil {
+		globalSettings = nil
+	} else {
+		_ = config.MigrateBypassPermissions(cfg)
+	}
+
+	factory := tui.ManagerFactory(tui.DefaultManagerFactory)
+	repoSettings := make(map[string]*config.RepoSettings, len(cfg.Repos))
+	resolvedCache := make(map[string]config.ResolvedSettings, len(cfg.Repos))
+	managers := make(map[string]tui.SessionManager, len(cfg.Repos))
+	for _, repo := range cfg.Repos {
+		rs, _ := config.LoadRepoSettings(repo.Path)
+		repoSettings[repo.Path] = rs
+		resolved := config.Resolve(globalSettings, rs)
+		resolvedCache[repo.Path] = resolved
+		managers[repo.Path] = factory(repo.Path, resolved)
+	}
+
+	// GitHub client is best-effort (nil when gh auth is absent).
+	ghClient, _ := github.NewClient()
+
+	return tui.AppDeps{
+		Cfg:            cfg,
+		GlobalSettings: globalSettings,
+		RepoSettings:   repoSettings,
+		ResolvedCache:  resolvedCache,
+		Managers:       managers,
+		GHClient:       ghClient,
+		Factory:        factory,
+	}, nil
 }
 
 func Execute() {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -157,6 +157,10 @@ type App struct {
 	// it to assert wiring without building a real Manager. See deps.go.
 	managerFactory ManagerFactory
 
+	// initWarning is a non-fatal wiring warning injected by cmd/ (e.g.
+	// unreadable global settings) that handleInit surfaces transiently.
+	initWarning string
+
 	// debugDumpPath, when non-empty, names a file that the latest composed
 	// dashboard frame is written to on every tick. Set once at startup from
 	// REFRAIN_E2E_DEBUG_DUMP so the env read stays out of the render loop;

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -612,7 +612,7 @@ func (a *App) openNewSession(returnTo ViewMode) tea.Cmd {
 	a.view = ViewNewSession
 	a.newSession.repoName = a.activeRepoDisplayName()
 	a.newSession.baseBranch, _ = git.BaseBranch(a.activeRepo)
-	a.newSession.SetSize(a.width, a.height-1)
+	a.newSession.SetSize(a.width, a.height-statusBarHeight)
 	return a.newSession.Open(returnTo)
 }
 
@@ -1026,7 +1026,7 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 		}
 		return nil, true
 	case focusSectionShipping:
-		a.openShipping(newShippingPanel(sess, items[idx].repoPath, a.width, a.height-1))
+		a.openShipping(newShippingPanel(sess, items[idx].repoPath, a.width, a.height-statusBarHeight))
 		return nil, true
 	}
 	return nil, false
@@ -1161,7 +1161,7 @@ func (a App) View() tea.View {
 				Padding(0, 1).
 				Width(modalW).
 				Render(overlayContent)
-			body = placeCentered(a.width, a.height-1, overlay)
+			body = placeCentered(a.width, a.height-statusBarHeight, overlay)
 		}
 		statusbar := renderStatusBar(hints, a.width)
 		content = lipgloss.JoinVertical(lipgloss.Left, body, statusbar)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -95,11 +95,11 @@ type diffStatsMsg struct {
 	stats     *diffSummaryData
 }
 
-// initAppMsg carries the result of app initialization.
-type initAppMsg struct {
-	cfg *config.Config
-	err error
-}
+// initAppMsg triggers the post-wiring TUI init in handleInit. Config, managers,
+// and the GitHub client are already injected by cmd/ (see NewAppFromDeps), so
+// this message carries no payload — it just kicks the Update loop into starting
+// event listeners and background session resume.
+type initAppMsg struct{}
 
 // resumeDoneMsg signals that background session resume has completed.
 type resumeDoneMsg struct {
@@ -151,6 +151,11 @@ type App struct {
 	managers   map[string]SessionManager
 	activeRepo string
 	cfg        *config.Config
+
+	// managerFactory builds a SessionManager when a repo is added at runtime
+	// (addRepo). NewApp() defaults it to DefaultManagerFactory; tests override
+	// it to assert wiring without building a real Manager. See deps.go.
+	managerFactory ManagerFactory
 
 	// debugDumpPath, when non-empty, names a file that the latest composed
 	// dashboard frame is written to on every tick. Set once at startup from
@@ -339,6 +344,7 @@ func NewApp() App {
 		cursor:          NewFocusedCursor(),
 		keys:            DefaultKeyMap(),
 		wellness:        newWellnessState(),
+		managerFactory:  DefaultManagerFactory,
 		managers:        make(map[string]SessionManager),
 		repoSettings:    make(map[string]*config.RepoSettings),
 		resolvedCache:   make(map[string]config.ResolvedSettings),
@@ -362,22 +368,10 @@ func (a App) Init() tea.Cmd {
 
 func initAppCmd() tea.Cmd {
 	return func() tea.Msg {
-		cfg, err := config.Load()
-		if err != nil {
-			return initAppMsg{err: err}
-		}
-
-		if len(cfg.Repos) == 0 {
-			// Auto-register the current working directory on first run.
-			if err := config.AddRepo(cfg, "."); err != nil {
-				return initAppMsg{err: err}
-			}
-			if err := config.Save(cfg); err != nil {
-				return initAppMsg{err: err}
-			}
-		}
-
-		return initAppMsg{cfg: cfg}
+		// Config, settings, managers, and the GitHub client are wired in cmd/
+		// and injected via NewAppFromDeps. The remaining init work (listeners,
+		// resume) lives in handleInit; this just dispatches into it.
+		return initAppMsg{}
 	}
 }
 
@@ -540,9 +534,8 @@ func (a *App) addRepo(path string) tea.Cmd {
 	a.resolvedCache[absPath] = config.Resolve(a.globalSettings, rs)
 
 	if a.managers[absPath] == nil {
-		mgr := agent.NewManager(absPath, a.resolvedCache[absPath])
+		mgr := a.managerFactory(absPath, a.resolvedCache[absPath])
 		a.managers[absPath] = mgr
-		ensureGitignore(absPath)
 		a.refreshAgentList()
 		return tea.Batch(listenEvents(mgr), listenPlannerQuestions(mgr))
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -5801,8 +5801,9 @@ func TestRecordInput_MouseClick(t *testing.T) {
 // the idle-decay path starts from a known reference rather than the zero value.
 func TestInit_SeedsLastInputAt(t *testing.T) {
 	app := NewApp()
+	app.cfg = &config.Config{}
 	before := time.Now()
-	model, _ := app.Update(initAppMsg{cfg: &config.Config{}})
+	model, _ := app.Update(initAppMsg{})
 	after := time.Now()
 	app = model.(App)
 

--- a/internal/tui/branchpicker.go
+++ b/internal/tui/branchpicker.go
@@ -226,14 +226,7 @@ func (m *branchPickerModel) applyFilter() {
 
 // View renders the branch picker as a two-panel overlay.
 func (m branchPickerModel) View() string {
-	leftWidth := m.width / 3
-	if leftWidth < 25 {
-		leftWidth = 25
-	}
-	rightWidth := m.width - leftWidth - 1
-	if rightWidth < 0 {
-		rightWidth = 0
-	}
+	leftWidth, rightWidth := splitColumns(m.width, columnStrategy{num: 1, den: 3, min: 25}, separatorWidth)
 
 	left := m.renderList(leftWidth)
 	right := m.renderDetails(rightWidth)
@@ -258,7 +251,7 @@ func (m branchPickerModel) View() string {
 // renderList renders the left panel with the grouped branch list.
 func (m branchPickerModel) renderList(width int) string {
 	title := StyleTitle.Render("OPEN BRANCH")
-	sepWidth := width - 2
+	sepWidth := innerWidth(width)
 	if sepWidth < 0 {
 		sepWidth = 0
 	}
@@ -322,7 +315,7 @@ func (m branchPickerModel) renderList(width int) string {
 		if item.kind == "pr" {
 			label = fmt.Sprintf("#%d %s", item.prNumber, item.branch)
 		}
-		maxLen := width - 4
+		maxLen := modalContentWidth(width)
 		if len(label) > maxLen && maxLen > 3 {
 			label = label[:maxLen-1] + "…"
 		}

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -208,7 +208,7 @@ func (f configForm) View() string {
 	}
 
 	labelStyle := lipgloss.NewStyle().Width(22).Foreground(ColorText)
-	focusedLabelStyle := lipgloss.NewStyle().Width(22).Foreground(ColorSecondary).Bold(true)
+	focusedLabelStyle := StyleActive.Bold(true).Width(22)
 	toggleOn := StyleSuccess.Render("[x]")
 	toggleOff := StyleSubtle.Render("[ ]")
 

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -13,7 +13,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
-	"github.com/devenjarvis/refrain/internal/config"
 	"github.com/devenjarvis/refrain/internal/vt"
 )
 
@@ -261,10 +260,7 @@ func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
 // fixedTermWidth() must return the same value on any given frame, otherwise
 // the sidebar and the agent VT will disagree about column counts.
 func (d dashboardModel) listWidth() int {
-	if d.sidebarWidth > 0 {
-		return d.sidebarWidth
-	}
-	return config.DefaultSidebarWidth
+	return resolveSidebarWidth(d.sidebarWidth)
 }
 
 func (d dashboardModel) View() string {
@@ -285,14 +281,14 @@ func (d dashboardModel) View() string {
 }
 
 func (d dashboardModel) contentHeight() int {
-	return d.height - 2 // statusbar + title
+	return d.height - statusBarHeight - titleHeight
 }
 
 // fixedTermWidth returns the terminal column count that all agents should use.
 // Held constant across panel focus changes so transitions never trigger a
 // resize.
 func (d dashboardModel) fixedTermWidth() int {
-	return d.width - d.listWidth() - 1 - 2 // list border + preview border
+	return previewTermWidth(d.width, d.listWidth())
 }
 
 // fixedTermHeight returns the terminal row count that all agents should use.
@@ -300,7 +296,7 @@ func (d dashboardModel) fixedTermWidth() int {
 // the PR line — accepting 1 row of clipping when PR is visible is better than
 // per-session resize churn.
 func (d dashboardModel) fixedTermHeight() int {
-	return d.contentHeight() - 2 - 2 // 2 metadata rows (sessionInfo + blank) + 2 border rows
+	return d.contentHeight() - 2 - 2*borderWidth // 2 metadata rows (sessionInfo + blank) + 2 border rows
 }
 
 // renderRepoConfigOverlay renders the per-repo settings form full-screen. It's

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -62,11 +62,6 @@ type sessionTicker struct {
 	atEnd       bool
 }
 
-// ColorWaiting is the accent used for agents in StatusWaiting (permission
-// prompts, input blocks). Scoped to the dashboard because no other view
-// needs it today — add to theme.go if another view ever surfaces waiting.
-var ColorWaiting = initColor("#D946EF")
-
 // listItemKind distinguishes repo headers, session rows, and agent rows in the dashboard list.
 type listItemKind int
 
@@ -539,17 +534,17 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 		}
 	}
 	if hasError {
-		return lipgloss.NewStyle().Foreground(ColorError).Render("✗ error")
+		return StyleError.Render("✗ error")
 	}
 	if waitingCount > 0 {
 		badge := fmt.Sprintf("⏸ %d waiting", waitingCount)
 		if firstWaitingReason != "" {
 			badge += " — " + truncateVisible(firstWaitingReason, 40)
 		}
-		return lipgloss.NewStyle().Foreground(ColorWaiting).Render(badge)
+		return StyleWaiting.Render(badge)
 	}
 	if idleAskingCount > 0 {
-		return lipgloss.NewStyle().Foreground(ColorWarning).Render(fmt.Sprintf("? %d idle — may need input", idleAskingCount))
+		return StyleWarning.Render(fmt.Sprintf("? %d idle — may need input", idleAskingCount))
 	}
 	// Progress bar takes priority over the idle/reviewable badge so it
 	// stays visible while the agent pauses between tasks. Once all tasks
@@ -588,10 +583,10 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 		}
 	}
 	if sess.IsReviewable() && sess.DoneAt().IsZero() && activeCount == 0 {
-		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ idle — press m to review")
+		return StyleSuccess.Render("✓ idle — press m to review")
 	}
 	if !sess.DoneAt().IsZero() {
-		return lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ finished — awaiting prompt")
+		return StyleSuccess.Render("✓ finished — awaiting prompt")
 	}
 	return StyleSubtle.Render(fmt.Sprintf("%d active, %d idle", activeCount, idleCount))
 }
@@ -726,7 +721,7 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	// strips ANSI (e2e screenshots, terminal recordings). The "> " stays
 	// leftmost so the muted repo prefix never gets between the cursor and the
 	// stripe.
-	nameStyled := lipgloss.NewStyle().Foreground(ColorText).Bold(true).Render(sess.GetDisplayName())
+	nameStyled := StyleCardTitle.Render(sess.GetDisplayName())
 	if repoName != "" {
 		nameStyled = StyleSubtle.Render(repoName+" › ") + nameStyled
 	}
@@ -772,7 +767,7 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	if planningPhase {
 		descStyle := StyleSubtle
 		if descPending {
-			descStyle = lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
+			descStyle = StyleMutedItalic
 		}
 		line2 = stripe + indent + descStyle.Render(descLine1)
 		line3 = stripe + indent
@@ -783,7 +778,7 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 		// Line 2: session description — StyleSubtle or muted-italic when pending.
 		descStyle := StyleSubtle
 		if descPending {
-			descStyle = lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
+			descStyle = StyleMutedItalic
 		}
 		line2 = stripe + indent + descStyle.Render(descLine1)
 		// Line 3: current task (label muted, name bold) or description overflow.
@@ -795,7 +790,7 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 				taskBudget = 0
 			}
 			taskLabel := StyleSubtle.Render("current task: ")
-			taskName := lipgloss.NewStyle().Bold(true).Render(truncateVisible(task, taskBudget))
+			taskName := StyleBold.Render(truncateVisible(task, taskBudget))
 			line3 = stripe + indent + taskLabel + taskName
 		} else if descLine2 != "" {
 			line3 = stripe + indent + descStyle.Render(descLine2)
@@ -897,17 +892,17 @@ func renderBranchLabel(branch string) string {
 func planningStatusBadge(sess *agent.Session) string {
 	if sess.IsDrafting() {
 		if cur, max := sess.DraftAttempt(); cur > 1 && max > 0 {
-			return lipgloss.NewStyle().Foreground(ColorWarning).Render(
+			return StyleWarning.Render(
 				fmt.Sprintf("✎ retrying… (%d/%d)", cur, max),
 			)
 		}
-		return lipgloss.NewStyle().Foreground(ColorWarning).Render("✎ drafting…")
+		return StyleWarning.Render("✎ drafting…")
 	}
 	if sess.IsRevising() {
-		return lipgloss.NewStyle().Foreground(ColorWarning).Render("✎ revising…")
+		return StyleWarning.Render("✎ revising…")
 	}
 	if err := sess.DraftError(); err != nil {
-		return lipgloss.NewStyle().Foreground(ColorError).Render("✗ draft failed")
+		return StyleError.Render("✗ draft failed")
 	}
 	plan, present := sess.CachedPlan()
 	if !present {
@@ -915,9 +910,9 @@ func planningStatusBadge(sess *agent.Session) string {
 	}
 	total, done := planTaskCounts(plan)
 	if total == 0 {
-		return lipgloss.NewStyle().Foreground(ColorPrimary).Render("✎ plan ready")
+		return StyleAccent.Render("✎ plan ready")
 	}
-	return lipgloss.NewStyle().Foreground(ColorPrimary).Render(
+	return StyleAccent.Render(
 		fmt.Sprintf("✎ %d/%d tasks", done, total),
 	)
 }
@@ -1176,9 +1171,9 @@ func (d dashboardModel) renderPipelineWidget(width int) string {
 	return lipgloss.JoinHorizontal(
 		lipgloss.Top,
 		cell("PLANNING", planning, ColorMuted, false),
-		cell("BUILDING", building, lipgloss.Color("#7ec8e3"), false),
+		cell("BUILDING", building, ColorBuilding, false),
 		cell("REVIEWING", reviewing, ColorWarning, reviewing > 0),
-		cell("SHIPPING", shipping, lipgloss.Color("#5ab58a"), false),
+		cell("SHIPPING", shipping, ColorShipping, false),
 	)
 }
 
@@ -1443,7 +1438,7 @@ func (d dashboardModel) renderBreakOverlay(width, height int) string {
 
 	animBlock := d.renderBreatheBlock(width, height)
 
-	titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#38BDF8")).Bold(true)
+	titleStyle := StyleHeading.Foreground(ColorBreakTitle)
 	title := titleStyle.Render("BREAK")
 
 	var blockLine string
@@ -1529,9 +1524,8 @@ func (d dashboardModel) renderBreakCompleteOverlay(width, height int) string {
 		blockLine = StyleSubtle.Render(fmt.Sprintf("Block %d so far", d.focusBlockCount))
 	}
 
-	prompt := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#34D399")).
-		Bold(true).
+	prompt := StyleBold.
+		Foreground(ColorBreakAccent).
 		Render("[b] resume focus session")
 	hint := StyleSubtle.Render("(no rush — the timer won't drag you back in)")
 
@@ -1656,7 +1650,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, StyleSubtle.Render("SHIPPING"))
 		for i, item := range shippingItems {
 			selected := d.cursor.Section() == focusSectionShipping && i == d.cursor.Index(focusSectionShipping)
-			row := d.renderQueueRow(item.session, item.repoName, item.repoPath, selected, lipgloss.Color("#5ab58a"), width)
+			row := d.renderQueueRow(item.session, item.repoName, item.repoPath, selected, ColorShipping, width)
 			lines = append(lines, row...)
 			if i < len(shippingItems)-1 {
 				lines = append(lines, "")
@@ -1697,7 +1691,7 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName, repoPath s
 	// The (reviewing) tag distinguishes InReview rows in the merged Reviewing
 	// section so the user can tell which session is open in the panel.
 	if sess.LifecyclePhase() == agent.LifecycleInReview {
-		tag := lipgloss.NewStyle().Foreground(lipgloss.Color("#9b7fdb")).Render(" (reviewing)")
+		tag := StyleAccent.Foreground(ColorReviewing).Render(" (reviewing)")
 		nameRendered += tag
 	}
 	line1 := prefix + nameRendered
@@ -1715,7 +1709,7 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName, repoPath s
 
 	var taskDisplay string
 	if d.prDraftSessionID != "" && sess.ID == d.prDraftSessionID && repoPath == d.prDraftRepoPath {
-		taskDisplay = lipgloss.NewStyle().Foreground(ColorWarning).Render(reviewSpinnerFrame(d.now) + " drafting PR…")
+		taskDisplay = StyleWarning.Render(reviewSpinnerFrame(d.now) + " drafting PR…")
 	} else {
 		origPrompt := sess.OriginalPrompt()
 		switch {

--- a/internal/tui/deps.go
+++ b/internal/tui/deps.go
@@ -34,6 +34,10 @@ type AppDeps struct {
 	Managers       map[string]SessionManager          // keyed by repo path
 	GHClient       *github.Client
 	Factory        ManagerFactory // used by the runtime addRepo path
+
+	// InitWarning is a non-fatal wiring warning (e.g. unreadable global
+	// settings) that the TUI surfaces transiently on init. Empty when clean.
+	InitWarning string
 }
 
 // NewAppFromDeps builds an App with concretes injected by cmd/. It delegates
@@ -56,5 +60,6 @@ func NewAppFromDeps(deps AppDeps) App {
 		a.managers = deps.Managers
 	}
 	a.ghClient = deps.GHClient
+	a.initWarning = deps.InitWarning
 	return a
 }

--- a/internal/tui/deps.go
+++ b/internal/tui/deps.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
+	"github.com/devenjarvis/refrain/internal/github"
+)
+
+// ManagerFactory builds a SessionManager for the repo at path with resolved
+// settings. cmd/ wires the production DefaultManagerFactory; tests inject a
+// fake so paths like addRepo can run without spinning up PTYs, git worktrees,
+// or a hook socket. Per CONVENTIONS.md §2 this factory is the single seam
+// through which the presentation layer obtains a concrete manager.
+type ManagerFactory func(path string, resolved config.ResolvedSettings) SessionManager
+
+// DefaultManagerFactory is the production ManagerFactory. It is the one place
+// agent.NewManager is constructed for the TUI, and it also ensures the repo's
+// .gitignore excludes .refrain/ — bundling the two so every manager-creation
+// path (startup wiring in cmd/, runtime addRepo) stays consistent.
+func DefaultManagerFactory(path string, resolved config.ResolvedSettings) SessionManager {
+	mgr := agent.NewManager(path, resolved)
+	ensureGitignore(path)
+	return mgr
+}
+
+// AppDeps carries the concrete dependencies wired by cmd/ into the App. Per
+// CONVENTIONS.md §2, cmd/ is the only place these concretes are constructed;
+// the TUI receives them through this struct rather than building them itself.
+type AppDeps struct {
+	Cfg            *config.Config
+	GlobalSettings *config.GlobalSettings
+	RepoSettings   map[string]*config.RepoSettings    // keyed by repo path
+	ResolvedCache  map[string]config.ResolvedSettings // keyed by repo path
+	Managers       map[string]SessionManager          // keyed by repo path
+	GHClient       *github.Client
+	Factory        ManagerFactory // used by the runtime addRepo path
+}
+
+// NewAppFromDeps builds an App with concretes injected by cmd/. It delegates
+// base field initialization to NewApp() (keeping that constructor zero-arg so
+// the existing tests are untouched) and then overlays the wired dependencies.
+func NewAppFromDeps(deps AppDeps) App {
+	a := NewApp()
+	if deps.Factory != nil {
+		a.managerFactory = deps.Factory
+	}
+	a.cfg = deps.Cfg
+	a.globalSettings = deps.GlobalSettings
+	if deps.RepoSettings != nil {
+		a.repoSettings = deps.RepoSettings
+	}
+	if deps.ResolvedCache != nil {
+		a.resolvedCache = deps.ResolvedCache
+	}
+	if deps.Managers != nil {
+		a.managers = deps.Managers
+	}
+	a.ghClient = deps.GHClient
+	return a
+}

--- a/internal/tui/deps_test.go
+++ b/internal/tui/deps_test.go
@@ -1,0 +1,93 @@
+package tui
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/devenjarvis/refrain/internal/config"
+)
+
+// TestAddRepo_UsesInjectedFactory verifies that addRepo obtains its manager
+// through the injectable managerFactory rather than constructing a real
+// *agent.Manager. A fake factory lets the test assert the wiring without
+// spinning up PTYs, worktrees, or a hook socket.
+func TestAddRepo_UsesInjectedFactory(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate config.Save from the real config.
+	repo := t.TempDir()
+	makeGitRepo(t, repo)
+
+	app := NewApp()
+	app.cfg = &config.Config{}
+
+	var calls int
+	var gotPath string
+	var gotResolved config.ResolvedSettings
+	fake := newFakeManager(repo)
+	app.managerFactory = func(path string, resolved config.ResolvedSettings) SessionManager {
+		calls++
+		gotPath = path
+		gotResolved = resolved
+		return fake
+	}
+
+	cmd := app.addRepo(repo)
+
+	if calls != 1 {
+		t.Fatalf("managerFactory called %d times, want 1", calls)
+	}
+	absRepo, _ := filepath.Abs(repo)
+	if gotPath != absRepo {
+		t.Errorf("factory got path %q, want %q", gotPath, absRepo)
+	}
+	if app.managers[absRepo] != SessionManager(fake) {
+		t.Error("addRepo did not store the manager returned by the factory")
+	}
+	// The factory must receive the resolved settings addRepo cached for the repo.
+	if got, want := gotResolved, app.resolvedCache[absRepo]; !reflect.DeepEqual(got, want) {
+		t.Errorf("factory got resolved %+v, want cached %+v", got, want)
+	}
+	if cmd == nil {
+		t.Error("addRepo should return a listen cmd for the newly created manager")
+	}
+}
+
+// TestNewAppFromDeps_OverlaysInjectedConcretes verifies the dependency-injecting
+// constructor keeps NewApp's zero-arg defaults while overlaying the wired
+// concretes, and leaves the default factory in place when none is injected.
+func TestNewAppFromDeps_OverlaysInjectedConcretes(t *testing.T) {
+	cfg := &config.Config{Repos: []config.Repo{{Path: "/repo"}}}
+	gs := &config.GlobalSettings{}
+	mgr := newFakeManager("/repo")
+	deps := AppDeps{
+		Cfg:            cfg,
+		GlobalSettings: gs,
+		Managers:       map[string]SessionManager{"/repo": mgr},
+		ResolvedCache:  map[string]config.ResolvedSettings{"/repo": {AgentProgram: "bash"}},
+		RepoSettings:   map[string]*config.RepoSettings{"/repo": {}},
+	}
+
+	app := NewAppFromDeps(deps)
+
+	if app.cfg != cfg {
+		t.Error("cfg not injected")
+	}
+	if app.globalSettings != gs {
+		t.Error("globalSettings not injected")
+	}
+	if app.managers["/repo"] != SessionManager(mgr) {
+		t.Error("managers not injected")
+	}
+	if app.resolvedCache["/repo"].AgentProgram != "bash" {
+		t.Error("resolvedCache not injected")
+	}
+	// No factory in deps → the NewApp default must remain non-nil so the
+	// runtime addRepo path still works.
+	if app.managerFactory == nil {
+		t.Error("managerFactory must default to DefaultManagerFactory when none injected")
+	}
+	// Base defaults from NewApp() must survive.
+	if app.view != ViewDashboard {
+		t.Error("NewAppFromDeps lost NewApp's base initialization")
+	}
+}

--- a/internal/tui/deps_test.go
+++ b/internal/tui/deps_test.go
@@ -91,3 +91,22 @@ func TestNewAppFromDeps_OverlaysInjectedConcretes(t *testing.T) {
 		t.Error("NewAppFromDeps lost NewApp's base initialization")
 	}
 }
+
+// TestNewAppFromDeps_SurfacesInitWarning verifies a non-fatal wiring warning
+// from cmd/ (e.g. unreadable global settings) is surfaced transiently on init,
+// preserving the pre-injection behavior.
+func TestNewAppFromDeps_SurfacesInitWarning(t *testing.T) {
+	app := NewAppFromDeps(AppDeps{
+		Cfg:         &config.Config{},
+		InitWarning: "settings: bad json",
+	})
+	if app.initWarning != "settings: bad json" {
+		t.Fatalf("initWarning = %q, want %q", app.initWarning, "settings: bad json")
+	}
+
+	model, _ := app.Update(initAppMsg{})
+	got := model.(App)
+	if got.err != "settings: bad json" {
+		t.Errorf("handleInit did not surface the warning: err = %q", got.err)
+	}
+}

--- a/internal/tui/diffview.go
+++ b/internal/tui/diffview.go
@@ -238,7 +238,7 @@ func (d diffModel) View() string {
 	}
 	header := d.renderHeader()
 	if d.model == nil || len(d.model.Files) == 0 {
-		empty := lipgloss.NewStyle().Foreground(ColorMuted).Render(
+		empty := StyleSubtle.Render(
 			fmt.Sprintf("No changes for %s", d.agentName),
 		)
 		body := padViewBody(empty, d.width, d.bodyHeight())
@@ -267,7 +267,7 @@ func (d diffModel) renderHeader() string {
 		if d.sideBySide && d.width >= diff.SideBySideMinWidth {
 			mode = "side-by-side"
 		}
-		sub = lipgloss.NewStyle().Foreground(ColorMuted).Render(
+		sub = StyleSubtle.Render(
 			fmt.Sprintf("  %s  [%s]", d.selected, mode),
 		)
 	}
@@ -280,7 +280,7 @@ func (d diffModel) renderHeader() string {
 
 // renderVerticalSeparator returns a 1-col vertical rule of `h` rows.
 func renderVerticalSeparator(h int) string {
-	style := lipgloss.NewStyle().Foreground(ColorMuted)
+	style := StyleSubtle
 	lines := make([]string, h)
 	for i := range lines {
 		lines[i] = style.Render("│")

--- a/internal/tui/feedbacknotemodal.go
+++ b/internal/tui/feedbacknotemodal.go
@@ -38,7 +38,7 @@ func newFeedbackNoteModal() feedbackNoteModal {
 func (m *feedbackNoteModal) SetSize(w, h int) {
 	m.width = w
 	m.height = h
-	m.ta.SetWidth(modalWidth(w) - 4)
+	m.ta.SetWidth(modalContentWidth(modalWidth(w)))
 }
 
 // Open shows the modal, pre-populating the textarea with an existing note.
@@ -46,7 +46,7 @@ func (m *feedbackNoteModal) Open(itemKey, existing string) tea.Cmd {
 	m.active = true
 	m.itemKey = itemKey
 	m.ta.SetValue(existing)
-	m.ta.SetWidth(modalWidth(m.width) - 4)
+	m.ta.SetWidth(modalContentWidth(modalWidth(m.width)))
 	return m.ta.Focus()
 }
 
@@ -84,7 +84,7 @@ func (m *feedbackNoteModal) Update(msg tea.Msg) (tea.Cmd, bool, string) {
 // View renders the modal box. Caller should overlay this when Active().
 func (m *feedbackNoteModal) View() string {
 	w := modalWidth(m.width)
-	innerW := w - 4
+	innerW := modalContentWidth(w)
 
 	// Header: "FEEDBACK NOTE" left, truncated itemKey right.
 	left := StyleSubtle.Render("FEEDBACK NOTE")

--- a/internal/tui/filebrowser.go
+++ b/internal/tui/filebrowser.go
@@ -152,14 +152,7 @@ func (m fileBrowserModel) Update(msg tea.Msg) (fileBrowserModel, tea.Cmd) {
 
 // View renders the two-panel file browser.
 func (m fileBrowserModel) View() string {
-	leftWidth := m.width / 3
-	if leftWidth < 20 {
-		leftWidth = 20
-	}
-	rightWidth := m.width - leftWidth - 1 // 1 for border
-	if rightWidth < 0 {
-		rightWidth = 0
-	}
+	leftWidth, rightWidth := splitColumns(m.width, columnStrategy{num: 1, den: 3, min: 20}, separatorWidth)
 
 	left := m.renderDirList(leftWidth)
 	right := m.renderDetails(rightWidth)
@@ -281,7 +274,7 @@ func (m fileBrowserModel) renderBreadcrumb(maxWidth int) string {
 // renderDirList renders the left panel with the directory listing.
 func (m fileBrowserModel) renderDirList(width int) string {
 	title := StyleTitle.Render("DIRECTORIES")
-	sepWidth := width - 2
+	sepWidth := innerWidth(width)
 	if sepWidth < 0 {
 		sepWidth = 0
 	}
@@ -289,7 +282,7 @@ func (m fileBrowserModel) renderDirList(width int) string {
 
 	lines := make([]string, 0, 6+len(m.filtered))
 	lines = append(lines, title, separator)
-	lines = append(lines, m.renderBreadcrumb(width-2))
+	lines = append(lines, m.renderBreadcrumb(innerWidth(width)))
 	if m.showHidden {
 		lines = append(lines, StyleSubtle.Render("(showing hidden)"))
 	}
@@ -332,7 +325,7 @@ func (m fileBrowserModel) renderDirList(width int) string {
 		}
 
 		name := m.entries[idx].Name()
-		maxLen := width - 4
+		maxLen := modalContentWidth(width)
 		if len(name) > maxLen {
 			name = name[:maxLen-1] + "…"
 		}

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -1,0 +1,80 @@
+package tui
+
+import "github.com/devenjarvis/refrain/internal/config"
+
+// Layout primitives. Per CONVENTIONS.md §5, width/height arithmetic lives here
+// so a border/sidebar/chrome change is a one-line edit, not a multi-file grep.
+// All helpers are pure (inputs → ints) and read no model or global state.
+
+const (
+	// borderWidth is the column/row cost of a single lipgloss border edge.
+	borderWidth = 1
+	// separatorWidth is the single column between two side-by-side panes.
+	separatorWidth = 1
+	// statusBarHeight is the height of the bottom status bar.
+	statusBarHeight = 1
+	// titleHeight is the height of a screen's top title row.
+	titleHeight = 1
+	// modalChrome is the total horizontal cost of a bordered, 1×2-padded modal
+	// box: 2 border columns + 2 padding columns.
+	modalChrome = 2*borderWidth + 2
+)
+
+// defaultSidebarWidth is the single source for the dashboard/new-session
+// sidebar width. It generalizes config.DefaultSidebarWidth so a width change
+// lands in one place.
+const defaultSidebarWidth = config.DefaultSidebarWidth
+
+// resolveSidebarWidth returns the configured sidebar width, falling back to the
+// default when it has not been plumbed in yet (configured <= 0).
+func resolveSidebarWidth(configured int) int {
+	if configured > 0 {
+		return configured
+	}
+	return defaultSidebarWidth
+}
+
+// innerWidth is the usable width inside a region framed by a single-column
+// border on each side (dividers, panel content). Covers the `width - 2` idiom.
+func innerWidth(w int) int {
+	return w - 2*borderWidth
+}
+
+// modalContentWidth is the usable width inside a bordered+padded modal box.
+// Covers the `w - 4` idiom.
+func modalContentWidth(w int) int {
+	return w - modalChrome
+}
+
+// previewTermWidth is the terminal column count for the agent preview pane:
+// total minus the sidebar, the separator border, and the preview's own two
+// border columns.
+func previewTermWidth(total, sidebar int) int {
+	return total - sidebar - separatorWidth - 2*borderWidth
+}
+
+// columnStrategy parameterizes the left pane of a two-column split.
+type columnStrategy struct {
+	num, den int // left target width = total*num/den
+	min      int // minimum left width
+	reserve  int // if >0, cap left so the right pane keeps at least `reserve` cols
+}
+
+// splitColumns sizes the left pane of a two-column layout per strategy s and
+// returns (left, right), where `gap` columns sit between the panes. It is the
+// single source for the repo-picker / file-browser / branch-picker / shipping
+// feedback splits, each of which differs only in strategy and gap.
+func splitColumns(total int, s columnStrategy, gap int) (left, right int) {
+	left = total * s.num / s.den
+	if left < s.min {
+		left = s.min
+	}
+	if s.reserve > 0 && total > s.reserve && left > total-s.reserve {
+		left = total - s.reserve
+	}
+	right = total - left - gap
+	if right < 0 {
+		right = 0
+	}
+	return left, right
+}

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -1,0 +1,141 @@
+package tui
+
+import "testing"
+
+func TestInnerWidth(t *testing.T) {
+	cases := []struct {
+		name string
+		w    int
+		want int
+	}{
+		{"typical", 80, 78},
+		{"narrow", 10, 8},
+		{"two", 2, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := innerWidth(tc.w); got != tc.want {
+				t.Errorf("innerWidth(%d) = %d, want %d", tc.w, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModalContentWidth(t *testing.T) {
+	cases := []struct {
+		name string
+		w    int
+		want int
+	}{
+		{"typical", 80, 76},
+		{"chrome-exact", 4, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := modalContentWidth(tc.w); got != tc.want {
+				t.Errorf("modalContentWidth(%d) = %d, want %d", tc.w, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveSidebarWidth(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured int
+		want       int
+	}{
+		{"configured", 42, 42},
+		{"zero falls back to default", 0, defaultSidebarWidth},
+		{"negative falls back to default", -5, defaultSidebarWidth},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveSidebarWidth(tc.configured); got != tc.want {
+				t.Errorf("resolveSidebarWidth(%d) = %d, want %d", tc.configured, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPreviewTermWidth(t *testing.T) {
+	// total - sidebar - separator(1) - 2*border(2) = total - sidebar - 3.
+	if got := previewTermWidth(100, 30); got != 67 {
+		t.Errorf("previewTermWidth(100, 30) = %d, want 67", got)
+	}
+}
+
+func TestSplitColumns(t *testing.T) {
+	cases := []struct {
+		name      string
+		total     int
+		strategy  columnStrategy
+		gap       int
+		wantLeft  int
+		wantRight int
+	}{
+		{
+			// repo picker: half width, min 30, cap so right keeps 20.
+			name:     "repopicker wide",
+			total:    120,
+			strategy: columnStrategy{num: 1, den: 2, min: 30, reserve: 20},
+			gap:      separatorWidth,
+			wantLeft: 60, wantRight: 59,
+		},
+		{
+			name:     "repopicker min floor",
+			total:    50,
+			strategy: columnStrategy{num: 1, den: 2, min: 30, reserve: 20},
+			gap:      separatorWidth,
+			wantLeft: 30, wantRight: 19,
+		},
+		{
+			name:     "repopicker reserve cap",
+			total:    44,
+			strategy: columnStrategy{num: 1, den: 2, min: 30, reserve: 20},
+			gap:      separatorWidth,
+			// half=22 → but min 30 floors it to 30, then reserve caps to 44-20=24.
+			wantLeft: 24, wantRight: 19,
+		},
+		{
+			// file browser: third width, min 20, no cap.
+			name:     "filebrowser",
+			total:    90,
+			strategy: columnStrategy{num: 1, den: 3, min: 20},
+			gap:      separatorWidth,
+			wantLeft: 30, wantRight: 59,
+		},
+		{
+			// branch picker: third width, min 25.
+			name:     "branchpicker min",
+			total:    60,
+			strategy: columnStrategy{num: 1, den: 3, min: 25},
+			gap:      separatorWidth,
+			wantLeft: 25, wantRight: 34,
+		},
+		{
+			// shipping feedback: 4/10, min 30, gap 5.
+			name:     "shipping",
+			total:    100,
+			strategy: columnStrategy{num: 4, den: 10, min: 30},
+			gap:      5,
+			wantLeft: 40, wantRight: 55,
+		},
+		{
+			name:     "right clamps to zero",
+			total:    30,
+			strategy: columnStrategy{num: 1, den: 1, min: 0},
+			gap:      separatorWidth,
+			wantLeft: 30, wantRight: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			left, right := splitColumns(tc.total, tc.strategy, tc.gap)
+			if left != tc.wantLeft || right != tc.wantRight {
+				t.Errorf("splitColumns(%d, %+v, %d) = (%d, %d), want (%d, %d)",
+					tc.total, tc.strategy, tc.gap, left, right, tc.wantLeft, tc.wantRight)
+			}
+		})
+	}
+}

--- a/internal/tui/newsession.go
+++ b/internal/tui/newsession.go
@@ -211,7 +211,7 @@ func (m *newSessionModel) renderSidebar() string {
 	w := newSessionSidebarWidth
 
 	flowLabel := StyleSubtle.Render("FLOW")
-	flow := lipgloss.NewStyle().Foreground(ColorPrimary).Render("Plan → Build → Review → Ship")
+	flow := StyleAccent.Render("Plan → Build → Review → Ship")
 	flowBlock := lipgloss.JoinVertical(lipgloss.Left, flowLabel, flow)
 
 	exLabel := StyleSubtle.Render("EXAMPLES")

--- a/internal/tui/newsession.go
+++ b/internal/tui/newsession.go
@@ -51,7 +51,9 @@ var promptModalPlaceholders = []string{
 var pickPrompt = func(n int) int { return rand.IntN(n) }
 
 const (
-	newSessionSidebarWidth  = 28
+	// newSessionSidebarWidth matches the dashboard sidebar (defaultSidebarWidth)
+	// so the new-session form lines up with the pipeline view behind it.
+	newSessionSidebarWidth  = defaultSidebarWidth
 	newSessionSidebarMinVP  = 110 // sidebar shown only when viewport width >= this
 	newSessionMaxTextareaW  = 120
 	newSessionVerticalSlack = 8 // rows consumed by header + title + blank rows + footer

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -8,7 +8,6 @@ import (
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
 	"github.com/devenjarvis/refrain/internal/tui/mdrender"
@@ -930,7 +929,7 @@ func (m *planEditorModel) View() string {
 }
 
 func (m *planEditorModel) renderHeader() string {
-	title := lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true).Render("PLAN")
+	title := StyleTitle.Render("PLAN")
 	if m.sess == nil {
 		return title
 	}

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -213,13 +213,13 @@ func newPlanEditor(sess *agent.Session, repoPath string, width, height int) plan
 	ti := textinput.New()
 	ti.Placeholder = "What should change?"
 	ti.CharLimit = 512
-	ti.SetWidth(width - 4)
+	ti.SetWidth(modalContentWidth(width))
 	m.reviseInput = ti
 
 	qi := textinput.New()
 	qi.Placeholder = "Type an answer (enter to submit, esc to skip)"
 	qi.CharLimit = 1024
-	qi.SetWidth(width - 4)
+	qi.SetWidth(modalContentWidth(width))
 	m.questionInput = qi
 
 	m.reload()
@@ -233,8 +233,8 @@ func newPlanEditor(sess *agent.Session, repoPath string, width, height int) plan
 // what lets renderBody stay pure.
 func (m *planEditorModel) SetSize(w, h int) {
 	m.doc.SetSize(w, h)
-	m.reviseInput.SetWidth(w - 4)
-	m.questionInput.SetWidth(w - 4)
+	m.reviseInput.SetWidth(modalContentWidth(w))
+	m.questionInput.SetWidth(modalContentWidth(w))
 	m.clampScroll()
 }
 
@@ -906,7 +906,7 @@ func (m *planEditorModel) clampCursor() {
 func (m *planEditorModel) View() string {
 	var lines []string
 	lines = append(lines, m.renderHeader())
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, m.doc.width-2))))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, innerWidth(m.doc.width)))))
 
 	if status := m.renderStatusLine(); status != "" {
 		lines = append(lines, status)
@@ -1049,7 +1049,7 @@ func (m *planEditorModel) renderFooter() string {
 			StyleActive.Render("q") + StyleSubtle.Render(" abandon  ") +
 			StyleActive.Render("esc") + StyleSubtle.Render(" back")
 	}
-	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.doc.width-2)))
+	divider := StyleSubtle.Render(strings.Repeat("─", max(1, innerWidth(m.doc.width))))
 	return divider + "\n" + hints
 }
 
@@ -1062,7 +1062,7 @@ func (m *planEditorModel) renderQuestionBody() string {
 	var b strings.Builder
 	b.WriteString(StyleActive.Render("planner is asking:"))
 	b.WriteString("\n\n")
-	b.WriteString(ansi.Wrap(m.questionText, max(20, m.doc.width-4), ""))
+	b.WriteString(ansi.Wrap(m.questionText, max(20, modalContentWidth(m.doc.width)), ""))
 	b.WriteString("\n\n")
 	b.WriteString(StyleActive.Render("answer:") + " " + m.questionInput.View())
 	return b.String()

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -114,16 +114,16 @@ func checkSymbolFor(checks *github.CheckStatus) string {
 	switch checks.State {
 	case "success":
 		sym = "\u2713"
-		style = lipgloss.NewStyle().Foreground(ColorSuccess)
+		style = StyleSuccess
 	case "failure":
 		sym = "\u2717"
-		style = lipgloss.NewStyle().Foreground(ColorError)
+		style = StyleError
 	case "pending":
 		sym = "\u25cb"
-		style = lipgloss.NewStyle().Foreground(ColorWarning)
+		style = StyleWarning
 	default:
 		sym = "?"
-		style = lipgloss.NewStyle().Foreground(ColorMuted)
+		style = StyleSubtle
 	}
 	return style.Render(sym)
 }
@@ -187,13 +187,13 @@ func prIndicator(entry *prCacheEntry) string {
 func statePhraseStyle(phrase string) lipgloss.Style {
 	switch phrase {
 	case "Ready":
-		return lipgloss.NewStyle().Foreground(ColorSuccess)
+		return StyleSuccess
 	case "Conflicts", "Changes requested":
-		return lipgloss.NewStyle().Foreground(ColorError)
+		return StyleError
 	case "Waiting on CI":
-		return lipgloss.NewStyle().Foreground(ColorWarning)
+		return StyleWarning
 	default: // "CI N/M failing"
-		return lipgloss.NewStyle().Foreground(ColorError)
+		return StyleError
 	}
 }
 

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -5,7 +5,6 @@ import (
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -293,16 +292,16 @@ func (m *prComposeModal) renderFooter() string {
 }
 
 func (m *prComposeModal) renderHeader() string {
-	title := lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true).Render("PR DRAFT")
+	title := StyleHeading.Render("PR DRAFT")
 	left := title
 	if m.sessName != "" {
 		left = title + "  " + StyleSubtle.Render("›") + "  " + m.sessName
 	}
 	var draftLabel string
 	if m.draft {
-		draftLabel = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Bold(true).Render("● draft")
+		draftLabel = StyleWarning.Bold(true).Render("● draft")
 	} else {
-		draftLabel = lipgloss.NewStyle().Foreground(lipgloss.Color("#10B981")).Bold(true).Render("● ready")
+		draftLabel = StyleSuccess.Bold(true).Render("● ready")
 	}
 	gap := m.doc.width - ansi.StringWidth(left) - ansi.StringWidth(draftLabel) - 4
 	if gap < 1 {

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -78,7 +78,7 @@ func (m *prComposeModal) Active() bool { return m.active }
 // SetSize updates the viewport dimensions.
 func (m *prComposeModal) SetSize(w, h int) {
 	m.doc.SetSize(w, h)
-	m.titleInput.SetWidth(w - 4)
+	m.titleInput.SetWidth(modalContentWidth(w))
 	m.doc.textarea.SetHeight(m.doc.BodyHeight(8))
 	rendered := m.doc.RenderLines()
 	m.doc.ClampScroll(len(rendered))
@@ -211,7 +211,7 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 func (m *prComposeModal) View() string {
 	var lines []string
 	lines = append(lines, m.renderHeader())
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, m.doc.width-2))))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, innerWidth(m.doc.width)))))
 	switch m.mode {
 	case prComposeModeEdit:
 		lines = append(lines, m.renderEditBody())
@@ -273,7 +273,7 @@ func (m *prComposeModal) renderScrollBody() string {
 }
 
 func (m *prComposeModal) renderFooter() string {
-	divider := StyleSubtle.Render(strings.Repeat("─", max(1, m.doc.width-2)))
+	divider := StyleSubtle.Render(strings.Repeat("─", max(1, innerWidth(m.doc.width))))
 	var hints string
 	switch m.mode {
 	case prComposeModeEdit:

--- a/internal/tui/repopicker.go
+++ b/internal/tui/repopicker.go
@@ -211,17 +211,7 @@ func (m *repoPickerModel) applyFilter() {
 
 // View renders the two-panel picker. The App wraps this with a statusbar.
 func (m repoPickerModel) View() string {
-	leftWidth := m.width / 2
-	if leftWidth < 30 {
-		leftWidth = 30
-	}
-	if leftWidth > m.width-20 && m.width > 20 {
-		leftWidth = m.width - 20
-	}
-	rightWidth := m.width - leftWidth - 1
-	if rightWidth < 0 {
-		rightWidth = 0
-	}
+	leftWidth, rightWidth := splitColumns(m.width, columnStrategy{num: 1, den: 2, min: 30, reserve: 20}, separatorWidth)
 
 	left := m.renderList(leftWidth)
 	right := m.renderDetails(rightWidth)
@@ -250,7 +240,7 @@ func (m repoPickerModel) renderList(width int) string {
 		titleText = "MANAGE REPOS"
 	}
 	title := StyleTitle.Render(titleText)
-	sepWidth := width - 2
+	sepWidth := innerWidth(width)
 	if sepWidth < 0 {
 		sepWidth = 0
 	}
@@ -292,7 +282,7 @@ func (m repoPickerModel) renderList(width int) string {
 
 		if idx == repoPickerAddRepoIdx {
 			label := "+ add new repo…"
-			lines = append(lines, prefix+StyleActive.Render(truncateVisible(label, width-4)))
+			lines = append(lines, prefix+StyleActive.Render(truncateVisible(label, modalContentWidth(width))))
 			continue
 		}
 
@@ -306,7 +296,7 @@ func (m repoPickerModel) renderList(width int) string {
 		// Reserve room: prefix (2) + countLabel + 1 space gap.
 		countWidth := lipgloss.Width(countLabel)
 		// Inner width available for name + path; allow a couple cells of padding.
-		nameRoom := width - 2 - countWidth - 2
+		nameRoom := innerWidth(width) - countWidth - 2
 		if nameRoom < 4 {
 			nameRoom = 4
 		}

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -48,13 +48,13 @@ func verdictBadge(rec *taskVerdictRecord, now time.Time) (icon, label string, st
 	// User flag wins over the AI verdict: the human reviewer is explicitly
 	// asking for rework on this task.
 	if rec.userFlagged {
-		return "⚑", "flagged", lipgloss.NewStyle().Foreground(ColorWarning)
+		return "⚑", "flagged", StyleWarning
 	}
 	switch rec.state {
 	case verdictPending:
 		return "⋯", "Pending", StyleSubtle
 	case verdictRunning:
-		return reviewSpinnerFrame(now), "Reviewing…", lipgloss.NewStyle().Foreground(ColorPrimary)
+		return reviewSpinnerFrame(now), "Reviewing…", StyleAccent
 	case verdictDone:
 		switch rec.verdict.Kind {
 		case agent.VerdictPass:
@@ -80,7 +80,7 @@ func checkBadge(result validationCheckResult, now time.Time) (icon string, style
 	case checkPending:
 		return "⋯", StyleSubtle
 	case checkRunning:
-		return reviewSpinnerFrame(now), lipgloss.NewStyle().Foreground(ColorPrimary)
+		return reviewSpinnerFrame(now), StyleAccent
 	case checkPassed:
 		return "✓", StyleSuccess
 	case checkFailed:
@@ -108,7 +108,7 @@ func renderChecksTab(cs *checksTabState, width, height int, now time.Time) []str
 	}
 
 	// Build list pane.
-	header := lipgloss.NewStyle().Foreground(lipgloss.Color("#06B6D4")).Bold(true).Render("CHECKS")
+	header := StyleHeading.Foreground(ColorSecondary).Render("CHECKS")
 	listLines := make([]string, 0, len(cs.checks)+1)
 	listLines = append(listLines, header)
 	for i, ch := range cs.checks {
@@ -185,7 +185,7 @@ func renderReviewHeader(sess *agent.Session, width int, now time.Time) []string 
 		mins := int(now.Sub(sess.DoneAt()).Minutes())
 		age = fmt.Sprintf("done %dm ago", mins)
 	}
-	headerLeft := lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true).Render("REVIEW") +
+	headerLeft := StyleHeading.Render("REVIEW") +
 		"  " + StyleSubtle.Render("›") +
 		"  " + lipgloss.NewStyle().Render(sess.GetDisplayName())
 	headerRight := StyleSubtle.Render(age)
@@ -265,7 +265,7 @@ func renderReviewPlaceholderTab(label string, width, height int) []string {
 // inactive tabs in StyleSubtle. Line 1: a subtle horizontal divider.
 func renderReviewTabBar(activeTab, width int) []string {
 	labels := []string{"Tasks", "Diff", "Checks"}
-	activeStyle := lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
+	activeStyle := StyleActive.Bold(true)
 	var parts []string
 	for i, label := range labels {
 		if i == activeTab {
@@ -351,7 +351,7 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 
 	// In-flight PR draft status line.
 	if prDraftInFlight {
-		draftStatus := lipgloss.NewStyle().Foreground(ColorWarning).Render(reviewSpinnerFrame(now) + " Pushing branch and drafting PR…")
+		draftStatus := StyleWarning.Render(reviewSpinnerFrame(now) + " Pushing branch and drafting PR…")
 		lines = append(lines, draftStatus)
 	}
 
@@ -416,7 +416,7 @@ func reviewListPaneRowAt(entry *reviewDiffEntry, mouseX, mouseY, paneTop, paneLe
 // Row format: <icon> [N] <truncated text>  +X -Y
 func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int, now time.Time) []string {
 	const headerLines = 2
-	planTasksStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#06B6D4")).Bold(true)
+	planTasksStyle := StyleHeading.Foreground(ColorSecondary)
 	header := []string{
 		planTasksStyle.Render("PLAN TASKS"),
 		StyleSubtle.Render(strings.Repeat("─", ansi.StringWidth("PLAN TASKS"))),
@@ -467,7 +467,7 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int, now t
 	// cursor row. We reserve 2 columns globally (one per side) so moving the
 	// cursor never reflows text — both selected and unselected rows have the
 	// same content budget.
-	cursorBar := lipgloss.NewStyle().Foreground(ColorPrimary).Render("│")
+	cursorBar := StyleAccent.Render("│")
 	subtleGreen := StyleSuccess
 	subtleRed := StyleError
 
@@ -640,7 +640,7 @@ func renderTaskDetailPane(entry *reviewDiffEntry, cursor, width, height int, now
 	maxW := measure - 2
 
 	// H2 heading style: matches colHeading2 / styleH2 in mdrender.
-	headingStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#06B6D4")).Bold(true)
+	headingStyle := StyleHeading.Foreground(ColorSecondary)
 
 	// (1) Task heading with H2 color and thin underline.
 	heading := ""
@@ -743,7 +743,7 @@ func sortFileStatsByChurn(files []git.FileStat) {
 // sess and plan are passed so callers can cache plan reads; if plan is empty
 // or the session has no plan, shows a brief "no plan available" message.
 func renderReviewSpecOverlay(sess *agent.Session, plan string, scrollOffset, width, height int) string {
-	titleStyle := lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true)
+	titleStyle := StyleHeading
 	title := titleStyle.Render("SPEC") + "  " + StyleSubtle.Render("›") + "  " + sess.GetDisplayName()
 	header := title + "\n" + StyleSubtle.Render(strings.Repeat("─", width-2))
 	bodyH := height - 2 // title + divider

--- a/internal/tui/reviewpanel.go
+++ b/internal/tui/reviewpanel.go
@@ -147,7 +147,7 @@ func renderChecksTab(cs *checksTabState, width, height int, now time.Time) []str
 
 	// Build output pane.
 	var outputLines []string
-	outputLines = append(outputLines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	outputLines = append(outputLines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 	if cs.cursor < len(cs.results) {
 		result := cs.results[cs.cursor]
 		out := result.output
@@ -242,7 +242,7 @@ func renderReviewHeader(sess *agent.Session, width int, now time.Time) []string 
 	for _, l := range intentLines {
 		lines = append(lines, "  "+l)
 	}
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 	return lines
 }
 
@@ -275,7 +275,7 @@ func renderReviewTabBar(activeTab, width int) []string {
 		}
 	}
 	labelLine := "  " + strings.Join(parts, "  ")
-	divider := StyleSubtle.Render(strings.Repeat("─", width-2))
+	divider := StyleSubtle.Render(strings.Repeat("─", innerWidth(width)))
 	return []string{labelLine, divider}
 }
 
@@ -337,9 +337,9 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 		if detailH < 2 {
 			detailH = 2
 		}
-		paneW := width - 2
+		paneW := innerWidth(width)
 		bodyLines = append(bodyLines, renderTaskListPane(entry, paneW, listH, cursor, now)...)
-		bodyLines = append(bodyLines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+		bodyLines = append(bodyLines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 		bodyLines = append(bodyLines, renderTaskDetailPane(entry, cursor, paneW, detailH, now)...)
 	}
 
@@ -357,7 +357,7 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 
 	// Action footer.
 	lines = append(lines, "")
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 	var pHint string
 	if prDraftInFlight {
 		pHint = StyleSubtle.Render("p — (in progress…)")
@@ -535,7 +535,7 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int, now t
 		rowText := iconStr + " " + StyleSubtle.Render(label) + " " + textStr
 		if statStr != "" {
 			usedW := iconW + 1 + labelW + 1 + ansi.StringWidth(textStr)
-			padW := width - 4 - usedW - 2 - statW
+			padW := modalContentWidth(width) - usedW - 2 - statW
 			if padW < 1 {
 				padW = 1
 			}
@@ -543,7 +543,7 @@ func renderTaskListPane(entry *reviewDiffEntry, width, height, cursor int, now t
 		}
 
 		if selected {
-			contentW := width - 4
+			contentW := modalContentWidth(width)
 			if w := ansi.StringWidth(rowText); w < contentW {
 				rowText += strings.Repeat(" ", contentW-w)
 			}
@@ -745,7 +745,7 @@ func sortFileStatsByChurn(files []git.FileStat) {
 func renderReviewSpecOverlay(sess *agent.Session, plan string, scrollOffset, width, height int) string {
 	titleStyle := StyleHeading
 	title := titleStyle.Render("SPEC") + "  " + StyleSubtle.Render("›") + "  " + sess.GetDisplayName()
-	header := title + "\n" + StyleSubtle.Render(strings.Repeat("─", width-2))
+	header := title + "\n" + StyleSubtle.Render(strings.Repeat("─", innerWidth(width)))
 	bodyH := height - 2 // title + divider
 	if bodyH < 1 {
 		bodyH = 1
@@ -758,7 +758,7 @@ func renderReviewSpecOverlay(sess *agent.Session, plan string, scrollOffset, wid
 
 	sections := agent.ParsePlanSections(plan)
 	r := mdrender.New(docEditorChromaStyle)
-	contentW := width - 4
+	contentW := modalContentWidth(width)
 
 	type namedSection struct {
 		heading string
@@ -804,7 +804,7 @@ func renderReviewSpecOverlay(sess *agent.Session, plan string, scrollOffset, wid
 	body := strings.Join(window, "\n")
 
 	// Footer hint.
-	footer := "\n" + StyleSubtle.Render(strings.Repeat("─", width-2)) + "\n" +
+	footer := "\n" + StyleSubtle.Render(strings.Repeat("─", innerWidth(width))) + "\n" +
 		"  " + StyleActive.Render("pgdn") + StyleSubtle.Render("/") + StyleActive.Render("pgup") + StyleSubtle.Render(" — scroll") +
 		"  " + StyleActive.Render("g") + StyleSubtle.Render("/") + StyleActive.Render("G") + StyleSubtle.Render(" — top/bottom") +
 		"  " + StyleActive.Render("esc") + StyleSubtle.Render(" — back to review")

--- a/internal/tui/shippingpanel.go
+++ b/internal/tui/shippingpanel.go
@@ -30,12 +30,12 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 		gap = 1
 	}
 	lines = append(lines, headerLeft+strings.Repeat(" ", gap)+headerRight)
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 
 	if entry == nil || entry.pr == nil {
 		lines = append(lines, StyleSubtle.Render("  fetching PR status…"))
 		lines = append(lines, "")
-		lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+		lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 		lines = append(lines, shippingHints(false))
 		return strings.Join(lines, "\n")
 	}
@@ -65,7 +65,7 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 	}
 	lines = append(lines, baseLine)
 	lines = append(lines, "")
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 
 	// ── CI checks ─────────────────────────────────────────────────────────────
 	lines = append(lines, StyleSubtle.Render("CI CHECKS"))
@@ -77,7 +77,7 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 		}
 	}
 	lines = append(lines, "")
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 
 	// ── Review feedback (two-pane) ────────────────────────────────────────────
 	lines = append(lines, StyleSubtle.Render("REVIEW FEEDBACK"))
@@ -103,17 +103,13 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 			if detailH < 2 {
 				detailH = 2
 			}
-			w := width - 2
+			w := innerWidth(width)
 			lines = append(lines, renderFeedbackList(items, cursor, triage, w, listH)...)
-			lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+			lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 			lines = append(lines, renderFeedbackDetail(items, cursor, triage, scroll, w, detailH)...)
 		} else {
 			// Wide: side-by-side panes.
-			leftW := width * 4 / 10
-			if leftW < 30 {
-				leftW = 30
-			}
-			rightW := width - leftW - 5
+			leftW, rightW := splitColumns(width, columnStrategy{num: 4, den: 10, min: 30}, 5)
 			if rightW < 20 {
 				rightW = 20
 			}
@@ -146,7 +142,7 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 	if remaining := height - used; remaining > 0 {
 		lines = append(lines, strings.Repeat("\n", remaining-1))
 	}
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 	lines = append(lines, shippingHints(isMergeReady(entry)))
 
 	return strings.Join(lines, "\n")
@@ -237,7 +233,7 @@ func renderFeedbackList(items []feedbackItem, cursor int, triage map[string]*fee
 		rowText := glyph + " " + labelStr + noteGlyph
 
 		if selected {
-			contentW := w - 4
+			contentW := modalContentWidth(w)
 			if rw := ansi.StringWidth(rowText); rw < contentW {
 				rowText += strings.Repeat(" ", contentW-rw)
 			}
@@ -357,7 +353,7 @@ func renderCheckRow(run github.CheckRun, width int) string {
 	name := truncateVisible(run.Name, width-20)
 	row := "  " + iconStyle.Render(icon) + "  " + name
 	if dur != "" {
-		padW := width - 4 - ansi.StringWidth(name) - ansi.StringWidth(dur) - 6
+		padW := modalContentWidth(width) - ansi.StringWidth(name) - ansi.StringWidth(dur) - 6
 		if padW < 1 {
 			padW = 1
 		}

--- a/internal/tui/shippingpanel.go
+++ b/internal/tui/shippingpanel.go
@@ -18,7 +18,7 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 	var lines []string
 
 	// ── Header ────────────────────────────────────────────────────────────────
-	headerLeft := lipgloss.NewStyle().Foreground(lipgloss.Color("#5ab58a")).Bold(true).Render("SHIPPING") +
+	headerLeft := StyleHeading.Foreground(ColorShipping).Render("SHIPPING") +
 		"  " + StyleSubtle.Render("›") +
 		"  " + lipgloss.NewStyle().Render(sess.GetDisplayName())
 	var headerRight string
@@ -43,15 +43,15 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 	pr := entry.pr
 
 	// ── PR summary ────────────────────────────────────────────────────────────
-	titleLine := "  " + lipgloss.NewStyle().Bold(true).Render(pr.Title)
+	titleLine := "  " + StyleBold.Render(pr.Title)
 	lines = append(lines, titleLine)
 
 	var mergeableLabel string
 	switch pr.MergeableState {
 	case "clean":
-		mergeableLabel = lipgloss.NewStyle().Foreground(ColorSuccess).Render("✓ mergeable")
+		mergeableLabel = StyleSuccess.Render("✓ mergeable")
 	case "dirty":
-		mergeableLabel = lipgloss.NewStyle().Foreground(ColorError).Render("✗ conflicts")
+		mergeableLabel = StyleError.Render("✗ conflicts")
 	default:
 		mergeableLabel = StyleSubtle.Render("⋯ checking")
 	}
@@ -184,7 +184,7 @@ func renderFeedbackList(items []feedbackItem, cursor int, triage map[string]*fee
 		}
 	}
 
-	cursorBar := lipgloss.NewStyle().Foreground(ColorPrimary).Render("│")
+	cursorBar := StyleAccent.Render("│")
 
 	end := offset + rowsH
 	if end > len(items) {
@@ -275,7 +275,7 @@ func renderFeedbackDetail(items []feedbackItem, cursor int, triage map[string]*f
 		}
 		heading = StyleSubtle.Render(loc) + "  " + stateStyle.Render(strings.ToLower(strings.ReplaceAll(item.State, "_", " ")))
 	} else {
-		heading = lipgloss.NewStyle().Bold(true).Render(item.Reviewer) + "  " + stateStyle.Render(strings.ToLower(strings.ReplaceAll(item.State, "_", " ")))
+		heading = StyleBold.Render(item.Reviewer) + "  " + stateStyle.Render(strings.ToLower(strings.ReplaceAll(item.State, "_", " ")))
 	}
 	lines = append(lines, heading, "")
 
@@ -335,13 +335,13 @@ func renderCheckRow(run github.CheckRun, width int) string {
 	switch {
 	case run.Status != "completed":
 		icon = "○"
-		iconStyle = lipgloss.NewStyle().Foreground(ColorWarning)
+		iconStyle = StyleWarning
 	case run.Conclusion == "success" || run.Conclusion == "skipped" || run.Conclusion == "neutral":
 		icon = "✓"
-		iconStyle = lipgloss.NewStyle().Foreground(ColorSuccess)
+		iconStyle = StyleSuccess
 	default:
 		icon = "✗"
-		iconStyle = lipgloss.NewStyle().Foreground(ColorError)
+		iconStyle = StyleError
 	}
 
 	var dur string
@@ -433,13 +433,12 @@ func feedbackItemKey(item feedbackItem) string {
 
 // shippingHints returns the action hint line for the shipping panel footer.
 func shippingHints(mergeReady bool) string {
-	mKey := lipgloss.NewStyle().Foreground(lipgloss.Color("#5ab58a")).Render("m")
+	mKey := StyleAccent.Foreground(ColorShipping).Render("m")
 	mDesc := StyleSubtle.Render(" — merge")
 	if !mergeReady {
 		mKey = StyleSubtle.Render("m")
 	}
-	blue := lipgloss.Color("#7ec8e3")
-	key := func(s string) string { return lipgloss.NewStyle().Foreground(blue).Render(s) }
+	key := func(s string) string { return StyleAccent.Foreground(ColorBuilding).Render(s) }
 	return "  " +
 		mKey + mDesc +
 		"   " + StyleSubtle.Render("M — force merge") +

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -2,8 +2,6 @@ package tui
 
 import (
 	"strings"
-
-	"github.com/charmbracelet/lipgloss"
 )
 
 type keyHint struct {
@@ -113,12 +111,8 @@ var (
 )
 
 func renderStatusBar(hints []keyHint, width int) string {
-	keyStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(ColorText)
-
-	descStyle := lipgloss.NewStyle().
-		Foreground(ColorMuted)
+	keyStyle := StyleBold.Foreground(ColorText)
+	descStyle := StyleSubtle
 
 	parts := make([]string, 0, len(hints))
 	for _, h := range hints {

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -18,6 +18,20 @@ var (
 	ColorText      = initColor("#F9FAFB")
 	ColorBg        = initColor("#111827")
 
+	// ColorWaiting is the accent for agents in StatusWaiting (permission
+	// prompts, input blocks); surfaced as a status badge in the dashboard.
+	ColorWaiting = initColor("#D946EF")
+
+	// Pipeline-section accents: the colors that identify the BUILDING,
+	// REVIEWING, and SHIPPING stages across the dashboard and panels.
+	ColorBuilding  = initColor("#7ec8e3")
+	ColorReviewing = initColor("#9b7fdb")
+	ColorShipping  = initColor("#5ab58a")
+
+	// Break-overlay accents: the wellness break overlay's title and resume cue.
+	ColorBreakTitle  = initColor("#38BDF8")
+	ColorBreakAccent = initColor("#34D399")
+
 	StyleTitle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(ColorPrimary)
@@ -25,6 +39,7 @@ var (
 	StyleSubtle = lipgloss.NewStyle().
 			Foreground(ColorMuted)
 
+	// Status badges: colored, non-bold status text rendered in section rows.
 	StyleSuccess = lipgloss.NewStyle().
 			Foreground(ColorSuccess)
 
@@ -34,12 +49,39 @@ var (
 	StyleWarning = lipgloss.NewStyle().
 			Foreground(ColorWarning)
 
+	StyleWaiting = lipgloss.NewStyle().
+			Foreground(ColorWaiting)
+
 	StyleActive = lipgloss.NewStyle().
 			Foreground(ColorSecondary)
 
 	StyleLink = lipgloss.NewStyle().
 			Underline(true).
 			Foreground(ColorSecondary)
+
+	// Section headings: bold accent text titling a panel/section (REVIEW,
+	// CHECKS, SHIPPING…). Override the foreground inline for non-primary
+	// sections, e.g. StyleHeading.Foreground(ColorShipping).
+	StyleHeading = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(ColorPrimary)
+
+	// StyleCardTitle is a session/card name: bold body-text color.
+	StyleCardTitle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(ColorText)
+
+	// StyleBold is plain bold text that inherits or overrides its color inline.
+	StyleBold = lipgloss.NewStyle().Bold(true)
+
+	// StyleMutedItalic is a de-emphasized description line.
+	StyleMutedItalic = lipgloss.NewStyle().
+				Foreground(ColorMuted).
+				Italic(true)
+
+	// StyleAccent is plain primary-accent text: cursor bars and primary badges.
+	StyleAccent = lipgloss.NewStyle().
+			Foreground(ColorPrimary)
 
 	StyleStatusBar = lipgloss.NewStyle().
 			Foreground(ColorText).

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -589,7 +589,7 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 		// Open file browser to add a new repo.
 		a.repoBrowser = newFileBrowserModel()
 		a.repoBrowser.width = a.width
-		a.repoBrowser.height = a.height - 1
+		a.repoBrowser.height = a.height - statusBarHeight
 		a.view = ViewFileBrowser
 		return a, nil, true
 
@@ -611,7 +611,7 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 		}
 		a.branchPicker = newBranchPickerModel()
 		a.branchPicker.width = a.width
-		a.branchPicker.height = a.height - 1
+		a.branchPicker.height = a.height - statusBarHeight
 		a.activeRepo = repoPath
 		a.view = ViewBranchPicker
 		return a, loadBranchPickerData(repoPath, a.ghClient, activeBranches), true
@@ -700,7 +700,7 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 		}
 		a.repoPicker = newRepoPickerModel()
 		a.repoPicker.width = a.width
-		a.repoPicker.height = a.height - 1
+		a.repoPicker.height = a.height - statusBarHeight
 		a.repoPicker.SetMode(repoPickerModeManage)
 		a.repoPicker.setRepos(a.cfg.Repos, counts, a.activeRepo)
 		a.view = ViewRepoPicker
@@ -730,7 +730,7 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 			return a, nil, true
 		}
 		a.view = ViewDiff
-		a.diff = newDiffModel(sess.GetDisplayName(), m, a.width, a.height-1)
+		a.diff = newDiffModel(sess.GetDisplayName(), m, a.width, a.height-statusBarHeight)
 		return a, nil, true
 
 	case "x":
@@ -1110,7 +1110,7 @@ func (a App) handlePipelineKeys(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 			}
 			a.repoPicker = newRepoPickerModel()
 			a.repoPicker.width = a.width
-			a.repoPicker.height = a.height - 1
+			a.repoPicker.height = a.height - statusBarHeight
 			a.repoPicker.SetMode(repoPickerModeSession)
 			a.repoPicker.setRepos(a.cfg.Repos, counts, a.activeRepo)
 			a.view = ViewRepoPicker

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -58,6 +58,11 @@ func (a App) handleInit(msg initAppMsg) (tea.Model, tea.Cmd) {
 	if a.cfg == nil {
 		a.cfg = &config.Config{}
 	}
+	// Surface any non-fatal wiring warning from cmd/ (e.g. unreadable global
+	// settings) transiently, preserving the pre-injection behavior.
+	if a.initWarning != "" {
+		a.setError(a.initWarning)
+	}
 	now := time.Now()
 	a.wellness.appStart = now
 	a.wellness.sessionStart = now

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devenjarvis/refrain/internal/agent"
 	"github.com/devenjarvis/refrain/internal/audio"
 	"github.com/devenjarvis/refrain/internal/config"
-	"github.com/devenjarvis/refrain/internal/github"
 	"github.com/devenjarvis/refrain/internal/state"
 )
 
@@ -55,24 +54,18 @@ func (a App) handleWindowSize(msg tea.WindowSizeMsg) App {
 }
 
 func (a App) handleInit(msg initAppMsg) (tea.Model, tea.Cmd) {
-	if msg.err != nil {
-		a.setError(msg.err.Error())
-		return a, nil
+	_ = msg
+	if a.cfg == nil {
+		a.cfg = &config.Config{}
 	}
-	a.cfg = msg.cfg
 	now := time.Now()
 	a.wellness.appStart = now
 	a.wellness.sessionStart = now
 	a.wellness.lastInputAt = now
 
-	// Load global settings and run one-time migration.
-	globalSettings, err := config.LoadGlobalSettings()
-	if err != nil {
-		a.setError(err.Error())
-	} else {
-		a.globalSettings = globalSettings
-		_ = config.MigrateBypassPermissions(a.cfg)
-	}
+	// Derive UI state from the injected global settings. config.Resolve here is
+	// a pure derivation, not wiring — globalSettings was loaded in cmd/ and
+	// injected via NewAppFromDeps.
 	resolved := config.Resolve(a.globalSettings, nil)
 	a.dashboard.sidebarWidth = resolved.SidebarWidth
 	a.wellness.focusSessionMinutes = resolved.FocusSessionMinutes
@@ -81,32 +74,18 @@ func (a App) handleInit(msg initAppMsg) (tea.Model, tea.Cmd) {
 	// Default activeRepo to the first registered repo so the pipeline
 	// header shows "repo: <name>" and workflow keys ('n', 'a', 'o') target
 	// a known repo on a fresh dashboard.
-	if a.activeRepo == "" && len(msg.cfg.Repos) > 0 {
-		a.activeRepo = msg.cfg.Repos[0].Path
-	}
-
-	// Load per-repo settings and build resolved cache.
-	for _, repo := range msg.cfg.Repos {
-		rs, _ := config.LoadRepoSettings(repo.Path)
-		a.repoSettings[repo.Path] = rs
-		a.resolvedCache[repo.Path] = config.Resolve(a.globalSettings, rs)
+	if a.activeRepo == "" && len(a.cfg.Repos) > 0 {
+		a.activeRepo = a.cfg.Repos[0].Path
 	}
 
 	// Initialize audio player (best-effort — nil on failure).
 	if p, err := audio.NewPlayer(); err == nil {
 		a.audioPlayer = p
 	}
-	// Initialize GitHub client (best-effort — nil on failure).
-	if ghc, err := github.NewClient(); err == nil {
-		a.ghClient = ghc
-	}
-	// Create a manager for every registered repo and start event listeners.
+	// Start event listeners for every injected manager.
 	var cmds []tea.Cmd
-	for _, repo := range msg.cfg.Repos {
-		if a.managers[repo.Path] == nil {
-			mgr := agent.NewManager(repo.Path, a.resolvedCache[repo.Path])
-			a.managers[repo.Path] = mgr
-			ensureGitignore(repo.Path)
+	for _, repo := range a.cfg.Repos {
+		if mgr := a.managers[repo.Path]; mgr != nil {
 			cmds = append(cmds, listenEvents(mgr), listenPlannerQuestions(mgr))
 		}
 	}
@@ -117,9 +96,9 @@ func (a App) handleInit(msg initAppMsg) (tea.Model, tea.Cmd) {
 		resumeCfg agent.Config
 		sessions  []state.SessionState
 	}
-	resumeItems := make([]resumeItem, 0, len(msg.cfg.Repos))
+	resumeItems := make([]resumeItem, 0, len(a.cfg.Repos))
 	totalPruned := 0
-	for _, repo := range msg.cfg.Repos {
+	for _, repo := range a.cfg.Repos {
 		bs, err := state.Load(repo.Path)
 		if err != nil || bs == nil {
 			continue

--- a/internal/tui/update_pickers.go
+++ b/internal/tui/update_pickers.go
@@ -33,7 +33,7 @@ func (a App) updateFileBrowser(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			a.repoPicker.width = a.width
-			a.repoPicker.height = a.height - 1
+			a.repoPicker.height = a.height - statusBarHeight
 			a.repoPicker.setRepos(a.cfg.Repos, counts, newPath)
 			a.view = ViewRepoPicker
 			return a, cmd
@@ -213,7 +213,7 @@ func (a App) updateRepoPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.repoPickerPending = true
 		a.repoBrowser = newFileBrowserModel()
 		a.repoBrowser.width = a.width
-		a.repoBrowser.height = a.height - 1
+		a.repoBrowser.height = a.height - statusBarHeight
 		a.view = ViewFileBrowser
 		return a, nil
 

--- a/internal/tui/update_plan.go
+++ b/internal/tui/update_plan.go
@@ -363,7 +363,7 @@ func (a *App) openPlanEditor(sess *agent.Session, repoPath string) {
 	if sess == nil {
 		return
 	}
-	editorH := a.height - 1 // status row reserved
+	editorH := a.height - statusBarHeight // status row reserved
 	editor := newPlanEditor(sess, repoPath, a.width, editorH)
 	if sess.IsDrafting() {
 		editor.SetDrafting(true)

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -712,7 +712,7 @@ func (a App) handleReviewOpenTaskDiff(msg reviewOpenTaskDiffMsg) (tea.Model, tea
 		return a, nil
 	}
 	a.view = ViewDiff
-	a.diff = newDiffModel(msg.taskLabel, m, a.width, a.height-1)
+	a.diff = newDiffModel(msg.taskLabel, m, a.width, a.height-statusBarHeight)
 	return a, nil
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of the `internal/tui` migration toward `CONVENTIONS.md` (Phase 1 was #255). "Foundations" closes three §2/§5 gaps that later phases build on. Three logical commits + a review-fix commit; no behavioral change beyond the one intentional sidebar width unify.

### 1. Style registry (§5)
`theme.go` gains the missing semantic colors (`ColorBuilding/Reviewing/Shipping`, break-overlay accents, `ColorWaiting` moved in) and named styles (`StyleHeading`, `StyleCardTitle`, `StyleBold`, `StyleMutedItalic`, `StyleAccent`, `StyleWaiting`). ~50 inline `lipgloss.NewStyle().Foreground(...)` semantic constructions and all hardcoded hex literals across 13 files now reference the registry; `#06B6D4`/`#F59E0B`/`#10B981` collapse to the existing `ColorSecondary`/`ColorWarning`/`ColorSuccess`. Geometric and dynamic-color `NewStyle()` calls stay inline per the §5 carve-out. Render output is byte-identical.

### 2. Layout helpers (§5)
New `layout.go` centralizes width/height math: constants (`borderWidth`, `modalChrome`, `statusBarHeight`, `separatorWidth`, `defaultSidebarWidth`) and pure helpers (`innerWidth`, `modalContentWidth`, `previewTermWidth`, `resolveSidebarWidth`, `splitColumns`). The dashboard helpers, the four bespoke two-column splits (repo-picker / file-browser / branch-picker / shipping feedback), `width-2` dividers, `w-4` content widths, and `height-1` status-row reservations all route through them. The new-session sidebar is unified **28 → 30** to match the dashboard — the single intentional visible change.

### 3. cmd wiring (§2)
`cmd/root.go` becomes the sole place concrete domain types are wired: it loads config (+ first-run bootstrap), global/per-repo settings, builds a manager per repo, and the GitHub client, then injects them via `tui.AppDeps`/`NewAppFromDeps`. A `ManagerFactory` seam routes `addRepo` and startup through one place; `NewApp()` stays zero-arg (100+ tests untouched); `handleInit` is trimmed to TUI-side init + listeners + resume. `config.Load`/`LoadGlobalSettings`/`github.NewClient` no longer appear in `internal/tui`; the only `agent.NewManager` is the injectable `DefaultManagerFactory` seam.

## Tests
- `layout_test.go` — table-driven coverage of the layout helpers (split math, modal/content sizing, clamps).
- `deps_test.go` — `addRepo` routes through an injected fake factory (no real Manager built); `NewAppFromDeps` overlays concretes while keeping `NewApp` defaults; init-warning surfacing.
- Changelog fragment added.

## Verification
- `gofumpt` clean · `go vet ./...` clean · `golangci-lint run` 0 issues
- `go test -race ./...` pass
- `go test -tags e2e ./internal/e2e/` pass (validates the 28→30 sidebar shift renders)
- `./refrain doctor` all checks pass

A fresh code-review pass flagged the dropped global-settings-load warning (restored via `AppDeps.InitWarning`) and one stray semantic style (migrated). `DefaultManagerFactory` intentionally stays in `internal/tui` as the injectable seam so `NewApp()` can default it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)