### PR TITLE
Phase 3 — Eliminate dashboard mirror fields (CONVENTIONS.md §5/§6)

### DIFF
--- a/changelog.d/phase-3-eliminate-mirror-fields.md
+++ b/changelog.d/phase-3-eliminate-mirror-fields.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Internal architecture (CONVENTIONS.md §5/§6): the dashboard view no longer mirrors root `App` state onto its own model. Modal state, the wellness snapshot, the pipeline cursor, per-session caches, and the session/agent row list are now read live each frame through a freshly built `dashboardProps` (the dashboard's analogue of `PanelServices`), eliminating the `syncModalsToDashboard` / `syncFocusCursorToDashboard` / `refreshAgentList` / `updateDashboardPRCache` sync path and the drift it allowed between ticks.
+- Resolved the dual cursor: `App.cursor` (the pipeline cursor) is now the sole owner of selection; the vestigial flat-list `dashboard.selected` index and its `selectedItem`/`clampToRepo`/`clampToAgent` helpers were removed.
+- Removed the dead diff-stats refresh path (it was computed and cached but never rendered).

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -85,16 +85,6 @@ func filterNotFound(err error) error {
 	return err
 }
 
-// diffStatsMsg carries the result of an async diff stats refresh. repoPath
-// identifies the repo that owns sessionID so the handler keys the cache by
-// (repoPath, sessionID) rather than colliding across repos with the same
-// session counter (session-1, session-2, …).
-type diffStatsMsg struct {
-	sessionID string
-	repoPath  string
-	stats     *diffSummaryData
-}
-
 // initAppMsg triggers the post-wiring TUI init in handleInit. Config, managers,
 // and the GitHub client are already injected by cmd/ (see NewAppFromDeps), so
 // this message carries no payload — it just kicks the Update loop into starting
@@ -135,12 +125,6 @@ type mergePRMsg struct {
 	sessionID string
 	repoPath  string
 	err       error
-}
-
-// diffStatsEntry holds cached diff stats for a single session.
-type diffStatsEntry struct {
-	stats       *diffSummaryData
-	lastRefresh time.Time
 }
 
 // App is the root Bubble Tea model.
@@ -216,8 +200,8 @@ type App struct {
 	// is enforced by the Modals type; see internal/tui/modals.go. App callers
 	// must reach overlay models via modals.Review(), modals.Shipping(), etc.,
 	// and must transition via app.openReview / openShipping / openPlanEditor /
-	// openConfig / openLaunch / closeModal helpers (which keep the dashboard
-	// mirror fields in sync).
+	// openConfig / openLaunch / closeModal helpers. The dashboard reads this
+	// state live each frame via dashboardProps(); there is no mirror to sync.
 	modals          Modals
 	reviewDiffCache map[string]*reviewDiffEntry                // keyed by cacheKey(repoPath, sessionID); lifetime exceeds panel
 	validationRuns  map[string]*validationRunState             // keyed by sessionID; lifetime exceeds panel
@@ -238,9 +222,6 @@ type App struct {
 	lastPipelineClick    time.Time
 	lastPipelineClickSec focusSection
 	lastPipelineClickIdx int
-
-	diffStatsCache      map[string]*diffStatsEntry // keyed by cacheKey(repoPath, sessionID)
-	diffRefreshInFlight bool
 
 	ghClient        *github.Client
 	prCache         map[string]*prCacheEntry   // keyed by cacheKey(repoPath, sessionID)
@@ -269,45 +250,32 @@ type App struct {
 	prModalTransitionShipping bool
 }
 
-// syncModalsToDashboard mirrors the current Modals state into the dashboard
-// model's render-time fields. The dashboard renderer reads these fields
-// directly; calling this after every Modals mutation keeps the two in sync.
-// Modal callers should prefer the openX / closeModal helpers below, which
-// invoke this automatically.
-func (a *App) syncModalsToDashboard() {
-	a.dashboard.panelFocus = a.modals.Current()
-	a.dashboard.repoConfigForm = a.modals.Config()
-	a.dashboard.configRepoPath = a.modals.ConfigRepoPath()
-	a.dashboard.repoChecksEditor = a.modals.RepoChecks()
-	a.dashboard.repoChecksRepoPath = a.modals.RepoChecksRepoPath()
-	a.dashboard.focusLaunchAgent = a.modals.LaunchAgent()
-	a.dashboard.focusLaunchSession = a.modals.LaunchSession()
-}
+// The modal helpers below are thin forwards to a.modals.*. They survive as
+// wrappers (rather than callers reaching a.modals directly) so the App-level
+// vocabulary stays stable and a future cross-cut (logging, guards) has one
+// seam. The dashboard reads modal state live each frame via dashboardProps(),
+// so there is no mirror to keep in sync here.
 
-// openReview opens the review panel and syncs the dashboard mirror.
+// openReview opens the review panel.
 func (a *App) openReview(rp *reviewPanelModel) {
 	a.modals.OpenReview(rp)
-	a.syncModalsToDashboard()
 }
 
-// openShipping opens the shipping panel and syncs the dashboard mirror.
+// openShipping opens the shipping panel.
 func (a *App) openShipping(sp *shippingPanelModel) {
 	a.modals.OpenShipping(sp)
-	a.syncModalsToDashboard()
 }
 
-// openPlanEditorPanel installs an existing plan editor model and syncs the
-// dashboard mirror. The high-level "open the plan editor for this session"
-// flow lives in openPlanEditor (which builds the model, then calls this).
+// openPlanEditorPanel installs an existing plan editor model. The high-level
+// "open the plan editor for this session" flow lives in openPlanEditor (which
+// builds the model, then calls this).
 func (a *App) openPlanEditorPanel(pe *planEditorModel) {
 	a.modals.OpenPlanEditor(pe)
-	a.syncModalsToDashboard()
 }
 
-// openConfigForm opens the per-repo config form for repoPath and syncs.
+// openConfigForm opens the per-repo config form for repoPath.
 func (a *App) openConfigForm(form *configForm, repoPath string) {
 	a.modals.OpenConfig(form, repoPath)
-	a.syncModalsToDashboard()
 }
 
 // openRepoChecksEditor switches focus from the repo config form to the
@@ -315,29 +283,25 @@ func (a *App) openConfigForm(form *configForm, repoPath string) {
 // preserved in modals so the user returns to it on save/cancel.
 func (a *App) openRepoChecksEditor(editor *repoChecksModel, repoPath string) {
 	a.modals.OpenRepoChecks(editor, repoPath)
-	a.syncModalsToDashboard()
 }
 
 // closeRepoChecksEditor pops the checks sub-editor without disturbing the
 // parent config form.
 func (a *App) closeRepoChecksEditor() {
 	a.modals.CloseRepoChecks()
-	a.syncModalsToDashboard()
 }
 
-// openLaunchPanel sets the fullscreen agent terminal target and syncs.
+// openLaunchPanel sets the fullscreen agent terminal target.
 // repoPath pins which repo owns sess so ctrl+t/ctrl+n/ctrl+w inside the
 // launch view route to the right manager without re-searching by ID.
 func (a *App) openLaunchPanel(sess *agent.Session, ag *agent.Agent, repoPath string) {
 	a.modals.OpenLaunch(sess, ag, repoPath)
-	a.syncModalsToDashboard()
 }
 
 // closeModal returns focus to the pipeline list and nils every overlay model.
 // This is the canonical "close any panel" path.
 func (a *App) closeModal() {
 	a.modals.Close()
-	a.syncModalsToDashboard()
 }
 
 func NewApp() App {
@@ -353,7 +317,6 @@ func NewApp() App {
 		repoSettings:    make(map[string]*config.RepoSettings),
 		resolvedCache:   make(map[string]config.ResolvedSettings),
 		lastKnownStatus: make(map[string]agent.Status),
-		diffStatsCache:  make(map[string]*diffStatsEntry),
 		reviewDiffCache: make(map[string]*reviewDiffEntry),
 		validationRuns:  make(map[string]*validationRunState),
 		prCache:         make(map[string]*prCacheEntry),
@@ -476,8 +439,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.handlePRDraftReady(msg)
 	case prCreatedMsg:
 		return a.handlePRCreated(msg)
-	case diffStatsMsg:
-		return a.handleDiffStats(msg)
 	case prPollMsg:
 		return a.handlePRPoll(msg)
 	case mergePRMsg:
@@ -540,10 +501,10 @@ func (a *App) addRepo(path string) tea.Cmd {
 	if a.managers[absPath] == nil {
 		mgr := a.managerFactory(absPath, a.resolvedCache[absPath])
 		a.managers[absPath] = mgr
-		a.refreshAgentList()
+		a.clampCursor()
 		return tea.Batch(listenEvents(mgr), listenPlannerQuestions(mgr))
 	}
-	a.refreshAgentList()
+	a.clampCursor()
 	return nil
 }
 
@@ -573,7 +534,7 @@ func (a *App) resizeAllForDashboard() {
 		return
 	}
 	launchAgent := a.modals.LaunchAgent()
-	for _, ag := range a.dashboard.agentItems() {
+	for _, ag := range a.listItems().agents() {
 		if launchAgent != nil && ag.ID == launchAgent.ID {
 			continue
 		}
@@ -768,68 +729,47 @@ func (a *App) dashboardTopY() int {
 	return y
 }
 
-func (a *App) refreshAgentList() {
-	a.dashboard.closingAgents = a.closingAgents
-	a.dashboard.closingSessions = a.closingSessions
-	a.dashboard.sessionElapsed = a.wellness.EffectiveElapsed()
-	a.dashboard.lastReviewAt = a.wellness.lastReviewAt
-	a.dashboard.focusSessionMinutes = a.wellness.focusSessionMinutes
-	a.dashboard.focusBreakMode = a.wellness.focusBreakMode
-	if a.wellness.focusBreakMode {
-		a.dashboard.focusBreakElapsed = time.Since(a.wellness.focusBreakStart)
-	} else {
-		a.dashboard.focusBreakElapsed = 0
-	}
-	a.dashboard.focusBlockCount = a.wellness.focusBlockCount
-	a.dashboard.focusBreakMinutes = a.wellness.focusBreakMinutes
-	a.dashboard.focusBreakAnimFrame = a.wellness.focusBreakAnimFrame
-	a.dashboard.focusBreakShortWarning = a.wellness.focusBreakShortWarning
-	a.dashboard.focusBreakTimerUp = a.wellness.focusBreakTimerUp
-	a.dashboard.cursor = a.cursor
-	a.dashboard.prDraftSessionID = a.prDraftSessionID
-	a.dashboard.prDraftRepoPath = a.prDraftRepoPath
-	a.dashboard.activeRepoName = a.activeRepoDisplayName()
-	a.dashboard.activeRepoPath = a.activeRepo
-	a.syncModalsToDashboard()
+// listItems builds the hierarchical repo/session/agent row list fresh from the
+// managers. It is called once per frame (cheap: ListSessions takes an RLock and
+// allocates one slice) and is the single source for everything the dashboard
+// renders — there is no mirrored copy on the model (CONVENTIONS.md §5/§6).
+//
+// Two shapes, matching the legacy refreshAgentList: when cfg is nil (tests that
+// wire managers directly) the list is session > agent for the active repo with
+// no repo header; otherwise it is repo > session > agent across every
+// configured repo. Sessions are sorted by CreatedAt ascending in both paths.
+func (a *App) listItems() listItems {
 	if a.cfg == nil {
-		// Fallback used in tests that set up managers directly without cfg.
-		if mgr := a.managers[a.activeRepo]; mgr != nil {
-			var items []listItem
-			sessions := mgr.ListSessions()
-			sort.Slice(sessions, func(i, j int) bool {
-				return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
-			})
-			repoName := a.activeRepoDisplayName()
-			for _, sess := range sessions {
-				items = append(items, listItem{
-					kind:     listItemSession,
-					repoPath: a.activeRepo,
-					repoName: repoName,
-					session:  sess,
-				})
-				for _, ag := range sess.Agents() {
-					items = append(items, listItem{
-						kind:     listItemAgent,
-						repoPath: a.activeRepo,
-						session:  sess,
-						agent:    ag,
-					})
-				}
-			}
-			a.dashboard.items = items
-			a.dashboard.clampToAgent()
+		var items listItems
+		mgr := a.managers[a.activeRepo]
+		if mgr == nil {
+			return items
 		}
-		return
+		sessions := mgr.ListSessions()
+		sort.Slice(sessions, func(i, j int) bool {
+			return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
+		})
+		repoName := a.activeRepoDisplayName()
+		for _, sess := range sessions {
+			items = append(items, listItem{
+				kind:     listItemSession,
+				repoPath: a.activeRepo,
+				repoName: repoName,
+				session:  sess,
+			})
+			for _, ag := range sess.Agents() {
+				items = append(items, listItem{
+					kind:     listItemAgent,
+					repoPath: a.activeRepo,
+					session:  sess,
+					agent:    ag,
+				})
+			}
+		}
+		return items
 	}
 
-	// Remember which repo the cursor is in before rebuilding.
-	var prevRepo string
-	if a.dashboard.selected >= 0 && a.dashboard.selected < len(a.dashboard.items) {
-		prevRepo = a.dashboard.items[a.dashboard.selected].repoPath
-	}
-
-	// Build hierarchical list: repo > session > agent.
-	items := make([]listItem, 0, len(a.cfg.Repos))
+	items := make(listItems, 0, len(a.cfg.Repos))
 	for _, repo := range a.cfg.Repos {
 		items = append(items, listItem{
 			kind:     listItemRepo,
@@ -837,50 +777,84 @@ func (a *App) refreshAgentList() {
 			repoName: repo.DisplayName(),
 		})
 		mgr := a.managers[repo.Path]
-		if mgr != nil {
-			sessions := mgr.ListSessions()
-			sort.Slice(sessions, func(i, j int) bool {
-				return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
+		if mgr == nil {
+			continue
+		}
+		sessions := mgr.ListSessions()
+		sort.Slice(sessions, func(i, j int) bool {
+			return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
+		})
+		for _, sess := range sessions {
+			items = append(items, listItem{
+				kind:     listItemSession,
+				repoPath: repo.Path,
+				repoName: repo.DisplayName(),
+				session:  sess,
 			})
-			for _, sess := range sessions {
+			for _, ag := range sess.Agents() {
 				items = append(items, listItem{
-					kind:     listItemSession,
+					kind:     listItemAgent,
 					repoPath: repo.Path,
-					repoName: repo.DisplayName(),
 					session:  sess,
+					agent:    ag,
 				})
-				for _, ag := range sess.Agents() {
-					items = append(items, listItem{
-						kind:     listItemAgent,
-						repoPath: repo.Path,
-						session:  sess,
-						agent:    ag,
-					})
-				}
 			}
 		}
 	}
+	return items
+}
 
-	// Clamp selection to valid range.
-	if len(items) > 0 && a.dashboard.selected >= len(items) {
-		a.dashboard.selected = len(items) - 1
-	}
-	a.dashboard.items = items
-	a.dashboard.clampToRepo()
+// clampCursor keeps the pipeline cursor in range as sessions transition phases
+// or are killed. Replaces the cursor-clamping side effect that the old
+// refreshAgentList performed; call it after any mutation that can change the
+// per-section row counts.
+func (a *App) clampCursor() {
+	a.cursor.Clamp(a.listItems().sectionCounts())
+}
 
-	// If the selection landed in a different repo, search backward for the
-	// nearest repo header in the original repo so the dashboard's items
-	// `selected` row stays anchored to the right repo for things like
-	// activeRepoPath and the cross-repo summary.
-	if prevRepo != "" && len(items) > 0 && items[a.dashboard.selected].repoPath != prevRepo {
-		for i := a.dashboard.selected; i >= 0; i-- {
-			if items[i].repoPath == prevRepo && items[i].kind == listItemRepo {
-				a.dashboard.selected = i
-				break
-			}
-		}
+// dashboardProps assembles the per-frame snapshot the dashboard renders from.
+// Built fresh on every View()/Update so the dashboard never holds a mirror of
+// App state (CONVENTIONS.md §5/§6). All time-derived fields are computed
+// against the tick-refreshed render clock (a.dashboard.now), never time.Now(),
+// so this stays pure when called from View() (§5).
+func (a *App) dashboardProps() dashboardProps {
+	now := a.dashboard.now
+	var focusBreakElapsed time.Duration
+	if a.wellness.focusBreakMode {
+		focusBreakElapsed = now.Sub(a.wellness.focusBreakStart)
 	}
-	a.cursor.Clamp(a.dashboard.sectionCounts())
+	return dashboardProps{
+		panelFocus:         a.modals.Current(),
+		repoConfigForm:     a.modals.Config(),
+		configRepoPath:     a.modals.ConfigRepoPath(),
+		repoChecksEditor:   a.modals.RepoChecks(),
+		repoChecksRepoPath: a.modals.RepoChecksRepoPath(),
+		focusLaunchAgent:   a.modals.LaunchAgent(),
+		focusLaunchSession: a.modals.LaunchSession(),
+
+		cursor: a.cursor,
+
+		sessionElapsed:         a.wellness.EffectiveElapsedAt(now),
+		focusSessionMinutes:    a.wellness.focusSessionMinutes,
+		focusBreakMode:         a.wellness.focusBreakMode,
+		focusBreakElapsed:      focusBreakElapsed,
+		focusBlockCount:        a.wellness.focusBlockCount,
+		focusBreakMinutes:      a.wellness.focusBreakMinutes,
+		focusBreakAnimFrame:    a.wellness.focusBreakAnimFrame,
+		focusBreakShortWarning: a.wellness.focusBreakShortWarning,
+		focusBreakTimerUp:      a.wellness.focusBreakTimerUp,
+
+		prDraftSessionID: a.prDraftSessionID,
+		prDraftRepoPath:  a.prDraftRepoPath,
+
+		activeRepoName: a.activeRepoDisplayName(),
+		activeRepoPath: a.activeRepo,
+
+		prCache:         a.prCache,
+		closingSessions: a.closingSessions,
+
+		items: a.listItems(),
+	}
 }
 
 // pipelineHitTest maps a mouse-click Y coordinate (relative to the dashboard
@@ -918,9 +892,10 @@ func (a *App) pipelineHitTest(dashboardContentY int) (focusSection, int, bool) {
 		}
 	}
 
+	allItems := a.listItems()
 	rowCursor := headerRows + sepRows + pipelineRows + blankRows
 	for _, section := range focusSectionsInOrder() {
-		items := a.dashboard.sectionItems(section)
+		items := allItems.sectionItems(section)
 		if len(items) == 0 {
 			continue
 		}
@@ -944,11 +919,11 @@ func (a *App) pipelineHitTest(dashboardContentY int) (focusSection, int, bool) {
 
 // cursorSelectedSession returns the session under the pipeline cursor, or nil
 // when the cursor's section is empty. Workflow keys (c, x, X, t, e, p, d) use
-// this rather than dashboard.selectedSession() because the pipeline addresses
-// sessions by section + index, not by a `selected` row in the items list.
+// this because the pipeline addresses sessions by section + index, derived
+// fresh from a.listItems().
 func (a *App) cursorSelectedSession() *agent.Session {
 	section := a.cursor.Section()
-	items := a.dashboard.sectionItems(section)
+	items := a.listItems().sectionItems(section)
 	if len(items) == 0 {
 		return nil
 	}
@@ -965,7 +940,7 @@ func (a *App) cursorSelectedRepoPath() string {
 	sess := a.cursorSelectedSession()
 	if sess != nil {
 		// Find the repo that owns this session.
-		for _, item := range a.dashboard.items {
+		for _, item := range a.listItems() {
 			if item.kind == listItemSession && item.session == sess {
 				return item.repoPath
 			}
@@ -977,15 +952,6 @@ func (a *App) cursorSelectedRepoPath() string {
 	return a.activeRepo
 }
 
-// syncFocusCursorToDashboard mirrors the cursor-related App fields onto the
-// dashboard model so the next render reflects navigation immediately, without
-// waiting for the 100ms tick that drives refreshAgentList.
-func (a *App) syncFocusCursorToDashboard() {
-	a.dashboard.cursor = a.cursor
-	a.dashboard.prDraftSessionID = a.prDraftSessionID
-	a.dashboard.prDraftRepoPath = a.prDraftRepoPath
-}
-
 // activateFocusCursor opens the row currently under the fullscreen-focus
 // cursor. Planning + Building rows jump into a focusLaunch terminal so the
 // user can drive the agent. Reviewing rows open the review panel. Shipping
@@ -994,7 +960,7 @@ func (a *App) syncFocusCursorToDashboard() {
 // section has no actionable row.
 func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 	section := a.cursor.Section()
-	items := a.dashboard.sectionItems(section)
+	items := a.listItems().sectionItems(section)
 	if len(items) == 0 {
 		return nil, false
 	}
@@ -1091,9 +1057,10 @@ func (a App) View() tea.View {
 			v.AltScreen = true
 			return v
 		}
-		body := a.dashboard.View()
+		props := a.dashboardProps()
+		body := a.dashboard.View(props)
 		hints := dashboardHints
-		switch a.dashboard.panelFocus {
+		switch props.panelFocus {
 		case focusConfig:
 			hints = repoConfigHints
 		case focusRepoChecks:
@@ -1107,7 +1074,7 @@ func (a App) View() tea.View {
 		// overflowing 120 cols — when the cursor is not on Planning AND the
 		// wellness timer is enabled, swap the desc on the static `b` entry to
 		// "break". Skip in focusLaunch: b routes to the agent terminal there.
-		if a.dashboard.panelFocus != focusLaunch {
+		if props.panelFocus != focusLaunch {
 			if a.wellness.focusBreakMode {
 				if a.wellness.focusBreakTimerUp {
 					hints = []keyHint{{key: "b", desc: "resume focus"}}
@@ -1225,74 +1192,6 @@ func (a App) View() tea.View {
 	return v
 }
 
-// refreshDiffStatsCmd returns a Cmd that fetches diff stats for the currently selected session.
-func (a *App) refreshDiffStatsCmd() tea.Cmd {
-	sess := a.dashboard.selectedSession()
-	if sess == nil {
-		return nil
-	}
-	repoPath := a.dashboard.selectedRepoPath()
-	if repoPath == "" {
-		return nil
-	}
-	a.diffRefreshInFlight = true
-	sessionID := sess.ID
-	wt := sess.Worktree
-	return func() tea.Msg {
-		fileStats, agg, err := git.GetPerFileDiffStats(repoPath, wt)
-		if err != nil {
-			return diffStatsMsg{sessionID: sessionID, repoPath: repoPath, stats: nil}
-		}
-		// Convert git.FileStat to diffFileStat.
-		var files []diffFileStat
-		for _, fs := range fileStats {
-			files = append(files, diffFileStat{
-				Path:       fs.Path,
-				Status:     fs.Status,
-				Insertions: fs.Insertions,
-				Deletions:  fs.Deletions,
-			})
-		}
-		return diffStatsMsg{
-			sessionID: sessionID,
-			repoPath:  repoPath,
-			stats: &diffSummaryData{
-				Files: files,
-				Aggregate: diffAggregateStats{
-					Files:      agg.Files,
-					Insertions: agg.Insertions,
-					Deletions:  agg.Deletions,
-				},
-			},
-		}
-	}
-}
-
-// updateDashboardDiffStats passes cached diff stats to the dashboard for the current selection.
-func (a *App) updateDashboardDiffStats() {
-	sess := a.dashboard.selectedSession()
-	if sess == nil {
-		a.dashboard.diffStats = nil
-		return
-	}
-	repoPath := a.dashboard.selectedRepoPath()
-	if repoPath == "" {
-		a.dashboard.diffStats = nil
-		return
-	}
-	if entry, ok := a.diffStatsCache[cacheKey(repoPath, sess.ID)]; ok {
-		a.dashboard.diffStats = entry.stats
-	} else {
-		a.dashboard.diffStats = nil
-	}
-}
-
-// updateDashboardPRCache passes the PR cache and poll states to the dashboard for rendering.
-func (a *App) updateDashboardPRCache() {
-	a.dashboard.prCache = a.prCache
-	a.dashboard.prPollStates = a.prPollStates
-}
-
 // cacheKey composes a repo-scoped key for App-level per-session caches.
 // Always use this — never key a session cache by sessionID alone. Session
 // IDs are minted by a per-manager counter (session-1, session-2, …), so with
@@ -1374,11 +1273,6 @@ func (a *App) cleanStaleCaches() {
 			for _, ag := range sess.Agents() {
 				activeAgents[agentCacheKey(repoPath, ag.ID)] = true
 			}
-		}
-	}
-	for k := range a.diffStatsCache {
-		if !activeSessions[k] {
-			delete(a.diffStatsCache, k)
 		}
 	}
 	for k := range a.prCache {

--- a/internal/tui/app_keys_test.go
+++ b/internal/tui/app_keys_test.go
@@ -7,15 +7,14 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/devenjarvis/refrain/internal/agent"
-	"github.com/devenjarvis/refrain/internal/config"
 )
 
 // These tests fill the per-key gaps in app.go's focusList dispatch
 // (app.go:1599-2193) and updateFocusLaunchKeys (app.go:2423-2520) that the
 // existing app_test.go suite did not yet cover.
 //
-// Most tests build the App synthetically (no claude subprocess) by injecting
-// pre-seeded sessions into dashboard.items + an empty manager for the temp
+// Most tests build the App synthetically (no claude subprocess) by seeding
+// pre-built sessions into a fakeManager via seedDashboardItems for the temp
 // repo dir. This keeps the suite fast and deterministic.
 
 // appWithSeededSession returns an App with a single test session at the given
@@ -37,9 +36,6 @@ func appWithSeededSession(t *testing.T, phase agent.LifecyclePhase) (App, *agent
 			t.Fatalf("git setup %v: %v\n%s", args, err, out)
 		}
 	}
-	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
-	t.Cleanup(func() { mgr.Shutdown() })
-
 	sess := agent.NewSessionForTest("s1", "session-1")
 	sess.SetLifecyclePhase(phase)
 
@@ -48,12 +44,11 @@ func appWithSeededSession(t *testing.T, phase agent.LifecyclePhase) (App, *agent
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.managers[dir] = mgr
 	app.activeRepo = dir
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: dir, repoName: "repo"},
 		{kind: listItemSession, repoPath: dir, session: sess},
-	}
+	})
 	// Position cursor on the seeded session's section.
 	switch phase {
 	case agent.LifecyclePlanning, agent.LifecycleDrafting:
@@ -176,7 +171,7 @@ func TestPipeline_UnknownKey_NoOp(t *testing.T) {
 		panel    panelFocus
 		err      string
 		confQuit bool
-	}{app.view, app.dashboard.panelFocus, app.err, app.confirmQuit}
+	}{app.view, app.modals.Current(), app.err, app.confirmQuit}
 
 	for _, k := range []tea.KeyPressMsg{
 		{Code: 'z', Text: "z"},
@@ -197,7 +192,7 @@ func TestPipeline_UnknownKey_NoOp(t *testing.T) {
 		panel    panelFocus
 		err      string
 		confQuit bool
-	}{app.view, app.dashboard.panelFocus, app.err, app.confirmQuit}
+	}{app.view, app.modals.Current(), app.err, app.confirmQuit}
 
 	if before != after {
 		t.Errorf("unknown keys changed state: before=%+v after=%+v", before, after)
@@ -225,12 +220,11 @@ func TestFocusLaunch_NilAgent_RoutesBackToList(t *testing.T) {
 	// directly — production code can't construct this state, but the guard at
 	// the top of updateFocusLaunchKeys must still handle it.
 	app.modals.OpenLaunch(nil, nil, "")
-	app.syncModalsToDashboard()
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	app = model.(App)
-	if app.dashboard.panelFocus != focusList {
-		t.Errorf("nil focusLaunchAgent should route back to focusList, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusList {
+		t.Errorf("nil focusLaunchAgent should route back to focusList, got %v", app.modals.Current())
 	}
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -43,7 +43,7 @@ func requireClaude(t *testing.T) {
 // returnToList exits the focusLaunch overlay (where keys forward to the agent
 // terminal) so app-level key handlers can fire.
 func returnToList(app App) App {
-	if app.dashboard.panelFocus == focusLaunch {
+	if app.modals.Current() == focusLaunch {
 		model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 		return model.(App)
 	}
@@ -128,7 +128,7 @@ func TestCreateAgentViaN(t *testing.T) {
 	app = createAgent(t, app)
 
 	t.Logf("After creation: view=%v, err=%q, agents=%d, dashboard=%d, focus=%v",
-		app.view, app.err, mgr.AgentCount(), len(app.dashboard.agentItems()), app.dashboard.panelFocus)
+		app.view, app.err, mgr.AgentCount(), len(app.listItems().agents()), app.modals.Current())
 
 	if app.view != ViewDashboard {
 		t.Errorf("Expected ViewDashboard, got %v", app.view)
@@ -139,13 +139,13 @@ func TestCreateAgentViaN(t *testing.T) {
 	if mgr.AgentCount() != 1 {
 		t.Errorf("Expected 1 agent, got %d", mgr.AgentCount())
 	}
-	if len(app.dashboard.agentItems()) != 1 {
-		t.Errorf("Expected 1 dashboard agent, got %d", len(app.dashboard.agentItems()))
+	if len(app.listItems().agents()) != 1 {
+		t.Errorf("Expected 1 dashboard agent, got %d", len(app.listItems().agents()))
 	}
 	// After creation the agent is auto-opened in focusLaunch (the fullscreen
 	// pipeline view's per-agent terminal).
-	if app.dashboard.panelFocus != focusLaunch {
-		t.Errorf("Expected focusLaunch after creation, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusLaunch {
+		t.Errorf("Expected focusLaunch after creation, got %v", app.modals.Current())
 	}
 	// Session should be present.
 	sessions := mgr.ListSessions()
@@ -189,7 +189,7 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 	t.Log("=== Creating session 1 ===")
 	app = createAgent(t, app)
 	t.Logf("After session1: view=%v, err=%q, agents=%d, dashboard=%d",
-		app.view, app.err, mgr.AgentCount(), len(app.dashboard.agentItems()))
+		app.view, app.err, mgr.AgentCount(), len(app.listItems().agents()))
 
 	if app.err != "" {
 		t.Fatalf("Session 1 error: %s", app.err)
@@ -202,7 +202,7 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 	t.Log("=== Creating session 2 ===")
 	app = createAgent(t, app)
 	t.Logf("After session2: view=%v, err=%q, agents=%d, dashboard=%d",
-		app.view, app.err, mgr.AgentCount(), len(app.dashboard.agentItems()))
+		app.view, app.err, mgr.AgentCount(), len(app.listItems().agents()))
 
 	if app.err != "" {
 		t.Fatalf("Session 2 error: %s", app.err)
@@ -210,15 +210,15 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 	if mgr.AgentCount() != 2 {
 		t.Fatalf("Expected 2 agents, got %d", mgr.AgentCount())
 	}
-	if len(app.dashboard.agentItems()) != 2 {
-		t.Fatalf("Expected 2 dashboard agents, got %d", len(app.dashboard.agentItems()))
+	if len(app.listItems().agents()) != 2 {
+		t.Fatalf("Expected 2 dashboard agents, got %d", len(app.listItems().agents()))
 	}
 
 	// Create third session+agent
 	t.Log("=== Creating session 3 ===")
 	app = createAgent(t, app)
 	t.Logf("After session3: view=%v, err=%q, agents=%d, dashboard=%d",
-		app.view, app.err, mgr.AgentCount(), len(app.dashboard.agentItems()))
+		app.view, app.err, mgr.AgentCount(), len(app.listItems().agents()))
 
 	if app.err != "" {
 		t.Fatalf("Session 3 error: %s", app.err)
@@ -226,8 +226,8 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 	if mgr.AgentCount() != 3 {
 		t.Fatalf("Expected 3 agents, got %d", mgr.AgentCount())
 	}
-	if len(app.dashboard.agentItems()) != 3 {
-		t.Fatalf("Expected 3 dashboard agents, got %d", len(app.dashboard.agentItems()))
+	if len(app.listItems().agents()) != 3 {
+		t.Fatalf("Expected 3 dashboard agents, got %d", len(app.listItems().agents()))
 	}
 
 	// Should have 3 sessions.
@@ -236,7 +236,7 @@ func TestCreateMultipleAgentsViaTUI(t *testing.T) {
 		t.Fatalf("Expected 3 sessions, got %d", len(sessions))
 	}
 
-	t.Logf("SUCCESS: Created %d sessions with %d agents", len(sessions), len(app.dashboard.agentItems()))
+	t.Logf("SUCCESS: Created %d sessions with %d agents", len(sessions), len(app.listItems().agents()))
 }
 
 func TestAddAgentToSessionViaC(t *testing.T) {
@@ -340,20 +340,20 @@ func TestPanelFocusSwitching(t *testing.T) {
 	app.activeRepo = dir
 
 	app = createAgent(t, app)
-	if len(app.dashboard.agentItems()) == 0 {
+	if len(app.listItems().agents()) == 0 {
 		t.Fatal("Expected at least one agent")
 	}
 
 	// After creation focusLaunch is open on the new agent.
-	if app.dashboard.panelFocus != focusLaunch {
-		t.Fatalf("Expected focusLaunch after creation, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusLaunch {
+		t.Fatalf("Expected focusLaunch after creation, got %v", app.modals.Current())
 	}
 
 	// Esc returns to the pipeline (focusList).
 	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	app = model.(App)
-	if app.dashboard.panelFocus != focusList {
-		t.Fatalf("Expected focusList after esc, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusList {
+		t.Fatalf("Expected focusList after esc, got %v", app.modals.Current())
 	}
 
 	// Sessions created by the legacy `n` path land in LifecyclePlanning by
@@ -365,8 +365,8 @@ func TestPanelFocusSwitching(t *testing.T) {
 	// Enter on the cursor-selected session re-opens focusLaunch.
 	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	app = model.(App)
-	if app.dashboard.panelFocus != focusLaunch {
-		t.Fatalf("Expected focusLaunch after enter, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusLaunch {
+		t.Fatalf("Expected focusLaunch after enter, got %v", app.modals.Current())
 	}
 }
 
@@ -408,8 +408,8 @@ func TestActionKeysBlockedInFocusLaunch(t *testing.T) {
 	app = createAgent(t, app)
 
 	// After creation focusLaunch is the active panel.
-	if app.dashboard.panelFocus != focusLaunch {
-		t.Fatalf("Expected focusLaunch after creation, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusLaunch {
+		t.Fatalf("Expected focusLaunch after creation, got %v", app.modals.Current())
 	}
 
 	// Press "n" — should be forwarded to agent, NOT create a new agent.
@@ -419,8 +419,8 @@ func TestActionKeysBlockedInFocusLaunch(t *testing.T) {
 	if app.view != ViewDashboard {
 		t.Fatalf("Expected ViewDashboard (n forwarded to agent, not new-agent), got %v", app.view)
 	}
-	if app.dashboard.panelFocus != focusLaunch {
-		t.Fatalf("Expected focusLaunch to persist after 'n', got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusLaunch {
+		t.Fatalf("Expected focusLaunch to persist after 'n', got %v", app.modals.Current())
 	}
 }
 
@@ -456,23 +456,23 @@ func TestShiftEscForwardsEscapeToAgent(t *testing.T) {
 	app.activeRepo = dir
 
 	app = createAgent(t, app)
-	if app.dashboard.panelFocus != focusLaunch {
-		t.Fatalf("Expected focusLaunch after creation, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusLaunch {
+		t.Fatalf("Expected focusLaunch after creation, got %v", app.modals.Current())
 	}
 
 	// Press shift+esc — should stay in focusLaunch (escape forwarded as
 	// interrupt to the agent, not a panel exit).
 	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEscape, Mod: tea.ModShift})
 	app = model.(App)
-	if app.dashboard.panelFocus != focusLaunch {
-		t.Fatalf("Expected focusLaunch after shift+esc (should forward, not exit), got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusLaunch {
+		t.Fatalf("Expected focusLaunch after shift+esc (should forward, not exit), got %v", app.modals.Current())
 	}
 
 	// Press plain esc — should exit to focusList.
 	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	app = model.(App)
-	if app.dashboard.panelFocus != focusList {
-		t.Fatalf("Expected focusList after esc, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusList {
+		t.Fatalf("Expected focusList after esc, got %v", app.modals.Current())
 	}
 }
 
@@ -493,12 +493,12 @@ func TestPipelineClickMovesCursor(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessA},
 		{kind: listItemSession, repoPath: "/r", session: sessB},
 		{kind: listItemSession, repoPath: "/r", session: sessR},
-	}
+	})
 	app.cursor.SetSection(focusSectionBuilding)
 	app.cursor.SetIndex(focusSectionBuilding, 0)
 
@@ -546,11 +546,11 @@ func TestPipelineClickMovesCursor_PlanningAndShipping(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessP},
 		{kind: listItemSession, repoPath: "/r", session: sessS},
-	}
+	})
 	// Start the cursor on Building so a successful click has somewhere to move
 	// the selection FROM (Building is empty here, but the cursor is held there
 	// until the first click).
@@ -584,25 +584,25 @@ func TestPipelineDoubleClickActivatesReview(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessR},
-	}
+	})
 
 	// With no active sessions, REVIEW QUEUE starts at row 7 (header(0) + sep(1)
 	// + pipeline(2..5) + blank(6) + "REVIEW QUEUE"(7) + queue0(8..9)).
 	first := tea.MouseClickMsg{Button: tea.MouseLeft, X: 30, Y: 8}
 	model, _ := app.Update(first)
 	app = model.(App)
-	if app.dashboard.panelFocus == focusReview {
+	if app.modals.Current() == focusReview {
 		t.Fatal("single click should not enter focusReview")
 	}
 
 	// Second click within the double-click window opens the review panel.
 	model, _ = app.Update(first)
 	app = model.(App)
-	if app.dashboard.panelFocus != focusReview {
-		t.Fatalf("expected focusReview after double-click, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusReview {
+		t.Fatalf("expected focusReview after double-click, got %v", app.modals.Current())
 	}
 	if app.modals.Review() == nil || app.modals.Review().Session() != sessR {
 		t.Fatalf("expected reviewSession=sessR, got %v", app.modals.Review())
@@ -674,9 +674,6 @@ func TestMouseWheelForwardsInAltScreen(t *testing.T) {
 	app.dashboard.height = 39
 	app.managers[dir] = mgr
 	app.activeRepo = dir
-	app.dashboard.items = []listItem{
-		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
-	}
 	app.openLaunchPanel(sess, ag, dir)
 
 	// Set a non-zero offset so we can tell the wheel branch didn't mutate it.
@@ -730,14 +727,13 @@ func TestScrollOffsetResetsOnAltScreenEntry(t *testing.T) {
 	app.dashboard.height = 39
 	app.managers[dir] = mgr
 	app.activeRepo = dir
-	app.dashboard.items = []listItem{
-		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
-	}
-	app.dashboard.selected = 0
+	// Open the launch panel on this agent so modals.LaunchAgent() targets it;
+	// the alt-screen-entered consumer keys the scrollOffset reset off it.
+	app.openLaunchPanel(sess, ag, dir)
 	app.dashboard.scrollOffset = 42
 
-	// A tickMsg drives the alt-screen-entered consumer. Since selected==ag,
-	// the transition should reset scrollOffset to 0.
+	// A tickMsg drives the alt-screen-entered consumer. Since the launch agent
+	// is ag, the transition should reset scrollOffset to 0.
 	model, _ := app.Update(tickMsg(time.Now()))
 	app = model.(App)
 	if app.dashboard.scrollOffset != 0 {
@@ -826,15 +822,24 @@ func TestKillAgentAsyncMarksClosing(t *testing.T) {
 	app.dashboard.height = 39
 	app.managers[dir] = mgr
 	app.activeRepo = dir
-	app.refreshAgentList()
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+	app.clampCursor()
 
-	// Select the agent row.
-	for i, it := range app.dashboard.items {
-		if it.kind == listItemAgent && it.agent != nil && it.agent.ID == ag.ID {
-			app.dashboard.selected = i
+	// Position the pipeline cursor on the session so 'x' targets it. The session
+	// was created via CreateSessionWithCommand, so it lands in the Planning
+	// section by default.
+	planning := app.listItems().sectionItems(focusSectionPlanning)
+	idx := -1
+	for i, it := range planning {
+		if it.session != nil && it.session.ID == sess.ID {
+			idx = i
 			break
 		}
 	}
+	if idx < 0 {
+		t.Fatalf("session %s not found in planning section", sess.ID)
+	}
+	app.cursor.JumpTo(focusSectionPlanning, idx)
 
 	// Press 'x' — should mark closing and return a non-nil cmd. The agent
 	// must still be present in the manager because the kill is now async.
@@ -847,10 +852,6 @@ func TestKillAgentAsyncMarksClosing(t *testing.T) {
 	agentKey := agentCacheKey(dir, ag.ID)
 	if !app.closingAgents[agentKey] {
 		t.Fatalf("Expected closingAgents[%s]=true, got %v", agentKey, app.closingAgents)
-	}
-	// Dashboard should see the closing flag too.
-	if !app.dashboard.closingAgents[agentKey] {
-		t.Fatalf("Expected dashboard.closingAgents[%s]=true", agentKey)
 	}
 	// The manager still has the agent because the goroutine hasn't run yet.
 	if mgr.Get(ag.ID) == nil {
@@ -875,22 +876,22 @@ func TestKillAgentAsyncMarksClosing(t *testing.T) {
 	}
 
 	// Feed the killResultMsg back into the app — closing set should clear
-	// and refreshAgentList should drop the agent from dashboard items.
+	// and the live list should drop the agent.
 	model, _ = app.Update(kr)
 	app = model.(App)
 	if app.closingAgents[ag.ID] {
 		t.Fatalf("Expected closingAgents[%s] cleared after killResultMsg, still set", ag.ID)
 	}
-	for _, it := range app.dashboard.items {
+	for _, it := range app.listItems() {
 		if it.kind == listItemAgent && it.agent != nil && it.agent.ID == ag.ID {
-			t.Fatalf("Expected agent %s removed from dashboard after killResultMsg", ag.ID)
+			t.Fatalf("Expected agent %s removed from list after killResultMsg", ag.ID)
 		}
 	}
 }
 
 // TestKillResultMsgClearsClosingSet verifies the session-scope killResultMsg
-// path: closingSessions and closingAgents are both cleared, diff stats cache
-// is invalidated, and refreshAgentList runs.
+// path: closingSessions and closingAgents are both cleared and lastKnownStatus
+// is invalidated.
 func TestKillResultMsgClearsClosingSet(t *testing.T) {
 	app := NewApp()
 	app.width = 120
@@ -903,13 +904,12 @@ func TestKillResultMsgClearsClosingSet(t *testing.T) {
 	agentAKey := agentCacheKey(repo, "agent-a")
 	agentBKey := agentCacheKey(repo, "agent-b")
 
-	// Pre-populate closing sets and diff cache as if 'X' had dispatched.
+	// Pre-populate closing sets as if 'X' had dispatched.
 	app.closingSessions[sessKey] = true
 	app.closingAgents[agentAKey] = true
 	app.closingAgents[agentBKey] = true
 	app.lastKnownStatus[agentAKey] = agent.StatusActive
 	app.lastKnownStatus[agentBKey] = agent.StatusActive
-	app.diffStatsCache[sessKey] = &diffStatsEntry{}
 
 	model, _ := app.Update(killResultMsg{
 		scope:     killScopeSession,
@@ -925,18 +925,8 @@ func TestKillResultMsgClearsClosingSet(t *testing.T) {
 	if app.closingAgents[agentAKey] || app.closingAgents[agentBKey] {
 		t.Fatal("Expected closingAgents cleared for both agents")
 	}
-	if _, ok := app.diffStatsCache[sessKey]; ok {
-		t.Fatal("Expected diffStatsCache[sess-1] removed")
-	}
 	if _, ok := app.lastKnownStatus[agentAKey]; ok {
 		t.Fatal("Expected lastKnownStatus cleared for agent-a")
-	}
-	// Dashboard should also see the cleared maps (refreshAgentList was called).
-	if app.dashboard.closingSessions == nil {
-		t.Fatal("Expected dashboard.closingSessions wired up after refresh")
-	}
-	if app.dashboard.closingSessions[sessKey] {
-		t.Fatal("Expected dashboard.closingSessions[sess-1] cleared after refresh")
 	}
 }
 
@@ -971,104 +961,6 @@ func TestKillResultMsgClearsClosingSetOnError(t *testing.T) {
 	}
 }
 
-// TestRefreshAgentListRepoAffinity verifies that after killing the last agent
-// in a repo's session, the cursor lands on that repo's header — not on an item
-// in a different repo.
-func TestRefreshAgentListRepoAffinity(t *testing.T) {
-	requireClaude(t)
-	// Set up two temp repos with git init.
-	dir1, err := os.MkdirTemp("", "refrain-repo1-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(dir1) }()
-	dir2, err := os.MkdirTemp("", "refrain-repo2-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.RemoveAll(dir2) }()
-
-	initRepo := func(dir string) {
-		for _, args := range [][]string{
-			{"git", "init"},
-			{"git", "config", "commit.gpgsign", "false"},
-			{"git", "commit", "--allow-empty", "-m", "init"},
-		} {
-			cmd := exec.Command(args[0], args[1:]...)
-			cmd.Dir = dir
-			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Fatalf("cmd %v in %s: %v\n%s", args, dir, err, out)
-			}
-		}
-	}
-	initRepo(dir1)
-	initRepo(dir2)
-
-	mgr1 := agent.NewManager(dir1, config.Resolve(nil, nil))
-	defer mgr1.Shutdown()
-	mgr2 := agent.NewManager(dir2, config.Resolve(nil, nil))
-	defer mgr2.Shutdown()
-
-	app := NewApp()
-	app.width = 120
-	app.height = 40
-	app.dashboard.width = 120
-	app.dashboard.height = 39
-	app.managers[dir1] = mgr1
-	app.managers[dir2] = mgr2
-	app.activeRepo = dir1
-
-	app.cfg = &config.Config{
-		Repos: []config.Repo{
-			{Path: dir1, Name: "repo1"},
-			{Path: dir2, Name: "repo2"},
-		},
-	}
-
-	// Create an agent under repo1 (the first repo).
-	sess1, _, err := mgr1.CreateSessionWithCommand(
-		agent.Config{Name: "test-agent", Task: "test"},
-		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 999") },
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	app.refreshAgentList()
-	// List should be: [repo1, session1, agent1, repo2]
-	// Select the agent in repo1 (index 2).
-	for i, it := range app.dashboard.items {
-		if it.kind == listItemAgent && it.repoPath == dir1 {
-			app.dashboard.selected = i
-			break
-		}
-	}
-	if app.dashboard.items[app.dashboard.selected].repoPath != dir1 {
-		t.Fatalf("setup: expected selected item in repo1")
-	}
-
-	// Now kill the session, simulating what happens when 'X' is pressed.
-	_ = mgr1.KillSession(sess1.ID)
-	// Give the agent time to exit.
-	time.Sleep(200 * time.Millisecond)
-	// Refresh the list — list becomes [repo1, repo2].
-	// Without the fix, selected=2 clamps to 1 which is repo2 (wrong repo).
-	app.refreshAgentList()
-
-	// After refresh, the cursor should still be on a repo1 item (the repo header).
-	if len(app.dashboard.items) == 0 {
-		t.Fatal("expected non-empty items after refresh")
-	}
-	selected := app.dashboard.items[app.dashboard.selected]
-	if selected.repoPath != dir1 {
-		t.Errorf("cursor jumped to repo %q, want %q (selected=%d, kind=%v)",
-			selected.repoPath, dir1, app.dashboard.selected, selected.kind)
-	}
-	if selected.kind != listItemRepo {
-		t.Errorf("expected cursor on repo header, got kind=%v", selected.kind)
-	}
-}
-
 // Cursor-placement regression coverage for focusLaunch lives in the e2e suite;
 // the original split-panel preview cursor tests targeted screen offsets that
 // only exist in the deleted layout.
@@ -1098,7 +990,7 @@ func TestChimeSuppressionByStatus(t *testing.T) {
 	mgr := agent.NewManager(dir, config.Resolve(nil, nil))
 	defer mgr.Shutdown()
 
-	sess, ag, err := mgr.CreateSessionWithCommand(agent.Config{
+	_, ag, err := mgr.CreateSessionWithCommand(agent.Config{
 		Name: "chime-test", Task: "test", RepoPath: dir, Rows: 24, Cols: 80,
 	}, func(_ string) *exec.Cmd {
 		return exec.Command("bash", "-c", "sleep 10")
@@ -1122,9 +1014,6 @@ func TestChimeSuppressionByStatus(t *testing.T) {
 	app.managers[dir] = mgr
 	app.activeRepo = dir
 	app.resolvedCache[dir] = resolved
-	app.dashboard.items = []listItem{
-		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
-	}
 
 	// Try to wire up a real audio player so MarkChimedForTurn() can actually
 	// fire. Best-effort — if the environment has no audio device the player
@@ -1195,7 +1084,7 @@ func TestRKey_NoopWithEmptyQueue(t *testing.T) {
 	// r with no queued sessions should be a no-op.
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	app = model.(App)
-	if app.dashboard.panelFocus == focusReview {
+	if app.modals.Current() == focusReview {
 		t.Error("r with empty review queue should not enter focusReview")
 	}
 }
@@ -1212,8 +1101,8 @@ func TestFocusMode_RKey_OpensReviewWithItems(t *testing.T) {
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	app = model.(App)
 
-	if app.dashboard.panelFocus != focusReview {
-		t.Fatalf("expected panelFocus=focusReview after r, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusReview {
+		t.Fatalf("expected panelFocus=focusReview after r, got %v", app.modals.Current())
 	}
 	if app.modals.Review() == nil || app.modals.Review().Session() != sessR {
 		t.Fatalf("expected reviewSession=sessR, got %v", app.modals.Review())
@@ -1281,8 +1170,8 @@ func TestSoftAgentLimitGuard(t *testing.T) {
 	// Return to list focus so 'n' reaches the app-level handler.
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
 	app = model.(App)
-	if app.dashboard.panelFocus != focusList {
-		t.Fatalf("Expected focusList after ctrl+e, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusList {
+		t.Fatalf("Expected focusList after ctrl+e, got %v", app.modals.Current())
 	}
 
 	// Enable focus mode.
@@ -1402,8 +1291,8 @@ func TestSoftAgentLimitGuardMultiRepo(t *testing.T) {
 
 	// Return to list focus so 'n' reaches the app-level handler.
 	app = returnToList(app)
-	if app.dashboard.panelFocus != focusList {
-		t.Fatalf("Expected focusList after exit, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusList {
+		t.Fatalf("Expected focusList after exit, got %v", app.modals.Current())
 	}
 
 	// First 'n' press: should show modal and set sessionLimitModalActive; picker must NOT open.
@@ -1436,57 +1325,6 @@ func TestSoftAgentLimitGuardMultiRepo(t *testing.T) {
 	}
 }
 
-// TestClampToRepo verifies that clampToRepo always lands on a listItemRepo row.
-func TestClampToRepo(t *testing.T) {
-	sess := &agent.Session{Name: "s"}
-	ag := &agent.Agent{Name: "a"}
-
-	items := []listItem{
-		{kind: listItemRepo, repoPath: "/r1", repoName: "repo1"},         // 0
-		{kind: listItemSession, repoPath: "/r1", session: sess},          // 1
-		{kind: listItemAgent, repoPath: "/r1", session: sess, agent: ag}, // 2
-		{kind: listItemRepo, repoPath: "/r2", repoName: "repo2"},         // 3
-		{kind: listItemAgent, repoPath: "/r2", session: sess, agent: ag}, // 4
-	}
-
-	// Already on a repo row: no-op.
-	d := newDashboardModel()
-	d.items = items
-	d.selected = 0
-	d.clampToRepo()
-	if d.selected != 0 {
-		t.Fatalf("no-op case: expected 0, got %d", d.selected)
-	}
-
-	// On an agent row: should find the owning repo header above (backward search).
-	d.selected = 2
-	d.clampToRepo()
-	if d.selected != 0 {
-		t.Fatalf("agent in repo1: expected 0 (repo1 header), got %d", d.selected)
-	}
-
-	// On the session row: should find the repo header above.
-	d.selected = 1
-	d.clampToRepo()
-	if d.selected != 0 {
-		t.Fatalf("session row: expected 0 (repo1 header), got %d", d.selected)
-	}
-
-	// On agent in repo2 (index 4): repo2 header is at index 3, above.
-	d.selected = 4
-	d.clampToRepo()
-	if d.selected != 3 {
-		t.Fatalf("agent in repo2: expected 3 (repo2 header), got %d", d.selected)
-	}
-
-	// Out-of-range selected: should clamp down and then find a repo.
-	d.selected = 99
-	d.clampToRepo()
-	if d.items[d.selected].kind != listItemRepo {
-		t.Fatalf("out-of-range: expected listItemRepo, got kind=%d at selected=%d", d.items[d.selected].kind, d.selected)
-	}
-}
-
 // makeFocusModeApp wires up an App in focus mode with two in-progress sessions
 // and one ready-for-review session. Used by the tests below to exercise unified
 // cursor navigation across the Building and Reviewing sections.
@@ -1504,12 +1342,12 @@ func makeFocusModeApp(t *testing.T) (App, *agent.Session) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessA},
 		{kind: listItemSession, repoPath: "/r", session: sessB},
 		{kind: listItemSession, repoPath: "/r", session: sessR},
-	}
+	})
 	return app, sessR
 }
 
@@ -1519,8 +1357,8 @@ func makeFocusModeApp(t *testing.T) (App, *agent.Session) {
 func TestFocusModeNavigationCrossesSections(t *testing.T) {
 	app, _ := makeFocusModeApp(t)
 	if app.cursor.Section() != focusSectionBuilding {
-		// clampFocusCursor only runs from refreshAgentList; here we drive the
-		// state directly. Make the starting condition explicit.
+		// The cursor is clamped via clampCursor() on ticks/events; here we
+		// drive the state directly. Make the starting condition explicit.
 		app.cursor.SetSection(focusSectionBuilding)
 	}
 
@@ -1557,9 +1395,9 @@ func TestFocusModeNavigationCrossesSections(t *testing.T) {
 		t.Fatalf("after k from review: expected active[1], got section=%v active=%d", app.cursor.Section(), app.cursor.Index(focusSectionBuilding))
 	}
 
-	// Verify the dashboard model received the synced state immediately.
-	if app.dashboard.cursor.Section() != focusSectionBuilding || app.dashboard.cursor.Index(focusSectionBuilding) != 1 {
-		t.Fatalf("dashboard not synced: section=%v active=%d", app.dashboard.cursor.Section(), app.dashboard.cursor.Index(focusSectionBuilding))
+	// Verify the cursor reflects the updated state immediately.
+	if app.cursor.Section() != focusSectionBuilding || app.cursor.Index(focusSectionBuilding) != 1 {
+		t.Fatalf("cursor not updated: section=%v active=%d", app.cursor.Section(), app.cursor.Index(focusSectionBuilding))
 	}
 }
 
@@ -1607,19 +1445,15 @@ func TestFocusModeEnterOnActiveOpensFocusLaunch(t *testing.T) {
 	app.dashboard.height = 39
 	app.managers[dir] = mgr
 	app.activeRepo = dir
-	app.dashboard.items = []listItem{
-		{kind: listItemRepo, repoPath: dir, repoName: "repo"},
-		{kind: listItemSession, repoPath: dir, session: sess},
-		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
-	}
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir, Alias: "repo"}}}
 	app.cursor.SetSection(focusSectionBuilding)
 	app.cursor.SetIndex(focusSectionBuilding, 0)
 
 	// Press enter on the active section: should jump into focusLaunch on ag.
 	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Text: ""})
 	app = model.(App)
-	if app.dashboard.panelFocus != focusLaunch {
-		t.Fatalf("expected panelFocus=focusLaunch after enter on active, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusLaunch {
+		t.Fatalf("expected panelFocus=focusLaunch after enter on active, got %v", app.modals.Current())
 	}
 	if app.modals.LaunchAgent() == nil || app.modals.LaunchAgent().ID != ag.ID {
 		t.Fatalf("expected focusLaunchAgent=ag, got %v", app.modals.LaunchAgent())
@@ -1641,32 +1475,32 @@ func TestFocusModeNavigationVisibleOnActiveOnly(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessA},
 		{kind: listItemSession, repoPath: "/r", session: sessB},
-	}
+	})
 	app.cursor.SetSection(focusSectionBuilding)
 
 	// j moves within active (active is the only non-empty section).
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	app = model.(App)
-	if app.dashboard.cursor.Index(focusSectionBuilding) != 1 {
-		t.Fatalf("expected dashboard.focusBuildingIdx=1 after j, got %d", app.dashboard.cursor.Index(focusSectionBuilding))
+	if app.cursor.Index(focusSectionBuilding) != 1 {
+		t.Fatalf("expected focusBuildingIdx=1 after j, got %d", app.cursor.Index(focusSectionBuilding))
 	}
 
 	// j again at the bottom: no-op (no other section to fall through to).
 	model, _ = app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	app = model.(App)
-	if app.dashboard.cursor.Index(focusSectionBuilding) != 1 {
-		t.Fatalf("expected dashboard.focusBuildingIdx=1 (no-op at end), got %d", app.dashboard.cursor.Index(focusSectionBuilding))
+	if app.cursor.Index(focusSectionBuilding) != 1 {
+		t.Fatalf("expected focusBuildingIdx=1 (no-op at end), got %d", app.cursor.Index(focusSectionBuilding))
 	}
 
 	// k moves back up.
 	model, _ = app.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	app = model.(App)
-	if app.dashboard.cursor.Index(focusSectionBuilding) != 0 {
-		t.Fatalf("expected dashboard.focusBuildingIdx=0 after k, got %d", app.dashboard.cursor.Index(focusSectionBuilding))
+	if app.cursor.Index(focusSectionBuilding) != 0 {
+		t.Fatalf("expected focusBuildingIdx=0 after k, got %d", app.cursor.Index(focusSectionBuilding))
 	}
 }
 
@@ -1683,14 +1517,14 @@ func TestClampFocusCursorHopsToNonEmptySection(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessR},
-	}
+	})
 	app.cursor.SetSection(focusSectionBuilding)
 	app.cursor.SetIndex(focusSectionBuilding, 0)
 
-	app.cursor.Clamp(app.dashboard.sectionCounts())
+	app.cursor.Clamp(app.listItems().sectionCounts())
 	if app.cursor.Section() != focusSectionReview {
 		t.Fatalf("expected hop to review section, got %v", app.cursor.Section())
 	}
@@ -1737,8 +1571,9 @@ func TestFocusLaunch_FocusModeKeysForwardToAgent(t *testing.T) {
 	sess.MarkDone() // would qualify the session for "m" if it were intercepted
 
 	// Also queue a ReadyForReview session — would be picked up by "r" if intercepted.
-	sessR := &agent.Session{Name: "ready"}
+	sessR := agent.NewSessionForTest("ready", "ready")
 	sessR.SetLifecyclePhase(agent.LifecycleReadyForReview)
+	mgr.AddSessionForTest(sessR)
 
 	app := NewApp()
 	app.width = 120
@@ -1747,20 +1582,15 @@ func TestFocusLaunch_FocusModeKeysForwardToAgent(t *testing.T) {
 	app.dashboard.height = 39
 	app.managers[dir] = mgr
 	app.activeRepo = dir
-	app.dashboard.items = []listItem{
-		{kind: listItemRepo, repoPath: dir, repoName: "repo"},
-		{kind: listItemSession, repoPath: dir, session: sess},
-		{kind: listItemAgent, repoPath: dir, session: sess, agent: ag},
-		{kind: listItemSession, repoPath: dir, session: sessR},
-	}
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir, Alias: "repo"}}}
 	app.openLaunchPanel(sess, ag, dir)
 
 	for _, ch := range []rune{'m', 'r'} {
 		model, _ := app.Update(tea.KeyPressMsg{Code: ch, Text: string(ch)})
 		app = model.(App)
 
-		if app.dashboard.panelFocus != focusLaunch {
-			t.Fatalf("press %q: expected panelFocus=focusLaunch (key forwarded to agent), got %v", ch, app.dashboard.panelFocus)
+		if app.modals.Current() != focusLaunch {
+			t.Fatalf("press %q: expected panelFocus=focusLaunch (key forwarded to agent), got %v", ch, app.modals.Current())
 		}
 		if app.modals.LaunchAgent() == nil || app.modals.LaunchAgent().ID != ag.ID {
 			t.Fatalf("press %q: expected focusLaunchAgent unchanged, got %v", ch, app.modals.LaunchAgent())
@@ -1796,11 +1626,11 @@ func TestFocusMode_MKey_IsCursorAware(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessA},
 		{kind: listItemSession, repoPath: "/r", session: sessB},
-	}
+	})
 	app.cursor.SetSection(focusSectionBuilding)
 	app.cursor.SetIndex(focusSectionBuilding, 1) // cursor on sessB, not sessA
 
@@ -1830,11 +1660,11 @@ func makeFocusModeMRApp(t *testing.T) (App, *agent.Session, *agent.Session) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessA},
 		{kind: listItemSession, repoPath: "/r", session: sessR},
-	}
+	})
 	return app, sessA, sessR
 }
 
@@ -1923,10 +1753,10 @@ func TestFocusMode_RKey_EmptyQueue_ShowsError(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessA},
-	}
+	})
 	app.cursor.SetSection(focusSectionBuilding)
 	app.cursor.SetIndex(focusSectionBuilding, 0)
 
@@ -1939,7 +1769,7 @@ func TestFocusMode_RKey_EmptyQueue_ShowsError(t *testing.T) {
 	if !strings.Contains(app.err, "review queue is empty") {
 		t.Errorf("expected error to mention empty review queue, got %q", app.err)
 	}
-	if app.dashboard.panelFocus == focusReview {
+	if app.modals.Current() == focusReview {
 		t.Error("expected panelFocus to stay focusList, got focusReview")
 	}
 	if app.modals.Review() != nil {
@@ -1961,8 +1791,8 @@ func TestFocusMode_RKey_NonEmptyQueue_OpensReviewPanel(t *testing.T) {
 	if app.err != "" {
 		t.Errorf("expected no error, got %q", app.err)
 	}
-	if app.dashboard.panelFocus != focusReview {
-		t.Errorf("expected panelFocus=focusReview, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusReview {
+		t.Errorf("expected panelFocus=focusReview, got %v", app.modals.Current())
 	}
 	if app.modals.Review() == nil || app.modals.Review().Session() != sessR {
 		t.Errorf("expected reviewSession=sessR, got %v", app.modals.Review())
@@ -1983,8 +1813,8 @@ func TestReviewPanel_CKey_MarksComplete(t *testing.T) {
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 	app = model.(App)
 
-	if app.dashboard.panelFocus != focusList {
-		t.Errorf("expected panelFocus=focusList after c, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusList {
+		t.Errorf("expected panelFocus=focusList after c, got %v", app.modals.Current())
 	}
 	if app.modals.Review() != nil {
 		t.Errorf("expected reviewSession cleared, got %v", app.modals.Review())
@@ -2011,8 +1841,8 @@ func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
 	model, cmd := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 	got := model.(App)
 
-	if got.dashboard.panelFocus != focusList {
-		t.Errorf("expected panelFocus=focusList after c, got %v", got.dashboard.panelFocus)
+	if got.modals.Current() != focusList {
+		t.Errorf("expected panelFocus=focusList after c, got %v", got.modals.Current())
 	}
 	if got.modals.Review() != nil {
 		t.Errorf("expected reviewSession cleared after c, got %v", got.modals.Review())
@@ -2112,15 +1942,15 @@ func TestReviewPanel_PKey_NoPR_DoesNotOrphan(t *testing.T) {
 	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	app = model.(App)
 
-	if app.dashboard.panelFocus != focusList {
-		t.Errorf("expected panelFocus=focusList after esc, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusList {
+		t.Errorf("expected panelFocus=focusList after esc, got %v", app.modals.Current())
 	}
 	if sessR.LifecyclePhase() != agent.LifecycleInReview {
 		t.Errorf("expected sessR phase=InReview after esc, got %v", sessR.LifecyclePhase())
 	}
 
 	// Regression: the InReview session must still appear in the review queue.
-	queue := app.dashboard.reviewQueueSessions()
+	queue := app.listItems().reviewQueueSessions()
 	found := false
 	for _, item := range queue {
 		if item.session == sessR {
@@ -2172,10 +2002,7 @@ func TestPipeline_DKey_OpensDiffViewer(t *testing.T) {
 	app.dashboard.height = 39
 	app.managers[dir] = mgr
 	app.activeRepo = dir
-	app.dashboard.items = []listItem{
-		{kind: listItemRepo, repoPath: dir, repoName: "repo"},
-		{kind: listItemSession, repoPath: dir, session: sess},
-	}
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir, Alias: "repo"}}}
 	app.cursor.SetSection(focusSectionBuilding)
 	app.cursor.SetIndex(focusSectionBuilding, 0)
 
@@ -2315,7 +2142,7 @@ func TestRepoPicker_ManageMode_EditSettingsOpensConfigFormAndReturns(t *testing.
 	// Send edit-settings msg: should open config form and stay on dashboard.
 	model, _ := app.Update(repoPickerEditSettingsMsg{path: dir1})
 	app = model.(App)
-	if app.dashboard.repoConfigForm == nil {
+	if app.modals.Config() == nil {
 		t.Fatal("expected repoConfigForm to be non-nil after edit-settings")
 	}
 	if !app.repoPickerPendingFromConfig {
@@ -2334,7 +2161,7 @@ func TestRepoPicker_ManageMode_EditSettingsOpensConfigFormAndReturns(t *testing.
 	if app.repoPickerPendingFromConfig {
 		t.Error("expected repoPickerPendingFromConfig to be cleared after cancel")
 	}
-	if app.dashboard.repoConfigForm != nil {
+	if app.modals.Config() != nil {
 		t.Error("expected repoConfigForm to be nil after cancel")
 	}
 }
@@ -2535,10 +2362,10 @@ func TestPipeline_PKey_NoPRStartsDraft(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sess},
-	}
+	})
 	app.cursor.SetSection(focusSectionReview)
 	app.cursor.SetIndex(focusSectionReview, 0)
 	// ghClient must be non-nil to pass the auth guard before startPRDraftCmd.
@@ -2584,10 +2411,10 @@ func TestPipelinePRClickResetsDoubleClick(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessR},
-	}
+	})
 	// Seed a PR cache entry so the indicator shows up and the early-return path is reachable.
 	sessKey := cacheKey("/r", sessR.ID)
 	app.prCache = map[string]*prCacheEntry{
@@ -2597,7 +2424,6 @@ func TestPipelinePRClickResetsDoubleClick(t *testing.T) {
 	// First click on the right edge of the review row triggers the PR
 	// early-return path. URL is empty so openURL is skipped, but the early
 	// return runs.
-	app.dashboard.prCache = app.prCache
 	prClick := tea.MouseClickMsg{Button: tea.MouseLeft, X: app.width - 2, Y: 8}
 	model, _ := app.Update(prClick)
 	app = model.(App)
@@ -2605,7 +2431,6 @@ func TestPipelinePRClickResetsDoubleClick(t *testing.T) {
 		// Empty URL skipped the early return — set a URL and try again so
 		// the test exercises the path we actually care about.
 		app.prCache[sessKey].pr.URL = "https://example/pr/42"
-		app.dashboard.prCache = app.prCache
 		model, _ = app.Update(prClick)
 		app = model.(App)
 	}
@@ -2618,7 +2443,7 @@ func TestPipelinePRClickResetsDoubleClick(t *testing.T) {
 	model, _ = app.Update(cardClick)
 	app = model.(App)
 
-	if app.dashboard.panelFocus == focusReview {
+	if app.modals.Current() == focusReview {
 		t.Fatalf("expected card click after PR click to single-click only, but it triggered focusReview (phantom double-click)")
 	}
 }
@@ -2881,13 +2706,13 @@ func makeFourPhaseApp(t *testing.T) (App, *agent.Session, *agent.Session, *agent
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessP},
 		{kind: listItemSession, repoPath: "/r", session: sessB},
 		{kind: listItemSession, repoPath: "/r", session: sessR},
 		{kind: listItemSession, repoPath: "/r", session: sessS},
-	}
+	})
 	app.cursor.SetSection(focusSectionPlanning)
 	return app, sessP, sessB, sessR, sessS
 }
@@ -3068,7 +2893,6 @@ func TestTick_BreakDoesNotEnterWhilePanelOpen(t *testing.T) {
 			case focusConfig:
 				app.modals.OpenConfig(&configForm{}, "/repo")
 			}
-			app.syncModalsToDashboard()
 
 			model, _ := app.Update(tickMsg(time.Now()))
 			app = model.(App)
@@ -3149,10 +2973,10 @@ func TestActivateFocusCursor_Shipping_OpensShippingPanel(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessS},
-	}
+	})
 	app.prCache = map[string]*prCacheEntry{
 		sessS.ID: {pr: &github.PRState{Number: 7, URL: "https://example/pr/7"}},
 	}
@@ -3163,8 +2987,8 @@ func TestActivateFocusCursor_Shipping_OpensShippingPanel(t *testing.T) {
 	if !ok {
 		t.Fatal("expected activateFocusCursor on Shipping to return ok=true")
 	}
-	if app.dashboard.panelFocus != focusShipping {
-		t.Fatalf("expected panelFocus=focusShipping, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusShipping {
+		t.Fatalf("expected panelFocus=focusShipping, got %v", app.modals.Current())
 	}
 	if app.modals.Shipping() == nil || app.modals.Shipping().Session() != sessS {
 		t.Fatalf("expected shippingSession to be set to the selected session")
@@ -3183,10 +3007,10 @@ func TestActivateFocusCursor_Shipping_NoPREntry(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.dashboard.items = []listItem{
+	seedDashboardItems(&app, []listItem{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessS},
-	}
+	})
 	app.cursor.SetSection(focusSectionShipping)
 	app.cursor.SetIndex(focusSectionShipping, 0)
 
@@ -3194,8 +3018,8 @@ func TestActivateFocusCursor_Shipping_NoPREntry(t *testing.T) {
 	if !ok {
 		t.Fatal("expected ok=true even without a cached PR")
 	}
-	if app.dashboard.panelFocus != focusShipping {
-		t.Fatalf("expected focusShipping, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusShipping {
+		t.Fatalf("expected focusShipping, got %v", app.modals.Current())
 	}
 }
 
@@ -3218,7 +3042,7 @@ func TestMergePRMsg_ClosesPanel(t *testing.T) {
 	model, cmd := app.Update(mergePRMsg{sessionID: "sess-1", repoPath: dir})
 	got := model.(App)
 
-	if got.dashboard.panelFocus == focusShipping {
+	if got.modals.Current() == focusShipping {
 		t.Error("shipping panel should close after successful merge")
 	}
 	if got.modals.Shipping() != nil {
@@ -3265,7 +3089,7 @@ func TestPRPollMsg_ExternalMergeClosesPanelAndTransitions(t *testing.T) {
 	model, cmd := app.Update(msg)
 	got := model.(App)
 
-	if got.dashboard.panelFocus == focusShipping {
+	if got.modals.Current() == focusShipping {
 		t.Error("shipping panel should close when external merge is detected")
 	}
 	if got.modals.Shipping() != nil {
@@ -3311,7 +3135,7 @@ func TestPRPollMsg_ExternalCloseCleansSession(t *testing.T) {
 	model, cmd := app.Update(msg)
 	got := model.(App)
 
-	if got.dashboard.panelFocus == focusShipping {
+	if got.modals.Current() == focusShipping {
 		t.Error("shipping panel should close when PR is closed")
 	}
 	if got.modals.Shipping() != nil {
@@ -3414,8 +3238,8 @@ func TestPRPollMsg_ExternalOpenPRPromotesInReviewToShipping_ClosesReviewPanel(t 
 	if sess.LifecyclePhase() != agent.LifecycleShipping {
 		t.Errorf("session lifecycle = %v, want LifecycleShipping", sess.LifecyclePhase())
 	}
-	if got.dashboard.panelFocus != focusList {
-		t.Errorf("panelFocus = %v, want focusList", got.dashboard.panelFocus)
+	if got.modals.Current() != focusList {
+		t.Errorf("panelFocus = %v, want focusList", got.modals.Current())
 	}
 	if got.modals.Review() != nil {
 		t.Error("reviewSession should be nil after auto-promotion closes the panel")
@@ -3677,7 +3501,7 @@ func TestMergePRMsg_ErrorSetsError(t *testing.T) {
 	model, _ := app.Update(mergePRMsg{sessionID: "s", err: errors.New("403 forbidden")})
 	got := model.(App)
 
-	if got.dashboard.panelFocus != focusShipping {
+	if got.modals.Current() != focusShipping {
 		t.Error("panel should stay open on merge error")
 	}
 	if got.err == "" {
@@ -3701,8 +3525,8 @@ func TestShippingPanel_MKeyGatedOnReady(t *testing.T) {
 	got := model.(App)
 
 	// Panel stays open, error is shown.
-	if got.dashboard.panelFocus != focusShipping {
-		t.Errorf("panel should stay open; got %v", got.dashboard.panelFocus)
+	if got.modals.Current() != focusShipping {
+		t.Errorf("panel should stay open; got %v", got.modals.Current())
 	}
 	if got.err == "" {
 		t.Error("expected error message for not-ready merge")
@@ -4414,7 +4238,7 @@ func TestSubmitPromptModal_PlanningPath_StaysDashboard(t *testing.T) {
 		app = model.(App)
 	}
 
-	if app.dashboard.panelFocus == focusPlanEditor {
+	if app.modals.Current() == focusPlanEditor {
 		t.Error("planning path should stay on dashboard, not open the plan editor")
 	}
 	sessions := mgr.ListSessions()
@@ -4428,7 +4252,7 @@ func TestSubmitPromptModal_PlanningPath_StaysDashboard(t *testing.T) {
 	if app.cursor.Section() != focusSectionPlanning {
 		t.Errorf("cursor section: got %v, want focusSectionPlanning", app.cursor.Section())
 	}
-	planning := app.dashboard.planningSessions()
+	planning := app.listItems().planningSessions()
 	if len(planning) == 0 {
 		t.Fatal("planning section is empty after submitPromptModal planning path")
 	}
@@ -4507,8 +4331,8 @@ func TestPlannerQuestionMsg_AutoOpensPlanEditor(t *testing.T) {
 	if app.modals.PlanEditor().sess == nil || app.modals.PlanEditor().sess.ID != sess.ID {
 		t.Errorf("editor opened for wrong session: got %v", app.modals.PlanEditor().sess)
 	}
-	if app.dashboard.panelFocus != focusPlanEditor {
-		t.Errorf("expected panelFocus=focusPlanEditor, got %v", app.dashboard.panelFocus)
+	if app.modals.Current() != focusPlanEditor {
+		t.Errorf("expected panelFocus=focusPlanEditor, got %v", app.modals.Current())
 	}
 	if !app.modals.PlanEditor().HasPendingQuestion() {
 		t.Error("expected editor to have a pending question after plannerQuestionMsg")
@@ -4551,8 +4375,8 @@ func TestPlannerQuestionMsg_DoesNotReplaceOpenEditor(t *testing.T) {
 	if app.modals.PlanEditor() == nil || app.modals.PlanEditor().sess != sessA {
 		t.Error("session A's editor should remain open; got replaced or nil")
 	}
-	if app.dashboard.panelFocus != focusPlanEditor {
-		t.Errorf("panelFocus changed: got %v, want focusPlanEditor", app.dashboard.panelFocus)
+	if app.modals.Current() != focusPlanEditor {
+		t.Errorf("panelFocus changed: got %v, want focusPlanEditor", app.modals.Current())
 	}
 	select {
 	case answer := <-answerCh:
@@ -4621,11 +4445,10 @@ func TestSubmitPromptModalRoutesToActiveRepo(t *testing.T) {
 	app.resolvedCache[dir1] = resolved
 	app.resolvedCache[dir2] = resolved
 
-	app.refreshAgentList()
-	// refreshAgentList runs clampToRepo, which anchors d.selected to the first
-	// repo header. That's exactly the state that produced the original bug —
-	// dashboard.selectedRepoPath() returns dir1 even after the user picks
-	// dir2 from the picker.
+	app.clampCursor()
+	// The pipeline cursor starts on the first repo's section. That's the state
+	// that produced the original bug — the new session must still land in the
+	// repo the user picks from the picker (dir2), not the active/first repo.
 
 	// Press `n`. With multiple repos this routes to the repo picker overlay
 	// rather than spawning directly.
@@ -5088,8 +4911,8 @@ func TestReviewPanel_SpaceIsNoOp(t *testing.T) {
 	if updated.view != ViewDashboard {
 		t.Errorf("space: expected view=ViewDashboard, got %v", updated.view)
 	}
-	if updated.dashboard.panelFocus != focusReview {
-		t.Errorf("space: expected panelFocus=focusReview, got %v", updated.dashboard.panelFocus)
+	if updated.modals.Current() != focusReview {
+		t.Errorf("space: expected panelFocus=focusReview, got %v", updated.modals.Current())
 	}
 }
 
@@ -5106,12 +4929,13 @@ func TestCreateResult_SkipFocusLaunch_StaysOnDashboard(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	// Pre-populate items; no manager is set so refreshAgentList returns early
-	// and leaves these items intact.
-	app.dashboard.items = []listItem{
+	// Seed the session into a fake manager so app.listItems() reproduces the
+	// Building row the createResultMsg handler moves the cursor to.
+	seedDashboardItems(&app, []listItem{
+		{kind: listItemRepo, repoPath: "/repo", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/repo", session: sess},
 		{kind: listItemAgent, repoPath: "/repo", session: sess, agent: ag},
-	}
+	})
 
 	model, _ := app.Update(createResultMsg{
 		sessionID:       sess.ID,
@@ -5120,7 +4944,7 @@ func TestCreateResult_SkipFocusLaunch_StaysOnDashboard(t *testing.T) {
 	})
 	app = model.(App)
 
-	if app.dashboard.panelFocus == focusLaunch {
+	if app.modals.Current() == focusLaunch {
 		t.Error("panelFocus: got focusLaunch, want focusList (skipFocusLaunch should suppress terminal open)")
 	}
 	if app.modals.LaunchAgent() != nil {
@@ -5129,7 +4953,7 @@ func TestCreateResult_SkipFocusLaunch_StaysOnDashboard(t *testing.T) {
 	if app.cursor.Section() != focusSectionBuilding {
 		t.Errorf("focusCursorSection: got %v, want focusSectionBuilding", app.cursor.Section())
 	}
-	building := app.dashboard.buildingSessions()
+	building := app.listItems().buildingSessions()
 	if len(building) == 0 {
 		t.Fatal("building section is empty — cursor-move block must run even when skipFocusLaunch is true")
 	}
@@ -5215,7 +5039,7 @@ func TestApprovePlanAndSpawn_StaysOnDashboard(t *testing.T) {
 	} else {
 		app = model2.(App)
 	}
-	if app.dashboard.panelFocus == focusLaunch {
+	if app.modals.Current() == focusLaunch {
 		t.Error("panelFocus: got focusLaunch after plan approval, want focusList")
 	}
 	if app.modals.LaunchAgent() != nil {
@@ -5712,9 +5536,9 @@ func TestManualMarkReady_TriggersValidation(t *testing.T) {
 			{Name: "Lint", Command: "echo lint"},
 		},
 	}
-	// Populate the dashboard so the m-key handler can find the session.
-	app.refreshAgentList()
-	// Move cursor to the Building section.
+	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
+	app.clampCursor()
+	// Move cursor to the Building section so the m-key handler targets the session.
 	app.cursor.SetSection(focusSectionBuilding)
 	app.cursor.SetIndex(focusSectionBuilding, 0)
 
@@ -5742,7 +5566,6 @@ func TestRecordInput_NonDashboardView(t *testing.T) {
 	// We use openRepoChecksEditor directly to bypass the normal init path.
 	editor := newRepoChecksModel("repo", nil)
 	app.openRepoChecksEditor(editor, "/repo")
-	app.syncModalsToDashboard()
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	app = model.(App)

--- a/internal/tui/consts.go
+++ b/internal/tui/consts.go
@@ -72,10 +72,6 @@ const (
 	// the same pipeline row that still counts as a double-click activation.
 	PipelineDoubleClickWindow = 500 * time.Millisecond
 
-	// DiffStatsCacheTTL is how long App.diffStatsCache entries are
-	// considered fresh before the dashboard triggers a background refresh.
-	DiffStatsCacheTTL = 5 * time.Second
-
 	// ErrorOverlayTicks is the number of dashboard ticks the bottom-row
 	// error message stays visible after setError() (3 seconds at the
 	// 100ms tick interval).

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -79,58 +79,35 @@ type listItem struct {
 	agent    *agent.Agent   // set for agent items
 }
 
-// diffSummaryData holds cached diff stats for rendering in the dashboard.
-type diffSummaryData struct {
-	Files     []diffFileStat
-	Aggregate diffAggregateStats
+// listItems is the hierarchical repo/session/agent row list. App.listItems()
+// rebuilds it from the managers each frame; the phase-filter / section
+// accessors and the per-session agent-status helpers hang off it so the
+// dashboard can derive everything it renders from props.items without the
+// model owning a mirrored copy (CONVENTIONS.md §5/§6).
+type listItems []listItem
+
+// agents returns every agent row in the list (for resize operations).
+func (items listItems) agents() []*agent.Agent {
+	var result []*agent.Agent
+	for _, item := range items {
+		if item.kind == listItemAgent {
+			result = append(result, item.agent)
+		}
+	}
+	return result
 }
 
-type diffFileStat struct {
-	Path       string
-	Status     string // "A", "M", or "D"
-	Insertions int
-	Deletions  int
-}
-
-type diffAggregateStats struct {
-	Files      int
-	Insertions int
-	Deletions  int
-}
-
-// dashboardModel shows the hierarchical repo/session/agent list and terminal preview.
+// dashboardModel owns only the transient UI state the dashboard genuinely
+// holds across frames: its viewport size, scroll offset, marquee tickers, the
+// in-flight mouse text selection, and the tick-refreshed render clock.
+// Everything else it renders (modal state, the wellness snapshot, the pipeline
+// cursor, caches, the active repo, and the item list) is read live each frame
+// from a fresh dashboardProps — see CONVENTIONS.md §5/§6.
 type dashboardModel struct {
-	items           []listItem
-	selected        int
-	width           int
-	height          int
-	sidebarWidth    int // resolved global SidebarWidth; 0 means use DefaultSidebarWidth
-	panelFocus      panelFocus
-	scrollOffset    int
-	diffStats       *diffSummaryData           // nil when no session selected or no data
-	prCache         map[string]*prCacheEntry   // keyed by cacheKey(repoPath, sessionID), passed from App
-	prPollStates    map[string]*prSessionState // keyed by cacheKey(repoPath, sessionID), passed from App
-	closingAgents   map[string]bool            // keyed by agentCacheKey(repoPath, agentID), passed from App
-	closingSessions map[string]bool            // keyed by cacheKey(repoPath, sessionID), passed from App
-
-	// Pipeline / wellness state, synced from App on every refresh.
-	sessionElapsed         time.Duration
-	lastReviewAt           time.Time
-	focusSessionMinutes    int
-	focusBreakMode         bool
-	focusBreakElapsed      time.Duration
-	focusBlockCount        int
-	focusBreakMinutes      int
-	focusBreakAnimFrame    int
-	focusBreakShortWarning bool
-	focusBreakTimerUp      bool
-	cursor                 FocusedCursor  // pipeline cursor mirror; synced from App on every refresh
-	prDraftSessionID       string         // session ID whose PR draft is in flight; "" when idle
-	prDraftRepoPath        string         // repo path whose PR draft is in flight; "" when idle
-	activeRepoName         string         // display name of the active repo
-	activeRepoPath         string         // canonical path of the active repo (for pipeline filtering)
-	focusLaunchAgent       *agent.Agent   // agent open in focusLaunch terminal; nil otherwise
-	focusLaunchSession     *agent.Session // session owning focusLaunchAgent; nil otherwise
+	width        int
+	height       int
+	sidebarWidth int // resolved global SidebarWidth; 0 means use DefaultSidebarWidth
+	scrollOffset int
 
 	// tickers tracks marquee scroll state for session names that overflow the sidebar.
 	tickers map[string]*sessionTicker
@@ -139,15 +116,6 @@ type dashboardModel struct {
 	// "idle Nm" / "done Nm ago" / elapsed strings and the review spinner from
 	// it so rendering stays pure (§5: no clock read at render time).
 	now time.Time
-
-	// Repo config form shown in the right panel when focusConfig is active.
-	repoConfigForm *configForm
-	configRepoPath string // path of the repo being configured
-
-	// Validation-checks sub-editor, mirrored from Modals when focusRepoChecks
-	// is active. nil at all other times.
-	repoChecksEditor   *repoChecksModel
-	repoChecksRepoPath string
 
 	// Mouse text selection state in VT-cell coordinates, bound to a specific
 	// agent so a sidebar selection change clears it cleanly.
@@ -171,9 +139,9 @@ func newDashboardModel() dashboardModel {
 
 // advanceTickers steps the marquee scroll state for all sessions whose names
 // overflow the sidebar. Must be called once per tick before rendering.
-func (d *dashboardModel) advanceTickers(now time.Time) {
+func (d *dashboardModel) advanceTickers(now time.Time, props dashboardProps) {
 	width := d.listWidth()
-	for _, item := range d.items {
+	for _, item := range props.items {
 		if item.kind != listItemSession || item.session == nil {
 			continue
 		}
@@ -181,10 +149,10 @@ func (d *dashboardModel) advanceTickers(now time.Time) {
 		displayName := sess.GetDisplayName()
 
 		sessKey := cacheKey(item.repoPath, sess.ID)
-		closing := d.closingSessions != nil && d.closingSessions[sessKey]
+		closing := props.closingSessions != nil && props.closingSessions[sessKey]
 		prSuffixLen := 0
 		if !closing {
-			if entry := d.prCache[sessKey]; entry != nil && entry.pr != nil {
+			if entry := props.prCache[sessKey]; entry != nil && entry.pr != nil {
 				prSuffixLen = 1 + prIndicatorWidth(entry) // 1 for leading space
 			}
 		}
@@ -238,17 +206,17 @@ func (d *dashboardModel) advanceTickers(now time.Time) {
 	}
 }
 
-func (d dashboardModel) Update(msg tea.Msg) (dashboardModel, tea.Cmd) {
+func (d dashboardModel) Update(msg tea.Msg, props dashboardProps) (dashboardModel, tea.Cmd) {
 	if msg, ok := msg.(tea.KeyPressMsg); ok {
 		// Config overlay: delegate to the form. Pipeline navigation (j/k/enter)
 		// is handled at the app level via moveFocusCursorUp/Down and
 		// activateFocusCursor; nothing else needs to reach the dashboard here.
-		if d.panelFocus == focusConfig && d.repoConfigForm != nil {
-			cmd := d.repoConfigForm.Update(msg)
+		if props.panelFocus == focusConfig && props.repoConfigForm != nil {
+			cmd := props.repoConfigForm.Update(msg)
 			return d, cmd
 		}
-		if d.panelFocus == focusRepoChecks && d.repoChecksEditor != nil {
-			cmd := d.repoChecksEditor.Update(msg)
+		if props.panelFocus == focusRepoChecks && props.repoChecksEditor != nil {
+			cmd := props.repoChecksEditor.Update(msg)
 			return d, cmd
 		}
 	}
@@ -263,19 +231,19 @@ func (d dashboardModel) listWidth() int {
 	return resolveSidebarWidth(d.sidebarWidth)
 }
 
-func (d dashboardModel) View() string {
+func (d dashboardModel) View(props dashboardProps) string {
 	var out string
 	switch {
-	case len(d.items) == 0:
+	case len(props.items) == 0:
 		out = d.emptyView()
-	case d.panelFocus == focusLaunch:
-		out = d.renderFocusLaunchView(d.width, d.height)
-	case d.panelFocus == focusConfig && d.repoConfigForm != nil:
-		out = d.renderRepoConfigOverlay(d.width, d.height)
-	case d.panelFocus == focusRepoChecks && d.repoChecksEditor != nil:
-		out = d.renderRepoChecksOverlay(d.width, d.height)
+	case props.panelFocus == focusLaunch:
+		out = d.renderFocusLaunchView(props, d.width, d.height)
+	case props.panelFocus == focusConfig && props.repoConfigForm != nil:
+		out = d.renderRepoConfigOverlay(props, d.width, d.height)
+	case props.panelFocus == focusRepoChecks && props.repoChecksEditor != nil:
+		out = d.renderRepoChecksOverlay(props, d.width, d.height)
 	default:
-		out = d.renderFullscreenFocus(d.width, d.height)
+		out = d.renderFullscreenFocus(props, d.width, d.height)
 	}
 	return out
 }
@@ -303,21 +271,21 @@ func (d dashboardModel) fixedTermHeight() int {
 // reached from the pipeline by selecting a repo header (when there are
 // multiple repos) and pressing enter, or from the cross-repo summary header.
 // The form mirrors the global settings overlay's centered-box layout.
-func (d dashboardModel) renderRepoConfigOverlay(width, height int) string {
-	if d.repoConfigForm == nil {
+func (d dashboardModel) renderRepoConfigOverlay(props dashboardProps, width, height int) string {
+	if props.repoConfigForm == nil {
 		return d.emptyView()
 	}
 
 	var repoName, repoPath string
-	for _, item := range d.items {
-		if item.kind == listItemRepo && item.repoPath == d.configRepoPath {
+	for _, item := range props.items {
+		if item.kind == listItemRepo && item.repoPath == props.configRepoPath {
 			repoName = item.repoName
 			repoPath = item.repoPath
 			break
 		}
 	}
 	if repoName == "" {
-		repoName = d.configRepoPath
+		repoName = props.configRepoPath
 	}
 
 	title := StyleTitle.Render(repoName + " Settings")
@@ -328,7 +296,7 @@ func (d dashboardModel) renderRepoConfigOverlay(width, height int) string {
 		lipgloss.Left,
 		title,
 		pathLine, "",
-		d.repoConfigForm.View(), "",
+		props.repoConfigForm.View(), "",
 		hint,
 	)
 
@@ -339,21 +307,21 @@ func (d dashboardModel) renderRepoConfigOverlay(width, height int) string {
 // renderRepoChecksOverlay renders the validation-checks list editor as a
 // centered modal box, styled to match renderRepoConfigOverlay so the user
 // perceives it as a sub-form of the repo settings overlay.
-func (d dashboardModel) renderRepoChecksOverlay(width, height int) string {
-	if d.repoChecksEditor == nil {
+func (d dashboardModel) renderRepoChecksOverlay(props dashboardProps, width, height int) string {
+	if props.repoChecksEditor == nil {
 		return d.emptyView()
 	}
 
-	repoName := d.repoChecksEditor.repoName
+	repoName := props.repoChecksEditor.repoName
 	if repoName == "" {
-		repoName = d.repoChecksRepoPath
+		repoName = props.repoChecksRepoPath
 	}
 
 	title := StyleTitle.Render(repoName + " · Validation Checks")
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
 		title, "",
-		d.repoChecksEditor.View(),
+		props.repoChecksEditor.View(),
 	)
 
 	box := modalBoxStyle(72).Render(content)
@@ -373,9 +341,9 @@ func (d dashboardModel) emptyView() string {
 // any of the given phases. Repo filtering is intentionally NOT applied here
 // because the pipeline shows cross-repo work; callers that want a per-repo
 // view should filter the result themselves.
-func (d dashboardModel) sessionsInPhase(phases ...agent.LifecyclePhase) []listItem {
+func (items listItems) sessionsInPhase(phases ...agent.LifecyclePhase) []listItem {
 	var result []listItem
-	for _, item := range d.items {
+	for _, item := range items {
 		if item.kind != listItemSession || item.session == nil {
 			continue
 		}
@@ -395,8 +363,8 @@ func (d dashboardModel) sessionsInPhase(phases ...agent.LifecyclePhase) []listIt
 // the user presses 'b'. Drafting sessions (LifecycleDrafting) are included
 // here so they're visible from the dashboard while the background draft runs;
 // the card renderer detects the sub-phase and shows a "drafting…" badge.
-func (d dashboardModel) planningSessions() []listItem {
-	return d.sessionsInPhase(agent.LifecyclePlanning, agent.LifecycleDrafting)
+func (items listItems) planningSessions() []listItem {
+	return items.sessionsInPhase(agent.LifecyclePlanning, agent.LifecycleDrafting)
 }
 
 // reviewQueueSessions returns listItems for sessions in ReadyForReview or
@@ -405,15 +373,15 @@ func (d dashboardModel) planningSessions() []listItem {
 // peeked at the review panel and backed out (or hit "open PR" with no PR
 // cached) would disappear from both BUILDING (InProgress only) and the queue,
 // even though the pipeline IN REVIEW count showed it was still there.
-func (d dashboardModel) reviewQueueSessions() []listItem {
-	return d.sessionsInPhase(agent.LifecycleReadyForReview, agent.LifecycleInReview)
+func (items listItems) reviewQueueSessions() []listItem {
+	return items.sessionsInPhase(agent.LifecycleReadyForReview, agent.LifecycleInReview)
 }
 
 // shippingSessions returns sessions whose PR is open and awaiting CI/merge.
 // They leave this list automatically when polling detects a merge (transition
 // to LifecycleComplete) or when the user presses 'c' in the review panel.
-func (d dashboardModel) shippingSessions() []listItem {
-	return d.sessionsInPhase(agent.LifecycleShipping)
+func (items listItems) shippingSessions() []listItem {
+	return items.sessionsInPhase(agent.LifecycleShipping)
 }
 
 // buildingSessions returns listItems for all sessions in InProgress phase,
@@ -421,11 +389,11 @@ func (d dashboardModel) shippingSessions() []listItem {
 // moved to ReadyForReview. This is the "active work" section — agents are
 // running, the user is interacting with them, and the work has moved past the
 // scoping done in Planning.
-func (d dashboardModel) buildingSessions() []listItem {
-	result := d.sessionsInPhase(agent.LifecycleInProgress)
+func (items listItems) buildingSessions() []listItem {
+	result := items.sessionsInPhase(agent.LifecycleInProgress)
 	sort.SliceStable(result, func(i, j int) bool {
-		pi := d.sessionFocusPriority(result[i].session)
-		pj := d.sessionFocusPriority(result[j].session)
+		pi := items.sessionFocusPriority(result[i].session)
+		pj := items.sessionFocusPriority(result[j].session)
 		if pi != pj {
 			return pi < pj
 		}
@@ -442,28 +410,28 @@ func (d dashboardModel) buildingSessions() []listItem {
 // section. The panic case enforces the focusSection enum invariant: a new
 // section added without updating this switch fails loudly at the first call
 // rather than silently rendering empty.
-func (d dashboardModel) sectionItems(s focusSection) []listItem {
+func (items listItems) sectionItems(s focusSection) []listItem {
 	switch s {
 	case focusSectionPlanning:
-		return d.planningSessions()
+		return items.planningSessions()
 	case focusSectionBuilding:
-		return d.buildingSessions()
+		return items.buildingSessions()
 	case focusSectionReview:
-		return d.reviewQueueSessions()
+		return items.reviewQueueSessions()
 	case focusSectionShipping:
-		return d.shippingSessions()
+		return items.shippingSessions()
 	}
-	panic(fmt.Sprintf("dashboardModel.sectionItems: unknown focusSection %d", s))
+	panic(fmt.Sprintf("listItems.sectionItems: unknown focusSection %d", s))
 }
 
 // sectionCounts returns the number of rows in each fullscreen-focus section,
 // indexed by focusSection. Used by FocusedCursor navigation methods.
-func (d dashboardModel) sectionCounts() [4]int {
+func (items listItems) sectionCounts() [4]int {
 	return [4]int{
-		focusSectionPlanning: len(d.planningSessions()),
-		focusSectionBuilding: len(d.buildingSessions()),
-		focusSectionReview:   len(d.reviewQueueSessions()),
-		focusSectionShipping: len(d.shippingSessions()),
+		focusSectionPlanning: len(items.planningSessions()),
+		focusSectionBuilding: len(items.buildingSessions()),
+		focusSectionReview:   len(items.reviewQueueSessions()),
+		focusSectionShipping: len(items.shippingSessions()),
 	}
 }
 
@@ -504,11 +472,11 @@ func renderCardProgressBar(done, total, width int, primary lipgloss.Color) strin
 // sessionFocusStatus returns a styled inline status badge for a session row in
 // the unified SESSIONS list. Priority: Error > Waiting > May Need Input >
 // idle-but-reviewable (only when no active agents) > finished (DoneAt set) > normal (N active, M idle).
-func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
+func (items listItems) sessionFocusStatus(sess *agent.Session) string {
 	var waitingCount, activeCount, idleCount, idleAskingCount int
 	var firstWaitingReason string
 	var hasError bool
-	for _, item := range d.items {
+	for _, item := range items {
 		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
 			continue
 		}
@@ -590,9 +558,9 @@ func (d dashboardModel) sessionFocusStatus(sess *agent.Session) string {
 // sessionFocusPriority returns an integer priority for sorting sessions in the
 // focus mode SESSIONS list. Lower values surface first (needs attention first).
 // 0=error, 1=waiting, 2=active, 3=idle/other.
-func (d dashboardModel) sessionFocusPriority(sess *agent.Session) int {
+func (items listItems) sessionFocusPriority(sess *agent.Session) int {
 	var hasError, hasWaiting, hasActive bool
-	for _, item := range d.items {
+	for _, item := range items {
 		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
 			continue
 		}
@@ -621,9 +589,9 @@ func (d dashboardModel) sessionFocusPriority(sess *agent.Session) int {
 // in the focus mode SESSIONS list. Mirrors the priority order in
 // sessionFocusStatus so the stripe and the badge agree on the dominant
 // condition. Selection highlight is applied by the caller.
-func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Color {
+func (items listItems) sessionFocusStripeColor(sess *agent.Session) lipgloss.Color {
 	var hasError, hasWaiting, hasIdleAsking bool
-	for _, item := range d.items {
+	for _, item := range items {
 		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
 			continue
 		}
@@ -659,9 +627,9 @@ func (d dashboardModel) sessionFocusStripeColor(sess *agent.Session) lipgloss.Co
 // the session name, so the reader can identify state at a glance even when ANSI
 // colors are unavailable. planningPhase callers pass true to suppress the glyph
 // when the right-side badge already begins with one.
-func (d dashboardModel) sessionStatusGlyph(sess *agent.Session) (glyph string, col lipgloss.Color) {
+func (items listItems) sessionStatusGlyph(sess *agent.Session) (glyph string, col lipgloss.Color) {
 	var hasError, hasWaiting, hasIdleAsking, hasActive bool
-	for _, item := range d.items {
+	for _, item := range items {
 		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
 			continue
 		}
@@ -703,8 +671,8 @@ func (d dashboardModel) sessionStatusGlyph(sess *agent.Session) (glyph string, c
 // Line 2: <stripe>   <active task (bold)>   (building) | <description (muted/italic)> (planning/other)
 // Line 3: <stripe>   next: <next task (muted-italic)>   (building) | <description line 2 or empty>
 // Line 4: <stripe>   [⎇ branch] [· detail]      ... right-aligned ⏱ <elapsed>
-func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName string, selected bool, width int) []string {
-	stripeColor := d.sessionFocusStripeColor(sess)
+func (d dashboardModel) renderFocusSessionCard(props dashboardProps, sess *agent.Session, repoName string, selected bool, width int) []string {
+	stripeColor := props.items.sessionFocusStripeColor(sess)
 	if selected {
 		stripeColor = ColorSecondary
 	}
@@ -733,12 +701,12 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	if planningPhase {
 		badge = planningStatusBadge(sess)
 	} else {
-		badge = d.sessionFocusStatus(sess)
+		badge = props.items.sessionFocusStatus(sess)
 	}
 	// Status glyph: prepend between stripe and name for non-planning cards.
 	// Planning cards suppress the glyph because the badge already leads with ✎/✗/○.
 	if !planningPhase {
-		glyph, glyphColor := d.sessionStatusGlyph(sess)
+		glyph, glyphColor := props.items.sessionStatusGlyph(sess)
 		glyphStyled := lipgloss.NewStyle().Foreground(glyphColor).Render(glyph)
 		nameStyled = glyphStyled + " " + nameStyled
 	}
@@ -807,7 +775,7 @@ func (d dashboardModel) renderFocusSessionCard(sess *agent.Session, repoName str
 	var waitingReason string
 	allIdle := true
 	anyAgent := false
-	for _, item := range d.items {
+	for _, item := range props.items {
 		if item.kind != listItemAgent || item.agent == nil || item.agent.IsShell || item.session != sess {
 			continue
 		}
@@ -1127,13 +1095,13 @@ func rightAlign(left, right string, width int) string {
 
 // renderPipelineWidget renders the 4-cell pipeline row, one cell per phase:
 // PLANNING → BUILDING → REVIEWING → SHIPPING. Counts mirror the section lists.
-func (d dashboardModel) renderPipelineWidget(width int) string {
+func (d dashboardModel) renderPipelineWidget(props dashboardProps, width int) string {
 	var planning, building, reviewing, shipping int
-	for _, item := range d.items {
+	for _, item := range props.items {
 		if item.kind != listItemSession || item.session == nil {
 			continue
 		}
-		if d.activeRepoPath != "" && item.repoPath != d.activeRepoPath {
+		if props.activeRepoPath != "" && item.repoPath != props.activeRepoPath {
 			continue
 		}
 		switch item.session.LifecyclePhase() {
@@ -1195,11 +1163,11 @@ func focusLaunchTabText(ag *agent.Agent) string {
 // renderFocusLaunchTabBar renders the tab strip row for focusLaunch. Returns
 // the styled tab bar string and, as side-data for click handling, the starting
 // column of each tab (returned to avoid duplicating layout math in App).
-func (d dashboardModel) renderFocusLaunchTabBar(width int) string {
-	if d.focusLaunchSession == nil || d.focusLaunchAgent == nil {
+func (d dashboardModel) renderFocusLaunchTabBar(props dashboardProps, width int) string {
+	if props.focusLaunchSession == nil || props.focusLaunchAgent == nil {
 		return ""
 	}
-	agents := d.focusLaunchSession.Agents()
+	agents := props.focusLaunchSession.Agents()
 	if len(agents) == 0 {
 		return ""
 	}
@@ -1207,7 +1175,7 @@ func (d dashboardModel) renderFocusLaunchTabBar(width int) string {
 	var parts []string
 	for _, ag := range agents {
 		text := focusLaunchTabText(ag)
-		if ag.ID == d.focusLaunchAgent.ID {
+		if ag.ID == props.focusLaunchAgent.ID {
 			parts = append(parts, StyleTitle.Render(text))
 		} else {
 			parts = append(parts, StyleSubtle.Render(text))
@@ -1222,22 +1190,22 @@ func (d dashboardModel) renderFocusLaunchTabBar(width int) string {
 }
 
 // renderFocusLaunchView renders the "focus mode paused" view with a single agent terminal.
-func (d dashboardModel) renderFocusLaunchView(width, height int) string {
-	ag := d.focusLaunchAgent
+func (d dashboardModel) renderFocusLaunchView(props dashboardProps, width, height int) string {
+	ag := props.focusLaunchAgent
 	if ag == nil {
-		return d.renderFullscreenFocus(width, height)
+		return d.renderFullscreenFocus(props, width, height)
 	}
 
 	agentName := ag.GetDisplayName()
 	headerParts := []string{fmt.Sprintf("agent: %s", agentName)}
-	if d.focusLaunchSession != nil {
-		if branch := d.focusLaunchSession.Branch(); branch != "" {
+	if props.focusLaunchSession != nil {
+		if branch := props.focusLaunchSession.Branch(); branch != "" {
 			headerParts = append(headerParts, fmt.Sprintf("branch: %s", branch))
 		}
 	}
 	header := StyleSubtle.Render(strings.Join(headerParts, "  "))
 
-	tabBar := d.renderFocusLaunchTabBar(width)
+	tabBar := d.renderFocusLaunchTabBar(props, width)
 
 	vpWidth := width
 	vpHeight := height - 2
@@ -1384,21 +1352,21 @@ func generateBreatheFrames() [breathFrameCount][breathHeight]string {
 // renderBreatheBlock returns the current breath frame as a colored block.
 // Falls back to the compact frames when the terminal can't fit the bigger
 // canvas.
-func (d dashboardModel) renderBreatheBlock(width, height int) string {
+func (d dashboardModel) renderBreatheBlock(props dashboardProps, width, height int) string {
 	if width < breathWidth+4 || height < breathHeight+8 {
-		cycle := d.focusBreakAnimFrame % breathFrameCount
+		cycle := props.focusBreakAnimFrame % breathFrameCount
 		frame := cycle * len(breatheFramesCompact) / breathFrameCount
-		animColor := breatheColors[(d.focusBreakAnimFrame/breathFrameCount)%len(breatheColors)]
+		animColor := breatheColors[(props.focusBreakAnimFrame/breathFrameCount)%len(breatheColors)]
 		animStyle := lipgloss.NewStyle().Foreground(animColor)
 		rows := breatheFramesCompact[frame]
 		return animStyle.Render(rows[0]) + "\n" +
 			animStyle.Render(rows[1]) + "\n" +
 			animStyle.Render(rows[2])
 	}
-	frame := d.focusBreakAnimFrame % breathFrameCount
+	frame := props.focusBreakAnimFrame % breathFrameCount
 	// Color rotates per breath cycle, not per frame, so the eye gets a
 	// stable hue to settle on for the duration of one breath.
-	cycle := d.focusBreakAnimFrame / breathFrameCount
+	cycle := props.focusBreakAnimFrame / breathFrameCount
 	animColor := breatheColors[cycle%len(breatheColors)]
 	animStyle := lipgloss.NewStyle().Foreground(animColor)
 
@@ -1413,8 +1381,8 @@ func (d dashboardModel) renderBreatheBlock(width, height int) string {
 // breathPhaseLabel returns a one-word cue ("inhale" / "exhale") matching
 // the current breath phase. No hold phase — the sparkle ring in
 // generateBreatheFrames provides the held feeling visually at the peak.
-func (d dashboardModel) breathPhaseLabel() string {
-	frame := d.focusBreakAnimFrame % breathFrameCount
+func (d dashboardModel) breathPhaseLabel(props dashboardProps) string {
+	frame := props.focusBreakAnimFrame % breathFrameCount
 	half := breathFrameCount / 2
 	if frame < half {
 		return "inhale"
@@ -1427,27 +1395,27 @@ func (d dashboardModel) breathPhaseLabel() string {
 //   - Active break: large breath animation, countdown, exit-early hint.
 //   - Timer up: warm "BREAK COMPLETE" panel that waits for the user to
 //     explicitly opt back in (no auto-resume).
-func (d dashboardModel) renderBreakOverlay(width, height int) string {
-	if d.focusBreakTimerUp {
-		return d.renderBreakCompleteOverlay(width, height)
+func (d dashboardModel) renderBreakOverlay(props dashboardProps, width, height int) string {
+	if props.focusBreakTimerUp {
+		return d.renderBreakCompleteOverlay(props, width, height)
 	}
 
-	animBlock := d.renderBreatheBlock(width, height)
+	animBlock := d.renderBreatheBlock(props, width, height)
 
 	titleStyle := StyleHeading.Foreground(ColorBreakTitle)
 	title := titleStyle.Render("BREAK")
 
 	var blockLine string
-	if d.focusBlockCount > 0 {
-		blockLine = StyleSubtle.Render(fmt.Sprintf("Block %d", d.focusBlockCount))
+	if props.focusBlockCount > 0 {
+		blockLine = StyleSubtle.Render(fmt.Sprintf("Block %d", props.focusBlockCount))
 	}
 
-	phaseLine := StyleSubtle.Render(d.breathPhaseLabel())
+	phaseLine := StyleSubtle.Render(d.breathPhaseLabel(props))
 
 	var countdownLine string
-	if d.focusBreakMinutes > 0 {
-		totalSecs := d.focusBreakMinutes * 60
-		remainSecs := totalSecs - int(d.focusBreakElapsed.Seconds())
+	if props.focusBreakMinutes > 0 {
+		totalSecs := props.focusBreakMinutes * 60
+		remainSecs := totalSecs - int(props.focusBreakElapsed.Seconds())
 		if remainSecs < 0 {
 			remainSecs = 0
 		}
@@ -1457,7 +1425,7 @@ func (d dashboardModel) renderBreakOverlay(width, height int) string {
 	}
 
 	var actionLine string
-	if d.focusBreakShortWarning {
+	if props.focusBreakShortWarning {
 		actionLine = StyleWarning.Render("break too short — press b again to override")
 	} else {
 		actionLine = StyleSubtle.Render("[b] return early")
@@ -1486,8 +1454,8 @@ func (d dashboardModel) renderBreakOverlay(width, height int) string {
 // The visual is intentionally loud: warm bordered banner, pulsing colour,
 // over-time counter. The user must press b to leave — we never advance on
 // their behalf.
-func (d dashboardModel) renderBreakCompleteOverlay(width, height int) string {
-	pulse := completeColors[(d.focusBreakAnimFrame/3)%len(completeColors)]
+func (d dashboardModel) renderBreakCompleteOverlay(props dashboardProps, width, height int) string {
+	pulse := completeColors[(props.focusBreakAnimFrame/3)%len(completeColors)]
 	bannerStyle := lipgloss.NewStyle().
 		Foreground(pulse).
 		Bold(true).
@@ -1500,10 +1468,10 @@ func (d dashboardModel) renderBreakCompleteOverlay(width, height int) string {
 	subhead := subStyle.Render("ready when you are")
 
 	var stats string
-	if d.focusBreakMinutes > 0 {
-		breakSecs := int(d.focusBreakElapsed.Seconds())
+	if props.focusBreakMinutes > 0 {
+		breakSecs := int(props.focusBreakElapsed.Seconds())
 		bm, bs := breakSecs/60, breakSecs%60
-		over := breakSecs - d.focusBreakMinutes*60
+		over := breakSecs - props.focusBreakMinutes*60
 		if over < 0 {
 			over = 0
 		}
@@ -1516,8 +1484,8 @@ func (d dashboardModel) renderBreakCompleteOverlay(width, height int) string {
 	}
 
 	var blockLine string
-	if d.focusBlockCount > 0 {
-		blockLine = StyleSubtle.Render(fmt.Sprintf("Block %d so far", d.focusBlockCount))
+	if props.focusBlockCount > 0 {
+		blockLine = StyleSubtle.Render(fmt.Sprintf("Block %d so far", props.focusBlockCount))
 	}
 
 	prompt := StyleBold.
@@ -1540,22 +1508,22 @@ func (d dashboardModel) renderBreakCompleteOverlay(width, height int) string {
 
 // renderFullscreenFocus renders the pipeline dashboard: header, pipeline
 // widget, SESSIONS section, and REVIEW QUEUE section.
-func (d dashboardModel) renderFullscreenFocus(width, height int) string {
-	if d.focusBreakMode {
-		return d.renderBreakOverlay(width, height)
+func (d dashboardModel) renderFullscreenFocus(props dashboardProps, width, height int) string {
+	if props.focusBreakMode {
+		return d.renderBreakOverlay(props, width, height)
 	}
 
 	var lines []string
 
 	// Header: title + timer
 	title := StyleTitle.Render("FOCUS")
-	if d.focusBlockCount > 0 {
-		title += "  " + StyleSubtle.Render(fmt.Sprintf("Block %d", d.focusBlockCount))
+	if props.focusBlockCount > 0 {
+		title += "  " + StyleSubtle.Render(fmt.Sprintf("Block %d", props.focusBlockCount))
 	}
 	timerStr := ""
-	if d.focusSessionMinutes > 0 {
-		threshold := time.Duration(d.focusSessionMinutes) * time.Minute
-		elapsed := d.sessionElapsed
+	if props.focusSessionMinutes > 0 {
+		threshold := time.Duration(props.focusSessionMinutes) * time.Minute
+		elapsed := props.sessionElapsed
 		if elapsed > threshold {
 			elapsed = threshold
 		}
@@ -1582,29 +1550,33 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		)
 		barModel.SetWidth(barWidth)
 
-		elapsedMin := int(d.sessionElapsed.Minutes())
-		timerStr = barModel.ViewAs(pct) + " " + fmt.Sprintf("%dm/%dm", elapsedMin, d.focusSessionMinutes)
+		elapsedMin := int(props.sessionElapsed.Minutes())
+		timerStr = barModel.ViewAs(pct) + " " + fmt.Sprintf("%dm/%dm", elapsedMin, props.focusSessionMinutes)
 	}
 	headerLine := title
-	if d.activeRepoName != "" {
-		headerLine += "  " + StyleSubtle.Render(d.activeRepoName)
+	if props.activeRepoName != "" {
+		headerLine += "  " + StyleSubtle.Render(props.activeRepoName)
 	}
 	headerLine += "  " + timerStr
 	lines = append(lines, headerLine)
-	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width-2)))
+	// width can be 0 on the very first frame, before the initial
+	// WindowSizeMsg arrives: props.items is non-empty immediately (cfg repo
+	// headers), so View() reaches this path before a size is known. Clamp so
+	// strings.Repeat never gets a negative count.
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(0, width-2))))
 
 	// Pipeline widget
-	lines = append(lines, d.renderPipelineWidget(width))
+	lines = append(lines, d.renderPipelineWidget(props, width))
 	lines = append(lines, "")
 
 	// Section render order matches focusSectionsInOrder() so navigation walks
 	// the same sequence the user reads top-to-bottom.
-	planningItems := d.planningSessions()
+	planningItems := props.items.planningSessions()
 	if len(planningItems) > 0 {
 		lines = append(lines, StyleSubtle.Render("PLANNING"))
 		for i, item := range planningItems {
-			selected := d.cursor.Section() == focusSectionPlanning && i == d.cursor.Index(focusSectionPlanning)
-			card := d.renderFocusSessionCard(item.session, item.repoName, selected, width)
+			selected := props.cursor.Section() == focusSectionPlanning && i == props.cursor.Index(focusSectionPlanning)
+			card := d.renderFocusSessionCard(props, item.session, item.repoName, selected, width)
 			lines = append(lines, card...)
 			if i < len(planningItems)-1 {
 				lines = append(lines, "")
@@ -1613,12 +1585,12 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, "")
 	}
 
-	buildingItems := d.buildingSessions()
+	buildingItems := props.items.buildingSessions()
 	if len(buildingItems) > 0 {
 		lines = append(lines, StyleSubtle.Render("BUILDING"))
 		for i, item := range buildingItems {
-			selected := d.cursor.Section() == focusSectionBuilding && i == d.cursor.Index(focusSectionBuilding)
-			card := d.renderFocusSessionCard(item.session, item.repoName, selected, width)
+			selected := props.cursor.Section() == focusSectionBuilding && i == props.cursor.Index(focusSectionBuilding)
+			card := d.renderFocusSessionCard(props, item.session, item.repoName, selected, width)
 			lines = append(lines, card...)
 			if i < len(buildingItems)-1 {
 				lines = append(lines, "")
@@ -1627,12 +1599,12 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, "")
 	}
 
-	reviewSessions := d.reviewQueueSessions()
+	reviewSessions := props.items.reviewQueueSessions()
 	if len(reviewSessions) > 0 {
 		lines = append(lines, StyleSubtle.Render("REVIEWING"))
 		for i, item := range reviewSessions {
-			selected := d.cursor.Section() == focusSectionReview && i == d.cursor.Index(focusSectionReview)
-			row := d.renderQueueRow(item.session, item.repoName, item.repoPath, selected, ColorWarning, width)
+			selected := props.cursor.Section() == focusSectionReview && i == props.cursor.Index(focusSectionReview)
+			row := d.renderQueueRow(props, item.session, item.repoName, item.repoPath, selected, ColorWarning, width)
 			lines = append(lines, row...)
 			if i < len(reviewSessions)-1 {
 				lines = append(lines, "")
@@ -1641,12 +1613,12 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 		lines = append(lines, "")
 	}
 
-	shippingItems := d.shippingSessions()
+	shippingItems := props.items.shippingSessions()
 	if len(shippingItems) > 0 {
 		lines = append(lines, StyleSubtle.Render("SHIPPING"))
 		for i, item := range shippingItems {
-			selected := d.cursor.Section() == focusSectionShipping && i == d.cursor.Index(focusSectionShipping)
-			row := d.renderQueueRow(item.session, item.repoName, item.repoPath, selected, ColorShipping, width)
+			selected := props.cursor.Section() == focusSectionShipping && i == props.cursor.Index(focusSectionShipping)
+			row := d.renderQueueRow(props, item.session, item.repoName, item.repoPath, selected, ColorShipping, width)
 			lines = append(lines, row...)
 			if i < len(shippingItems)-1 {
 				lines = append(lines, "")
@@ -1662,7 +1634,7 @@ func (d dashboardModel) renderFullscreenFocus(width, height int) string {
 // accent for the cursor stripe and prefix when selected (warning for review,
 // success for shipping). Used by both the REVIEWING and SHIPPING sections so
 // they share layout/age/prIndicator handling.
-func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName, repoPath string, selected bool, selectedColor lipgloss.Color, width int) []string {
+func (d dashboardModel) renderQueueRow(props dashboardProps, sess *agent.Session, repoName, repoPath string, selected bool, selectedColor lipgloss.Color, width int) []string {
 	name := sess.GetDisplayName()
 	age := ""
 	if !sess.DoneAt().IsZero() {
@@ -1692,19 +1664,19 @@ func (d dashboardModel) renderQueueRow(sess *agent.Session, repoName, repoPath s
 	}
 	line1 := prefix + nameRendered
 	prIndSet := false
-	if prEntry := d.prCache[cacheKey(repoPath, sess.ID)]; prEntry != nil {
+	if prEntry := props.prCache[cacheKey(repoPath, sess.ID)]; prEntry != nil {
 		if prInd := prIndicator(prEntry); prInd != "" {
 			line1 = rightAlign(prefix+nameRendered, prInd, width)
 			prIndSet = true
 		}
 	}
 	if !prIndSet && !sess.IsReviewable() {
-		badge := d.sessionFocusStatus(sess)
+		badge := props.items.sessionFocusStatus(sess)
 		line1 = rightAlign(prefix+nameRendered, badge, width)
 	}
 
 	var taskDisplay string
-	if d.prDraftSessionID != "" && sess.ID == d.prDraftSessionID && repoPath == d.prDraftRepoPath {
+	if props.prDraftSessionID != "" && sess.ID == props.prDraftSessionID && repoPath == props.prDraftRepoPath {
 		taskDisplay = StyleWarning.Render(reviewSpinnerFrame(d.now) + " drafting PR…")
 	} else {
 		origPrompt := sess.OriginalPrompt()
@@ -1786,104 +1758,6 @@ func applySelectionHighlight(lines []string, rect vt.SelectionRect) string {
 	return strings.Join(result, "\n")
 }
 
-// selectedItem returns the currently selected list item, or nil if the list is empty.
-func (d dashboardModel) selectedItem() *listItem {
-	if d.selected < 0 || d.selected >= len(d.items) {
-		return nil
-	}
-	return &d.items[d.selected]
-}
-
-// selectedAgent returns the currently selected agent, or nil if a repo/session header is selected.
-func (d dashboardModel) selectedAgent() *agent.Agent {
-	item := d.selectedItem()
-	if item == nil || item.kind != listItemAgent {
-		return nil
-	}
-	return item.agent
-}
-
-// selectedSession returns the session for the currently selected item.
-// Works for both session and agent items.
-func (d dashboardModel) selectedSession() *agent.Session {
-	item := d.selectedItem()
-	if item == nil {
-		return nil
-	}
-	return item.session
-}
-
-// selectedRepoPath returns the repo path of the currently selected item.
-func (d dashboardModel) selectedRepoPath() string {
-	item := d.selectedItem()
-	if item == nil {
-		return ""
-	}
-	return item.repoPath
-}
-
-// clampToRepo adjusts selected to the nearest listItemRepo row.
-// Searches backward first (repo headers appear above their agents), then forward.
-func (d *dashboardModel) clampToRepo() {
-	if len(d.items) == 0 {
-		return
-	}
-	if d.selected >= len(d.items) {
-		d.selected = len(d.items) - 1
-	}
-	if d.selected < 0 {
-		d.selected = 0
-	}
-	if d.items[d.selected].kind == listItemRepo {
-		return
-	}
-	// Search backward first: repo headers appear above their agents.
-	for i := d.selected - 1; i >= 0; i-- {
-		if d.items[i].kind == listItemRepo {
-			d.selected = i
-			return
-		}
-	}
-	// Fall forward if no repo header above (shouldn't happen in a valid list).
-	for i := d.selected + 1; i < len(d.items); i++ {
-		if d.items[i].kind == listItemRepo {
-			d.selected = i
-			return
-		}
-	}
-}
-
-// clampToAgent adjusts selected to the nearest non-session row.
-// Searches forward first, then backward. Falls through to repo rows if no agents exist.
-func (d *dashboardModel) clampToAgent() {
-	if len(d.items) == 0 {
-		return
-	}
-	if d.selected >= len(d.items) {
-		d.selected = len(d.items) - 1
-	}
-	if d.selected < 0 {
-		d.selected = 0
-	}
-	if d.items[d.selected].kind != listItemSession {
-		return
-	}
-	// Search forward for an agent or repo.
-	for i := d.selected + 1; i < len(d.items); i++ {
-		if d.items[i].kind != listItemSession {
-			d.selected = i
-			return
-		}
-	}
-	// Search backward.
-	for i := d.selected - 1; i >= 0; i-- {
-		if d.items[i].kind != listItemSession {
-			d.selected = i
-			return
-		}
-	}
-}
-
 // clearSelection resets the mouse text-selection state. Safe to call when no
 // selection is active.
 func (d *dashboardModel) clearSelection() {
@@ -1909,15 +1783,4 @@ func (d dashboardModel) selectionRect() (startX, startY, endX, endY int, ok bool
 		startY, endY = endY, startY
 	}
 	return startX, startY, endX, endY, true
-}
-
-// agentItems returns all agent items from the list (for resize operations).
-func (d dashboardModel) agentItems() []*agent.Agent {
-	var result []*agent.Agent
-	for _, item := range d.items {
-		if item.kind == listItemAgent {
-			result = append(result, item.agent)
-		}
-	}
-	return result
 }

--- a/internal/tui/dashboard_props.go
+++ b/internal/tui/dashboard_props.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"time"
+
+	"github.com/devenjarvis/refrain/internal/agent"
+)
+
+// dashboardProps carries every value the dashboard renders from but does not
+// own. App.dashboardProps() rebuilds it fresh each frame and threads it into
+// dashboardModel.View/Update (and their render helpers), so the dashboard reads
+// live App state without mirroring it onto its own struct — the CONVENTIONS.md
+// §5/§6 replacement for the old syncModalsToDashboard / refreshAgentList sync
+// path. It is the dashboard's analogue of PanelServices.
+//
+// Purity rule (§5): every time-derived field here is computed from the
+// tick-refreshed render clock (dashboardModel.now), never time.Now(), because
+// dashboardProps() is invoked inside View().
+type dashboardProps struct {
+	// Modal state, owned by App.modals.
+	panelFocus         panelFocus
+	repoConfigForm     *configForm
+	configRepoPath     string
+	repoChecksEditor   *repoChecksModel
+	repoChecksRepoPath string
+	focusLaunchAgent   *agent.Agent
+	focusLaunchSession *agent.Session
+
+	// Pipeline cursor, owned by App.cursor.
+	cursor FocusedCursor
+
+	// Wellness snapshot, owned by App.wellness. Elapsed values are computed
+	// against the render clock (see purity rule above).
+	sessionElapsed         time.Duration
+	focusSessionMinutes    int
+	focusBreakMode         bool
+	focusBreakElapsed      time.Duration
+	focusBlockCount        int
+	focusBreakMinutes      int
+	focusBreakAnimFrame    int
+	focusBreakShortWarning bool
+	focusBreakTimerUp      bool
+
+	// PR draft-in-flight indicator, owned by App.
+	prDraftSessionID string
+	prDraftRepoPath  string
+
+	// Active repo, owned by App.
+	activeRepoName string
+	activeRepoPath string
+
+	// Per-session caches, owned by App. Only the entries the dashboard renders
+	// are carried: the PR badge cache and the session closing-set.
+	prCache         map[string]*prCacheEntry
+	closingSessions map[string]bool
+
+	// items is the hierarchical repo/session/agent row list, rebuilt from the
+	// managers each frame by App.listItems().
+	items listItems
+}

--- a/internal/tui/dashboard_props_test_helpers_test.go
+++ b/internal/tui/dashboard_props_test_helpers_test.go
@@ -1,0 +1,52 @@
+package tui
+
+import (
+	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
+)
+
+// seedDashboardItems wires app.managers / app.cfg / app.activeRepo so that
+// app.listItems() reproduces the hierarchical item list the caller passes.
+//
+// Before Phase 3 these tests injected the list straight onto the dashboard
+// model (app.dashboard.items = []listItem{…}); that mirror field is gone, so
+// the list is now derived live from the managers each frame. This helper keeps
+// the call sites nearly identical — wrap the old literal in seedDashboardItems
+// — while routing the data through the real derivation path.
+//
+// Agent rows in the input are ignored: each session already carries its agents
+// (added via Session.AddTestAgent), and listItems() regenerates the agent rows
+// from sess.Agents(). Repo headers define the cfg repo order and display name.
+func seedDashboardItems(app *App, items []listItem) {
+	var order []string
+	seen := map[string]bool{}
+	sessByRepo := map[string][]*agent.Session{}
+	repoName := map[string]string{}
+	for _, it := range items {
+		rp := it.repoPath
+		if !seen[rp] {
+			seen[rp] = true
+			order = append(order, rp)
+		}
+		switch it.kind {
+		case listItemRepo:
+			repoName[rp] = it.repoName
+		case listItemSession:
+			if it.session != nil {
+				sessByRepo[rp] = append(sessByRepo[rp], it.session)
+			}
+		}
+	}
+	for _, rp := range order {
+		app.managers[rp] = newFakeManager(rp, sessByRepo[rp]...)
+	}
+	// Build cfg so listItems() emits repo headers in the same order as the
+	// injected list (matching the legacy hierarchical layout the tests expect).
+	app.cfg = &config.Config{}
+	for _, rp := range order {
+		app.cfg.Repos = append(app.cfg.Repos, config.Repo{Path: rp, Alias: repoName[rp]})
+	}
+	if len(order) > 0 && app.activeRepo == "" {
+		app.activeRepo = order[0]
+	}
+}

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -114,16 +114,20 @@ func TestClearSelection(t *testing.T) {
 }
 
 // tickerDashboard builds a minimal dashboardModel for ticker tests with
-// sidebarWidth=30 (yielding maxNameLen=20 in the ticker tests below).
-func tickerDashboard(sessions ...*agent.Session) dashboardModel {
+// sidebarWidth=30 (yielding maxNameLen=20 in the ticker tests below). It also
+// returns the dashboardProps carrying the session items (plus empty prCache /
+// closingSessions maps) that advanceTickers now reads from.
+func tickerDashboard(sessions ...*agent.Session) (dashboardModel, dashboardProps) {
 	d := newDashboardModel()
 	d.sidebarWidth = 30
-	d.prCache = make(map[string]*prCacheEntry)
-	d.closingSessions = make(map[string]bool)
-	for _, s := range sessions {
-		d.items = append(d.items, listItem{kind: listItemSession, session: s})
+	props := dashboardProps{
+		prCache:         make(map[string]*prCacheEntry),
+		closingSessions: make(map[string]bool),
 	}
-	return d
+	for _, s := range sessions {
+		props.items = append(props.items, listItem{kind: listItemSession, session: s})
+	}
+	return d, props
 }
 
 // past returns a time in the past so ticker pause/advance checks pass immediately.
@@ -171,8 +175,8 @@ func TestTickerSlice_MultibyteRunes(t *testing.T) {
 func TestAdvanceTickers_NameFits_NoTickerCreated(t *testing.T) {
 	// sidebarW=30 → maxNameLen=20; "short" (5 chars) fits easily.
 	sess := &agent.Session{ID: "s1", Name: "short"}
-	d := tickerDashboard(sess)
-	d.advanceTickers(time.Now())
+	d, props := tickerDashboard(sess)
+	d.advanceTickers(time.Now(), props)
 	if _, exists := d.tickers["s1"]; exists {
 		t.Error("ticker should not be created for a name that fits")
 	}
@@ -181,9 +185,9 @@ func TestAdvanceTickers_NameFits_NoTickerCreated(t *testing.T) {
 func TestAdvanceTickers_NameFits_ClearsStale(t *testing.T) {
 	// Stale ticker entry from a previous long name should be removed.
 	sess := &agent.Session{ID: "s1", Name: "short"}
-	d := tickerDashboard(sess)
+	d, props := tickerDashboard(sess)
 	d.tickers["s1"] = &sessionTicker{offset: 5}
-	d.advanceTickers(time.Now())
+	d.advanceTickers(time.Now(), props)
 	if _, exists := d.tickers["s1"]; exists {
 		t.Error("stale ticker should be removed when name fits")
 	}
@@ -193,9 +197,9 @@ func TestAdvanceTickers_OverflowCreatesTickerWithPause(t *testing.T) {
 	// sidebarW=30 → maxNameLen=20; long name (26 chars) overflows.
 	longName := "abcdefghijklmnopqrstuvwxyz"
 	sess := &agent.Session{ID: "s1", Name: longName}
-	d := tickerDashboard(sess)
+	d, props := tickerDashboard(sess)
 	now := time.Now()
-	d.advanceTickers(now)
+	d.advanceTickers(now, props)
 	tk := d.tickers["s1"]
 	if tk == nil {
 		t.Fatal("expected ticker to be created for overflowing name")
@@ -211,10 +215,10 @@ func TestAdvanceTickers_OverflowCreatesTickerWithPause(t *testing.T) {
 func TestAdvanceTickers_AdvancePastPause_IncrementsOffset(t *testing.T) {
 	longName := "abcdefghijklmnopqrstuvwxyz"
 	sess := &agent.Session{ID: "s1", Name: longName}
-	d := tickerDashboard(sess)
+	d, props := tickerDashboard(sess)
 	// Pre-seed expired ticker so initial pause is already over.
 	d.tickers["s1"] = &sessionTicker{pauseUntil: past(), nextAdvance: past()}
-	d.advanceTickers(time.Now())
+	d.advanceTickers(time.Now(), props)
 	tk := d.tickers["s1"]
 	if tk.offset != 1 {
 		t.Errorf("offset after advance: got %d, want 1", tk.offset)
@@ -227,9 +231,9 @@ func TestAdvanceTickers_WideCharName_ScrollsNotStuck(t *testing.T) {
 	// offset=0 (0+20=20 >= 14), preventing the name from ever scrolling.
 	wideName := strings.Repeat("日", 12)
 	sess := &agent.Session{ID: "s1", Name: wideName}
-	d := tickerDashboard(sess)
+	d, props := tickerDashboard(sess)
 	d.tickers["s1"] = &sessionTicker{pauseUntil: past(), nextAdvance: past()}
-	d.advanceTickers(time.Now())
+	d.advanceTickers(time.Now(), props)
 	tk := d.tickers["s1"]
 	if tk.atEnd {
 		t.Error("wide-char name: atEnd should not fire on first advance")
@@ -245,11 +249,11 @@ func TestAdvanceTickers_EndReached_SnapsBack(t *testing.T) {
 	// end condition: offset+20 >= 28 → offset >= 8
 	longName := "12345678901234567890123456"
 	sess := &agent.Session{ID: "s1", Name: longName}
-	d := tickerDashboard(sess)
+	d, props := tickerDashboard(sess)
 
 	// Set offset to 7 (one step before end); advance once → hits 8 → atEnd=true.
 	d.tickers["s1"] = &sessionTicker{offset: 7, pauseUntil: past(), nextAdvance: past()}
-	d.advanceTickers(time.Now())
+	d.advanceTickers(time.Now(), props)
 	tk := d.tickers["s1"]
 	if !tk.atEnd {
 		t.Fatal("expected atEnd=true after reaching end")
@@ -262,7 +266,7 @@ func TestAdvanceTickers_EndReached_SnapsBack(t *testing.T) {
 	tk.pauseUntil = past()
 	tk.nextAdvance = past()
 	beforeSnap := time.Now()
-	d.advanceTickers(time.Now())
+	d.advanceTickers(time.Now(), props)
 	if tk.offset != 0 {
 		t.Errorf("offset after snap: got %d, want 0", tk.offset)
 	}
@@ -282,14 +286,12 @@ func TestSessionFocusPriority_DefaultIsIdle(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleInProgress)
 	ag := &agent.Agent{Name: "a1"}
 
-	d := newDashboardModel()
-	d.prCache = make(map[string]*prCacheEntry)
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, session: sess},
 		{kind: listItemAgent, session: sess, agent: ag},
 	}
 
-	if got := d.sessionFocusPriority(sess); got != 3 {
+	if got := items.sessionFocusPriority(sess); got != 3 {
 		t.Errorf("sessionFocusPriority with StatusStarting agent: got %d, want 3", got)
 	}
 }
@@ -308,17 +310,15 @@ func TestSessionFocusPriority_ActiveBeforeIdle(t *testing.T) {
 	sessIdle.SetLifecyclePhase(agent.LifecycleInProgress)
 	agIdle := &agent.Agent{Name: "ag-idle"}
 
-	d := newDashboardModel()
-	d.prCache = make(map[string]*prCacheEntry)
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, session: sessActive},
 		{kind: listItemAgent, session: sessActive, agent: agActive},
 		{kind: listItemSession, session: sessIdle},
 		{kind: listItemAgent, session: sessIdle, agent: agIdle},
 	}
 
-	pa := d.sessionFocusPriority(sessActive)
-	pi := d.sessionFocusPriority(sessIdle)
+	pa := items.sessionFocusPriority(sessActive)
+	pi := items.sessionFocusPriority(sessIdle)
 	if pa != 2 {
 		t.Errorf("active session priority: got %d, want 2", pa)
 	}
@@ -342,17 +342,15 @@ func TestAllInProgressSessions_SortOrder(t *testing.T) {
 	// Drive to StatusActive.
 	agActive.OnHookEvent(hook.Event{Kind: hook.KindSessionStart})
 
-	d := newDashboardModel()
-	d.prCache = make(map[string]*prCacheEntry)
 	// Idle session is listed first in items; active second — sort should invert.
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, session: sessIdle},
 		{kind: listItemAgent, session: sessIdle, agent: agIdle},
 		{kind: listItemSession, session: sessActive},
 		{kind: listItemAgent, session: sessActive, agent: agActive},
 	}
 
-	sessions := d.buildingSessions()
+	sessions := items.buildingSessions()
 	if len(sessions) != 2 {
 		t.Fatalf("expected 2 sessions, got %d", len(sessions))
 	}
@@ -378,17 +376,15 @@ func TestAllInProgressSessions_StableWithinPriority(t *testing.T) {
 	sessNewer := &agent.Session{ID: "sn", Name: "newer", CreatedAt: t0.Add(time.Minute)}
 	sessNewer.SetLifecyclePhase(agent.LifecycleInProgress)
 
-	d := newDashboardModel()
-	d.prCache = make(map[string]*prCacheEntry)
 	// Insert newer first so we can confirm the sort actually runs and the
 	// result is keyed on CreatedAt, not insertion order.
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, session: sessNewer},
 		{kind: listItemSession, session: sessOlder},
 	}
 
 	for i := 0; i < 5; i++ {
-		sessions := d.buildingSessions()
+		sessions := items.buildingSessions()
 		if len(sessions) != 2 {
 			t.Fatalf("iter %d: expected 2 sessions, got %d", i, len(sessions))
 		}
@@ -414,15 +410,13 @@ func TestReviewQueueSessions_IncludesInReview(t *testing.T) {
 	sessProgress := &agent.Session{ID: "sp", Name: "in-progress"}
 	sessProgress.SetLifecyclePhase(agent.LifecycleInProgress)
 
-	d := newDashboardModel()
-	d.prCache = make(map[string]*prCacheEntry)
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, session: sessReady},
 		{kind: listItemSession, session: sessInReview},
 		{kind: listItemSession, session: sessProgress},
 	}
 
-	queue := d.reviewQueueSessions()
+	queue := items.reviewQueueSessions()
 	if len(queue) != 2 {
 		t.Fatalf("expected 2 sessions in queue (Ready+InReview), got %d", len(queue))
 	}
@@ -449,12 +443,11 @@ func TestRenderPipelineWidget_CountsDraftingAsPlanning(t *testing.T) {
 	sessDrafting.SetLifecyclePhase(agent.LifecycleDrafting)
 
 	d := newDashboardModel()
-	d.prCache = make(map[string]*prCacheEntry)
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, session: sessDrafting},
 	}
 
-	out := ansi.Strip(d.renderPipelineWidget(120))
+	out := ansi.Strip(d.renderPipelineWidget(dashboardProps{items: items}, 120))
 	// Cells are joined horizontally so the labels share a row and the counts
 	// share the row below. Find the count row by locating the line that holds
 	// the BUILDING/REVIEWING/SHIPPING zeros, then slice out the leading
@@ -503,16 +496,14 @@ func TestPlanningSessions_OnlyPlanningPhase(t *testing.T) {
 	sessShipping := &agent.Session{ID: "ss", Name: "shipping"}
 	sessShipping.SetLifecyclePhase(agent.LifecycleShipping)
 
-	d := newDashboardModel()
-	d.prCache = make(map[string]*prCacheEntry)
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, session: sessPlanning},
 		{kind: listItemSession, session: sessBuilding},
 		{kind: listItemSession, session: sessReady},
 		{kind: listItemSession, session: sessShipping},
 	}
 
-	planning := d.planningSessions()
+	planning := items.planningSessions()
 	if len(planning) != 1 || planning[0].session != sessPlanning {
 		t.Fatalf("expected exactly the planning session, got %d entries", len(planning))
 	}
@@ -531,15 +522,13 @@ func TestShippingSessions_OnlyShippingPhase(t *testing.T) {
 	sessReady := &agent.Session{ID: "sr", Name: "ready"}
 	sessReady.SetLifecyclePhase(agent.LifecycleReadyForReview)
 
-	d := newDashboardModel()
-	d.prCache = make(map[string]*prCacheEntry)
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, session: sessShipping},
 		{kind: listItemSession, session: sessComplete},
 		{kind: listItemSession, session: sessReady},
 	}
 
-	shipping := d.shippingSessions()
+	shipping := items.shippingSessions()
 	if len(shipping) != 1 || shipping[0].session != sessShipping {
 		t.Fatalf("expected exactly the shipping session, got %d entries", len(shipping))
 	}
@@ -715,9 +704,10 @@ func TestRenderQueueRow_PRDraftBadge(t *testing.T) {
 
 	repo := "/repo/a"
 
+	var d dashboardModel
 	// With prDraftSessionID+prDraftRepoPath matching the session: badge should appear.
-	d := dashboardModel{prDraftSessionID: sess.ID, prDraftRepoPath: repo}
-	rows := d.renderQueueRow(sess, "", repo, false, ColorWarning, 80)
+	props := dashboardProps{prDraftSessionID: sess.ID, prDraftRepoPath: repo}
+	rows := d.renderQueueRow(props, sess, "", repo, false, ColorWarning, 80)
 	if len(rows) < 2 {
 		t.Fatalf("renderQueueRow returned %d lines, want 2", len(rows))
 	}
@@ -726,9 +716,9 @@ func TestRenderQueueRow_PRDraftBadge(t *testing.T) {
 	}
 
 	// With prDraftSessionID cleared: normal prompt should appear.
-	d.prDraftSessionID = ""
-	d.prDraftRepoPath = ""
-	rows = d.renderQueueRow(sess, "", repo, false, ColorWarning, 80)
+	props.prDraftSessionID = ""
+	props.prDraftRepoPath = ""
+	rows = d.renderQueueRow(props, sess, "", repo, false, ColorWarning, 80)
 	if strings.Contains(ansi.Strip(rows[1]), "drafting PR") {
 		t.Error("cleared state must not show badge; got 'drafting PR' on line 2")
 	}
@@ -765,13 +755,14 @@ func TestRenderQueueRow_PRDraftBadge_OnlyTargetSession(t *testing.T) {
 		targetIdx := rapid.IntRange(0, len(all)-1).Draw(t, "target")
 		target := all[targetIdx]
 
-		d := dashboardModel{
+		var d dashboardModel
+		props := dashboardProps{
 			prDraftSessionID: target.sess.ID,
 			prDraftRepoPath:  target.repoPath,
 		}
 
 		for i, rs := range all {
-			rows := d.renderQueueRow(rs.sess, "", rs.repoPath, false, ColorWarning, 80)
+			rows := d.renderQueueRow(props, rs.sess, "", rs.repoPath, false, ColorWarning, 80)
 			if len(rows) < 2 {
 				t.Fatalf("renderQueueRow for item %d returned %d lines, want 2", i, len(rows))
 			}

--- a/internal/tui/focus_render_test.go
+++ b/internal/tui/focus_render_test.go
@@ -16,6 +16,23 @@ import (
 // unselected sessions. The "> " chevron is also present on the selected row
 // (an ANSI-stripped fallback signal for screenshots / terminal recordings),
 // but the cyan stripe is the assertion this test owns.
+// TestRenderFullscreenFocus_ZeroWidthDoesNotPanic guards the first-frame render
+// path: before the initial WindowSizeMsg, the dashboard width is 0. Because the
+// item list is now derived live from cfg (props.items includes repo headers
+// immediately), View() reaches renderFullscreenFocus before a size is known, so
+// the header separator must not feed strings.Repeat a negative count.
+func TestRenderFullscreenFocus_ZeroWidthDoesNotPanic(t *testing.T) {
+	d := newDashboardModel()
+	// Single repo header, no sessions — the realistic pre-WindowSizeMsg state.
+	props := dashboardProps{items: listItems{
+		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
+	}}
+	// width 0, height 0: must not panic.
+	_ = d.renderFullscreenFocus(props, 0, 0)
+	// width 1 still yields width-2 < 0 for the separator.
+	_ = d.renderFullscreenFocus(props, 1, 5)
+}
+
 func TestRenderFocusActiveCursor(t *testing.T) {
 	// Force TrueColor so the rendered ANSI escapes carry the foreground color
 	// we want to assert against. Without this, lipgloss strips colors when
@@ -33,14 +50,15 @@ func TestRenderFocusActiveCursor(t *testing.T) {
 	d := newDashboardModel()
 	d.width = 120
 	d.height = 39
-	d.cursor.JumpTo(focusSectionBuilding, 1)
-	d.items = []listItem{
+	var cur FocusedCursor
+	cur.JumpTo(focusSectionBuilding, 1)
+	items := listItems{
 		{kind: listItemRepo, repoPath: "/r", repoName: "repo"},
 		{kind: listItemSession, repoPath: "/r", session: sessA},
 		{kind: listItemSession, repoPath: "/r", session: sessB},
 	}
 
-	out := d.renderFullscreenFocus(120, 39)
+	out := d.renderFullscreenFocus(dashboardProps{items: items, cursor: cur}, 120, 39)
 
 	selectedStripe := lipgloss.NewStyle().Foreground(ColorSecondary).Render("▎")
 	if !strings.Contains(selectedStripe, "▎") {
@@ -87,13 +105,12 @@ func TestSessionFocusStatus_IdleReviewableShowsCue(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleInProgress)
 	ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := d.sessionFocusStatus(sess)
+	badge := items.sessionFocusStatus(sess)
 	if !strings.Contains(badge, "press m to review") {
 		t.Errorf("expected reviewable cue, got %q", badge)
 	}
@@ -107,13 +124,12 @@ func TestSessionFocusStatus_ActiveDoesNotShowCue(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleInProgress)
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := d.sessionFocusStatus(sess)
+	badge := items.sessionFocusStatus(sess)
 	if strings.Contains(badge, "press m to review") {
 		t.Errorf("did not expect reviewable cue with active agent, got %q", badge)
 	}
@@ -128,13 +144,12 @@ func TestSessionFocusStripeColor_IdleReviewableMatchesBadge(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleInProgress)
 	ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	if got := d.sessionFocusStripeColor(sess); got != ColorSuccess {
+	if got := items.sessionFocusStripeColor(sess); got != ColorSuccess {
 		t.Errorf("expected stripe ColorSuccess for idle-reviewable session, got %v", got)
 	}
 }
@@ -148,13 +163,12 @@ func TestSessionFocusStatus_FinishedTakesPrecedence(t *testing.T) {
 	ag := sess.AddTestAgent("a-1", false, agent.StatusDone)
 	sess.MarkDone()
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := d.sessionFocusStatus(sess)
+	badge := items.sessionFocusStatus(sess)
 	if !strings.Contains(badge, "finished") {
 		t.Errorf("expected finished badge to win, got %q", badge)
 	}
@@ -176,12 +190,12 @@ func TestRenderFocusSessionCard_RepoPrefix(t *testing.T) {
 
 	d := newDashboardModel()
 	d.width = 120
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/a", repoName: "repoA", session: sessA},
 		{kind: listItemSession, repoPath: "/b", repoName: "repoB", session: sessB},
 	}
 
-	card := d.renderFocusSessionCard(sessA, "repoA", false, 120)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sessA, "repoA", false, 120)
 	if len(card) == 0 {
 		t.Fatalf("expected at least one rendered line")
 	}
@@ -201,7 +215,7 @@ func TestRenderFocusSessionCard_RepoPrefix(t *testing.T) {
 
 	// Empty repoName must not render the separator (defensive — the prefix is
 	// optional even though every real call passes a non-empty value).
-	bare := d.renderFocusSessionCard(sessA, "", false, 120)
+	bare := d.renderFocusSessionCard(dashboardProps{items: items}, sessA, "", false, 120)
 	if strings.Contains(ansi.Strip(bare[0]), "›") {
 		t.Errorf("empty repoName should not emit › separator, got %q", ansi.Strip(bare[0]))
 	}
@@ -265,13 +279,12 @@ func TestSessionFocusStatus_BuildingWithTodosShowsProgressBadge(t *testing.T) {
 		{Content: "step three", Status: "pending", ActiveForm: ""},
 	})
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	badge := ansi.Strip(items.sessionFocusStatus(sess))
 	if !strings.Contains(badge, "1/3") {
 		t.Errorf("expected progress badge with 1/3, got %q", badge)
 	}
@@ -290,13 +303,12 @@ func TestSessionFocusStatus_BuildingWithTodosErrorPreempts(t *testing.T) {
 		{Content: "step one", Status: "in_progress", ActiveForm: "Doing step one"},
 	})
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	badge := ansi.Strip(items.sessionFocusStatus(sess))
 	if !strings.Contains(badge, "error") {
 		t.Errorf("expected error badge to preempt todos, got %q", badge)
 	}
@@ -371,11 +383,11 @@ func TestRenderQueueRow_RepoPrefix(t *testing.T) {
 
 	d := newDashboardModel()
 	d.width = 120
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/a", repoName: "repoA", session: sess},
 	}
 
-	row := d.renderQueueRow(sess, "repoA", "", false, ColorWarning, 120)
+	row := d.renderQueueRow(dashboardProps{items: items}, sess, "repoA", "", false, ColorWarning, 120)
 	if len(row) == 0 {
 		t.Fatalf("expected at least one rendered line")
 	}
@@ -393,7 +405,7 @@ func TestRenderQueueRow_RepoPrefix(t *testing.T) {
 		}
 	}
 
-	bare := d.renderQueueRow(sess, "", "", false, ColorWarning, 120)
+	bare := d.renderQueueRow(dashboardProps{items: items}, sess, "", "", false, ColorWarning, 120)
 	if strings.Contains(ansi.Strip(bare[0]), "›") {
 		t.Errorf("empty repoName should not emit › separator, got %q", ansi.Strip(bare[0]))
 	}
@@ -414,12 +426,12 @@ func TestRenderFocusSessionCard_PlanBackedBuildingHasTaskProgressLine(t *testing
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 100)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 100)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card for plan-backed building session, got %d lines: %v", len(card), card)
 	}
@@ -460,12 +472,12 @@ func TestRenderFocusSessionCard_BuildingDescriptionFallsBackToOriginalPrompt(t *
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 100)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 100)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card, got %d", len(card))
 	}
@@ -488,12 +500,12 @@ func TestRenderFocusSessionCard_BuildingNoTasksFallsBackToDescriptionOverflow(t 
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 60)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 60)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card, got %d", len(card))
 	}
@@ -520,12 +532,12 @@ func TestRenderFocusSessionCard_BuildingNoTasksShortDescription(t *testing.T) {
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 100)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 100)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card, got %d", len(card))
 	}
@@ -559,12 +571,12 @@ func TestRenderFocusSessionCard_PlanBackedBuilding_TodoOverridesPlan(t *testing.
 	})
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 100)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 100)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card, got %d", len(card))
 	}
@@ -601,12 +613,12 @@ func TestRenderFocusSessionCard_PlanWithSingleOpenTaskDropsNextSuffix(t *testing
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 100)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 100)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card with single open task, got %d lines", len(card))
 	}
@@ -638,12 +650,12 @@ func TestRenderFocusSessionCard_PlanWithNoOpenTasksStaysFourLines(t *testing.T) 
 	ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 100)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 100)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card when all tasks done, got %d lines", len(card))
 	}
@@ -657,12 +669,12 @@ func TestRenderFocusSessionCard_NoPlanStaysFourLines(t *testing.T) {
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 100)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 100)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card with no plan, got %d lines", len(card))
 	}
@@ -692,13 +704,12 @@ func TestSessionFocusStatus_PlanProgressBeatsStaleTodos(t *testing.T) {
 		{Content: "step five", Status: "pending"},
 	})
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	badge := ansi.Strip(items.sessionFocusStatus(sess))
 	if !strings.Contains(badge, "2/5") {
 		t.Errorf("expected plan-driven badge '2/5', got %q", badge)
 	}
@@ -723,13 +734,12 @@ func TestSessionFocusStatus_BuildingWithPlanShowsProgressBadge(t *testing.T) {
 	}
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := d.sessionFocusStatus(sess)
+	badge := items.sessionFocusStatus(sess)
 	stripped := ansi.Strip(badge)
 	// Must contain the "1/3" count.
 	if !strings.Contains(stripped, "1/3") {
@@ -760,13 +770,12 @@ func TestSessionFocusStatus_BuildingWithPlanPreemptedByError(t *testing.T) {
 	}
 	ag := sess.AddTestAgent("a-1", false, agent.StatusError)
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	badge := ansi.Strip(items.sessionFocusStatus(sess))
 	if !strings.Contains(badge, "error") {
 		t.Errorf("expected error badge to preempt plan progress, got %q", badge)
 	}
@@ -786,13 +795,12 @@ func TestSessionFocusStatus_BuildingWithPlanPreemptedByWaiting(t *testing.T) {
 	}
 	ag := sess.AddTestAgent("a-1", false, agent.StatusWaiting)
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	badge := ansi.Strip(items.sessionFocusStatus(sess))
 	if !strings.Contains(badge, "waiting") {
 		t.Errorf("expected waiting badge to preempt plan progress, got %q", badge)
 	}
@@ -815,13 +823,12 @@ func TestSessionFocusStatus_BuildingWithPlanAllDoneReviewablePrefersReviewBadge(
 	// Idle agent → IsReviewable() == true and DoneAt is zero.
 	ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
 
-	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	badge := ansi.Strip(d.sessionFocusStatus(sess))
+	badge := ansi.Strip(items.sessionFocusStatus(sess))
 	if !strings.Contains(badge, "press m to review") {
 		t.Errorf("expected review badge to win when all tasks done + reviewable, got %q", badge)
 	}
@@ -883,16 +890,16 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		setup     func() (*agent.Session, []listItem)
+		setup     func() (*agent.Session, listItems)
 		wantGlyph string
 	}{
 		{
 			name: "error → ✗",
-			setup: func() (*agent.Session, []listItem) {
+			setup: func() (*agent.Session, listItems) {
 				sess := agent.NewSessionForTest("s", "my-session")
 				sess.SetLifecyclePhase(agent.LifecycleInProgress)
 				ag := sess.AddTestAgent("a-1", false, agent.StatusError)
-				return sess, []listItem{
+				return sess, listItems{
 					{kind: listItemSession, repoPath: "/r", session: sess},
 					{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 				}
@@ -901,11 +908,11 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 		},
 		{
 			name: "waiting → ⏸",
-			setup: func() (*agent.Session, []listItem) {
+			setup: func() (*agent.Session, listItems) {
 				sess := agent.NewSessionForTest("s", "my-session")
 				sess.SetLifecyclePhase(agent.LifecycleInProgress)
 				ag := sess.AddTestAgent("a-1", false, agent.StatusWaiting)
-				return sess, []listItem{
+				return sess, listItems{
 					{kind: listItemSession, repoPath: "/r", session: sess},
 					{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 				}
@@ -914,11 +921,11 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 		},
 		{
 			name: "active → ●",
-			setup: func() (*agent.Session, []listItem) {
+			setup: func() (*agent.Session, listItems) {
 				sess := agent.NewSessionForTest("s", "my-session")
 				sess.SetLifecyclePhase(agent.LifecycleInProgress)
 				ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
-				return sess, []listItem{
+				return sess, listItems{
 					{kind: listItemSession, repoPath: "/r", session: sess},
 					{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 				}
@@ -927,11 +934,11 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 		},
 		{
 			name: "reviewable → ✓",
-			setup: func() (*agent.Session, []listItem) {
+			setup: func() (*agent.Session, listItems) {
 				sess := agent.NewSessionForTest("s", "my-session")
 				sess.SetLifecyclePhase(agent.LifecycleInProgress)
 				ag := sess.AddTestAgent("a-1", false, agent.StatusIdle)
-				return sess, []listItem{
+				return sess, listItems{
 					{kind: listItemSession, repoPath: "/r", session: sess},
 					{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 				}
@@ -940,10 +947,10 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 		},
 		{
 			name: "idle, no agents → ○",
-			setup: func() (*agent.Session, []listItem) {
+			setup: func() (*agent.Session, listItems) {
 				sess := agent.NewSessionForTest("s", "my-session")
 				sess.SetLifecyclePhase(agent.LifecycleInProgress)
-				return sess, []listItem{
+				return sess, listItems{
 					{kind: listItemSession, repoPath: "/r", session: sess},
 				}
 			},
@@ -955,8 +962,7 @@ func TestRenderFocusSessionCard_StatusGlyphMapping(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sess, items := tc.setup()
 			d := newDashboardModel()
-			d.items = items
-			card := d.renderFocusSessionCard(sess, "", false, 100)
+			card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 100)
 			line1 := ansi.Strip(card[0])
 			if !strings.Contains(line1, tc.wantGlyph) {
 				t.Errorf("line 1 should contain glyph %q, got %q", tc.wantGlyph, line1)
@@ -980,12 +986,12 @@ func TestRenderFocusSessionCard_BranchChipAndElapsedGlyph(t *testing.T) {
 	ag := sess.AddTestAgent("a-1", false, agent.StatusActive)
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 120)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 120)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card, got %d", len(card))
 	}
@@ -1016,11 +1022,11 @@ func TestRenderFocusSessionCard_BranchChipAndElapsedGlyph(t *testing.T) {
 	sessNoBranch.SetLifecyclePhase(agent.LifecycleInProgress)
 	ag2 := sessNoBranch.AddTestAgent("a-2", false, agent.StatusActive)
 	d2 := newDashboardModel()
-	d2.items = []listItem{
+	items2 := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sessNoBranch},
 		{kind: listItemAgent, repoPath: "/r", session: sessNoBranch, agent: ag2},
 	}
-	card2 := d2.renderFocusSessionCard(sessNoBranch, "", false, 120)
+	card2 := d2.renderFocusSessionCard(dashboardProps{items: items2}, sessNoBranch, "", false, 120)
 	line4b := ansi.Strip(card2[3])
 	if strings.Contains(line4b, "⎇") {
 		t.Errorf("no-branch session should not render ⎇ label, got %q", line4b)
@@ -1154,12 +1160,12 @@ func TestRenderFocusSessionCard_StaleTodosLineLine3UsesPlan(t *testing.T) {
 	})
 
 	d := newDashboardModel()
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemSession, repoPath: "/r", session: sess},
 		{kind: listItemAgent, repoPath: "/r", session: sess, agent: ag},
 	}
 
-	card := d.renderFocusSessionCard(sess, "", false, 100)
+	card := d.renderFocusSessionCard(dashboardProps{items: items}, sess, "", false, 100)
 	if len(card) != 4 {
 		t.Fatalf("expected 4-line card, got %d lines", len(card))
 	}
@@ -1180,7 +1186,7 @@ func TestRenderFocusSessionCard_StaleTodosLineLine3UsesPlan(t *testing.T) {
 
 // TestHeaderOmitsCrossRepoSummary verifies that renderFullscreenFocus never
 // emits a "repo: " label or a "|" cross-repo separator on the header line,
-// even when multiple repo items are present in d.items.
+// even when multiple repo items are present in the item list.
 func TestHeaderOmitsCrossRepoSummary(t *testing.T) {
 	sessA := agent.NewSessionForTest("s-a", "add-dark-mode")
 	sessA.SetLifecyclePhase(agent.LifecycleInProgress)
@@ -1190,14 +1196,14 @@ func TestHeaderOmitsCrossRepoSummary(t *testing.T) {
 	d := newDashboardModel()
 	d.width = 120
 	d.height = 39
-	d.items = []listItem{
+	items := listItems{
 		{kind: listItemRepo, repoPath: "/a", repoName: "repoA"},
 		{kind: listItemSession, repoPath: "/a", repoName: "repoA", session: sessA},
 		{kind: listItemRepo, repoPath: "/b", repoName: "repoB"},
 		{kind: listItemSession, repoPath: "/b", repoName: "repoB", session: sessB},
 	}
 
-	out := d.renderFullscreenFocus(120, 39)
+	out := d.renderFullscreenFocus(dashboardProps{items: items}, 120, 39)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) == 0 {
@@ -1231,11 +1237,11 @@ func TestSessionFocusStatus_BuildingProgressCombinesPlanAndCommits(t *testing.T)
 		return sess
 	}
 
-	d := newDashboardModel()
+	var items listItems
 
 	t.Run("plan_only_1_of_5", func(t *testing.T) {
 		sess := newBuildingSession(t, plan5) // 1 checked, 5 total
-		badge := ansi.Strip(d.sessionFocusStatus(sess))
+		badge := ansi.Strip(items.sessionFocusStatus(sess))
 		if !strings.Contains(badge, "1/5") {
 			t.Errorf("expected 1/5 badge, got %q", badge)
 		}
@@ -1244,7 +1250,7 @@ func TestSessionFocusStatus_BuildingProgressCombinesPlanAndCommits(t *testing.T)
 	t.Run("commits_ahead_of_checkboxes_3_of_5", func(t *testing.T) {
 		sess := newBuildingSession(t, plan5) // 1 checked, 5 total
 		sess.SetCommitTaskCountForTest(3, 3) // commits: done=3, max=3
-		badge := ansi.Strip(d.sessionFocusStatus(sess))
+		badge := ansi.Strip(items.sessionFocusStatus(sess))
 		if !strings.Contains(badge, "3/5") {
 			t.Errorf("expected 3/5 badge (commits ahead of checkboxes), got %q", badge)
 		}
@@ -1257,7 +1263,7 @@ func TestSessionFocusStatus_BuildingProgressCombinesPlanAndCommits(t *testing.T)
 			t.Fatalf("WritePlan: %v", err)
 		}
 		sess.SetCommitTaskCountForTest(4, 4) // commits: done=4, max=4
-		badge := ansi.Strip(d.sessionFocusStatus(sess))
+		badge := ansi.Strip(items.sessionFocusStatus(sess))
 		if !strings.Contains(badge, "4/5") {
 			t.Errorf("expected 4/5 badge (max(2,4)/max(5,4)), got %q", badge)
 		}
@@ -1266,7 +1272,7 @@ func TestSessionFocusStatus_BuildingProgressCombinesPlanAndCommits(t *testing.T)
 	t.Run("no_plan_commits_drive_bar", func(t *testing.T) {
 		sess := newBuildingSession(t, "") // no plan
 		sess.SetCommitTaskCountForTest(2, 3)
-		badge := ansi.Strip(d.sessionFocusStatus(sess))
+		badge := ansi.Strip(items.sessionFocusStatus(sess))
 		if !strings.Contains(badge, "2/3") {
 			t.Errorf("expected 2/3 badge (commits only, no plan), got %q", badge)
 		}

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -80,7 +80,7 @@ func (m *reviewPanelModel) Session() *agent.Session {
 }
 
 // TaskCursor returns the current task-cursor row. Surfaced so App's
-// fetchReviewDiffCmd / refreshAgentList can read it.
+// click-handling and fetchReviewDiffCmd paths can read it.
 func (m *reviewPanelModel) TaskCursor() int {
 	if m == nil {
 		return 0

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -103,15 +103,6 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return newA, cmd
 		}
 
-		// Enter/right on a repo header: open repo config in right panel.
-		if (msg.String() == "enter" || msg.String() == "right") && a.modals.IsList() {
-			item := a.dashboard.selectedItem()
-			if item != nil && item.kind == listItemRepo {
-				a.initRepoConfigForm(item.repoPath)
-				return a, nil
-			}
-		}
-
 		newA, cmd, handled := a.handleQuitKey(msg)
 		if handled {
 			return newA, cmd
@@ -144,24 +135,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.handleMouseWheel(msg)
 	}
 
-	prevSelected := a.dashboard.selected
 	var cmd tea.Cmd
-	a.dashboard, cmd = a.dashboard.Update(msg)
-	// On selection change, update diff stats from cache (or trigger refresh).
-	if a.dashboard.selected != prevSelected {
-		a.updateDashboardDiffStats()
-		if sess := a.dashboard.selectedSession(); sess != nil {
-			repoPath := a.dashboard.selectedRepoPath()
-			var entry *diffStatsEntry
-			if repoPath != "" {
-				entry = a.diffStatsCache[cacheKey(repoPath, sess.ID)]
-			}
-			if (entry == nil || time.Since(entry.lastRefresh) > DiffStatsCacheTTL) && !a.diffRefreshInFlight {
-				diffCmd := a.refreshDiffStatsCmd()
-				return a, tea.Batch(cmd, diffCmd)
-			}
-		}
-	}
+	a.dashboard, cmd = a.dashboard.Update(msg, a.dashboardProps())
 	// Maintain the invariant: a text selection only persists while the user
 	// remains in focusLaunch viewing the same agent. Any focus or agent
 	// change (esc back to pipeline, tab switch, etc.) drops it.
@@ -226,7 +201,6 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				idx = (idx - 1 + len(agents)) % len(agents)
 			}
 			a.modals.SetLaunchAgent(agents[idx])
-			a.syncModalsToDashboard()
 			a.dashboard.scrollOffset = 0
 			agents[idx].Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 		}
@@ -243,7 +217,6 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				}
 				if newAg, err := mgr.AddShell(sess.ID, cfg); err == nil {
 					a.modals.SetLaunchAgent(newAg)
-					a.syncModalsToDashboard()
 					a.dashboard.scrollOffset = 0
 				} else {
 					a.setError(err.Error())
@@ -266,7 +239,6 @@ func (a App) updateFocusLaunchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				}
 				if newAg, err := mgr.AddAgent(sess.ID, cfg); err == nil {
 					a.modals.SetLaunchAgent(newAg)
-					a.syncModalsToDashboard()
 					a.dashboard.scrollOffset = 0
 				} else {
 					a.setError(err.Error())
@@ -321,7 +293,6 @@ func (a App) closeFocusLaunchAgent() (tea.Model, tea.Cmd) {
 			nextIdx = currentIdx - 1
 		}
 		a.modals.SetLaunchAgent(agents[nextIdx])
-		a.syncModalsToDashboard()
 		agents[nextIdx].Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 		a.dashboard.scrollOffset = 0
 	}
@@ -372,7 +343,6 @@ func (a App) handleKeysReviewPanel(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 	updated, cmd := snapshot.Update(msg, a.panelServices())
 	if rp, ok := updated.(*reviewPanelModel); ok {
 		a.modals.CompareAndSetReview(snapshot, rp)
-		a.syncModalsToDashboard()
 	}
 	return a, cmd, true
 }
@@ -387,7 +357,6 @@ func (a App) handleKeysShippingPanel(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 	updated, cmd := snapshot.Update(msg, a.panelServices())
 	if sp, ok := updated.(*shippingPanelModel); ok {
 		a.modals.CompareAndSetShipping(snapshot, sp)
-		a.syncModalsToDashboard()
 	}
 	return a, cmd, true
 }
@@ -438,8 +407,8 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 		return a, nil, true
 
 	case "n":
-		// Create a new session in the repo of the currently selected item.
-		repoPath := a.dashboard.selectedRepoPath()
+		// Create a new session in the repo of the cursor-selected session.
+		repoPath := a.cursorSelectedRepoPath()
 		if repoPath == "" {
 			repoPath = a.activeRepo
 		}
@@ -758,7 +727,6 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 			return a, nil, true
 		}
 		a.closingAgents[agentKey] = true
-		a.refreshAgentList()
 		return a, func() tea.Msg {
 			err := mgr.KillAgent(sessionID, agentID)
 			return killResultMsg{
@@ -793,7 +761,6 @@ func (a App) handleKeysWorkflow(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 			a.closingAgents[agentCacheKey(repoPath, ag.ID)] = true
 		}
 		a.closingSessions[sessKey] = true
-		a.refreshAgentList()
 		return a, func() tea.Msg {
 			err := mgr.KillSession(sessID)
 			return killResultMsg{
@@ -836,7 +803,6 @@ func (a App) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 			if idx := a.focusLaunchTabIndexAt(msg.X); idx >= 0 {
 				agents := sess.Agents()
 				a.modals.SetLaunchAgent(agents[idx])
-				a.syncModalsToDashboard()
 				a.dashboard.scrollOffset = 0
 				agents[idx].Resize(a.focusLaunchTermHeight(), a.dashboard.width)
 			}
@@ -879,7 +845,7 @@ func (a App) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	// is right-aligned on the card; the X-column check below narrows the
 	// hit region without needing per-row Y granularity from pipelineHitTest.
 	if section == focusSectionReview || section == focusSectionShipping {
-		items := a.dashboard.sectionItems(section)
+		items := a.listItems().sectionItems(section)
 		if idx < len(items) {
 			sess := items[idx].session
 			if entry := a.prCache[cacheKey(items[idx].repoPath, sess.ID)]; entry != nil && entry.pr != nil && entry.pr.URL != "" {
@@ -910,7 +876,6 @@ func (a App) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	a.lastPipelineClickIdx = idx
 
 	a.cursor.JumpTo(section, idx)
-	a.syncFocusCursorToDashboard()
 
 	if isDoubleClick {
 		if cmd, ok := a.activateFocusCursor(); ok {
@@ -1033,12 +998,10 @@ func (a App) handlePipelineKeys(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 	}
 	switch msg.String() {
 	case "up", "k":
-		a.cursor.MoveUp(a.dashboard.sectionCounts())
-		a.syncFocusCursorToDashboard()
+		a.cursor.MoveUp(a.listItems().sectionCounts())
 		return a, nil, true
 	case "down", "j":
-		a.cursor.MoveDown(a.dashboard.sectionCounts())
-		a.syncFocusCursorToDashboard()
+		a.cursor.MoveDown(a.listItems().sectionCounts())
 		return a, nil, true
 	case "space", "enter":
 		if cmd, ok := a.activateFocusCursor(); ok {
@@ -1056,7 +1019,7 @@ func (a App) handlePipelineKeys(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 			}
 			nextIdx := (currentIdx + 1) % len(a.cfg.Repos)
 			a.activeRepo = a.cfg.Repos[nextIdx].Path
-			a.refreshAgentList()
+			a.clampCursor()
 		}
 		return a, nil, true
 	case "b":
@@ -1068,7 +1031,7 @@ func (a App) handlePipelineKeys(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 		// the catch-all everywhere else — so the cursor location is
 		// the disambiguator the user already has at hand.
 		if !a.wellness.focusBreakMode && a.cursor.Section() == focusSectionPlanning {
-			planning := a.dashboard.planningSessions()
+			planning := a.listItems().planningSessions()
 			if len(planning) > 0 {
 				idx := a.cursor.Index(focusSectionPlanning)
 				if idx >= len(planning) {
@@ -1076,8 +1039,7 @@ func (a App) handlePipelineKeys(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 				}
 				if sess := planning[idx].session; sess != nil {
 					sess.SetLifecyclePhase(agent.LifecycleInProgress)
-					a.cursor.Clamp(a.dashboard.sectionCounts())
-					a.syncFocusCursorToDashboard()
+					a.clampCursor()
 				}
 			}
 			// Cursor is on Planning — even if the section was empty in
@@ -1132,13 +1094,13 @@ func (a App) handlePipelineMarkReady() (App, tea.Cmd, bool) {
 	var repoPath string
 	switch a.cursor.Section() {
 	case focusSectionPlanning:
-		planning := a.dashboard.planningSessions()
+		planning := a.listItems().planningSessions()
 		if pi := a.cursor.Index(focusSectionPlanning); pi < len(planning) {
 			sess = planning[pi].session
 			repoPath = planning[pi].repoPath
 		}
 	case focusSectionBuilding:
-		building := a.dashboard.buildingSessions()
+		building := a.listItems().buildingSessions()
 		if bi := a.cursor.Index(focusSectionBuilding); bi < len(building) {
 			sess = building[bi].session
 			repoPath = building[bi].repoPath
@@ -1173,7 +1135,7 @@ func (a App) handlePipelineMarkReady() (App, tea.Cmd, bool) {
 // handlePipelineOpenReview opens the review panel on the cursor-selected
 // review-queue session (r key).
 func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
-	reviewItems := a.dashboard.reviewQueueSessions()
+	reviewItems := a.listItems().reviewQueueSessions()
 	if len(reviewItems) == 0 {
 		a.setError("review queue is empty — press m on a finished session first")
 		return a, nil, true
@@ -1236,7 +1198,6 @@ func (a App) handleConfigFormSave() (tea.Model, tea.Cmd) {
 				if err := config.Save(a.cfg); err != nil {
 					a.setError(err.Error())
 				}
-				a.refreshAgentList()
 				break
 			}
 		}

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -184,8 +184,7 @@ func (a App) handleInit(msg initAppMsg) (tea.Model, tea.Cmd) {
 	}
 	// Always start on the dashboard — single repo or many.
 	a.view = ViewDashboard
-	a.refreshAgentList()
-	a.updateDashboardPRCache()
+	a.clampCursor()
 	return a, tea.Batch(cmds...)
 }
 
@@ -237,7 +236,8 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 			a.audioPlayer.Play()
 		}
 	}
-	a.refreshAgentList()
+	// Keep the pipeline cursor in range as sessions transition phases.
+	a.clampCursor()
 	// Refresh every component's render clock from a single tick timestamp so
 	// their View()/render helpers stay pure (§5: no clock read at render time).
 	renderNow := time.Now()
@@ -248,49 +248,40 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 	if rp := a.modals.Review(); rp != nil {
 		rp.SetNow(renderNow)
 	}
-	// Detect Active->Idle transitions for diff-stats refresh. Chime
-	// notifications are fired in the EventStatusChanged handler below,
-	// which reacts the instant Claude's Stop hook arrives.
-	idleTransition := false
-	for _, item := range a.dashboard.items {
+	// Snapshot the live item list for this tick's per-agent status bookkeeping
+	// and alt-screen resize. (advanceTickers and the debug dump below build
+	// their own props, which re-derive the list — cheap, and managers don't
+	// mutate mid-Update.)
+	items := a.listItems()
+	// Track per-agent status so cross-status logic (e.g. session-close cleanup)
+	// has a prior value to compare against.
+	for _, item := range items {
 		if item.kind != listItemAgent || item.agent == nil {
 			continue
 		}
-		ag := item.agent
-		currentStatus := ag.Status()
-		key := agentCacheKey(item.repoPath, ag.ID)
-		if prev, ok := a.lastKnownStatus[key]; ok {
-			if prev == agent.StatusActive && currentStatus == agent.StatusIdle && !ag.IsShell {
-				idleTransition = true
-			}
-		}
-		a.lastKnownStatus[key] = currentStatus
+		a.lastKnownStatus[agentCacheKey(item.repoPath, item.agent.ID)] = item.agent.Status()
 	}
 	// Detect alt-screen transitions and trigger a resize so Claude's TUI
 	// redraws cleanly (replaces the old splashResizeMsg delayed timer).
 	fixedW := a.dashboard.fixedTermWidth()
 	fixedH := a.dashboard.fixedTermHeight()
 	if fixedW > 0 && fixedH > 0 {
-		selected := a.dashboard.selectedAgent()
-		for _, item := range a.dashboard.items {
+		launchAgent := a.modals.LaunchAgent()
+		for _, item := range items {
 			if item.kind != listItemAgent || item.agent == nil {
 				continue
 			}
 			if item.agent.AltScreenEntered() {
 				// The focusLaunch agent renders fullscreen, so resize it
 				// to the fullscreen dimensions instead of shrinking it
-				// back to the preview size.
-				if launchAgent := a.modals.LaunchAgent(); launchAgent != nil && item.agent.ID == launchAgent.ID {
+				// back to the preview size. VT history is cleared on
+				// alt-screen entry; any prior scrollOffset now indexes into
+				// an empty buffer, so snap the focusLaunch agent back to live.
+				if launchAgent != nil && item.agent.ID == launchAgent.ID {
 					item.agent.Resize(a.focusLaunchTermHeight(), a.dashboard.width)
+					a.dashboard.scrollOffset = 0
 				} else {
 					item.agent.Resize(fixedH, fixedW)
-				}
-				// VT history is cleared on alt-screen entry; any prior
-				// scrollOffset now indexes into an empty buffer and would
-				// leave the preview visually frozen until the user hits
-				// home. Snap the currently focused agent back to live.
-				if item.agent == selected {
-					a.dashboard.scrollOffset = 0
 				}
 			}
 		}
@@ -303,36 +294,23 @@ func (a App) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 	}
 	// Clean stale diff cache entries periodically.
 	a.cleanStaleCaches()
-	// Refresh diff stats periodically or on idle transition.
-	var diffCmd tea.Cmd
-	if sess := a.dashboard.selectedSession(); sess != nil {
-		repoPath := a.dashboard.selectedRepoPath()
-		var entry *diffStatsEntry
-		if repoPath != "" {
-			entry = a.diffStatsCache[cacheKey(repoPath, sess.ID)]
-		}
-		stale := entry == nil || time.Since(entry.lastRefresh) > DiffStatsCacheTTL
-		if (stale || idleTransition) && !a.diffRefreshInFlight {
-			diffCmd = a.refreshDiffStatsCmd()
-		}
-	}
 	// Advance sidebar marquee tickers for overflowing session names. Reuse
 	// renderNow so all of the dashboard's time-derived state (now field +
 	// ticker advance) is coherent from a single per-tick timestamp.
-	a.dashboard.advanceTickers(renderNow)
+	a.dashboard.advanceTickers(renderNow, a.dashboardProps())
 	// E2E debug-dump: write the latest composed dashboard frame to the file
 	// named by REFRAIN_E2E_DEBUG_DUMP (read once at startup). Kept out of any
 	// View()/render helper so rendering stays pure (§5); dashboard.View() is
 	// itself pure, so calling it here from the Update path is side-effect free.
 	if a.debugDumpPath != "" {
-		_ = os.WriteFile(a.debugDumpPath, []byte(a.dashboard.View()), 0o644)
+		_ = os.WriteFile(a.debugDumpPath, []byte(a.dashboard.View(a.dashboardProps())), 0o644)
 	}
 	// Adaptive per-session PR polling.
 	var prCmds []tea.Cmd
 	if a.ghClient != nil {
 		prCmds = a.pollAllSessions()
 	}
-	allCmds := append([]tea.Cmd{tickCmd(), diffCmd}, prCmds...)
+	allCmds := append([]tea.Cmd{tickCmd()}, prCmds...)
 	return a, tea.Batch(allCmds...)
 }
 
@@ -482,8 +460,8 @@ func (a App) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// Refresh list on any agent event — all repos are visible in the dashboard.
-	a.refreshAgentList()
+	// Keep the cursor in range — an event may have advanced a session's phase.
+	a.clampCursor()
 	if mgr := a.managers[msg.repoPath]; mgr != nil {
 		if autoPromoteCmd != nil {
 			return a, tea.Batch(autoPromoteCmd, listenEvents(mgr))
@@ -505,13 +483,13 @@ func (a App) handleCreateResult(msg createResultMsg) (tea.Model, tea.Cmd) {
 	if msg.isNewSession {
 		a.wellness.sessionsCreatedCount++
 	}
-	a.refreshAgentList()
+	a.clampCursor()
 	// Find the new agent by ID. Cursor always moves to the new session's
 	// row; focusLaunch is only entered when skipFocusLaunch is false.
 	if msg.agentID != "" {
-		for i, item := range a.dashboard.items {
+		items := a.listItems()
+		for _, item := range items {
 			if item.kind == listItemAgent && item.agent != nil && item.agent.ID == msg.agentID {
-				a.dashboard.selected = i
 				if !msg.skipFocusLaunch {
 					a.openLaunchPanel(item.session, item.agent, item.repoPath)
 					a.dashboard.scrollOffset = 0
@@ -525,10 +503,9 @@ func (a App) handleCreateResult(msg createResultMsg) (tea.Model, tea.Cmd) {
 				if item.session != nil {
 				Sections:
 					for _, section := range focusSectionsInOrder() {
-						for idx, s := range a.dashboard.sectionItems(section) {
+						for idx, s := range items.sectionItems(section) {
 							if s.session == item.session {
 								a.cursor.JumpTo(section, idx)
-								a.syncFocusCursorToDashboard()
 								break Sections
 							}
 						}
@@ -574,32 +551,11 @@ func (a App) handleKillResult(msg killResultMsg) (tea.Model, tea.Cmd) {
 				a.dashboard.scrollOffset = 0
 			}
 		}
-		delete(a.diffStatsCache, sessKey)
 	}
 	if msg.err != nil {
 		a.setError(msg.err.Error())
 	}
-	a.refreshAgentList()
-	a.updateDashboardDiffStats()
-	return a, nil
-}
-
-func (a App) handleDiffStats(msg diffStatsMsg) (tea.Model, tea.Cmd) {
-	a.diffRefreshInFlight = false
-	if msg.repoPath == "" {
-		// Without a repoPath we can't key the cache safely; drop the result.
-		// All callers populate repoPath; this guard catches future regressions.
-		return a, nil
-	}
-	// Always update cache timestamp to prevent tight retry loops on persistent errors.
-	a.diffStatsCache[cacheKey(msg.repoPath, msg.sessionID)] = &diffStatsEntry{
-		stats:       msg.stats,
-		lastRefresh: time.Now(),
-	}
-	// Update dashboard with current session's stats.
-	if sess := a.dashboard.selectedSession(); sess != nil && sess.ID == msg.sessionID {
-		a.dashboard.diffStats = msg.stats
-	}
+	a.clampCursor()
 	return a, nil
 }
 
@@ -607,6 +563,6 @@ func (a App) handleResumeDone(msg resumeDoneMsg) (tea.Model, tea.Cmd) {
 	for _, repoPath := range msg.repoPaths {
 		_ = state.Remove(repoPath)
 	}
-	a.refreshAgentList()
+	a.clampCursor()
 	return a, nil
 }

--- a/internal/tui/update_pickers.go
+++ b/internal/tui/update_pickers.go
@@ -117,7 +117,7 @@ func (a App) updateRepoPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		a.activeRepo = repoPath
-		a.refreshAgentList()
+		a.clampCursor()
 		fixedW := a.dashboard.fixedTermWidth()
 		fixedH := a.dashboard.fixedTermHeight()
 		if fixedW <= 0 || fixedH <= 0 {
@@ -159,7 +159,7 @@ func (a App) updateRepoPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		a.activeRepo = msg.path
-		a.refreshAgentList()
+		a.clampCursor()
 		a.view = ViewDashboard
 		return a, nil
 
@@ -199,7 +199,7 @@ func (a App) updateRepoPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.activeRepo = a.cfg.Repos[0].Path
 			}
 		}
-		a.refreshAgentList()
+		a.clampCursor()
 		counts := make(map[string]int, len(a.cfg.Repos))
 		for _, repo := range a.cfg.Repos {
 			if m := a.managers[repo.Path]; m != nil {

--- a/internal/tui/update_plan.go
+++ b/internal/tui/update_plan.go
@@ -261,12 +261,9 @@ func (a *App) submitPromptModal(msg promptModalSubmitMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 	// The `n` handler / repo picker that opened this modal already resolved
-	// the target repo and stored it in a.activeRepo. Re-resolving via
-	// dashboard.selectedRepoPath here would override that with the legacy
-	// d.selected lookup — which clamps to the first repo's header and never
-	// follows the pipeline cursor or the picker's selection — pinning new
-	// sessions to the first registered repo regardless of what the user
-	// picked.
+	// the target repo and stored it in a.activeRepo. Trust that rather than
+	// re-deriving from the pipeline cursor, which may sit on an unrelated
+	// repo's session and would pin the new session to the wrong repo.
 	repoPath := a.activeRepo
 	if repoPath == "" {
 		a.setError("no repo selected")
@@ -341,15 +338,14 @@ func (a *App) submitPromptModal(msg promptModalSubmitMsg) (tea.Model, tea.Cmd) {
 	// createResultMsg with isNewSession=true), so each approved/skipped
 	// session is logged exactly once.
 	a.view = ViewDashboard
-	a.refreshAgentList()
+	a.clampCursor()
 	// Stay on the dashboard while the draft runs in the background — the
 	// planning card shows the "drafting…" badge. The user can press
 	// enter/space on the card to open the editor when ready, or the editor
 	// auto-opens if the planner raises a clarifying question.
-	for idx, item := range a.dashboard.planningSessions() {
+	for idx, item := range a.listItems().planningSessions() {
 		if item.session != nil && item.session.ID == sess.ID {
 			a.cursor.JumpTo(focusSectionPlanning, idx)
-			a.syncFocusCursorToDashboard()
 			break
 		}
 	}

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -64,7 +64,6 @@ func (a App) handlePRCreated(msg prCreatedMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	}
-	a.updateDashboardPRCache()
 	// Re-arm a burst poll so the new PR is discovered quickly.
 	if ps := a.prPollStates[key]; ps != nil {
 		ps.burstUntil = time.Now().Add(PRPollBurstAfterCreate)
@@ -105,7 +104,6 @@ func (a *App) handlePRNotFound(key string, ps *prSessionState) {
 		ps.lastCheckState = ""
 		ps.consecutiveNilPolls = 0
 	}
-	a.updateDashboardPRCache()
 }
 
 func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
@@ -220,7 +218,6 @@ func (a App) handlePRPoll(msg prPollMsg) (tea.Model, tea.Cmd) {
 		}
 		ps.lastCheckState = newState
 	}
-	a.updateDashboardPRCache()
 	return a, tea.Batch(cmds...)
 }
 

--- a/internal/tui/update_views.go
+++ b/internal/tui/update_views.go
@@ -197,7 +197,7 @@ func (a App) updateRepoChecks(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		a.wellness.RecordInput()
 		var cmd tea.Cmd
-		a.dashboard, cmd = a.dashboard.Update(msg)
+		a.dashboard, cmd = a.dashboard.Update(msg, a.dashboardProps())
 		return a, cmd
 	}
 	return a, nil

--- a/internal/tui/wellness.go
+++ b/internal/tui/wellness.go
@@ -22,9 +22,6 @@ type wellnessState struct {
 	appStart time.Time
 	// sessionStart is the work-block start time; reset whenever a break ends.
 	sessionStart time.Time
-	// lastReviewAt is the wall-clock time of the most recent review-panel
-	// open. Surfaced as a comfort metric in the wellness log.
-	lastReviewAt time.Time
 
 	// lastInputAt is the wall-clock time (monotonic stripped) of the most
 	// recent keyboard or mouse event from the human. Used by EffectiveElapsed
@@ -97,14 +94,21 @@ func (w *wellnessState) RecordInput() {
 // the display never goes negative. If lastInputAt has not been seeded yet
 // (tests or pre-init paths), falls back to raw time.Since(sessionStart).
 func (w wellnessState) EffectiveElapsed() time.Duration {
+	return w.EffectiveElapsedAt(time.Now())
+}
+
+// EffectiveElapsedAt is EffectiveElapsed against an explicit clock. The render
+// path passes the tick-refreshed clock (dashboardModel.now) so building
+// dashboardProps stays pure — no wall-clock read at render time (§5).
+func (w wellnessState) EffectiveElapsedAt(now time.Time) time.Duration {
 	if w.lastInputAt.IsZero() {
-		return time.Since(w.sessionStart)
+		return now.Sub(w.sessionStart)
 	}
-	currentExtendedIdle := time.Since(w.lastInputAt) - idleGrace
+	currentExtendedIdle := now.Sub(w.lastInputAt) - idleGrace
 	if currentExtendedIdle < 0 {
 		currentExtendedIdle = 0
 	}
-	elapsed := time.Since(w.sessionStart) - w.idleDebt - currentExtendedIdle
+	elapsed := now.Sub(w.sessionStart) - w.idleDebt - currentExtendedIdle
 	if elapsed < 0 {
 		return 0
 	}


### PR DESCRIPTION
## What & why

`internal/tui/dashboardModel` previously held ~25 fields that were **copies of state owned by the root `App`** — modal state, the wellness snapshot, the pipeline cursor, cache pointers, the closing-set maps, active-repo strings, and the derived `items` list — kept in sync by `syncModalsToDashboard()` / `syncFocusCursorToDashboard()` / `refreshAgentList()` / `updateDashboardPRCache()`. CONVENTIONS.md §5/§6 names exactly this (`syncModalsToDashboard`) as the canonical anti-pattern: one piece of state duplicated onto two structs and synced, free to drift between ticks.

This phase makes the dashboard read **everything derivable** through a freshly-built `dashboardProps` each frame (the dashboard's analogue of the existing `PanelServices`), leaving the model with only genuinely-owned transient UI state. It also resolves the **dual cursor** (`App.cursor` vs the vestigial `dashboard.selected`). Outcome: single ownership, no drift, and a thin dashboard model that unblocks the Phase 5 App-thinning.

Behavior-preserving. Shipped as one PR per the plan (mirror-field elimination + items relocation + dual-cursor resolution + diff-stats removal). Net **+776 / −1180**.

## Changes

- **New `dashboardProps`** (`dashboard_props.go`) + `App.dashboardProps()`, threaded into `dashboardModel.View(props)` / `Update(msg, props)` and every render helper. Time-derived fields compute from the tick-refreshed render clock `a.dashboard.now` via new `wellness.EffectiveElapsedAt(now)`, keeping `View()` pure (§5).
- **New `type listItems []listItem`** carrying the section-filter methods (`planningSessions`/`buildingSessions`/…/`sectionItems`/`sectionCounts`/`agents`) and the per-session status helpers; `App.listItems()` rebuilds the list from the managers each frame; `App.clampCursor()` replaces the cursor-clamp side effect of the deleted `refreshAgentList`.
- **Deleted** `syncModalsToDashboard`, `syncFocusCursorToDashboard`, `updateDashboardPRCache`, `refreshAgentList`, and all the dashboard mirror fields. `dashboardModel` is now just `width/height/sidebarWidth/scrollOffset/tickers/now/selection`.
- **Dual cursor resolved:** `App.cursor` is the sole selection owner; removed `dashboard.selected` and `selectedItem`/`selectedAgent`/`selectedSession`/`selectedRepoPath`/`clampToRepo`/`clampToAgent`.
- **Dead diff-stats path removed** (verified cached-but-never-rendered): `diffStatsCache`/`diffStatsMsg`/`diffStatsEntry`/`refreshDiffStatsCmd`/`updateDashboardDiffStats`/`handleDiffStats`/`DiffStatsCacheTTL`/`diffSummaryData`+`diffFileStat`+`diffAggregateStats`, plus dead `wellness.lastReviewAt`.

## Notable fix

The e2e suite caught a **first-frame panic**: `props.items` is non-empty immediately (cfg repo headers) where the old mirror was empty until `refreshAgentList` ran, so `View()` now reaches `renderFullscreenFocus` at `width==0`, where `strings.Repeat("─", width-2)` got a negative count. Fixed with `max(0, width-2)` and a regression test.

## Verification

- `gofumpt -l .` clean · `go vet ./...` · `golangci-lint run` (0 issues)
- `go test -race ./...` green
- Full `go test -tags e2e ./internal/e2e/` suite green
- `go build && ./refrain doctor` green
- Grep gate (`syncModalsToDashboard|syncFocusCursorToDashboard|refreshAgentList|updateDashboardPRCache|dashboard.selected`) returns nothing in production code
- Fresh code-reviewer subagent confirmed the refactor is correct and behavior-preserving

🤖 Generated with [Claude Code](https://claude.com/claude-code)