### PR TITLE
Phase 4 — Unify the Component contract (CONVENTIONS.md §3)

### DIFF
--- a/changelog.d/phase-4-component-contract.md
+++ b/changelog.d/phase-4-component-contract.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Internal TUI components now follow one standard contract (CONVENTIONS.md §3): `Update` uses value receivers and returns the concrete component type plus a command, `View` is a value receiver, and sizing flows through `SetSize`. Converted `configForm`, `repoChecksModel`, `newSessionModel`, `prComposeModal`, `planEditorModel`, `feedbackNoteModal`, and the shared `docEditor` sub-widget (renaming its `UpdateTextarea` to `Update`); added `SetSize` to `configForm` and `repoChecksModel`; and renamed `PanelModel.Resize` to `SetSize`. The feedback-note modal now reports a saved note via a `feedbackNoteSubmitMsg` (handled by the shipping panel) instead of a non-standard return tuple. No user-facing behavior changes.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -388,6 +388,8 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.handleReviewReworkRequest(msg)
 	case shippingFeedbackRequestMsg:
 		return a.handleShippingFeedbackRequest(msg)
+	case feedbackNoteSubmitMsg:
+		return a.handleFeedbackNoteSubmit(msg)
 	case initAppMsg:
 		return a.handleInit(msg)
 	case tickMsg:
@@ -576,7 +578,8 @@ func (a *App) openNewSession(returnTo ViewMode) tea.Cmd {
 
 // updateNewSession routes messages to the new-session model while in ViewNewSession.
 func (a App) updateNewSession(msg tea.Msg) (tea.Model, tea.Cmd) {
-	cmd := a.newSession.Update(msg)
+	var cmd tea.Cmd
+	a.newSession, cmd = a.newSession.Update(msg)
 	return a, cmd
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -5565,7 +5565,7 @@ func TestRecordInput_NonDashboardView(t *testing.T) {
 	// Open the checks editor to put the app into the focusRepoChecks path.
 	// We use openRepoChecksEditor directly to bypass the normal init path.
 	editor := newRepoChecksModel("repo", nil)
-	app.openRepoChecksEditor(editor, "/repo")
+	app.openRepoChecksEditor(&editor, "/repo")
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	app = model.(App)

--- a/internal/tui/component.go
+++ b/internal/tui/component.go
@@ -1,0 +1,37 @@
+package tui
+
+import tea "charm.land/bubbletea/v2"
+
+// Component is the documented target shape (CONVENTIONS.md §3) that every
+// self-contained screen, panel, modal, and picker follows: Update returns the
+// next state of the component plus a command, View renders purely from state,
+// and SetSize informs the component of the space it has to render in.
+//
+// Conformance is by shape, not by literal interface. Components follow this
+// contract by returning their own concrete type from Update (e.g.
+// `func (m configForm) Update(tea.Msg) (configForm, tea.Cmd)`), so there are
+// no `var _ Component = …` assertions and no type-assertion-based routing at
+// call sites — the parent forwards a message, gets back the concrete type, and
+// stores it. This keeps state transitions explicit and copy-safe: Update uses
+// value receivers and returns the updated value; View uses a value receiver;
+// SetSize uses a pointer receiver because it mutates stored dimensions.
+//
+// PanelModel (panel.go) is the deliberate services-injecting variant of this
+// contract: its Update/View additionally take a PanelServices value so panels
+// can reach app-level state without a back-pointer to App. Folding panels into
+// this shape (dropping PanelServices, moving panel state off App) is deferred
+// to Phase 5 of the CONVENTIONS migration.
+type Component interface {
+	// Update handles a message and returns the next state of this component
+	// plus any command to run. It must be pure w.r.t. I/O: side effects go in
+	// the returned Cmd, never inline.
+	Update(tea.Msg) (Component, tea.Cmd)
+
+	// View renders the component within its current size. Pure: no mutation,
+	// no I/O, deterministic from state.
+	View() string
+
+	// SetSize informs the component of the space it has to render in. The
+	// component must render within (w, h) and be safe at minimum size.
+	SetSize(w, h int)
+}

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -126,10 +126,17 @@ func (f *configForm) focusField(idx int) {
 	f.focused = idx
 }
 
-// Update handles key events for the form.
-func (f *configForm) Update(msg tea.Msg) tea.Cmd {
+// SetSize informs the form of the space it has to render in. Width drives
+// text input sizing; the form lays out vertically so height is advisory.
+func (f *configForm) SetSize(w, _ int) {
+	f.width = w
+}
+
+// Update handles key events for the form. It returns the next form state and
+// any command to run (CONVENTIONS.md §3).
+func (f configForm) Update(msg tea.Msg) (configForm, tea.Cmd) {
 	if len(f.fields) == 0 {
-		return nil
+		return f, nil
 	}
 
 	switch msg := msg.(type) {
@@ -142,15 +149,15 @@ func (f *configForm) Update(msg tea.Msg) tea.Cmd {
 			case "esc":
 				field.textInput.Blur()
 				field.editing = false
-				return nil
+				return f, nil
 			case "enter":
 				field.textInput.Blur()
 				field.editing = false
-				return nil
+				return f, nil
 			}
 			var cmd tea.Cmd
 			field.textInput, cmd = field.textInput.Update(msg)
-			return cmd
+			return f, cmd
 		}
 
 		// Navigation and actions when not editing.
@@ -159,22 +166,22 @@ func (f *configForm) Update(msg tea.Msg) tea.Cmd {
 			if f.focused < len(f.fields)-1 {
 				f.focusField(f.focused + 1)
 			}
-			return nil
+			return f, nil
 		case "k", "up":
 			if f.focused > 0 {
 				f.focusField(f.focused - 1)
 			}
-			return nil
+			return f, nil
 		case "right", "l":
 			if field.kind == fieldSelect && len(field.options) > 0 {
 				field.selected = (field.selected + 1) % len(field.options)
 			}
-			return nil
+			return f, nil
 		case "left", "h":
 			if field.kind == fieldSelect && len(field.options) > 0 {
 				field.selected = (field.selected - 1 + len(field.options)) % len(field.options)
 			}
-			return nil
+			return f, nil
 		case "enter", " ", "space":
 			switch field.kind {
 			case fieldToggle:
@@ -188,17 +195,17 @@ func (f *configForm) Update(msg tea.Msg) tea.Cmd {
 				}
 			case fieldAction:
 				label := field.label
-				return func() tea.Msg { return configFormActionMsg{Label: label} }
+				return f, func() tea.Msg { return configFormActionMsg{Label: label} }
 			}
-			return nil
+			return f, nil
 		case "ctrl+s":
-			return func() tea.Msg { return configFormSaveMsg{} }
+			return f, func() tea.Msg { return configFormSaveMsg{} }
 		case "esc":
-			return func() tea.Msg { return configFormCancelMsg{} }
+			return f, func() tea.Msg { return configFormCancelMsg{} }
 		}
 	}
 
-	return nil
+	return f, nil
 }
 
 // View renders the form as a vertical list of labeled fields.

--- a/internal/tui/configform_test.go
+++ b/internal/tui/configform_test.go
@@ -23,11 +23,11 @@ func TestConfigForm_InitialFocusIsFirstField(t *testing.T) {
 
 func TestConfigForm_DownArrowAdvancesFocus(t *testing.T) {
 	f := sampleForm()
-	f.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	f, _ = f.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if f.focused != 1 {
 		t.Errorf("after 'j', focused = %d, want 1", f.focused)
 	}
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	if f.focused != 2 {
 		t.Errorf("after 'down', focused = %d, want 2", f.focused)
 	}
@@ -36,7 +36,7 @@ func TestConfigForm_DownArrowAdvancesFocus(t *testing.T) {
 func TestConfigForm_DownClampsAtLastField(t *testing.T) {
 	f := sampleForm()
 	for range 10 {
-		f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+		f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	}
 	if f.focused != len(f.fields)-1 {
 		t.Errorf("expected focused = %d (last), got %d", len(f.fields)-1, f.focused)
@@ -45,7 +45,7 @@ func TestConfigForm_DownClampsAtLastField(t *testing.T) {
 
 func TestConfigForm_UpClampsAtFirstField(t *testing.T) {
 	f := sampleForm()
-	f.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	f, _ = f.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	if f.focused != 0 {
 		t.Errorf("up at top should clamp at 0, got %d", f.focused)
 	}
@@ -56,11 +56,11 @@ func TestConfigForm_SpaceTogglesBoolean(t *testing.T) {
 	if !f.toggleValue("Enable focus mode") {
 		t.Fatal("fixture should start with toggle=true")
 	}
-	f.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	f, _ = f.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
 	if f.toggleValue("Enable focus mode") {
 		t.Error("space should toggle boolean to false")
 	}
-	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !f.toggleValue("Enable focus mode") {
 		t.Error("enter on toggle should also toggle, back to true")
 	}
@@ -69,17 +69,17 @@ func TestConfigForm_SpaceTogglesBoolean(t *testing.T) {
 func TestConfigForm_RightCyclesSelect(t *testing.T) {
 	f := sampleForm()
 	// Move to select field (index 2).
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 
 	if got := f.selectValue("Theme"); got != "dark" {
 		t.Fatalf("initial Theme = %q, want dark", got)
 	}
-	f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	if got := f.selectValue("Theme"); got != "auto" {
 		t.Errorf("after right, Theme = %q, want auto", got)
 	}
-	f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	if got := f.selectValue("Theme"); got != "light" {
 		t.Errorf("after second right, Theme = %q (expected wraparound to light)", got)
 	}
@@ -87,14 +87,14 @@ func TestConfigForm_RightCyclesSelect(t *testing.T) {
 
 func TestConfigForm_LeftCyclesSelectBackwards(t *testing.T) {
 	f := sampleForm()
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 
-	f.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
 	if got := f.selectValue("Theme"); got != "light" {
 		t.Errorf("after left from dark, Theme = %q, want light", got)
 	}
-	f.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
 	if got := f.selectValue("Theme"); got != "auto" {
 		t.Errorf("after wraparound, Theme = %q, want auto", got)
 	}
@@ -102,16 +102,16 @@ func TestConfigForm_LeftCyclesSelectBackwards(t *testing.T) {
 
 func TestConfigForm_EnterOnTextEntersEditMode(t *testing.T) {
 	f := sampleForm()
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	if f.fields[1].editing {
 		t.Fatal("text field should not be editing initially")
 	}
-	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !f.fields[1].editing {
 		t.Error("enter on text field should enter edit mode")
 	}
 	// Esc exits edit mode without submitting form.
-	f.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if f.fields[1].editing {
 		t.Error("esc in edit mode should exit edit mode")
 	}
@@ -119,12 +119,12 @@ func TestConfigForm_EnterOnTextEntersEditMode(t *testing.T) {
 
 func TestConfigForm_EnterExitsEditModeOnText(t *testing.T) {
 	f := sampleForm()
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // enter edit
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // enter edit
 	if !f.fields[1].editing {
 		t.Fatal("expected editing=true")
 	}
-	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // exit edit
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // exit edit
 	if f.fields[1].editing {
 		t.Error("second enter should exit edit mode")
 	}
@@ -132,7 +132,7 @@ func TestConfigForm_EnterExitsEditModeOnText(t *testing.T) {
 
 func TestConfigForm_CtrlSEmitsSaveMsg(t *testing.T) {
 	f := sampleForm()
-	cmd := f.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	_, cmd := f.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
 	if cmd == nil {
 		t.Fatal("expected non-nil cmd for ctrl+s")
 	}
@@ -143,7 +143,7 @@ func TestConfigForm_CtrlSEmitsSaveMsg(t *testing.T) {
 
 func TestConfigForm_EscEmitsCancelMsg(t *testing.T) {
 	f := sampleForm()
-	cmd := f.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	_, cmd := f.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if cmd == nil {
 		t.Fatal("expected non-nil cmd for esc")
 	}
@@ -185,7 +185,7 @@ func TestConfigForm_AddSelectEmptyOptionsGetsPlaceholder(t *testing.T) {
 
 func TestConfigForm_EmptyFormUpdateNoCrash(t *testing.T) {
 	f := newConfigForm(nil, 60)
-	if cmd := f.Update(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd != nil {
+	if _, cmd := f.Update(tea.KeyPressMsg{Code: tea.KeyEnter}); cmd != nil {
 		t.Errorf("empty form should return nil cmd, got %v", cmd)
 	}
 }
@@ -198,7 +198,7 @@ func TestConfigForm_UnknownKey_NavMode_NoOp(t *testing.T) {
 		text    string
 		sel     string
 	}{f.focused, f.toggleValue("Enable focus mode"), f.textValue("Branch prefix"), f.selectValue("Theme")}
-	cmd := f.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
+	f, cmd := f.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
 	if cmd != nil {
 		t.Errorf("unknown key in nav mode produced cmd %T, want nil", cmd())
 	}
@@ -216,13 +216,13 @@ func TestConfigForm_UnknownKey_NavMode_NoOp(t *testing.T) {
 func TestConfigForm_PrintableKey_EditMode_AppendsToTextInput(t *testing.T) {
 	f := sampleForm()
 	// Focus the text field and enter edit mode.
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !f.fields[1].editing {
 		t.Fatal("test prereq: text field should be in edit mode")
 	}
 	before := f.textValue("Branch prefix")
-	f.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	f, _ = f.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
 	if got := f.textValue("Branch prefix"); got == before {
 		t.Errorf("text value unchanged after typing 'x': still %q", got)
 	}
@@ -235,18 +235,18 @@ func TestConfigForm_LeftRightOnNonSelect_NoOp(t *testing.T) {
 	if !f.toggleValue("Enable focus mode") {
 		t.Fatal("test prereq: toggle should start true")
 	}
-	f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	if !f.toggleValue("Enable focus mode") {
 		t.Error("right arrow on toggle field should not change its value")
 	}
-	f.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
 	if !f.toggleValue("Enable focus mode") {
 		t.Error("left arrow on toggle field should not change its value")
 	}
 	// And on a text field (index 1): also a no-op.
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	before := f.textValue("Branch prefix")
-	f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 	if got := f.textValue("Branch prefix"); got != before {
 		t.Errorf("right arrow on text field changed value from %q to %q", before, got)
 	}
@@ -256,12 +256,12 @@ func TestConfigForm_CtrlS_InEditMode_NotSubmitted(t *testing.T) {
 	// In edit mode the textinput swallows everything including ctrl+s — the
 	// outer save shortcut is intentionally only active in nav mode.
 	f := sampleForm()
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if !f.fields[1].editing {
 		t.Fatal("test prereq: edit mode")
 	}
-	cmd := f.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	_, cmd := f.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
 	if cmd != nil {
 		if _, bad := cmd().(configFormSaveMsg); bad {
 			t.Error("ctrl+s should not save while in edit mode")
@@ -273,9 +273,9 @@ func TestConfigForm_EscInEditMode_DoesNotEmitCancel(t *testing.T) {
 	// Esc in edit mode only blurs the textinput; it must NOT emit
 	// configFormCancelMsg or the user would unintentionally drop their edits.
 	f := sampleForm()
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	cmd := f.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	f, cmd := f.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if cmd != nil {
 		if _, bad := cmd().(configFormCancelMsg); bad {
 			t.Error("esc in edit mode should NOT emit configFormCancelMsg")
@@ -290,10 +290,10 @@ func TestConfigForm_KeysDeferToTextInputInEditMode(t *testing.T) {
 	// In edit mode, j/k/h/l are literal characters in the textinput, not
 	// navigation. Pin so they don't silently move focus.
 	f := sampleForm()
-	f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	f, _ = f.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	before := f.focused
-	f.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	f, _ = f.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if f.focused != before {
 		t.Errorf("'j' in edit mode moved focus: before=%d after=%d", before, f.focused)
 	}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -212,11 +212,13 @@ func (d dashboardModel) Update(msg tea.Msg, props dashboardProps) (dashboardMode
 		// is handled at the app level via moveFocusCursorUp/Down and
 		// activateFocusCursor; nothing else needs to reach the dashboard here.
 		if props.panelFocus == focusConfig && props.repoConfigForm != nil {
-			cmd := props.repoConfigForm.Update(msg)
+			var cmd tea.Cmd
+			*props.repoConfigForm, cmd = props.repoConfigForm.Update(msg)
 			return d, cmd
 		}
 		if props.panelFocus == focusRepoChecks && props.repoChecksEditor != nil {
-			cmd := props.repoChecksEditor.Update(msg)
+			var cmd tea.Cmd
+			*props.repoChecksEditor, cmd = props.repoChecksEditor.Update(msg)
 			return d, cmd
 		}
 	}

--- a/internal/tui/doceditor.go
+++ b/internal/tui/doceditor.go
@@ -169,11 +169,16 @@ func (d *docEditor) Focused() bool {
 	return d.textarea.Focused()
 }
 
-// UpdateTextarea forwards a message to the textarea and returns the resulting cmd.
-func (d *docEditor) UpdateTextarea(msg tea.Msg) tea.Cmd {
+// Update forwards a message to the textarea and returns the next docEditor
+// state plus the resulting cmd. docEditor is a shared embedded sub-widget, not
+// a top-level screen: it conforms to the Update/SetSize shape of the Component
+// contract (§3) but intentionally has no standalone View — parents render it
+// via RenderLines/ScrollWindow/etc. — so it does not implement the full
+// Component interface.
+func (d docEditor) Update(msg tea.Msg) (docEditor, tea.Cmd) {
 	var cmd tea.Cmd
 	d.textarea, cmd = d.textarea.Update(msg)
-	return cmd
+	return d, cmd
 }
 
 // textareaWidth/textareaHeight reserve space for the header, divider, status,

--- a/internal/tui/feedbacknotemodal.go
+++ b/internal/tui/feedbacknotemodal.go
@@ -59,30 +59,35 @@ func (m *feedbackNoteModal) Close() {
 // Active reports whether the modal is currently visible.
 func (m *feedbackNoteModal) Active() bool { return m.active }
 
-// Update routes a tea.Msg to the modal.
-// Returns (cmd, submitted, note). submitted is true when the user pressed enter.
-func (m *feedbackNoteModal) Update(msg tea.Msg) (tea.Cmd, bool, string) {
+// Update routes a tea.Msg to the modal and returns the next modal state plus a
+// command. On enter it closes synchronously and returns a command yielding a
+// feedbackNoteSubmitMsg so the owning panel persists the note one Update cycle
+// later (CONVENTIONS.md §3/§4); esc closes with no save.
+func (m feedbackNoteModal) Update(msg tea.Msg) (feedbackNoteModal, tea.Cmd) {
 	if !m.active {
-		return nil, false, ""
+		return m, nil
 	}
 	if key, ok := msg.(tea.KeyPressMsg); ok {
 		switch key.String() {
 		case "esc":
 			m.Close()
-			return nil, false, ""
+			return m, nil
 		case "enter":
 			val := strings.TrimSpace(m.ta.Value())
+			itemKey := m.itemKey
 			m.Close()
-			return nil, true, val
+			return m, func() tea.Msg {
+				return feedbackNoteSubmitMsg{itemKey: itemKey, note: val}
+			}
 		}
 	}
 	var cmd tea.Cmd
 	m.ta, cmd = m.ta.Update(msg)
-	return cmd, false, ""
+	return m, cmd
 }
 
 // View renders the modal box. Caller should overlay this when Active().
-func (m *feedbackNoteModal) View() string {
+func (m feedbackNoteModal) View() string {
 	w := modalWidth(m.width)
 	innerW := modalContentWidth(w)
 

--- a/internal/tui/feedbacknotemodal_test.go
+++ b/internal/tui/feedbacknotemodal_test.go
@@ -6,7 +6,18 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
-func TestFeedbackNoteModal_SubmitReturnsNote(t *testing.T) {
+// feedbackSubmitFromCmd runs cmd (if any) and reports the feedbackNoteSubmitMsg
+// it yields. ok is false when cmd is nil or yields a different message — i.e.
+// the modal did not submit.
+func feedbackSubmitFromCmd(cmd tea.Cmd) (feedbackNoteSubmitMsg, bool) {
+	if cmd == nil {
+		return feedbackNoteSubmitMsg{}, false
+	}
+	sm, ok := cmd().(feedbackNoteSubmitMsg)
+	return sm, ok
+}
+
+func TestFeedbackNoteModal_SubmitEmitsSubmitMsg(t *testing.T) {
 	m := newFeedbackNoteModal()
 	m.SetSize(100, 40)
 	_ = m.Open("comment:42", "old note")
@@ -18,18 +29,21 @@ func TestFeedbackNoteModal_SubmitReturnsNote(t *testing.T) {
 		t.Errorf("textarea value = %q, want %q", m.ta.Value(), "old note")
 	}
 
-	// Pressing enter should submit.
-	cmd, submitted, note := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	if !submitted {
-		t.Error("expected submitted=true on enter")
+	// Pressing enter should close the modal and emit a submit msg.
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	sm, ok := feedbackSubmitFromCmd(cmd)
+	if !ok {
+		t.Fatal("expected feedbackNoteSubmitMsg on enter")
 	}
-	if note != "old note" {
-		t.Errorf("note = %q, want %q", note, "old note")
+	if sm.note != "old note" {
+		t.Errorf("note = %q, want %q", sm.note, "old note")
+	}
+	if sm.itemKey != "comment:42" {
+		t.Errorf("itemKey = %q, want %q", sm.itemKey, "comment:42")
 	}
 	if m.Active() {
 		t.Error("expected modal inactive after submit")
 	}
-	_ = cmd
 }
 
 func TestFeedbackNoteModal_EscCancels(t *testing.T) {
@@ -37,24 +51,20 @@ func TestFeedbackNoteModal_EscCancels(t *testing.T) {
 	m.SetSize(100, 40)
 	_ = m.Open("comment:42", "existing")
 
-	cmd, submitted, note := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
-	if submitted {
-		t.Error("expected submitted=false on esc")
-	}
-	if note != "" {
-		t.Errorf("note = %q, want empty on cancel", note)
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if _, ok := feedbackSubmitFromCmd(cmd); ok {
+		t.Error("esc should not emit a submit msg")
 	}
 	if m.Active() {
 		t.Error("expected modal inactive after esc")
 	}
-	_ = cmd
 }
 
 func TestFeedbackNoteModal_InactiveNoop(t *testing.T) {
 	m := newFeedbackNoteModal()
-	cmd, submitted, note := m.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
-	if submitted || note != "" || cmd != nil {
-		t.Errorf("inactive modal should be a noop; got submitted=%v note=%q cmd=%v", submitted, note, cmd)
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	if cmd != nil {
+		t.Errorf("inactive modal should be a noop; got cmd=%v", cmd)
 	}
 }
 
@@ -62,28 +72,30 @@ func TestFeedbackNoteModal_SubmitTrimsWhitespace(t *testing.T) {
 	m := newFeedbackNoteModal()
 	m.SetSize(100, 40)
 	_ = m.Open("c", "  padded note  \n")
-	_, submitted, note := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	if !submitted {
-		t.Fatal("expected submitted=true")
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	sm, ok := feedbackSubmitFromCmd(cmd)
+	if !ok {
+		t.Fatal("expected feedbackNoteSubmitMsg")
 	}
-	if note != "padded note" {
-		t.Errorf("note = %q, want trimmed value %q", note, "padded note")
+	if sm.note != "padded note" {
+		t.Errorf("note = %q, want trimmed value %q", sm.note, "padded note")
 	}
 }
 
-func TestFeedbackNoteModal_SubmitEmptyReturnsBlankNote(t *testing.T) {
+func TestFeedbackNoteModal_SubmitEmptyEmitsBlankNote(t *testing.T) {
 	// Whitespace-only contents trim to "", but the user explicitly hit enter
-	// — submitted should be true and the caller decides what to do with an
-	// empty note. Pinned so the trim/submit semantics don't drift.
+	// — a submit msg should still be emitted and the owner decides what to do
+	// with an empty note. Pinned so the trim/submit semantics don't drift.
 	m := newFeedbackNoteModal()
 	m.SetSize(100, 40)
 	_ = m.Open("c", "   \t")
-	_, submitted, note := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	if !submitted {
-		t.Error("submitted should be true when enter is pressed, regardless of content")
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	sm, ok := feedbackSubmitFromCmd(cmd)
+	if !ok {
+		t.Error("expected a submit msg when enter is pressed, regardless of content")
 	}
-	if note != "" {
-		t.Errorf("note = %q, want empty (trim of whitespace-only)", note)
+	if sm.note != "" {
+		t.Errorf("note = %q, want empty (trim of whitespace-only)", sm.note)
 	}
 }
 
@@ -91,12 +103,9 @@ func TestFeedbackNoteModal_ShiftEnterInsertsNewline_DoesNotSubmit(t *testing.T) 
 	m := newFeedbackNoteModal()
 	m.SetSize(100, 40)
 	_ = m.Open("c", "line 1")
-	cmd, submitted, note := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift, Text: "shift+enter"})
-	if submitted {
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift, Text: "shift+enter"})
+	if _, ok := feedbackSubmitFromCmd(cmd); ok {
 		t.Error("shift+enter must NOT submit")
-	}
-	if note != "" {
-		t.Errorf("note = %q on shift+enter, want empty", note)
 	}
 	if !m.Active() {
 		t.Error("modal must stay open on shift+enter")
@@ -106,30 +115,26 @@ func TestFeedbackNoteModal_ShiftEnterInsertsNewline_DoesNotSubmit(t *testing.T) 
 	if got := m.ta.Value(); got == "line 1line 2" || got == "line 1 line 2" {
 		t.Errorf("textarea value = %q, want a newline between segments", got)
 	}
-	_ = cmd
 }
 
 func TestFeedbackNoteModal_PrintableKeyForwardedToTextarea(t *testing.T) {
 	m := newFeedbackNoteModal()
 	m.SetSize(100, 40)
 	_ = m.Open("c", "")
-	cmd, submitted, _ := m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
-	if submitted {
+	m, cmd := m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if _, ok := feedbackSubmitFromCmd(cmd); ok {
 		t.Error("printable key must not submit")
 	}
 	if !m.Active() {
 		t.Error("modal closed on printable key")
 	}
-	// bubbles' textarea cmd is for cursor blink; we just verify it doesn't
-	// trigger our submit/cancel control flow.
-	_ = cmd
 }
 
 func TestFeedbackNoteModal_PasteForwardedToTextarea(t *testing.T) {
 	m := newFeedbackNoteModal()
 	m.SetSize(100, 40)
 	_ = m.Open("c", "")
-	cmd, _, _ := m.Update(tea.PasteMsg{Content: "pasted-feedback"})
+	m, cmd := m.Update(tea.PasteMsg{Content: "pasted-feedback"})
 	if cmd != nil {
 		cmd()
 	}
@@ -141,17 +146,13 @@ func TestFeedbackNoteModal_PasteForwardedToTextarea(t *testing.T) {
 
 func TestFeedbackNoteModal_UnknownControlKey_NoOp(t *testing.T) {
 	// ctrl+x is not handled; modal forwards to textarea which should ignore
-	// it (or treat as a no-op for cursor). Either way: still active, no
-	// submit, no cancel.
+	// it (or treat as a no-op for cursor). Either way: still active, no submit.
 	m := newFeedbackNoteModal()
 	m.SetSize(100, 40)
 	_ = m.Open("c", "hi")
-	_, submitted, note := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
-	if submitted {
+	m, cmd := m.Update(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	if _, ok := feedbackSubmitFromCmd(cmd); ok {
 		t.Error("ctrl+x should not submit")
-	}
-	if note != "" {
-		t.Error("ctrl+x produced a non-empty note")
 	}
 	if !m.Active() {
 		t.Error("ctrl+x closed the modal")

--- a/internal/tui/globalconfig.go
+++ b/internal/tui/globalconfig.go
@@ -114,6 +114,14 @@ func newGlobalConfigModel(gs *config.GlobalSettings, width, height int) globalCo
 	}
 }
 
+// SetSize informs the overlay of its render space and passes width through to
+// the embedded form so its text inputs size correctly.
+func (m *globalConfigModel) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+	m.form.SetSize(w, h)
+}
+
 func (m globalConfigModel) Update(msg tea.Msg) (globalConfigModel, tea.Cmd) {
 	switch msg.(type) {
 	case configFormSaveMsg:
@@ -124,7 +132,8 @@ func (m globalConfigModel) Update(msg tea.Msg) (globalConfigModel, tea.Cmd) {
 		return m, func() tea.Msg { return globalConfigCancelMsg{} }
 	}
 
-	cmd := m.form.Update(msg)
+	var cmd tea.Cmd
+	m.form, cmd = m.form.Update(msg)
 	return m, cmd
 }
 

--- a/internal/tui/newsession.go
+++ b/internal/tui/newsession.go
@@ -124,39 +124,39 @@ func (m *newSessionModel) Close() {
 
 // Update routes a tea.Msg. Intercepts esc / enter / ctrl+enter for control;
 // all other messages (including ctrl+j via InsertNewline) go to the textarea.
-func (m *newSessionModel) Update(msg tea.Msg) tea.Cmd {
+func (m newSessionModel) Update(msg tea.Msg) (newSessionModel, tea.Cmd) {
 	if key, ok := msg.(tea.KeyPressMsg); ok {
 		switch key.String() {
 		case "esc":
 			m.Close()
-			return func() tea.Msg { return promptModalCancelMsg{} }
+			return m, func() tea.Msg { return promptModalCancelMsg{} }
 		case "ctrl+enter":
 			val := strings.TrimSpace(m.textarea.Value())
 			if val == "" {
-				return nil
+				return m, nil
 			}
 			m.Close()
-			return func() tea.Msg {
+			return m, func() tea.Msg {
 				return promptModalSubmitMsg{prompt: val, skipPlanning: true}
 			}
 		case "enter":
 			val := strings.TrimSpace(m.textarea.Value())
 			if val == "" {
-				return nil
+				return m, nil
 			}
 			m.Close()
-			return func() tea.Msg {
+			return m, func() tea.Msg {
 				return promptModalSubmitMsg{prompt: val, skipPlanning: false}
 			}
 		}
 	}
 	var cmd tea.Cmd
 	m.textarea, cmd = m.textarea.Update(msg)
-	return cmd
+	return m, cmd
 }
 
 // View renders the full-viewport composition screen.
-func (m *newSessionModel) View() string {
+func (m newSessionModel) View() string {
 	// Header: "NEW SESSION" left, "repoName · branch" right.
 	left := StyleSubtle.Render("NEW SESSION")
 	var rightStr string

--- a/internal/tui/newsession_test.go
+++ b/internal/tui/newsession_test.go
@@ -89,7 +89,7 @@ func TestNewSession_EnterSubmitsPlanning(t *testing.T) {
 	m.Open(ViewDashboard)
 	m.textarea.SetValue("add dark mode toggle")
 
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
 	if cmd == nil {
 		t.Fatal("expected cmd from enter")
 	}
@@ -115,7 +115,7 @@ func TestNewSession_CtrlEnterSubmitsSkip(t *testing.T) {
 	m.Open(ViewDashboard)
 	m.textarea.SetValue("trivial fix")
 
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl, Text: "ctrl+enter"})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl, Text: "ctrl+enter"})
 	if cmd == nil {
 		t.Fatal("expected cmd from ctrl+enter")
 	}
@@ -138,7 +138,7 @@ func TestNewSession_EscEmitsCancel(t *testing.T) {
 	m.Open(ViewDashboard)
 	m.textarea.SetValue("never mind")
 
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if cmd == nil {
 		t.Fatal("expected cancel cmd")
 	}
@@ -157,7 +157,7 @@ func TestNewSession_EmptyEnterIsNoop(t *testing.T) {
 	m.Open(ViewDashboard)
 	m.textarea.SetValue("   \n\t")
 
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
 	if cmd != nil {
 		t.Fatal("empty/whitespace enter should be a no-op")
 	}
@@ -172,7 +172,7 @@ func TestNewSession_CtrlJInsertsNewline(t *testing.T) {
 	m.Open(ViewDashboard)
 	m.textarea.SetValue("first line")
 
-	cmd := m.Update(tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl, Text: "ctrl+j"})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl, Text: "ctrl+j"})
 	// ctrl+j must not produce a submit/cancel cmd
 	if cmd != nil {
 		msg := cmd()
@@ -198,7 +198,7 @@ func TestNewSession_ShiftEnterInsertsNewline(t *testing.T) {
 	m.Open(ViewDashboard)
 	m.textarea.SetValue("first line")
 
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift, Text: "shift+enter"})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift, Text: "shift+enter"})
 	if cmd != nil {
 		if msg := cmd(); msg != nil {
 			if _, ok := msg.(promptModalSubmitMsg); ok {

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -20,7 +20,7 @@ import (
 type PanelModel interface {
 	Update(msg tea.Msg, svc PanelServices) (PanelModel, tea.Cmd)
 	View(svc PanelServices) string
-	Resize(w, h int)
+	SetSize(w, h int)
 }
 
 // Panels close synchronously by calling svc.ClosePanel(). The callback is

--- a/internal/tui/planeditor.go
+++ b/internal/tui/planeditor.go
@@ -422,37 +422,41 @@ func (m *planEditorModel) Reload() {
 
 // Update routes a key event. The caller should already have dispatched
 // other tea.Msg types (resize, ticks).
-func (m *planEditorModel) Update(msg tea.Msg) tea.Cmd {
+func (m planEditorModel) Update(msg tea.Msg) (planEditorModel, tea.Cmd) {
 	keyMsg, ok := msg.(tea.KeyPressMsg)
 	if !ok {
 		// Forward non-key events to whichever component is active.
 		if m.mode == planEditorModeEdit {
-			return m.doc.UpdateTextarea(msg)
+			var cmd tea.Cmd
+			m.doc, cmd = m.doc.Update(msg)
+			return m, cmd
 		}
 		if m.mode == planEditorModeReviseInput {
 			var cmd tea.Cmd
 			m.reviseInput, cmd = m.reviseInput.Update(msg)
-			return cmd
+			return m, cmd
 		}
 		if m.mode == planEditorModeQuestion {
 			var cmd tea.Cmd
 			m.questionInput, cmd = m.questionInput.Update(msg)
-			return cmd
+			return m, cmd
 		}
-		return nil
+		return m, nil
 	}
 	m.errMsg = ""
 
+	var cmd tea.Cmd
 	switch m.mode {
 	case planEditorModeEdit:
-		return m.updateEdit(keyMsg)
+		cmd = m.updateEdit(keyMsg)
 	case planEditorModeReviseInput:
-		return m.updateReviseInput(keyMsg)
+		cmd = m.updateReviseInput(keyMsg)
 	case planEditorModeQuestion:
-		return m.updateQuestion(keyMsg)
+		cmd = m.updateQuestion(keyMsg)
 	default:
-		return m.updateScroll(keyMsg)
+		cmd = m.updateScroll(keyMsg)
 	}
+	return m, cmd
 }
 
 func (m *planEditorModel) updateScroll(msg tea.KeyPressMsg) tea.Cmd {
@@ -632,7 +636,8 @@ func (m *planEditorModel) updateEdit(msg tea.KeyPressMsg) tea.Cmd {
 		return func() tea.Msg { return planEditorSavedMsg{sessionID: sessID} }
 	}
 	prev := m.doc.Value()
-	cmd := m.doc.UpdateTextarea(msg)
+	var cmd tea.Cmd
+	m.doc, cmd = m.doc.Update(msg)
 	if m.doc.Value() != prev {
 		m.dirty = true
 	}
@@ -902,7 +907,7 @@ func (m *planEditorModel) clampCursor() {
 }
 
 // View renders the full-page plan editor.
-func (m *planEditorModel) View() string {
+func (m planEditorModel) View() string {
 	var lines []string
 	lines = append(lines, m.renderHeader())
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, innerWidth(m.doc.width)))))

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -89,7 +89,7 @@ func TestPlanEditor_EditModeSavesOnCtrlS(t *testing.T) {
 	editor := newPlanEditor(sess, "", 80, 30)
 
 	// `i` enters edit mode.
-	cmd := editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
+	editor, cmd := editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
 	_ = cmd
 	if editor.mode != planEditorModeEdit {
 		t.Fatalf("mode after i = %v, want edit", editor.mode)
@@ -99,7 +99,7 @@ func TestPlanEditor_EditModeSavesOnCtrlS(t *testing.T) {
 	editor.doc.textarea.SetValue("rewritten\n")
 	editor.dirty = true
 
-	cmd = editor.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl, Text: "ctrl+s"})
+	editor, cmd = editor.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl, Text: "ctrl+s"})
 	if cmd == nil {
 		t.Fatal("expected planEditorSavedMsg cmd from ctrl+s")
 	}
@@ -127,11 +127,11 @@ func TestPlanEditor_EscFromEditPreservesEdits(t *testing.T) {
 	sess, _ := newEditorTestSession(t)
 	_ = sess.WritePlan("orig\n")
 	editor := newPlanEditor(sess, "", 80, 30)
-	editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
 	editor.doc.textarea.SetValue("typed but not saved\n")
 	editor.dirty = true
 
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if editor.mode != planEditorModeScroll {
 		t.Errorf("mode = %v, want scroll after esc", editor.mode)
 	}
@@ -148,7 +148,7 @@ func TestPlanEditor_ApproveEmptyPlanShowsError(t *testing.T) {
 	_ = sess.WritePlan("   \n\t\n")
 	editor := newPlanEditor(sess, "", 80, 30)
 
-	cmd := editor.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	editor, cmd := editor.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
 	if cmd != nil {
 		t.Fatal("expected no cmd from approve on empty plan")
 	}
@@ -163,12 +163,12 @@ func TestPlanEditor_ApprovePersistsAndEmits(t *testing.T) {
 	editor := newPlanEditor(sess, "", 80, 30)
 
 	// User edits, doesn't ctrl+s, esc back, then approves.
-	editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
 	editor.doc.textarea.SetValue("# revised\n- [ ] thing\n")
 	editor.dirty = true
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 
-	cmd := editor.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	editor, cmd := editor.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
 	if cmd == nil {
 		t.Fatal("approve produced no cmd")
 	}
@@ -194,7 +194,7 @@ func TestPlanEditor_AbandonEmitsMessage(t *testing.T) {
 	_ = sess.WritePlan("anything\n")
 	editor := newPlanEditor(sess, "", 80, 30)
 
-	cmd := editor.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	_, cmd := editor.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
 	if cmd == nil {
 		t.Fatal("abandon produced no cmd")
 	}
@@ -209,14 +209,16 @@ func TestPlanEditor_DraftingLocksEditAndApprove(t *testing.T) {
 	editor := newPlanEditor(sess, "", 80, 30)
 	editor.SetDrafting(true)
 
-	if cmd := editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"}); cmd != nil {
+	editor, cmd := editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
+	if cmd != nil {
 		t.Error("i should be a no-op while drafting")
 	}
-	if cmd := editor.Update(tea.KeyPressMsg{Code: 'a', Text: "a"}); cmd != nil {
+	editor, cmd = editor.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if cmd != nil {
 		t.Error("a should be a no-op while drafting")
 	}
 	// esc still works to back out.
-	cmd := editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	editor, cmd = editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if cmd == nil {
 		t.Fatal("esc should emit close even while drafting")
 	}
@@ -231,13 +233,13 @@ func TestPlanEditor_ReviseInputEmitsCritique(t *testing.T) {
 	_ = sess.WritePlan("# plan\n")
 	editor := newPlanEditor(sess, "", 80, 30)
 
-	editor.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	if editor.mode != planEditorModeReviseInput {
 		t.Fatalf("mode = %v, want reviseInput", editor.mode)
 	}
 	editor.reviseInput.SetValue("split task 2 into ui and persistence")
 
-	cmd := editor.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
+	editor, cmd := editor.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Text: "enter"})
 	if cmd == nil {
 		t.Fatal("expected revise cmd")
 	}
@@ -304,7 +306,7 @@ func TestPlanEditor_EditModeCenteredOnWideTerminal(t *testing.T) {
 		t.Fatal("displayLeftPad() == 0 at width 120; test precondition failed")
 	}
 
-	editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
 	if editor.mode != planEditorModeEdit {
 		t.Fatalf("mode = %v after 'i', want planEditorModeEdit", editor.mode)
 	}
@@ -479,14 +481,14 @@ func TestPlanEditor_TabTogglesFoldAtViewportTop(t *testing.T) {
 	}
 
 	// Cursor at 0 (Goal); pressing tab collapses it.
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	if !editor.folds["Goal"] {
 		t.Errorf("after tab at Goal (cursor=0), folds[Goal] = false, want true (collapsed)")
 	}
 
 	// Move cursor to Spec (index 1), then tab toggles Spec.
 	editor.sectionCursor = 1
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	if !editor.folds["Spec"] {
 		t.Errorf("after tab at Spec (cursor=1), folds[Spec] = false, want true (collapsed)")
 	}
@@ -507,29 +509,29 @@ func TestPlanEditor_BracketsJumpBetweenSections(t *testing.T) {
 	}
 
 	// ] from 0 → cursor 1 (Spec).
-	editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
 	if editor.sectionCursor != 1 {
 		t.Errorf("] from 0: sectionCursor = %d, want 1 (Spec)", editor.sectionCursor)
 	}
 
 	// ] again → cursor 2 (Tasks).
-	editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
 	if editor.sectionCursor != 2 {
 		t.Errorf("] from Spec: sectionCursor = %d, want 2 (Tasks)", editor.sectionCursor)
 	}
 
 	// ] at last section → still 2 (clamped).
-	editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
 	if editor.sectionCursor != 2 {
 		t.Errorf("] at last section: sectionCursor = %d, want 2 (clamp)", editor.sectionCursor)
 	}
 
 	// [ twice → back to 0 (Goal).
-	editor.Update(tea.KeyPressMsg{Code: '[', Text: "["})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: '[', Text: "["})
 	if editor.sectionCursor != 1 {
 		t.Errorf("[ from Tasks: sectionCursor = %d, want 1 (Spec)", editor.sectionCursor)
 	}
-	editor.Update(tea.KeyPressMsg{Code: '[', Text: "["})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: '[', Text: "["})
 	if editor.sectionCursor != 0 {
 		t.Errorf("[ from Spec: sectionCursor = %d, want 0 (Goal)", editor.sectionCursor)
 	}
@@ -547,7 +549,7 @@ func TestPlanEditor_ShiftZTogglesAllFolds(t *testing.T) {
 	editor := newPlanEditor(sess, "", 80, 30)
 
 	// Default: Goal/Spec/Tasks expanded, others collapsed. Press Z → all collapsed.
-	editor.Update(tea.KeyPressMsg{Code: 'Z', Text: "Z"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'Z', Text: "Z"})
 	for _, s := range editor.sections {
 		if !editor.folds[s.heading] {
 			t.Errorf("after first Z, folds[%q] = false, want true (all collapsed)", s.heading)
@@ -555,7 +557,7 @@ func TestPlanEditor_ShiftZTogglesAllFolds(t *testing.T) {
 	}
 
 	// All collapsed. Press Z again → all expanded.
-	editor.Update(tea.KeyPressMsg{Code: 'Z', Text: "Z"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'Z', Text: "Z"})
 	for _, s := range editor.sections {
 		if editor.folds[s.heading] {
 			t.Errorf("after second Z, folds[%q] = true, want false (all expanded)", s.heading)
@@ -651,7 +653,7 @@ func TestPlanEditor_R_RetryEmitsMsgWhenDraftError(t *testing.T) {
 	sess.SetOriginalPrompt("do the thing")
 	editor := newPlanEditor(sess, "testrepo", 80, 30)
 
-	cmd := editor.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
+	_, cmd := editor.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
 	if cmd == nil {
 		t.Fatal("R with draft error + original prompt should emit a cmd")
 	}
@@ -674,7 +676,7 @@ func TestPlanEditor_R_NoopWhenNoDraftError(t *testing.T) {
 	// No draft error set.
 	editor := newPlanEditor(sess, "testrepo", 80, 30)
 
-	cmd := editor.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
+	_, cmd := editor.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
 	if cmd != nil {
 		t.Errorf("R with no draft error should be a no-op, got cmd that returns %T", cmd())
 	}
@@ -686,7 +688,7 @@ func TestPlanEditor_R_NoopWhenNoOriginalPrompt(t *testing.T) {
 	// No original prompt set.
 	editor := newPlanEditor(sess, "testrepo", 80, 30)
 
-	cmd := editor.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
+	_, cmd := editor.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
 	if cmd != nil {
 		t.Errorf("R with no original prompt should be a no-op, got cmd that returns %T", cmd())
 	}
@@ -702,25 +704,25 @@ func TestPlanEditor_JK_ScrollLines(t *testing.T) {
 	if editor.sectionCursor != 0 {
 		t.Fatalf("sectionCursor = %d, want 0 initially", editor.sectionCursor)
 	}
-	editor.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if editor.sectionCursor != 1 {
 		t.Errorf("after j, sectionCursor = %d, want 1", editor.sectionCursor)
 	}
-	editor.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	if editor.sectionCursor != 0 {
 		t.Errorf("after k, sectionCursor = %d, want 0", editor.sectionCursor)
 	}
 	// k at first section → stays 0 (clamped).
-	editor.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	if editor.sectionCursor != 0 {
 		t.Errorf("k at first section: sectionCursor = %d, want 0", editor.sectionCursor)
 	}
 	// down/up are aliases for j/k.
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	if editor.sectionCursor != 1 {
 		t.Errorf("after down, sectionCursor = %d, want 1", editor.sectionCursor)
 	}
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyUp})
 	if editor.sectionCursor != 0 {
 		t.Errorf("after up, sectionCursor = %d, want 0", editor.sectionCursor)
 	}
@@ -737,12 +739,12 @@ func TestPlanEditor_CtrlD_CtrlU_HalfPage(t *testing.T) {
 		t.Fatal(err)
 	}
 	editor := newPlanEditor(sess, "", 80, 20)
-	editor.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
 	if editor.doc.scrollOff == 0 {
 		t.Errorf("ctrl+d did not scroll")
 	}
 	pre := editor.doc.scrollOff
-	editor.Update(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
 	if editor.doc.scrollOff >= pre {
 		t.Errorf("ctrl+u did not reverse scroll: pre=%d post=%d", pre, editor.doc.scrollOff)
 	}
@@ -760,21 +762,21 @@ func TestPlanEditor_GHomeAndShiftGEnd_Jump(t *testing.T) {
 	}
 	editor := newPlanEditor(sess, "", 80, 20)
 	// G jumps to bottom.
-	editor.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
 	if editor.doc.scrollOff == 0 {
 		t.Errorf("G did not move scroll")
 	}
 	// g jumps back to top.
-	editor.Update(tea.KeyPressMsg{Code: 'g', Text: "g"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'g', Text: "g"})
 	if editor.doc.scrollOff != 0 {
 		t.Errorf("g did not jump to top, got %d", editor.doc.scrollOff)
 	}
 	// home/end aliases.
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyEnd})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyEnd})
 	if editor.doc.scrollOff == 0 {
 		t.Errorf("end did not move scroll")
 	}
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyHome})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyHome})
 	if editor.doc.scrollOff != 0 {
 		t.Errorf("home did not jump to top, got %d", editor.doc.scrollOff)
 	}
@@ -786,7 +788,7 @@ func TestPlanEditor_U_NothingToUndo_ShowsInlineError(t *testing.T) {
 		t.Fatal(err)
 	}
 	editor := newPlanEditor(sess, "", 80, 20)
-	editor.Update(tea.KeyPressMsg{Code: 'u', Text: "u"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'u', Text: "u"})
 	if editor.errMsg == "" {
 		t.Error("u with no prev plan should set an inline error message")
 	}
@@ -816,7 +818,7 @@ func TestPlanEditor_DraftingState_BlocksAllExceptEscAndQ(t *testing.T) {
 		{Code: 'u', Text: "u"},
 		{Code: tea.KeyTab},
 	} {
-		editor.Update(k)
+		editor, _ = editor.Update(k)
 	}
 	if editor.doc.scrollOff != 0 {
 		t.Errorf("scroll changed during drafting, got %d", editor.doc.scrollOff)
@@ -838,12 +840,12 @@ func TestPlanEditor_ReviseInput_EnterOnEmpty_ShowsError(t *testing.T) {
 		t.Fatal(err)
 	}
 	editor := newPlanEditor(sess, "", 80, 20)
-	editor.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	if editor.mode != planEditorModeReviseInput {
 		t.Fatalf("test prereq: mode = %v, want reviseInput", editor.mode)
 	}
 	editor.reviseInput.SetValue("   ")
-	cmd := editor.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	editor, cmd := editor.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if cmd != nil {
 		if _, bad := cmd().(planEditorReviseMsg); bad {
 			t.Error("empty critique should NOT emit reviseMsg")
@@ -860,9 +862,9 @@ func TestPlanEditor_ReviseInput_EscCancels(t *testing.T) {
 		t.Fatal(err)
 	}
 	editor := newPlanEditor(sess, "", 80, 20)
-	editor.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	editor.reviseInput.SetValue("partial input")
-	cmd := editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	editor, cmd := editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if cmd != nil {
 		if _, bad := cmd().(planEditorReviseMsg); bad {
 			t.Error("esc in revise mode must not emit reviseMsg")
@@ -885,7 +887,7 @@ func TestPlanEditor_ScrollMode_UnknownKey_NoOp(t *testing.T) {
 		err    string
 		dirty  bool
 	}{editor.doc.scrollOff, editor.mode, editor.errMsg, editor.dirty}
-	cmd := editor.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
+	editor, cmd := editor.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
 	if cmd != nil {
 		t.Errorf("unknown key produced cmd %T, want nil", cmd())
 	}
@@ -907,7 +909,7 @@ func TestPlanEditor_R_NoopWhenDrafting(t *testing.T) {
 	editor := newPlanEditor(sess, "testrepo", 80, 30)
 	editor.SetDrafting(true)
 
-	cmd := editor.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
+	editor, cmd := editor.Update(tea.KeyPressMsg{Code: 'R', Text: "R"})
 	if cmd != nil {
 		t.Errorf("R while drafting should be a no-op, got cmd that returns %T", cmd())
 	}
@@ -927,23 +929,23 @@ func TestPlanEditor_Brackets_MoveCursor(t *testing.T) {
 	}
 
 	// ] twice: 0→1→2.
-	editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
 	if editor.sectionCursor != 1 {
 		t.Errorf("] once: sectionCursor=%d, want 1", editor.sectionCursor)
 	}
-	editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
 	if editor.sectionCursor != 2 {
 		t.Errorf("] twice: sectionCursor=%d, want 2", editor.sectionCursor)
 	}
 
 	// ] at last section → still 2 (clamped).
-	editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: ']', Text: "]"})
 	if editor.sectionCursor != 2 {
 		t.Errorf("] at last: sectionCursor=%d, want 2", editor.sectionCursor)
 	}
 
 	// [ once: 2→1.
-	editor.Update(tea.KeyPressMsg{Code: '[', Text: "["})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: '[', Text: "["})
 	if editor.sectionCursor != 1 {
 		t.Errorf("[ once: sectionCursor=%d, want 1", editor.sectionCursor)
 	}
@@ -971,14 +973,14 @@ func TestPlanEditor_TabFoldsCursorSection(t *testing.T) {
 
 	// Move cursor to Context (index 2), press tab → Context expands.
 	editor.sectionCursor = 2
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	if editor.folds["Context"] {
 		t.Error("after tab at Context (cursor=2), Context should be expanded")
 	}
 
 	// Move cursor back to Goal (index 0), press tab → Goal collapses.
 	editor.sectionCursor = 0
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	if !editor.folds["Goal"] {
 		t.Error("after tab at Goal (cursor=0), Goal should be collapsed")
 	}
@@ -1005,32 +1007,32 @@ func TestPlanEditor_JK_MoveSectionCursor(t *testing.T) {
 
 	// j three times: 0→1→2→3.
 	for want := 1; want <= 3; want++ {
-		editor.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+		editor, _ = editor.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 		if editor.sectionCursor != want {
 			t.Errorf("after j: sectionCursor=%d, want %d", editor.sectionCursor, want)
 		}
 	}
 
 	// j at last section → still 3 (clamped).
-	editor.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if editor.sectionCursor != 3 {
 		t.Errorf("j at last section: sectionCursor=%d, want 3", editor.sectionCursor)
 	}
 
 	// k twice: 3→2→1.
 	for want := 2; want >= 1; want-- {
-		editor.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+		editor, _ = editor.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 		if editor.sectionCursor != want {
 			t.Errorf("after k: sectionCursor=%d, want %d", editor.sectionCursor, want)
 		}
 	}
 
 	// down/up are aliases.
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyDown})
 	if editor.sectionCursor != 2 {
 		t.Errorf("after down: sectionCursor=%d, want 2", editor.sectionCursor)
 	}
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyUp})
 	if editor.sectionCursor != 1 {
 		t.Errorf("after up: sectionCursor=%d, want 1", editor.sectionCursor)
 	}

--- a/internal/tui/prcomposemodal.go
+++ b/internal/tui/prcomposemodal.go
@@ -86,27 +86,31 @@ func (m *prComposeModal) SetSize(w, h int) {
 
 // Update routes a tea.Msg to updateScroll or updateEdit based on mode.
 // PasteMsg in edit mode is forwarded to the focused field before mode dispatch.
-func (m *prComposeModal) Update(msg tea.Msg) tea.Cmd {
+func (m prComposeModal) Update(msg tea.Msg) (prComposeModal, tea.Cmd) {
 	if !m.active {
-		return nil
+		return m, nil
 	}
 	if paste, ok := msg.(tea.PasteMsg); ok {
 		if m.mode == prComposeModeEdit {
 			if m.titleInput.Focused() {
 				var cmd tea.Cmd
 				m.titleInput, cmd = m.titleInput.Update(paste)
-				return cmd
+				return m, cmd
 			}
-			return m.doc.UpdateTextarea(paste)
+			var cmd tea.Cmd
+			m.doc, cmd = m.doc.Update(paste)
+			return m, cmd
 		}
-		return nil
+		return m, nil
 	}
+	var cmd tea.Cmd
 	switch m.mode {
 	case prComposeModeEdit:
-		return m.updateEdit(msg)
+		cmd = m.updateEdit(msg)
 	default:
-		return m.updateScroll(msg)
+		cmd = m.updateScroll(msg)
 	}
+	return m, cmd
 }
 
 func (m *prComposeModal) updateScroll(msg tea.Msg) tea.Cmd {
@@ -169,7 +173,9 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 			m.titleInput, cmd = m.titleInput.Update(msg)
 			return cmd
 		}
-		return m.doc.UpdateTextarea(msg)
+		var cmd tea.Cmd
+		m.doc, cmd = m.doc.Update(msg)
+		return cmd
 	}
 	switch key.String() {
 	case "esc":
@@ -204,11 +210,13 @@ func (m *prComposeModal) updateEdit(msg tea.Msg) tea.Cmd {
 		m.titleInput, cmd = m.titleInput.Update(msg)
 		return cmd
 	}
-	return m.doc.UpdateTextarea(msg)
+	var cmd tea.Cmd
+	m.doc, cmd = m.doc.Update(msg)
+	return cmd
 }
 
 // View renders the full-page PR compose. Only call when Active() is true.
-func (m *prComposeModal) View() string {
+func (m prComposeModal) View() string {
 	var lines []string
 	lines = append(lines, m.renderHeader())
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, innerWidth(m.doc.width)))))

--- a/internal/tui/prcomposemodal_test.go
+++ b/internal/tui/prcomposemodal_test.go
@@ -9,12 +9,12 @@ import (
 
 // makePRComposeForTest returns an opened modal with sane defaults so each
 // test can focus on a single key.
-func makePRComposeForTest(t *testing.T) *prComposeModal {
+func makePRComposeForTest(t *testing.T) prComposeModal {
 	t.Helper()
 	m := newPRComposeModal()
 	m.SetSize(120, 40)
 	m.Open("Initial title", "Initial body line 1\nbody line 2", true, "")
-	return &m
+	return m
 }
 
 func TestPRCompose_OpenSetsScrollModeAndHasRenderer(t *testing.T) {
@@ -78,7 +78,7 @@ func TestPRCompose_ScrollKeyJ_IncrementsScrollOff(t *testing.T) {
 	m.doc.SetValue(strings.Repeat("line\n", 50))
 	m.SetSize(120, 40)
 	before := m.doc.scrollOff
-	m.Update(keyRune('j'))
+	m, _ = m.Update(keyRune('j'))
 	if m.doc.scrollOff <= before {
 		t.Errorf("j did not increment scrollOff: before=%d after=%d", before, m.doc.scrollOff)
 	}
@@ -88,10 +88,10 @@ func TestPRCompose_ScrollKeyK_DecrementsScrollOff(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.doc.SetValue(strings.Repeat("line\n", 50))
 	m.SetSize(120, 40)
-	m.Update(keyRune('j'))
-	m.Update(keyRune('j'))
+	m, _ = m.Update(keyRune('j'))
+	m, _ = m.Update(keyRune('j'))
 	after := m.doc.scrollOff
-	m.Update(keyRune('k'))
+	m, _ = m.Update(keyRune('k'))
 	if m.doc.scrollOff >= after {
 		t.Errorf("k did not decrement scrollOff: before=%d after=%d", after, m.doc.scrollOff)
 	}
@@ -101,9 +101,9 @@ func TestPRCompose_ScrollKeyG_GoesToTop(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.doc.SetValue(strings.Repeat("line\n", 50))
 	m.SetSize(120, 40)
-	m.Update(keyRune('j'))
-	m.Update(keyRune('j'))
-	m.Update(keyRune('g'))
+	m, _ = m.Update(keyRune('j'))
+	m, _ = m.Update(keyRune('j'))
+	m, _ = m.Update(keyRune('g'))
 	if m.doc.scrollOff != 0 {
 		t.Errorf("g did not reset scrollOff to 0, got %d", m.doc.scrollOff)
 	}
@@ -113,7 +113,7 @@ func TestPRCompose_ScrollKeyG_GoesToTop(t *testing.T) {
 
 func TestPRCompose_EscCancels(t *testing.T) {
 	m := makePRComposeForTest(t)
-	cmd := m.Update(keyNamed(tea.KeyEscape))
+	m, cmd := m.Update(keyNamed(tea.KeyEscape))
 	if cmd == nil {
 		t.Fatal("expected cancel cmd")
 	}
@@ -130,7 +130,7 @@ func TestPRCompose_CtrlEnterSubmitsTrimmedValues(t *testing.T) {
 	m.titleInput.SetValue("  trimmed title  ")
 	m.doc.SetValue("\nbody with leading newline\n")
 
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
 	if cmd == nil {
 		t.Fatal("expected submit cmd from ctrl+enter")
 	}
@@ -155,7 +155,7 @@ func TestPRCompose_CtrlEnterSubmitsTrimmedValues(t *testing.T) {
 func TestPRCompose_CtrlEnter_EmptyTitle_NoOp(t *testing.T) {
 	m := makePRComposeForTest(t)
 	m.titleInput.SetValue("   ")
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
 	if cmd != nil {
 		t.Fatalf("empty title submit should be a no-op (no cmd); got %T", cmd())
 	}
@@ -169,11 +169,11 @@ func TestPRCompose_CtrlD_ScrollMode_TogglesAndDraftReflectedOnSubmit(t *testing.
 	if !m.draft {
 		t.Fatal("prereq: draft should start true")
 	}
-	m.Update(keyCtrlRune('d')) // toggle to ready
+	m, _ = m.Update(keyCtrlRune('d')) // toggle to ready
 	if m.draft {
 		t.Fatal("ctrl+d did not toggle draft off in scroll mode")
 	}
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
 	if cmd == nil {
 		t.Fatal("expected submit cmd")
 	}
@@ -193,7 +193,7 @@ func TestPRCompose_I_EntersEditModeAndFocusesTitle(t *testing.T) {
 	if m.mode != prComposeModeScroll {
 		t.Fatalf("prereq: mode=%v, want scroll", m.mode)
 	}
-	m.Update(keyRune('i'))
+	m, _ = m.Update(keyRune('i'))
 	if m.mode != prComposeModeEdit {
 		t.Errorf("after i: mode=%v, want prComposeModeEdit", m.mode)
 	}
@@ -204,11 +204,11 @@ func TestPRCompose_I_EntersEditModeAndFocusesTitle(t *testing.T) {
 
 func TestPRCompose_EscInEditMode_ReturnsToScroll(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i'))
+	m, _ = m.Update(keyRune('i'))
 	if m.mode != prComposeModeEdit {
 		t.Fatalf("prereq: expected edit mode")
 	}
-	m.Update(keyNamed(tea.KeyEscape))
+	m, _ = m.Update(keyNamed(tea.KeyEscape))
 	if m.mode != prComposeModeScroll {
 		t.Errorf("esc in edit mode did not return to scroll: mode=%v", m.mode)
 	}
@@ -219,15 +219,15 @@ func TestPRCompose_EscInEditMode_ReturnsToScroll(t *testing.T) {
 
 func TestPRCompose_Tab_SwitchesFocusToBodyInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode; title focused first
+	m, _ = m.Update(keyRune('i')) // enter edit mode; title focused first
 	if !m.titleInput.Focused() {
 		t.Fatal("prereq: title input should be focused after i")
 	}
-	m.Update(keyNamed(tea.KeyTab))
+	m, _ = m.Update(keyNamed(tea.KeyTab))
 	if !m.doc.Focused() {
 		t.Error("after tab: body should be focused")
 	}
-	m.Update(keyNamed(tea.KeyTab))
+	m, _ = m.Update(keyNamed(tea.KeyTab))
 	if !m.titleInput.Focused() {
 		t.Error("after second tab: title should be focused again")
 	}
@@ -235,8 +235,8 @@ func TestPRCompose_Tab_SwitchesFocusToBodyInEditMode(t *testing.T) {
 
 func TestPRCompose_ShiftTab_SwitchesFocusInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode
-	m.Update(keyShiftNamed(tea.KeyTab))
+	m, _ = m.Update(keyRune('i')) // enter edit mode
+	m, _ = m.Update(keyShiftNamed(tea.KeyTab))
 	if !m.doc.Focused() {
 		t.Error("after shift+tab: body should be focused")
 	}
@@ -247,14 +247,14 @@ func TestPRCompose_CtrlD_TogglesDraft(t *testing.T) {
 	if !m.draft {
 		t.Fatal("test prereq: draft should start true")
 	}
-	cmd := m.Update(keyCtrlRune('d'))
+	m, cmd := m.Update(keyCtrlRune('d'))
 	if cmd != nil {
 		t.Errorf("ctrl+d should not emit a cmd, got %T", cmd())
 	}
 	if m.draft {
 		t.Error("ctrl+d did not toggle draft off")
 	}
-	m.Update(keyCtrlRune('d'))
+	m, _ = m.Update(keyCtrlRune('d'))
 	if !m.draft {
 		t.Error("second ctrl+d did not toggle draft back on")
 	}
@@ -262,8 +262,8 @@ func TestPRCompose_CtrlD_TogglesDraft(t *testing.T) {
 
 func TestPRCompose_CtrlEnterInEditMode_Submits(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+	m, _ = m.Update(keyRune('i')) // enter edit mode
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
 	if cmd == nil {
 		t.Fatal("expected submit cmd from ctrl+enter in edit mode")
 	}
@@ -277,11 +277,11 @@ func TestPRCompose_CtrlEnterInEditMode_Submits(t *testing.T) {
 
 func TestPRCompose_CtrlD_TogglesDraftInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode
+	m, _ = m.Update(keyRune('i')) // enter edit mode
 	if !m.draft {
 		t.Fatal("prereq: draft should be true")
 	}
-	m.Update(keyCtrlRune('d'))
+	m, _ = m.Update(keyCtrlRune('d'))
 	if m.draft {
 		t.Error("ctrl+d in edit mode did not toggle draft off")
 	}
@@ -289,9 +289,9 @@ func TestPRCompose_CtrlD_TogglesDraftInEditMode(t *testing.T) {
 
 func TestPRCompose_CtrlEnter_EmptyTitle_NoOp_EditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode
+	m, _ = m.Update(keyRune('i')) // enter edit mode
 	m.titleInput.SetValue("   ")
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
+	m, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl})
 	if cmd != nil {
 		t.Fatalf("empty title in edit mode should be a no-op; got cmd %T", cmd())
 	}
@@ -304,7 +304,7 @@ func TestPRCompose_CtrlEnter_EmptyTitle_NoOp_EditMode(t *testing.T) {
 
 func TestPRCompose_ViewEditMode_ContainsHeaderAndTitle(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode
+	m, _ = m.Update(keyRune('i')) // enter edit mode
 	v := m.View()
 	if !strings.Contains(v, "PR DRAFT") {
 		t.Errorf("edit view missing 'PR DRAFT', got: %q", v)
@@ -323,11 +323,11 @@ func TestPRCompose_ViewEditMode_ContainsHeaderAndTitle(t *testing.T) {
 
 func TestPRCompose_PasteInEditMode_TitleFocused_UpdatesTitle(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode, title focused
+	m, _ = m.Update(keyRune('i')) // enter edit mode, title focused
 	if !m.titleInput.Focused() {
 		t.Fatal("prereq: title input should be focused after i")
 	}
-	cmd := m.Update(tea.PasteMsg{Content: "pasted-title"})
+	m, cmd := m.Update(tea.PasteMsg{Content: "pasted-title"})
 	if cmd != nil {
 		cmd()
 	}
@@ -338,13 +338,13 @@ func TestPRCompose_PasteInEditMode_TitleFocused_UpdatesTitle(t *testing.T) {
 
 func TestPRCompose_PasteInEditMode_BodyFocused_UpdatesBody(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i'))         // enter edit mode
-	m.Update(keyNamed(tea.KeyTab)) // switch to body
+	m, _ = m.Update(keyRune('i'))         // enter edit mode
+	m, _ = m.Update(keyNamed(tea.KeyTab)) // switch to body
 	if !m.doc.Focused() {
 		t.Fatal("prereq: body should be focused after tab")
 	}
 	bodyBefore := m.doc.Value()
-	m.Update(tea.PasteMsg{Content: "pasted-body"})
+	m, _ = m.Update(tea.PasteMsg{Content: "pasted-body"})
 	if got := m.doc.Value(); got == bodyBefore {
 		t.Error("paste in body-focused edit mode did not update body")
 	}
@@ -353,7 +353,7 @@ func TestPRCompose_PasteInEditMode_BodyFocused_UpdatesBody(t *testing.T) {
 func TestPRCompose_PasteInScrollMode_IsNoOp(t *testing.T) {
 	m := makePRComposeForTest(t)
 	titleBefore := m.titleInput.Value()
-	m.Update(tea.PasteMsg{Content: "should-be-ignored"})
+	m, _ = m.Update(tea.PasteMsg{Content: "should-be-ignored"})
 	if m.titleInput.Value() != titleBefore {
 		t.Error("paste in scroll mode should not modify title")
 	}
@@ -361,9 +361,9 @@ func TestPRCompose_PasteInScrollMode_IsNoOp(t *testing.T) {
 
 func TestPRCompose_PrintableKey_AppendsToTitleInEditMode(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i')) // enter edit mode (title focused)
+	m, _ = m.Update(keyRune('i')) // enter edit mode (title focused)
 	m.titleInput.SetValue("hi")
-	m.Update(keyRune('!'))
+	m, _ = m.Update(keyRune('!'))
 	if got := m.titleInput.Value(); !strings.Contains(got, "!") {
 		t.Errorf("title = %q, want it to include '!' after typing in edit mode", got)
 	}
@@ -371,13 +371,13 @@ func TestPRCompose_PrintableKey_AppendsToTitleInEditMode(t *testing.T) {
 
 func TestPRCompose_PrintableKey_RoutedToBodyInEditModeWhenBodyFocused(t *testing.T) {
 	m := makePRComposeForTest(t)
-	m.Update(keyRune('i'))         // enter edit mode (title focused)
-	m.Update(keyNamed(tea.KeyTab)) // switch to body
+	m, _ = m.Update(keyRune('i'))         // enter edit mode (title focused)
+	m, _ = m.Update(keyNamed(tea.KeyTab)) // switch to body
 	if !m.doc.Focused() {
 		t.Fatal("body should be focused after tab")
 	}
 	bodyBefore := m.doc.Value()
-	m.Update(keyRune('?'))
+	m, _ = m.Update(keyRune('?'))
 	if m.doc.Value() == bodyBefore {
 		t.Error("typing in body did not change body value")
 	}
@@ -397,7 +397,7 @@ func TestPRCompose_NotActive_AllInputsNoOp(t *testing.T) {
 		keyNamed(tea.KeyTab),
 		keyRune('x'),
 	} {
-		cmd := m.Update(k)
+		_, cmd := m.Update(k)
 		if cmd != nil {
 			t.Errorf("inactive modal returned cmd for %v: %T", k, cmd())
 		}
@@ -409,7 +409,7 @@ func TestPRCompose_NotActive_AllInputsNoOp(t *testing.T) {
 
 func TestPRCompose_UnknownKey_DoesNotCloseOrSubmit(t *testing.T) {
 	m := makePRComposeForTest(t)
-	cmd := m.Update(keyRune('z'))
+	m, cmd := m.Update(keyRune('z'))
 	// 'z' is forwarded to the textarea; it may produce a cmd (cursor blink
 	// etc.) but it must NOT produce submit/cancel.
 	if cmd != nil {

--- a/internal/tui/repochecks_integration_test.go
+++ b/internal/tui/repochecks_integration_test.go
@@ -46,11 +46,12 @@ func TestRepoChecks_RoundTrip_FormToEditorToDisk(t *testing.T) {
 	}
 
 	// Add a check via the editor and commit it.
-	editor.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	*editor, _ = editor.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
 	editor.nameInput.SetValue("Smoke")
 	editor.cmdInput.SetValue("true")
-	editor.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	saveCmd := editor.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	*editor, _ = editor.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	var saveCmd tea.Cmd
+	*editor, saveCmd = editor.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
 	if saveCmd == nil {
 		t.Fatal("expected non-nil cmd from ctrl+s in editor")
 	}
@@ -132,7 +133,8 @@ func TestRepoChecks_CancelDiscardsPending(t *testing.T) {
 	app = model.(App)
 	editor := app.modals.RepoChecks()
 	editor.checks = []config.ValidationCheck{{Name: "Replaced", Command: "false"}}
-	cancelCmd := editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	var cancelCmd tea.Cmd
+	*editor, cancelCmd = editor.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if cancelCmd == nil {
 		t.Fatal("esc should produce a cancel cmd")
 	}

--- a/internal/tui/repochecksmodel.go
+++ b/internal/tui/repochecksmodel.go
@@ -44,30 +44,42 @@ type repoChecksModel struct {
 	activeInput repoChecksInput
 	nameInput   textinput.Model
 	cmdInput    textinput.Model
+	width       int
+	height      int
 }
 
 // newRepoChecksModel seeds the editor from an existing checks list. The
 // caller must pass a fresh copy if it wants edits to be discardable on cancel.
-func newRepoChecksModel(repoName string, checks []config.ValidationCheck) *repoChecksModel {
+func newRepoChecksModel(repoName string, checks []config.ValidationCheck) repoChecksModel {
 	cp := make([]config.ValidationCheck, len(checks))
 	copy(cp, checks)
-	return &repoChecksModel{
+	return repoChecksModel{
 		repoName: repoName,
 		checks:   cp,
 	}
 }
 
-// Update handles a key event for the editor.
-func (m *repoChecksModel) Update(msg tea.Msg) tea.Cmd {
+// SetSize informs the editor of the space it has to render in.
+func (m *repoChecksModel) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+}
+
+// Update handles a key event for the editor. It returns the next editor state
+// and any command to run (CONVENTIONS.md §3).
+func (m repoChecksModel) Update(msg tea.Msg) (repoChecksModel, tea.Cmd) {
 	key, ok := msg.(tea.KeyPressMsg)
 	if !ok {
-		return nil
+		return m, nil
 	}
 
+	var cmd tea.Cmd
 	if m.editing {
-		return m.updateEditing(key)
+		cmd = m.updateEditing(key)
+	} else {
+		cmd = m.updateList(key)
 	}
-	return m.updateList(key)
+	return m, cmd
 }
 
 func (m *repoChecksModel) updateList(msg tea.KeyPressMsg) tea.Cmd {
@@ -190,7 +202,7 @@ func (m *repoChecksModel) commitEdit() {
 
 // View renders the editor body (no surrounding border — that's the overlay's
 // job).
-func (m *repoChecksModel) View() string {
+func (m repoChecksModel) View() string {
 	subtitle := StyleSubtle.Render("Commands run with sh -c against the worktree during the review panel's Checks tab.")
 	var body string
 	if len(m.checks) == 0 {

--- a/internal/tui/repochecksmodel_test.go
+++ b/internal/tui/repochecksmodel_test.go
@@ -30,7 +30,7 @@ func TestRepoChecks_NewSeedsCopy(t *testing.T) {
 func TestRepoChecks_DownClampsAtLast(t *testing.T) {
 	m := newRepoChecksModel("r", sampleChecks())
 	for range 5 {
-		m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
+		m, _ = m.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	}
 	if m.cursor != 1 {
 		t.Errorf("cursor = %d, want 1", m.cursor)
@@ -39,7 +39,7 @@ func TestRepoChecks_DownClampsAtLast(t *testing.T) {
 
 func TestRepoChecks_UpClampsAtZero(t *testing.T) {
 	m := newRepoChecksModel("r", sampleChecks())
-	m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	if m.cursor != 0 {
 		t.Errorf("cursor = %d, want 0", m.cursor)
 	}
@@ -47,7 +47,7 @@ func TestRepoChecks_UpClampsAtZero(t *testing.T) {
 
 func TestRepoChecks_AddBeginsEditOnNewRow(t *testing.T) {
 	m := newRepoChecksModel("r", nil)
-	m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
 	if !m.editing {
 		t.Fatal("expected editing=true after 'a'")
 	}
@@ -61,10 +61,10 @@ func TestRepoChecks_AddBeginsEditOnNewRow(t *testing.T) {
 
 func TestRepoChecks_EditCommitsValuesAndExitsEditMode(t *testing.T) {
 	m := newRepoChecksModel("r", nil)
-	m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
 	m.nameInput.SetValue("Smoke")
 	m.cmdInput.SetValue("./smoke.sh")
-	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	if m.editing {
 		t.Error("editing should be false after committing")
@@ -76,11 +76,11 @@ func TestRepoChecks_EditCommitsValuesAndExitsEditMode(t *testing.T) {
 
 func TestRepoChecks_EditEscDiscardsBlankRow(t *testing.T) {
 	m := newRepoChecksModel("r", sampleChecks())
-	m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
 	if len(m.checks) != 3 {
 		t.Fatalf("setup: len = %d, want 3", len(m.checks))
 	}
-	m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 
 	if m.editing {
 		t.Error("editing should be false after esc")
@@ -94,7 +94,7 @@ func TestRepoChecks_EditEscPreservesNonBlankRow(t *testing.T) {
 	m := newRepoChecksModel("r", sampleChecks())
 	m.beginEdit(0)
 	m.nameInput.SetValue("Edited but cancelled")
-	m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 
 	if m.checks[0].Name != "Tests" {
 		t.Errorf("esc should not commit, got %q", m.checks[0].Name)
@@ -107,7 +107,7 @@ func TestRepoChecks_EditEscPreservesNonBlankRow(t *testing.T) {
 func TestRepoChecks_DeleteRemovesAndClampsCursor(t *testing.T) {
 	m := newRepoChecksModel("r", sampleChecks())
 	m.cursor = 1
-	m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
 	if len(m.checks) != 1 {
 		t.Errorf("after delete, len = %d, want 1", len(m.checks))
 	}
@@ -115,7 +115,7 @@ func TestRepoChecks_DeleteRemovesAndClampsCursor(t *testing.T) {
 		t.Errorf("cursor should clamp to last row, got %d", m.cursor)
 	}
 	// Delete the last remaining row -> cursor clamps to 0 with empty slice.
-	m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
 	if len(m.checks) != 0 {
 		t.Errorf("after second delete, len = %d, want 0", len(m.checks))
 	}
@@ -126,7 +126,7 @@ func TestRepoChecks_DeleteRemovesAndClampsCursor(t *testing.T) {
 
 func TestRepoChecks_DeleteOnEmptyIsNoOp(t *testing.T) {
 	m := newRepoChecksModel("r", nil)
-	m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
 	if len(m.checks) != 0 {
 		t.Errorf("delete on empty should keep len 0, got %d", len(m.checks))
 	}
@@ -134,7 +134,7 @@ func TestRepoChecks_DeleteOnEmptyIsNoOp(t *testing.T) {
 
 func TestRepoChecks_CtrlSEmitsSaveMsgWithCurrentList(t *testing.T) {
 	m := newRepoChecksModel("r", sampleChecks())
-	cmd := m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl})
 	if cmd == nil {
 		t.Fatal("ctrl+s should return a non-nil cmd")
 	}
@@ -150,7 +150,7 @@ func TestRepoChecks_CtrlSEmitsSaveMsgWithCurrentList(t *testing.T) {
 
 func TestRepoChecks_EscEmitsCancelMsg(t *testing.T) {
 	m := newRepoChecksModel("r", sampleChecks())
-	cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if cmd == nil {
 		t.Fatal("esc should return a non-nil cmd")
 	}
@@ -165,11 +165,11 @@ func TestRepoChecks_TabSwitchesInputFocus(t *testing.T) {
 	if m.activeInput != repoChecksInputName {
 		t.Fatalf("initial activeInput = %v, want name", m.activeInput)
 	}
-	m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	if m.activeInput != repoChecksInputCommand {
 		t.Errorf("after tab, activeInput = %v, want command", m.activeInput)
 	}
-	m.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
 	if m.activeInput != repoChecksInputName {
 		t.Errorf("after shift+tab, activeInput = %v, want name", m.activeInput)
 	}

--- a/internal/tui/reviewpanelmodel.go
+++ b/internal/tui/reviewpanelmodel.go
@@ -88,8 +88,8 @@ func (m *reviewPanelModel) TaskCursor() int {
 	return m.taskCursor
 }
 
-// Resize updates cached layout dimensions.
-func (m *reviewPanelModel) Resize(w, h int) {
+// SetSize updates cached layout dimensions.
+func (m *reviewPanelModel) SetSize(w, h int) {
 	if m == nil {
 		return
 	}
@@ -155,7 +155,7 @@ func (m *reviewPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel, t
 	}
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.Resize(msg.Width, msg.Height-1)
+		m.SetSize(msg.Width, msg.Height-1)
 		return m, nil
 	case tea.KeyPressMsg:
 		return m.handleKey(msg, svc)

--- a/internal/tui/shippingpanelmodel.go
+++ b/internal/tui/shippingpanelmodel.go
@@ -69,8 +69,8 @@ func (m *shippingPanelModel) DetailScroll() int {
 	return m.detailScroll
 }
 
-// Resize updates layout dimensions and forwards to the nested modal.
-func (m *shippingPanelModel) Resize(w, h int) {
+// SetSize updates layout dimensions and forwards to the nested modal.
+func (m *shippingPanelModel) SetSize(w, h int) {
 	if m == nil {
 		return
 	}
@@ -95,6 +95,15 @@ func closeShippingPanel(svc PanelServices) tea.Cmd {
 	return nil
 }
 
+// feedbackNoteSubmitMsg is emitted by the embedded feedbackNoteModal when the
+// user saves a note (enter). It is owned and handled here (§4): the shipping
+// panel persists the note via svc.SetFeedbackNote one Update cycle after the
+// modal closes.
+type feedbackNoteSubmitMsg struct {
+	itemKey string
+	note    string
+}
+
 // Update dispatches the shipping panel's key handling.
 func (m *shippingPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel, tea.Cmd) {
 	if m == nil || m.session == nil {
@@ -102,7 +111,12 @@ func (m *shippingPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel,
 	}
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.Resize(msg.Width, msg.Height-1)
+		m.SetSize(msg.Width, msg.Height-1)
+		return m, nil
+	case feedbackNoteSubmitMsg:
+		if svc.SetFeedbackNote != nil {
+			svc.SetFeedbackNote(m.repoPath, m.session.ID, msg.itemKey, msg.note)
+		}
 		return m, nil
 	case tea.KeyPressMsg:
 		return m.handleKey(msg, svc)
@@ -114,10 +128,8 @@ func (m *shippingPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel,
 // intercepts all keys when active.
 func (m *shippingPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (PanelModel, tea.Cmd) {
 	if m.feedbackNote.Active() {
-		cmd, submitted, note := m.feedbackNote.Update(msg)
-		if submitted && svc.SetFeedbackNote != nil {
-			svc.SetFeedbackNote(m.repoPath, m.session.ID, m.feedbackNote.itemKey, note)
-		}
+		var cmd tea.Cmd
+		m.feedbackNote, cmd = m.feedbackNote.Update(msg)
 		return m, cmd
 	}
 

--- a/internal/tui/shippingpanelmodel_test.go
+++ b/internal/tui/shippingpanelmodel_test.go
@@ -325,10 +325,20 @@ func TestShippingPanelModel_NoteModalEnter_SavesNote(t *testing.T) {
 	panel, svc, state := shippingPanelWithFeedback()
 	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"}, svc)
 	panel.feedbackNote.ta.SetValue("important note")
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEnter}, svc)
+	// Enter closes the modal synchronously and emits a feedbackNoteSubmitMsg;
+	// the note persists one Update cycle later when that msg is handled.
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: tea.KeyEnter}, svc)
 	if panel.NoteActive() {
 		t.Error("enter should close the modal")
 	}
+	if cmd == nil {
+		t.Fatal("enter should emit a submit cmd")
+	}
+	submit, ok := cmd().(feedbackNoteSubmitMsg)
+	if !ok {
+		t.Fatalf("enter cmd yielded %T, want feedbackNoteSubmitMsg", cmd())
+	}
+	_, _ = panel.Update(submit, svc)
 	got := state.triage["thread:alice"]
 	if got == nil || got.Note != "important note" {
 		t.Errorf("triage note = %+v, want %q", got, "important note")

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -40,7 +40,8 @@ func (a App) updateDashboard(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.wellness.RecordInput()
 		// PR compose modal consumes all keys while open.
 		if a.prComposeModal.Active() {
-			cmd := a.prComposeModal.Update(msg)
+			var cmd tea.Cmd
+			a.prComposeModal, cmd = a.prComposeModal.Update(msg)
 			return a, cmd
 		}
 		// focusLaunch: forward all keys to the launch agent; esc/ctrl+e returns to focus pipeline.
@@ -326,7 +327,8 @@ func (a App) handleKeysPlanEditor(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 	if pe == nil {
 		return a, nil, false
 	}
-	cmd := pe.Update(msg)
+	updated, cmd := pe.Update(msg)
+	*pe = updated
 	return a, cmd, true
 }
 
@@ -1211,7 +1213,8 @@ func (a App) handleConfigFormSave() (tea.Model, tea.Cmd) {
 // arbitrary text on the pipeline).
 func (a App) handleDashboardPaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
 	if a.prComposeModal.Active() {
-		cmd := a.prComposeModal.Update(msg)
+		var cmd tea.Cmd
+		a.prComposeModal, cmd = a.prComposeModal.Update(msg)
 		return a, cmd
 	}
 	if ag := a.modals.LaunchAgent(); ag != nil {

--- a/internal/tui/update_lifecycle.go
+++ b/internal/tui/update_lifecycle.go
@@ -35,6 +35,8 @@ func (a App) handleWindowSize(msg tea.WindowSizeMsg) App {
 
 	// newSession always tracks terminal dimensions (it may be open in any view).
 	a.newSession.SetSize(msg.Width, msg.Height-1)
+	// globalConfig may be open in its own view; keep its form sized.
+	a.globalConfig.SetSize(msg.Width, msg.Height-1)
 
 	// Resize agent terminals to match their current display container.
 	if a.view == ViewDashboard {
@@ -47,7 +49,13 @@ func (a App) handleWindowSize(msg tea.WindowSizeMsg) App {
 		}
 		a.prComposeModal.SetSize(msg.Width, msg.Height-1)
 		if sp := a.modals.Shipping(); sp != nil {
-			sp.Resize(msg.Width, msg.Height-1)
+			sp.SetSize(msg.Width, msg.Height-1)
+		}
+		if cf := a.modals.Config(); cf != nil {
+			cf.SetSize(msg.Width, msg.Height-1)
+		}
+		if rc := a.modals.RepoChecks(); rc != nil {
+			rc.SetSize(msg.Width, msg.Height-1)
 		}
 	}
 	return a

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -211,6 +211,22 @@ func (a *App) setFeedbackNote(repoPath, sessID, itemKey, note string) {
 	}
 }
 
+// handleFeedbackNoteSubmit forwards a feedbackNoteSubmitMsg to the active
+// shipping panel so it can persist the note via svc.SetFeedbackNote. Mirrors
+// the snapshot-and-restore pattern of handleKeysShippingPanel; the message is
+// otherwise local to the shipping panel.
+func (a App) handleFeedbackNoteSubmit(msg feedbackNoteSubmitMsg) (tea.Model, tea.Cmd) {
+	snapshot := a.modals.Shipping()
+	if snapshot == nil {
+		return a, nil
+	}
+	updated, cmd := snapshot.Update(msg, a.panelServices())
+	if sp, ok := updated.(*shippingPanelModel); ok {
+		a.modals.CompareAndSetShipping(snapshot, sp)
+	}
+	return a, cmd
+}
+
 // handleShippingFeedbackRequest spawns a new agent in the session's existing
 // worktree, synthesised from failing CI checks and unresolved review
 // comments, and transitions the session back to LifecycleInProgress. The

--- a/internal/tui/update_views.go
+++ b/internal/tui/update_views.go
@@ -177,7 +177,7 @@ func (a *App) initRepoChecksEditor(repoPath string) {
 		}
 	}
 	editor := newRepoChecksModel(repoName, a.pendingChecks)
-	a.openRepoChecksEditor(editor, repoPath)
+	a.openRepoChecksEditor(&editor, repoPath)
 }
 
 // updateRepoChecks handles save and cancel messages from the checks


### PR DESCRIPTION
## Summary

<!-- Bullet points describing what changed and why. Focus on the *why* — the diff shows the *what*. -->

Phase 4 of the `internal/tui` migration toward `CONVENTIONS.md` §3. Every screen/panel/modal/picker now follows **one** component shape so state transitions are explicit and reviewable in one place, and the architecture is uniform for Phase 5.

- **`Component` contract documented** — new `internal/tui/component.go` defines the target shape: value-receiver `Update` returning the concrete type + `tea.Cmd`, pure value-receiver `View()`, and sizing via `SetSize(w, h)`. Conformance is by **shape, not literal interface** (decision locked with maintainer): no `var _ Component = …` assertions and no type-assertion routing — components return their own concrete type, matching the 5 already-conforming components.
- **7 components converted to value-semantics** `Update`/`View`: `configForm`, `repoChecksModel`, `newSessionModel`, `prComposeModal`, `planEditorModel`, `feedbackNoteModal`, and the shared embedded `docEditor` sub-widget (its `UpdateTextarea` renamed to `Update`; it conforms to the shape but intentionally has no standalone `View`).
- **`SetSize` added** to `configForm` and `repoChecksModel`, with resize wiring in `update_lifecycle.go` (and a pass-through on `globalConfigModel`).
- **`repoChecksModel` constructor returns a value** (was a pointer); callers take the address when storing in `Modals`.
- **`PanelModel.Resize` → `SetSize`** for naming consistency. `PanelModel` keeps its `PanelServices` argument — folding panels fully into `Component` is deferred to Phase 5.
- **`feedbackNoteModal` drops its non-standard `(tea.Cmd, bool, string)` tuple.** On `enter` it closes synchronously and emits a `feedbackNoteSubmitMsg{itemKey, note}`, which is owned/handled by the shipping panel (`shippingPanelModel.Update` → `svc.SetFeedbackNote`) and routed there by `App.Update`. The note save lands one deterministic `Update` cycle later (no goroutine).

No user-facing behavior changes — this is a structural/contract refactor.

## Test plan

<!-- Check the commands you actually ran. Add manual TUI steps when UI behavior changed. -->

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofumpt -l .` (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test -race ./...`
- [x] `go test -tags e2e ./internal/e2e/` compiles under the build tag
- [ ] Manual TUI: per-repo + global config forms (incl. validation-checks sub-editor), new-session prompt, plan editor, PR compose, shipping-panel feedback note

## Checklist

- [x] Updated changelog (`changelog.d/phase-4-component-contract.md` under `### Changed`)
- [x] New behavior has tests (updated component tests + shipping-panel msg-routing test)
- [x] No new public API surface without a note in the PR description (the `Component` interface is documentation-only; see Summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)