### PR TITLE
Phase 5b — Fold panels into the §3 Component contract + fix validationRuns repo-keying

### DIFF
--- a/changelog.d/phase-5b-panel-component-contract.md
+++ b/changelog.d/phase-5b-panel-component-contract.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Validation-check run state is now keyed by `(repoPath, sessionID)` instead of
+  bare session ID, so two repos hosting a session with the same ID no longer
+  collide; stale entries are also cleaned up when their session disappears.
+
+### Changed
+
+- Review and shipping panels now conform to the §3 Component contract: their
+  `Update`/`View` no longer take a per-tick `PanelServices` value. Reference-typed
+  handles are injected at construction and panel→App scalar mutations flow as
+  messages applied centrally by `App.Update`. The `PanelServices` seam and its
+  per-tick builder have been removed.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -204,7 +204,7 @@ type App struct {
 	// state live each frame via dashboardProps(); there is no mirror to sync.
 	modals          Modals
 	reviewDiffCache map[string]*reviewDiffEntry                // keyed by cacheKey(repoPath, sessionID); lifetime exceeds panel
-	validationRuns  map[string]*validationRunState             // keyed by sessionID; lifetime exceeds panel
+	validationRuns  map[string]*validationRunState             // keyed by cacheKey(repoPath, sessionID); lifetime exceeds panel
 	feedbackTriage  map[string]map[string]*feedbackTriageEntry // keyed by cacheKey(repoPath, sessionID) → itemKey
 	newSession      newSessionModel                            // full-viewport new-session composition screen
 
@@ -261,8 +261,25 @@ func (a *App) openReview(rp *reviewPanelModel) {
 	a.modals.OpenReview(rp)
 }
 
+// openReviewPanel constructs a review panel for sess (deps bound, layout +
+// drafting state pushed) and opens it. The single review-panel entry point so
+// every call site wires the same deps and pushes the same live scalars.
+func (a *App) openReviewPanel(sess *agent.Session, repoPath string) {
+	rp := newReviewPanel(sess, repoPath, a.width, a.height, a.buildReviewDeps())
+	rp.SetDashboardTopY(a.dashboardTopY())
+	rp.SetDrafting(a.prDraftInFlight && a.prDraftSessionID == sess.ID && a.prDraftRepoPath == repoPath)
+	a.modals.OpenReview(rp)
+}
+
 // openShipping opens the shipping panel.
 func (a *App) openShipping(sp *shippingPanelModel) {
+	a.modals.OpenShipping(sp)
+}
+
+// openShippingPanel constructs a shipping panel for sess (deps bound) and opens
+// it. The single shipping-panel entry point.
+func (a *App) openShippingPanel(sess *agent.Session, repoPath string) {
+	sp := newShippingPanel(sess, repoPath, a.width, a.height-statusBarHeight, a.buildShippingDeps())
 	a.modals.OpenShipping(sp)
 }
 
@@ -390,6 +407,16 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.handleShippingFeedbackRequest(msg)
 	case feedbackNoteSubmitMsg:
 		return a.handleFeedbackNoteSubmit(msg)
+	case panelCloseMsg:
+		return a.handlePanelClose(msg)
+	case setErrorMsg:
+		return a.handleSetError(msg)
+	case startPRDraftRequestMsg:
+		return a.handleStartPRDraftRequest(msg)
+	case openAgentTerminalRequestMsg:
+		return a.handleOpenAgentTerminalRequest(msg)
+	case openURLResultMsg:
+		return a.handleOpenURLResult(msg)
 	case initAppMsg:
 		return a.handleInit(msg)
 	case tickMsg:
@@ -628,95 +655,161 @@ func (a *App) screenToTermCellFocusLaunch(screenX, screenY int) (termX, termY in
 	return termX, termY, inViewport
 }
 
-// panelServices builds a fresh PanelServices struct closing over a's current
-// state. Panels receive this on every Update so they always see live App
-// state without holding a back-pointer. Cmd factories returned here must be
-// pure: they produce tea.Cmds, never mutate App directly.
-func (a *App) panelServices() PanelServices {
-	return PanelServices{
-		Width:         a.width,
-		Height:        a.height,
-		DashboardTopY: a.dashboardTopY(),
-		Manager: func(repoPath string) SessionManager {
-			return a.managers[repoPath]
-		},
-		Resolved: func(repoPath string) config.ResolvedSettings {
-			return a.resolvedCache[repoPath]
-		},
-		GHClient: func() *github.Client { return a.ghClient },
+// panelCloseMsg asks App to drop the active overlay panel and return focus to
+// the pipeline. Panels emit it instead of mutating App directly (§4).
+type panelCloseMsg struct{}
+
+// handlePanelClose closes the active overlay panel.
+func (a App) handlePanelClose(_ panelCloseMsg) (tea.Model, tea.Cmd) {
+	a.closeModal()
+	return a, nil
+}
+
+// setErrorMsg carries a transient error string a panel wants surfaced. App is
+// the only place that mutates the error sink (§4).
+type setErrorMsg struct{ text string }
+
+// handleSetError surfaces a panel-supplied error transiently.
+func (a App) handleSetError(msg setErrorMsg) (tea.Model, tea.Cmd) {
+	a.setError(msg.text)
+	return a, nil
+}
+
+// startPRDraftRequestMsg asks App to begin the push+draft pipeline for a
+// session. App owns the prDraft* scalar flags, so the panel signals intent
+// rather than flipping them itself (§4).
+type startPRDraftRequestMsg struct {
+	session            *agent.Session
+	repoPath           string
+	transitionShipping bool
+}
+
+// handleStartPRDraftRequest sets the in-flight draft flags and kicks off the
+// async draft command. Mirrors the former StartPRDraftCmd closure.
+func (a App) handleStartPRDraftRequest(msg startPRDraftRequestMsg) (tea.Model, tea.Cmd) {
+	if msg.session == nil {
+		return a, nil
+	}
+	a.prDraftInFlight = true
+	a.prDraftSessionID = msg.session.ID
+	a.prDraftRepoPath = msg.repoPath
+	a.prModalTransitionShipping = msg.transitionShipping
+	a.syncReviewDrafting()
+	return a, a.startPRDraftCmd(msg.session, msg.repoPath, msg.transitionShipping)
+}
+
+// openAgentTerminalRequestMsg asks App to open the session's most-active agent
+// in the fullscreen launch terminal, falling back to fallbackURL (when set) or
+// surfacing fallbackError when no agent is available.
+type openAgentTerminalRequestMsg struct {
+	session       *agent.Session
+	repoPath      string
+	fallbackURL   string
+	fallbackError string
+}
+
+// handleOpenAgentTerminalRequest opens the agent terminal, applying the
+// caller's exact fallback when the session has no agents.
+func (a App) handleOpenAgentTerminalRequest(msg openAgentTerminalRequestMsg) (tea.Model, tea.Cmd) {
+	if a.openSessionInFocusLaunch(msg.session, msg.repoPath) {
+		return a, nil
+	}
+	if msg.fallbackURL != "" {
+		return a, a.openURLCmd(msg.fallbackURL)
+	}
+	if msg.fallbackError != "" {
+		a.setError(msg.fallbackError)
+	}
+	return a, nil
+}
+
+// openURLResultMsg carries the outcome of an async openURL call.
+type openURLResultMsg struct{ err error }
+
+// handleOpenURLResult surfaces an open-URL failure transiently (mirrors the
+// ideOpenedMsg pattern).
+func (a App) handleOpenURLResult(msg openURLResultMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		a.setError(fmt.Sprintf("failed to open: %v", msg.err))
+	}
+	return a, nil
+}
+
+// openURLCmd returns a pure tea.Cmd that opens url in the browser and reports
+// the result via openURLResultMsg. Panels return this instead of calling
+// openURL synchronously so the side effect flows through App.Update.
+func (a App) openURLCmd(url string) tea.Cmd {
+	return func() tea.Msg {
+		return openURLResultMsg{err: openURL(url)}
+	}
+}
+
+// buildReviewDeps binds the review panel's reference-typed handles to App's
+// maps/pointers. These are allocated once in NewApp / injected by cmd via
+// NewAppFromDeps before any panel opens, so binding to them (rather than to a)
+// keeps the closures live across App value-copies.
+func (a *App) buildReviewDeps() reviewDeps {
+	managers := a.managers
+	resolved := a.resolvedCache
+	prCache := a.prCache
+	reviewCache := a.reviewDiffCache
+	validationRuns := a.validationRuns
+	closingAgents := a.closingAgents
+	closingSessions := a.closingSessions
+	ghClient := a.ghClient
+	return reviewDeps{
+		Manager:  func(repoPath string) SessionManager { return managers[repoPath] },
+		Resolved: func(repoPath string) config.ResolvedSettings { return resolved[repoPath] },
+		GHClient: func() *github.Client { return ghClient },
 		PRCache: func(repoPath, sessionID string) *prCacheEntry {
-			return a.prCache[cacheKey(repoPath, sessionID)]
+			return prCache[cacheKey(repoPath, sessionID)]
 		},
 		ReviewCache: func(repoPath, sessionID string) *reviewDiffEntry {
-			return a.reviewDiffCache[cacheKey(repoPath, sessionID)]
+			return reviewCache[cacheKey(repoPath, sessionID)]
 		},
-		ClosePanel: func() {
-			// Drop the active overlay panel and return focus to the pipeline.
-			// Modals.Close enforces the invariant by nilling every owned model.
-			a.closeModal()
-		},
-		OpenInLaunch: func(sess *agent.Session, repoPath string) bool {
-			return a.openSessionInFocusLaunch(sess, repoPath)
-		},
-		OpenPlanEditor: func(sess *agent.Session, repoPath string) {
-			a.openPlanEditor(sess, repoPath)
-		},
-		OpenURL:  openURL,
-		SetError: a.setError,
-		MergePRCmd: func(sessionID, repoPath string, force bool) tea.Cmd {
-			if force {
-				return a.forceMergePRCmd(sessionID, repoPath)
-			}
-			return a.mergePRCmd(sessionID, repoPath)
-		},
-		StartPRDraftCmd: func(sess *agent.Session, repoPath string, transitionShipping bool) tea.Cmd {
-			a.prDraftInFlight = true
-			a.prDraftSessionID = sess.ID
-			a.prDraftRepoPath = repoPath
-			a.prModalTransitionShipping = transitionShipping
-			return a.startPRDraftCmd(sess, repoPath, transitionShipping)
-		},
-		KillSessionCmd: func(sess *agent.Session, repoPath string) tea.Cmd {
-			if repoPath == "" {
-				return nil
-			}
-			mgr := a.managers[repoPath]
-			if mgr == nil {
-				return nil
-			}
-			var agentIDs []string
-			for _, ag := range sess.Agents() {
-				agentIDs = append(agentIDs, ag.ID)
-				a.closingAgents[agentCacheKey(repoPath, ag.ID)] = true
-			}
-			sessID := sess.ID
-			a.closingSessions[cacheKey(repoPath, sessID)] = true
-			return func() tea.Msg {
-				return killResultMsg{
-					scope:     killScopeSession,
-					repoPath:  repoPath,
-					sessionID: sessID,
-					agentIDs:  agentIDs,
-					err:       filterNotFound(mgr.KillSession(sessID)),
-				}
-			}
-		},
-		FetchReviewDiff: func(sess *agent.Session, repoPath string) tea.Cmd { return a.fetchReviewDiffCmd(sess, repoPath) },
-		prDraftInFlightFor: func(sessionID, repoPath string) bool {
-			return a.prDraftInFlight && a.prDraftSessionID == sessionID && a.prDraftRepoPath == repoPath
-		},
-		ValidationRuns: func(sessID string) *validationRunState {
-			return a.validationRuns[sessID]
+		ValidationRuns: func(repoPath, sessID string) *validationRunState {
+			return validationRuns[cacheKey(repoPath, sessID)]
 		},
 		TriggerValidationRerun: func(sessID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd {
-			return triggerValidationRun(a, sessID, repoPath, worktreePath, checks)
+			return triggerValidationRunOn(managers, validationRuns, sessID, repoPath, worktreePath, checks)
+		},
+		KillSessionCmd: killSessionCmdFor(managers, closingAgents, closingSessions),
+	}
+}
+
+// buildShippingDeps binds the shipping panel's reference-typed handles. The
+// feedback setters are free functions over the feedbackTriage map so they stay
+// live across App value-copies.
+func (a *App) buildShippingDeps() shippingDeps {
+	prCache := a.prCache
+	feedbackTriage := a.feedbackTriage
+	return shippingDeps{
+		PRCache: func(repoPath, sessionID string) *prCacheEntry {
+			return prCache[cacheKey(repoPath, sessionID)]
 		},
 		FeedbackTriage: func(repoPath, sessionID string) map[string]*feedbackTriageEntry {
-			return a.feedbackTriage[cacheKey(repoPath, sessionID)]
+			return feedbackTriage[cacheKey(repoPath, sessionID)]
 		},
-		SetFeedbackVerdict: a.setFeedbackVerdict,
-		SetFeedbackNote:    a.setFeedbackNote,
+		SetFeedbackVerdict: func(repoPath, sessID, itemKey string, v feedbackVerdict) {
+			setFeedbackVerdictOn(feedbackTriage, repoPath, sessID, itemKey, v)
+		},
+		SetFeedbackNote: func(repoPath, sessID, itemKey, note string) {
+			setFeedbackNoteOn(feedbackTriage, repoPath, sessID, itemKey, note)
+		},
+		MergePRCmd: a.mergePRCmdFor(),
 	}
+}
+
+// syncReviewDrafting pushes the current PR-draft-in-flight state for the active
+// review panel's session into the panel, so its footer reflects the live flags.
+// Call after any mutation of the prDraft* scalars while a review panel may be
+// open. No-op when no review panel is active.
+func (a *App) syncReviewDrafting() {
+	rp := a.modals.Review()
+	if rp == nil {
+		return
+	}
+	rp.SetDrafting(a.prDraftInFlight && a.prDraftSessionID == rp.SessionID() && a.prDraftRepoPath == rp.repoPath)
 }
 
 // dashboardTopY returns the screen Y offset where the dashboard content
@@ -986,13 +1079,13 @@ func (a *App) activateFocusCursor() (tea.Cmd, bool) {
 	case focusSectionReview:
 		sess.SetLifecyclePhase(agent.LifecycleInReview)
 		rp := items[idx].repoPath
-		a.openReview(newReviewPanel(sess, rp, a.width, a.height))
+		a.openReviewPanel(sess, rp)
 		if _, ok := a.reviewDiffCache[cacheKey(rp, sess.ID)]; !ok {
 			return a.fetchReviewDiffCmd(sess, rp), true
 		}
 		return nil, true
 	case focusSectionShipping:
-		a.openShipping(newShippingPanel(sess, items[idx].repoPath, a.width, a.height-statusBarHeight))
+		a.openShippingPanel(sess, items[idx].repoPath)
 		return nil, true
 	}
 	return nil, false
@@ -1040,14 +1133,14 @@ func (a App) View() tea.View {
 			if a.prComposeModal.Active() {
 				panelStr = a.prComposeModal.View()
 			} else {
-				panelStr = rp.View(a.panelServices())
+				panelStr = rp.View()
 			}
 			v := tea.NewView(panelStr)
 			v.AltScreen = true
 			return v
 		}
 		if sp := a.modals.Shipping(); sp != nil {
-			panel := sp.View(a.panelServices())
+			panel := sp.View()
 			if sp.NoteActive() {
 				panel = placeCentered(a.width, a.height, sp.NoteView())
 			}
@@ -1296,6 +1389,11 @@ func (a *App) cleanStaleCaches() {
 	for k := range a.feedbackTriage {
 		if !activeSessions[k] {
 			delete(a.feedbackTriage, k)
+		}
+	}
+	for k := range a.validationRuns {
+		if !activeSessions[k] {
+			delete(a.validationRuns, k)
 		}
 	}
 	for k := range a.lastKnownStatus {

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1808,10 +1808,12 @@ func TestFocusMode_RKey_NonEmptyQueue_OpensReviewPanel(t *testing.T) {
 func TestReviewPanel_CKey_MarksComplete(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height, app.buildReviewDeps()))
 
-	model, _ := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 	app = model.(App)
+	// 'c' batches a panelCloseMsg (+ kill cmd); pump it so the close applies.
+	app = pumpPanelCmd(t, app, cmd)
 
 	if app.modals.Current() != focusList {
 		t.Errorf("expected panelFocus=focusList after c, got %v", app.modals.Current())
@@ -1834,12 +1836,20 @@ func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openReview(newReviewPanel(sess, dir, app.width, app.height))
+	app.openReview(newReviewPanel(sess, dir, app.width, app.height, app.buildReviewDeps()))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
 	model, cmd := app.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 	got := model.(App)
+
+	if cmd == nil {
+		t.Fatal("expected a cmd to trigger panel close + async session cleanup after marking complete")
+	}
+
+	// 'c' batches a panelCloseMsg and the KillSession cmd; pump both back through
+	// App.Update so the panel closes and the killResultMsg cleanup runs.
+	got = pumpPanelCmd(t, got, cmd)
 
 	if got.modals.Current() != focusList {
 		t.Errorf("expected panelFocus=focusList after c, got %v", got.modals.Current())
@@ -1847,19 +1857,10 @@ func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
 	if got.modals.Review() != nil {
 		t.Errorf("expected reviewSession cleared after c, got %v", got.modals.Review())
 	}
-	if cmd == nil {
-		t.Fatal("expected a cmd to trigger async session cleanup after marking complete")
-	}
-
-	// Run the cleanup cmd and dispatch the resulting killResultMsg.
-	killMsg := cmd()
-	model2, _ := got.Update(killMsg)
-	got2 := model2.(App)
-
 	if mgr.GetSession("sess-review") != nil {
 		t.Error("session should be removed from manager after marking complete")
 	}
-	if got2.closingSessions["sess-review"] {
+	if got.closingSessions[cacheKey(dir, "sess-review")] {
 		t.Error("closingSessions should be cleared after killResultMsg")
 	}
 }
@@ -1872,10 +1873,13 @@ func TestReviewPanel_CMarkCompleteClosesSession(t *testing.T) {
 func TestReviewPanel_TKey_NoAgents_ShowsError(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height, app.buildReviewDeps()))
 
-	model, _ := app.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
 	app = model.(App)
+	// 't' batches a panelCloseMsg and an openAgentTerminalRequestMsg; pump both
+	// so the close applies and App surfaces the no-agents fallback error.
+	app = pumpPanelCmd(t, app, cmd)
 
 	if app.err == "" {
 		t.Fatal("expected error when session has no agents")
@@ -1904,7 +1908,7 @@ func TestReviewPanel_ComposeModalRendersOverPanel(t *testing.T) {
 	app.height = 40
 	app.dashboard.width = 120
 	app.dashboard.height = 39
-	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height, app.buildReviewDeps()))
 	app.prComposeModal.SetSize(120, 39)
 	_ = app.prComposeModal.Open("My PR Title", "My PR Body", false, "ship-it")
 
@@ -1924,12 +1928,18 @@ func TestReviewPanel_ComposeModalRendersOverPanel(t *testing.T) {
 func TestReviewPanel_PKey_NoPR_DoesNotOrphan(t *testing.T) {
 	app, _, sessR := makeFocusModeMRApp(t)
 	sessR.SetLifecyclePhase(agent.LifecycleInReview)
-	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
 	// ghClient must be non-nil to pass the auth guard before startPRDraftCmd.
+	// Set it BEFORE building the review panel's deps: the panel binds its
+	// GHClient handle at construction (post-§3 fold), so a later assignment
+	// would be invisible to it.
 	app.ghClient = &github.Client{}
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height, app.buildReviewDeps()))
 
-	model, _ := app.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
 	app = model.(App)
+	// 'p' with no cached PR emits a startPRDraftRequestMsg; pump it so the
+	// handler sets the in-flight draft flags.
+	app = pumpPanelCmd(t, app, cmd)
 
 	// Pressing p with no open PR now starts the push+draft pipeline.
 	// The in-flight flag must be set; no error banner should appear.
@@ -1939,8 +1949,9 @@ func TestReviewPanel_PKey_NoPR_DoesNotOrphan(t *testing.T) {
 	}
 
 	// Press ESC to close the panel — session stays InReview.
-	model, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model, cmd = app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	app = model.(App)
+	app = pumpPanelCmd(t, app, cmd)
 
 	if app.modals.Current() != focusList {
 		t.Errorf("expected panelFocus=focusList after esc, got %v", app.modals.Current())
@@ -3035,7 +3046,7 @@ func TestMergePRMsg_ClosesPanel(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, dir, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, dir, app.width, app.height, app.buildShippingDeps()))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -3078,7 +3089,7 @@ func TestPRPollMsg_ExternalMergeClosesPanelAndTransitions(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
+	app.openShipping(newShippingPanel(sess, "", app.width, app.height, app.buildShippingDeps()))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -3124,7 +3135,7 @@ func TestPRPollMsg_ExternalCloseCleansSession(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
+	app.openShipping(newShippingPanel(sess, "", app.width, app.height, app.buildShippingDeps()))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -3224,7 +3235,7 @@ func TestPRPollMsg_ExternalOpenPRPromotesInReviewToShipping_ClosesReviewPanel(t 
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openReview(newReviewPanel(sess, dir, app.width, app.height))
+	app.openReview(newReviewPanel(sess, dir, app.width, app.height, app.buildReviewDeps()))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 
@@ -3496,7 +3507,7 @@ func TestHandlePRCreated_UsesMsgRepoPath_ForAutoOpen(t *testing.T) {
 // TestMergePRMsg_ErrorSetsError verifies that a mergePRMsg error is surfaced.
 func TestMergePRMsg_ErrorSetsError(t *testing.T) {
 	app := NewApp()
-	app.openShipping(newShippingPanel(agent.NewSessionForTest("s", "ship"), "", app.width, app.height))
+	app.openShipping(newShippingPanel(agent.NewSessionForTest("s", "ship"), "", app.width, app.height, app.buildShippingDeps()))
 
 	model, _ := app.Update(mergePRMsg{sessionID: "s", err: errors.New("403 forbidden")})
 	got := model.(App)
@@ -3516,13 +3527,16 @@ func TestShippingPanel_MKeyGatedOnReady(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, "", app.width, app.height))
-	app.prCache = map[string]*prCacheEntry{
-		sess.ID: {pr: &github.PRState{Number: 1, MergeableState: "dirty"}},
-	}
+	// Seed the cache BEFORE building deps: the shipping panel binds its PRCache
+	// handle to this map at construction (post-§3 fold), so the entry must be
+	// present (and repo-keyed) before newShippingPanel captures it.
+	app.prCache[cacheKey("", sess.ID)] = &prCacheEntry{pr: &github.PRState{Number: 1, MergeableState: "dirty"}}
+	app.openShipping(newShippingPanel(sess, "", app.width, app.height, app.buildShippingDeps()))
 
-	model, _ := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
 	got := model.(App)
+	// 'm' on a not-ready PR emits a setErrorMsg; pump it so the error applies.
+	got = pumpPanelCmd(t, got, cmd)
 
 	// Panel stays open, error is shown.
 	if got.modals.Current() != focusShipping {
@@ -4610,7 +4624,7 @@ func TestShippingPanel_CursorAndScrollKeys(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 	app := NewApp()
 	const repo = "/repo"
-	app.openShipping(newShippingPanel(sess, repo, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, repo, app.width, app.height, app.buildShippingDeps()))
 	app.width = 120
 	app.height = 40
 	app.prCache[cacheKey(repo, sess.ID)] = &prCacheEntry{
@@ -4674,7 +4688,7 @@ func TestShippingPanel_VerdictKeys(t *testing.T) {
 	sess.SetLifecyclePhase(agent.LifecycleShipping)
 	app := NewApp()
 	const repo = "/repo"
-	app.openShipping(newShippingPanel(sess, repo, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, repo, app.width, app.height, app.buildShippingDeps()))
 	app.width = 120
 	app.height = 40
 	sessKey := cacheKey(repo, sess.ID)
@@ -4725,7 +4739,7 @@ func TestAddressFeedback_ClearsTriage(t *testing.T) {
 	mgr.AddSessionForTest(sess)
 
 	app := NewApp()
-	app.openShipping(newShippingPanel(sess, dir, app.width, app.height))
+	app.openShipping(newShippingPanel(sess, dir, app.width, app.height, app.buildShippingDeps()))
 	app.managers[dir] = mgr
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 	app.width = 120
@@ -4785,7 +4799,7 @@ func TestAddressFeedback_RefusesOnMergedPR(t *testing.T) {
 			mgr.AddSessionForTest(sess)
 
 			app := NewApp()
-			app.openShipping(newShippingPanel(sess, dir, app.width, app.height))
+			app.openShipping(newShippingPanel(sess, dir, app.width, app.height, app.buildShippingDeps()))
 			app.managers[dir] = mgr
 			app.cfg = &config.Config{Repos: []config.Repo{{Path: dir}}}
 			app.width = 120
@@ -4853,7 +4867,7 @@ func TestReviewPanel_EnterOpensDiffViewer(t *testing.T) {
 	app := NewApp()
 	app.width = 120
 	app.height = 40
-	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height, app.buildReviewDeps()))
 	app.reviewDiffCache[cacheKey("", sessR.ID)] = entry
 
 	// Press enter: panel emits reviewOpenTaskDiffMsg, app handles it next tick.
@@ -4903,7 +4917,7 @@ func TestReviewPanel_SpaceIsNoOp(t *testing.T) {
 	app := NewApp()
 	app.width = 120
 	app.height = 40
-	app.openReview(newReviewPanel(sessR, "", app.width, app.height))
+	app.openReview(newReviewPanel(sessR, "", app.width, app.height, app.buildReviewDeps()))
 	app.reviewDiffCache[cacheKey("", sessR.ID)] = entry
 
 	model, _ := app.Update(tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
@@ -5496,9 +5510,9 @@ func TestAutoPromoteToReview_TriggersValidation(t *testing.T) {
 		repoPath: dir,
 	})
 
-	run := app.validationRuns[sess.ID]
+	run := app.validationRuns[cacheKey(dir, sess.ID)]
 	if run == nil {
-		t.Fatal("validationRuns[sess.ID] is nil — validation was not triggered")
+		t.Fatal("validationRuns[cacheKey(dir, sess.ID)] is nil — validation was not triggered")
 	}
 	if len(run.results) != 2 {
 		t.Errorf("len(results) = %d, want 2", len(run.results))
@@ -5544,12 +5558,73 @@ func TestManualMarkReady_TriggersValidation(t *testing.T) {
 
 	app.Update(tea.KeyPressMsg{Code: 'm', Text: "m"}) //nolint:errcheck
 
-	run := app.validationRuns[sess.ID]
+	run := app.validationRuns[cacheKey(dir, sess.ID)]
 	if run == nil {
-		t.Fatal("validationRuns[sess.ID] is nil — validation was not triggered on manual m")
+		t.Fatal("validationRuns[cacheKey(dir, sess.ID)] is nil — validation was not triggered on manual m")
 	}
 	if len(run.results) != 1 {
 		t.Errorf("len(results) = %d, want 1", len(run.results))
+	}
+}
+
+// TestValidationRuns_RepoKeyedNoCollision verifies that two repos hosting a
+// session with the SAME ID get independent validationRuns entries (keyed by
+// cacheKey(repoPath, sessionID)), and that cleanStaleCaches removes only the
+// composite key whose session no longer exists. Before the repo-keying fix,
+// validationRuns was keyed by bare sessionID, so the two repos collided.
+func TestValidationRuns_RepoKeyedNoCollision(t *testing.T) {
+	const repoA = "/repo/a"
+	const repoB = "/repo/b"
+	checks := []config.ValidationCheck{{Name: "Tests", Command: "echo test"}}
+
+	app := NewApp()
+
+	sessA := agent.NewSessionForTest("s1", "feat-a")
+	sessB := agent.NewSessionForTest("s1", "feat-b")
+	app.managers[repoA] = newFakeManager(repoA, sessA)
+	app.managers[repoB] = newFakeManager(repoB, sessB)
+
+	// Trigger validation in both repos for the colliding session ID.
+	triggerValidationRun(&app, sessA.ID, repoA, "", checks)
+	triggerValidationRun(&app, sessB.ID, repoB, "", checks)
+
+	// Two distinct composite keys must coexist; a bare-ID key would collapse them.
+	if got := len(app.validationRuns); got != 2 {
+		t.Fatalf("validationRuns has %d entries, want 2 (repo collision on bare session ID)", got)
+	}
+	runA := app.validationRuns[cacheKey(repoA, sessA.ID)]
+	runB := app.validationRuns[cacheKey(repoB, sessB.ID)]
+	if runA == nil || runB == nil {
+		t.Fatalf("expected both repo-keyed entries present; runA=%v runB=%v", runA, runB)
+	}
+	if runA == runB {
+		t.Fatal("repoA and repoB share the same validationRunState — keys collided")
+	}
+
+	// A result for repoA must update only repoA's run, leaving repoB untouched.
+	app.handleValidationCheckResult(validationCheckResultMsg{
+		sessionID:  sessA.ID,
+		repoPath:   repoA,
+		checkIndex: 0,
+		runID:      runA.runID,
+		state:      checkPassed,
+	})
+	if runA.results[0].state != checkPassed {
+		t.Errorf("repoA result not applied: state=%v, want checkPassed", runA.results[0].state)
+	}
+	if runB.results[0].state != checkRunning {
+		t.Errorf("repoB result mutated by repoA message: state=%v, want checkRunning", runB.results[0].state)
+	}
+
+	// Drop repoB's session, keep repoA's. cleanStaleCaches must delete only the
+	// stale repoB composite key and leave the active repoA entry intact.
+	app.managers[repoB] = newFakeManager(repoB) // no sessions
+	app.cleanStaleCaches()
+	if _, ok := app.validationRuns[cacheKey(repoA, sessA.ID)]; !ok {
+		t.Error("cleanStaleCaches removed the still-active repoA entry")
+	}
+	if _, ok := app.validationRuns[cacheKey(repoB, sessB.ID)]; ok {
+		t.Error("cleanStaleCaches leaked the stale repoB entry")
 	}
 }
 

--- a/internal/tui/component.go
+++ b/internal/tui/component.go
@@ -16,11 +16,12 @@ import tea "charm.land/bubbletea/v2"
 // value receivers and returns the updated value; View uses a value receiver;
 // SetSize uses a pointer receiver because it mutates stored dimensions.
 //
-// PanelModel (panel.go) is the deliberate services-injecting variant of this
-// contract: its Update/View additionally take a PanelServices value so panels
-// can reach app-level state without a back-pointer to App. Folding panels into
-// this shape (dropping PanelServices, moving panel state off App) is deferred
-// to Phase 5 of the CONVENTIONS migration.
+// PanelModel (panel.go) is the pointer-receiver sibling of this contract for
+// the review/shipping panels: the same Update(tea.Msg)/View() shape, but the
+// panels are nil-able pointer fields in Modals. They reach app-level state
+// through deps injected at construction and signal App-scalar mutations via
+// messages. Phase 5b completed this fold and removed the old per-tick services
+// value (CONVENTIONS.md §3).
 type Component interface {
 	// Update handles a message and returns the next state of this component
 	// plus any command to run. It must be pure w.r.t. I/O: side effects go in

--- a/internal/tui/dashboard_props.go
+++ b/internal/tui/dashboard_props.go
@@ -11,7 +11,7 @@ import (
 // dashboardModel.View/Update (and their render helpers), so the dashboard reads
 // live App state without mirroring it onto its own struct — the CONVENTIONS.md
 // §5/§6 replacement for the old syncModalsToDashboard / refreshAgentList sync
-// path. It is the dashboard's analogue of PanelServices.
+// path. It is the dashboard's analogue of the panels' construction-injected deps.
 //
 // Purity rule (§5): every time-derived field here is computed from the
 // tick-refreshed render clock (dashboardModel.now), never time.Now(), because

--- a/internal/tui/keytest_helpers_test.go
+++ b/internal/tui/keytest_helpers_test.go
@@ -87,3 +87,19 @@ func findMsg[T tea.Msg](msgs []tea.Msg) (T, bool) {
 	}
 	return zero, false
 }
+
+// pumpPanelCmd feeds the messages a panel-triggered cmd emits back through
+// App.Update, applying the async close/error/draft/kill effects that panels now
+// signal via messages (post-§3 fold) rather than mutating App synchronously.
+// Flattens one level of tea.Batch via runCmdAll. Returns the updated App.
+func pumpPanelCmd(t *testing.T, app App, cmd tea.Cmd) App {
+	t.Helper()
+	for _, msg := range runCmdAll(t, cmd) {
+		if msg == nil {
+			continue
+		}
+		m, _ := app.Update(msg)
+		app = m.(App)
+	}
+	return app
+}

--- a/internal/tui/manager_iface_test.go
+++ b/internal/tui/manager_iface_test.go
@@ -22,7 +22,7 @@ func TestSessionManager_FakeSatisfies(t *testing.T) {
 }
 
 // TestSessionManager_FakeDrivesKillSession demonstrates the unit-testing seam:
-// a fake manager is injected into App, App.KillSessionCmd via PanelServices is
+// a fake manager is injected into App, the review panel's KillSessionCmd dep is
 // invoked, and the test asserts on the fake's call counters without ever
 // starting a real PTY/git/hook stack.
 func TestSessionManager_FakeDrivesKillSession(t *testing.T) {
@@ -36,13 +36,13 @@ func TestSessionManager_FakeDrivesKillSession(t *testing.T) {
 	app.cfg = &config.Config{Repos: []config.Repo{{Path: repo}}}
 	app.resolvedCache[repo] = config.Resolve(nil, nil)
 
-	// Drive KillSessionCmd through the panel-services seam (the same path
-	// the shipping panel takes when the user confirms session teardown).
-	svc := app.panelServices()
-	if svc.KillSessionCmd == nil {
-		t.Fatal("KillSessionCmd should be wired by panelServices")
+	// Drive KillSessionCmd through the panel-deps seam (the same path the
+	// shipping panel takes when the user confirms session teardown).
+	deps := app.buildReviewDeps()
+	if deps.KillSessionCmd == nil {
+		t.Fatal("KillSessionCmd should be wired by buildReviewDeps")
 	}
-	cmd := svc.KillSessionCmd(sess, repo)
+	cmd := deps.KillSessionCmd(sess, repo)
 	if cmd == nil {
 		t.Fatal("KillSessionCmd returned nil for a known session")
 	}

--- a/internal/tui/panel.go
+++ b/internal/tui/panel.go
@@ -2,89 +2,26 @@ package tui
 
 import (
 	tea "charm.land/bubbletea/v2"
-	"github.com/devenjarvis/refrain/internal/agent"
-	"github.com/devenjarvis/refrain/internal/config"
-	"github.com/devenjarvis/refrain/internal/github"
 )
 
 // PanelModel is the contract every overlay panel implements. Panels are owned
 // by App as nil-when-inactive pointer fields. They consume keypresses,
 // resizes, and their own messages, and they ask to close by returning a
-// tea.Cmd that yields a panelClosedMsg.
+// tea.Cmd that yields a panelCloseMsg.
 //
-// PanelServices is passed by value on every Update call so the panel can
-// reach app-level state (managers, caches, error sink, navigation actions)
-// without holding a back-pointer to App. App constructs a fresh services
-// value each tick — the closures inside it close over &a, so they always
-// see the latest App state.
+// Panels reach app-level state through a per-panel deps struct (reviewDeps,
+// shippingDeps) bound at construction to App's maps/pointers, and mutate App
+// scalars only by emitting messages that App.Update handles (§3/§4). The
+// interface is therefore the same shape as Component (component.go) — Update
+// takes only a message; conformance is by shape, not a literal type assertion.
+//
+// Receiver-kind deviation: review/shipping panels keep POINTER receivers (they
+// are nil-able pointer fields in Modals and carry per-panel mutable state),
+// whereas the value-typed Components in component.go use value receivers.
+// Conformance to §3 is by Update/View shape (dropping the services arg), not by
+// receiver kind.
 type PanelModel interface {
-	Update(msg tea.Msg, svc PanelServices) (PanelModel, tea.Cmd)
-	View(svc PanelServices) string
+	Update(msg tea.Msg) (PanelModel, tea.Cmd)
+	View() string
 	SetSize(w, h int)
-}
-
-// Panels close synchronously by calling svc.ClosePanel(). The callback is
-// built each Update over &a (App's local copy), so the close ritual is a
-// direct field mutation rather than an async tea.Msg round-trip — this keeps
-// the test pattern simple (assert state immediately after panel.Update).
-
-// PanelServices is the slice of App state and behavior that panels are
-// allowed to reach. Keep this struct narrow: every field here is a coupling
-// point between App and every panel that uses it.
-//
-// Cmd factories (the *Cmd fields) must produce messages only — they must
-// never mutate App. Their return values flow through App.Update like any
-// other tea.Cmd, which is where mutation is centralised.
-type PanelServices struct {
-	// Layout.
-	Width         int
-	Height        int
-	DashboardTopY int
-
-	// Lookups. PRCache, ReviewCache, and FeedbackTriage take (repoPath,
-	// sessionID) because the App-level caches are keyed by the composite —
-	// see cacheKey in app.go. Session IDs collide across managers, so a
-	// bare-ID lookup would return the wrong repo's data.
-	Manager     func(repoPath string) SessionManager
-	Resolved    func(repoPath string) config.ResolvedSettings
-	GHClient    func() *github.Client
-	PRCache     func(repoPath, sessionID string) *prCacheEntry
-	ReviewCache func(repoPath, sessionID string) *reviewDiffEntry
-
-	// Navigation / cross-panel actions.
-	ClosePanel     func()
-	OpenInLaunch   func(sess *agent.Session, repoPath string) bool
-	OpenPlanEditor func(sess *agent.Session, repoPath string)
-	OpenURL        func(url string) error
-	SetError       func(msg string)
-
-	// Cmd factories. Each MUST be pure: build the tea.Cmd, but never
-	// mutate App state; the resulting tea.Msg flows back through App.Update.
-	MergePRCmd      func(sessionID, repoPath string, force bool) tea.Cmd
-	StartPRDraftCmd func(sess *agent.Session, repoPath string, transitionShipping bool) tea.Cmd
-	KillSessionCmd  func(sess *agent.Session, repoPath string) tea.Cmd
-	FetchReviewDiff func(sess *agent.Session, repoPath string) tea.Cmd
-
-	// prDraftInFlightFor reports whether a PR draft request is currently in
-	// flight for the given (sessionID, repoPath) pair. The review panel uses
-	// this to render the "Drafting PR…" footer hint.
-	prDraftInFlightFor func(sessionID, repoPath string) bool
-
-	// ValidationRuns returns the live validation run state for a session, or
-	// nil when no run has been started. The Checks tab uses this to render
-	// check rows and output; it is keyed by session ID (run state lives on App
-	// so results survive panel close/reopen).
-	ValidationRuns func(sessID string) *validationRunState
-	// TriggerValidationRerun starts a new validation run for sessID, resetting
-	// all results to checkRunning and returning a batched tea.Cmd that fires
-	// one runValidationCheckCmd per check.
-	TriggerValidationRerun func(sessID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd
-
-	// Shipping-panel feedback triage state. Reads return the live map (or
-	// nil); the setters lazily allocate and apply the same cleanup rules as
-	// the original App methods (neutral+empty -> delete entry). Keyed by
-	// (repoPath, sessionID); see PRCache notes.
-	FeedbackTriage     func(repoPath, sessionID string) map[string]*feedbackTriageEntry
-	SetFeedbackVerdict func(repoPath, sessionID, itemKey string, v feedbackVerdict)
-	SetFeedbackNote    func(repoPath, sessionID, itemKey, note string)
 }

--- a/internal/tui/reviewpanel_model.go
+++ b/internal/tui/reviewpanel_model.go
@@ -3,7 +3,10 @@ package tui
 import (
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/config"
+	"github.com/devenjarvis/refrain/internal/github"
 )
 
 const (
@@ -26,24 +29,55 @@ type reviewPanelModel struct {
 	checksCursor      int // cursor position in the Checks tab list
 	checksScroll      int // scroll offset for the Checks tab output pane
 
+	// dashboardTopY is the screen Y offset where dashboard content begins.
+	// App pushes this in via SetDashboardTopY; handleClick reads it instead of
+	// reaching through a services value (§3 fold).
+	dashboardTopY int
+
+	// drafting reflects whether a PR draft is in flight for THIS session. App
+	// pushes it via SetDrafting whenever the draft flags change; View renders
+	// from it instead of querying App.
+	drafting bool
+
 	// now is the render clock, refreshed from the app tick via SetNow. View
 	// derives elapsed/age strings and the verdict spinner from it so rendering
 	// stays pure (§5: no clock read at render time).
 	now time.Time
 
+	// deps carries the App-level reference handles the panel reaches through
+	// for lookups and cmd factories. Bound once at construction to maps and
+	// pointers that outlive App value-copies (§3 fold).
+	deps reviewDeps
+
 	width, height int
+}
+
+// reviewDeps holds the reference-typed App handles the review panel needs.
+// Bound at construction to the App's maps/pointers (never to App itself) so the
+// closures stay live across App value-copies (App.Update is a value receiver).
+type reviewDeps struct {
+	Manager     func(repoPath string) SessionManager
+	Resolved    func(repoPath string) config.ResolvedSettings
+	GHClient    func() *github.Client
+	PRCache     func(repoPath, sessionID string) *prCacheEntry
+	ReviewCache func(repoPath, sessionID string) *reviewDiffEntry
+
+	ValidationRuns         func(repoPath, sessID string) *validationRunState
+	TriggerValidationRerun func(sessID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd
+	KillSessionCmd         func(sess *agent.Session, repoPath string) tea.Cmd
 }
 
 // newReviewPanel constructs a review panel for sess at the given size.
 // repoPath pins which repo's manager is used for all key handlers — it must
 // match the repo the session belongs to so multi-repo ID collisions are safe.
-func newReviewPanel(sess *agent.Session, repoPath string, width, height int) *reviewPanelModel {
+func newReviewPanel(sess *agent.Session, repoPath string, width, height int, deps reviewDeps) *reviewPanelModel {
 	return &reviewPanelModel{
 		session:  sess,
 		repoPath: repoPath,
 		width:    width,
 		height:   height,
 		now:      time.Now(),
+		deps:     deps,
 	}
 }
 
@@ -90,4 +124,24 @@ func (m *reviewPanelModel) SetSize(w, h int) {
 	}
 	m.width = w
 	m.height = h
+}
+
+// SetDashboardTopY records the screen Y offset where dashboard content begins.
+// App pushes this whenever it sets the panel size or the offset changes; the
+// click-handler reads it instead of reaching through a services struct.
+func (m *reviewPanelModel) SetDashboardTopY(y int) {
+	if m == nil {
+		return
+	}
+	m.dashboardTopY = y
+}
+
+// SetDrafting records whether a PR draft is in flight for this session. App
+// pushes the updated value whenever its draft flags change; View renders the
+// "Drafting PR…" footer from it.
+func (m *reviewPanelModel) SetDrafting(v bool) {
+	if m == nil {
+		return
+	}
+	m.drafting = v
 }

--- a/internal/tui/reviewpanel_update.go
+++ b/internal/tui/reviewpanel_update.go
@@ -10,14 +10,11 @@ import (
 	"github.com/devenjarvis/refrain/internal/config"
 )
 
-// closeReviewPanel invokes svc.ClosePanel(), which clears App's reviewPanel
-// pointer and routes focus back to the pipeline. Returns nil so callers can
-// `return m, closeReviewPanel(svc)` inline.
-func closeReviewPanel(svc PanelServices) tea.Cmd {
-	if svc.ClosePanel != nil {
-		svc.ClosePanel()
-	}
-	return nil
+// closeReviewPanel returns a tea.Cmd yielding panelCloseMsg, which App.Update
+// handles by clearing the active panel and routing focus back to the pipeline.
+// Returns the cmd so callers can `return m, closeReviewPanel()` inline.
+func closeReviewPanel() tea.Cmd {
+	return func() tea.Msg { return panelCloseMsg{} }
 }
 
 // reviewReworkRequestMsg is emitted by the panel when the user presses 'b'
@@ -32,25 +29,23 @@ type reviewReworkRequestMsg struct {
 
 // reviewOpenIDECmd opens the configured IDE on the session's worktree.
 // Mirrors the inline 'i' / 'e' key handler shape: silent if the worktree is
-// missing, errors via svc.SetError when the IDE command isn't set. Returns the
-// launch tea.Cmd (or nil) so the caller routes it onto the command path; the
-// launch result surfaces as ideOpenedMsg.
-func reviewOpenIDECmd(sess *agent.Session, repoPath string, svc PanelServices) tea.Cmd {
+// missing, emits a setErrorMsg when the IDE command isn't set. Returns the
+// launch tea.Cmd (or a setErrorMsg cmd, or nil); the launch result surfaces as
+// ideOpenedMsg.
+func reviewOpenIDECmd(sess *agent.Session, repoPath string, resolved func(repoPath string) config.ResolvedSettings) tea.Cmd {
 	if sess == nil || sess.Worktree == nil {
 		return nil
 	}
 	if repoPath == "" {
 		return nil
 	}
-	ideCmd := strings.TrimSpace(svc.Resolved(repoPath).IDECommand)
+	ideCmd := strings.TrimSpace(resolved(repoPath).IDECommand)
 	if ideCmd == "" {
-		svc.SetError("No IDE configured (set 'IDE Command' in settings)")
-		return nil
+		return setErrorCmd("No IDE configured (set 'IDE Command' in settings)")
 	}
 	parts := splitIDECommand(ideCmd)
 	if len(parts) == 0 {
-		svc.SetError("No IDE configured (set 'IDE Command' in settings)")
-		return nil
+		return setErrorCmd("No IDE configured (set 'IDE Command' in settings)")
 	}
 	worktreePath := sess.Worktree.Path
 	exe := parts[0]
@@ -58,11 +53,24 @@ func reviewOpenIDECmd(sess *agent.Session, repoPath string, svc PanelServices) t
 	return openIDECmd(exe, args, worktreePath)
 }
 
+// setErrorCmd returns a tea.Cmd yielding a setErrorMsg, so panels can surface a
+// transient error without reaching App directly.
+func setErrorCmd(text string) tea.Cmd {
+	return func() tea.Msg { return setErrorMsg{text: text} }
+}
+
+// openURLRequestCmd returns a pure tea.Cmd that opens url in the browser and
+// reports the result via openURLResultMsg. Panels return this instead of
+// calling openURL synchronously so the side effect flows through App.Update,
+// where any failure is surfaced transiently.
+func openURLRequestCmd(url string) tea.Cmd {
+	return func() tea.Msg { return openURLResultMsg{err: openURL(url)} }
+}
+
 // Update dispatches the review panel's key handling. Returns the (possibly
-// updated) panel and a tea.Cmd. To close, the panel returns a
-// closeReviewPanel(svc); App's outer Update routes that back to
-// focusList and clears a.reviewPanel.
-func (m *reviewPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel, tea.Cmd) {
+// updated) panel and a tea.Cmd. To close, the panel returns closeReviewPanel();
+// App's outer Update handles the panelCloseMsg.
+func (m *reviewPanelModel) Update(msg tea.Msg) (PanelModel, tea.Cmd) {
 	if m == nil || m.session == nil {
 		return m, nil
 	}
@@ -71,9 +79,9 @@ func (m *reviewPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel, t
 		m.SetSize(msg.Width, msg.Height-1)
 		return m, nil
 	case tea.KeyPressMsg:
-		return m.handleKey(msg, svc)
+		return m.handleKey(msg)
 	case tea.MouseClickMsg:
-		m.handleClick(msg, svc)
+		m.handleClick(msg)
 		return m, nil
 	}
 	return m, nil
@@ -81,7 +89,7 @@ func (m *reviewPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel, t
 
 // handleKey is the per-key dispatch extracted from app.go's monolithic
 // Update. Spec overlay intercepts all keys while active.
-func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (PanelModel, tea.Cmd) {
+func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg) (PanelModel, tea.Cmd) {
 	// Tab-switching keys work even while spec overlay is open.
 	switch msg.String() {
 	case "1":
@@ -122,60 +130,63 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 
 	switch msg.String() {
 	case "esc":
-		return m, closeReviewPanel(svc)
+		return m, closeReviewPanel()
 	case "d":
 		m.session.SetLifecyclePhase(agent.LifecycleReadyForReview)
-		return m, closeReviewPanel(svc)
+		return m, closeReviewPanel()
 	case "p":
 		sess := m.session
-		entry := svc.PRCache(m.repoPath, sess.ID)
+		entry := m.deps.PRCache(m.repoPath, sess.ID)
 		if entry != nil && entry.pr != nil && entry.pr.URL != "" {
-			if err := svc.OpenURL(entry.pr.URL); err != nil {
-				svc.SetError(err.Error())
-				return m, nil
-			}
 			sess.SetLifecyclePhase(agent.LifecycleShipping)
-			return m, closeReviewPanel(svc)
+			return m, tea.Batch(openURLRequestCmd(entry.pr.URL), closeReviewPanel())
 		}
-		gh := svc.GHClient()
+		gh := m.deps.GHClient()
 		if gh == nil {
-			svc.SetError("GitHub auth not available")
-			return m, nil
+			return m, setErrorCmd("GitHub auth not available")
 		}
-		return m, svc.StartPRDraftCmd(sess, m.repoPath, true)
+		repoPath := m.repoPath
+		return m, func() tea.Msg {
+			return startPRDraftRequestMsg{session: sess, repoPath: repoPath, transitionShipping: true}
+		}
 	case "t":
 		sess := m.session
 		repoPath := m.repoPath
-		// Close first regardless of outcome: pressing 't' is an exit-the-panel
-		// intent. If the open fails, the error surfaces with the panel already
-		// closed, matching the pre-refactor behaviour.
-		closeReviewPanel(svc)
-		if !svc.OpenInLaunch(sess, repoPath) {
-			svc.SetError("session has no agents to open")
-		}
-		return m, nil
+		// Pressing 't' is an exit-the-panel intent: close, then ask App to open
+		// the agent terminal. If no agent is available, App surfaces the error
+		// with the panel already closed, matching the pre-refactor behaviour.
+		return m, tea.Batch(
+			closeReviewPanel(),
+			func() tea.Msg {
+				return openAgentTerminalRequestMsg{
+					session:       sess,
+					repoPath:      repoPath,
+					fallbackError: "session has no agents to open",
+				}
+			},
+		)
 	case "c":
 		sess := m.session
 		sess.SetLifecyclePhase(agent.LifecycleComplete)
-		mgr := svc.Manager(m.repoPath)
+		mgr := m.deps.Manager(m.repoPath)
 		if mgr == nil {
-			return m, closeReviewPanel(svc)
+			return m, closeReviewPanel()
 		}
-		return m, tea.Batch(closeReviewPanel(svc), svc.KillSessionCmd(sess, m.repoPath))
+		return m, tea.Batch(closeReviewPanel(), m.deps.KillSessionCmd(sess, m.repoPath))
 	case "e":
-		return m, reviewOpenIDECmd(m.session, m.repoPath, svc)
+		return m, reviewOpenIDECmd(m.session, m.repoPath, m.deps.Resolved)
 	case "j", "down":
 		switch m.activeTab {
 		case reviewTabTasks:
-			if entry := svc.ReviewCache(m.repoPath, m.session.ID); entry != nil {
+			if entry := m.deps.ReviewCache(m.repoPath, m.session.ID); entry != nil {
 				maxIdx := reviewTaskCount(entry) - 1
 				if m.taskCursor < maxIdx {
 					m.taskCursor++
 				}
 			}
 		case reviewTabChecks:
-			if svc.ValidationRuns != nil {
-				if run := svc.ValidationRuns(m.session.ID); run != nil {
+			if m.deps.ValidationRuns != nil {
+				if run := m.deps.ValidationRuns(m.repoPath, m.session.ID); run != nil {
 					maxIdx := len(run.results) - 1
 					if m.checksCursor < maxIdx {
 						m.checksCursor++
@@ -197,16 +208,16 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		}
 		return m, nil
 	case "r":
-		if m.activeTab == reviewTabChecks && svc.TriggerValidationRerun != nil {
+		if m.activeTab == reviewTabChecks && m.deps.TriggerValidationRerun != nil {
 			var run *validationRunState
-			if svc.ValidationRuns != nil {
-				run = svc.ValidationRuns(m.session.ID)
+			if m.deps.ValidationRuns != nil {
+				run = m.deps.ValidationRuns(m.repoPath, m.session.ID)
 			}
 			var checks []config.ValidationCheck
 			if run != nil {
 				checks = run.checks
-			} else if svc.Resolved != nil {
-				checks = svc.Resolved(m.repoPath).ValidationChecks
+			} else if m.deps.Resolved != nil {
+				checks = m.deps.Resolved(m.repoPath).ValidationChecks
 			}
 			if len(checks) == 0 {
 				return m, nil
@@ -215,7 +226,7 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 			if m.session.Worktree != nil {
 				worktreePath = m.session.Worktree.Path
 			}
-			return m, svc.TriggerValidationRerun(m.session.ID, m.repoPath, worktreePath, checks)
+			return m, m.deps.TriggerValidationRerun(m.session.ID, m.repoPath, worktreePath, checks)
 		}
 		return m, nil
 	case "pgdown":
@@ -232,7 +243,7 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		}
 		return m, nil
 	case "f":
-		entry := svc.ReviewCache(m.repoPath, m.session.ID)
+		entry := m.deps.ReviewCache(m.repoPath, m.session.ID)
 		if entry == nil {
 			return m, nil
 		}
@@ -251,11 +262,10 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		rec.userFlagged = !rec.userFlagged
 		return m, nil
 	case "b":
-		entry := svc.ReviewCache(m.repoPath, m.session.ID)
+		entry := m.deps.ReviewCache(m.repoPath, m.session.ID)
 		prompt := buildReviewReworkPrompt(entry)
 		if prompt == "" {
-			svc.SetError("no tasks flagged or marked concerns/fail")
-			return m, nil
+			return m, setErrorCmd("no tasks flagged or marked concerns/fail")
 		}
 		sessID := m.session.ID
 		repoPath := m.repoPath
@@ -264,7 +274,7 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 		}
 	case "enter":
 		if m.activeTab == reviewTabTasks {
-			entry := svc.ReviewCache(m.repoPath, m.session.ID)
+			entry := m.deps.ReviewCache(m.repoPath, m.session.ID)
 			group := reviewTaskGroupAtCursor(entry, m.taskCursor)
 			if group == nil || group.rawDiff == "" {
 				return m, nil
@@ -301,23 +311,23 @@ func (m *reviewPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (Pa
 // handleClick maps a mouse-click on the review task list pane to a cursor
 // move. Mirrors the offset math in renderTaskListPane so the visual row
 // under the click becomes the new cursor.
-func (m *reviewPanelModel) handleClick(msg tea.MouseClickMsg, svc PanelServices) {
+func (m *reviewPanelModel) handleClick(msg tea.MouseClickMsg) {
 	if m == nil || m.session == nil {
 		return
 	}
-	entry := svc.ReviewCache(m.repoPath, m.session.ID)
+	entry := m.deps.ReviewCache(m.repoPath, m.session.ID)
 	if entry == nil {
 		return
 	}
 	headerH := len(renderReviewHeader(m.session, m.width, m.now))
 	const tabBarH = 2
-	paneTop := svc.DashboardTopY + headerH + tabBarH
+	paneTop := m.dashboardTopY + headerH + tabBarH
 	rowIdx := reviewListPaneRowAt(entry, msg.X, msg.Y, paneTop, 0, m.width-2)
 	if rowIdx < 0 {
 		return
 	}
 	footerLines := 3
-	bodyH := m.height - svc.DashboardTopY - headerH - tabBarH - footerLines
+	bodyH := m.height - m.dashboardTopY - headerH - tabBarH - footerLines
 	if bodyH < 4 {
 		bodyH = 4
 	}

--- a/internal/tui/reviewpanel_view.go
+++ b/internal/tui/reviewpanel_view.go
@@ -842,7 +842,7 @@ func wrapText(s string, maxWidth int) []string {
 }
 
 // View renders the review panel — either the spec overlay or the main panel.
-func (m *reviewPanelModel) View(svc PanelServices) string {
+func (m *reviewPanelModel) View() string {
 	if m == nil || m.session == nil {
 		return ""
 	}
@@ -850,11 +850,11 @@ func (m *reviewPanelModel) View(svc PanelServices) string {
 		plan, _ := m.session.CachedPlan()
 		return renderReviewSpecOverlay(m.session, plan, m.specOverlayScroll, m.width, m.height)
 	}
-	entry := svc.ReviewCache(m.repoPath, m.session.ID)
-	prDraftInFlight := svc.prDraftInFlightFor(m.session.ID, m.repoPath)
+	entry := m.deps.ReviewCache(m.repoPath, m.session.ID)
+	prDraftInFlight := m.drafting
 	var checkState *checksTabState
-	if svc.ValidationRuns != nil {
-		if run := svc.ValidationRuns(m.session.ID); run != nil {
+	if m.deps.ValidationRuns != nil {
+		if run := m.deps.ValidationRuns(m.repoPath, m.session.ID); run != nil {
 			checkState = &checksTabState{
 				checks:  run.checks,
 				results: run.results,

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -13,74 +13,57 @@ import (
 	"github.com/devenjarvis/refrain/internal/github"
 )
 
-// panel-level test pattern: instantiate the panel directly, supply a stub
-// PanelServices, drive it with messages, assert state. No full App spin-up,
-// no goroutines, no claude binary.
+// panel-level test pattern (post-§3 fold): instantiate the panel directly with
+// a reviewDeps built from a stub App, drive it with messages, and assert on the
+// panel's own state plus the tea.Cmds/msgs it returns. Cross-cutting effects
+// (close, error, open-in-launch, PR draft) now flow as messages, so the helpers
+// below run a returned cmd and classify the resulting message.
 
-func newTestSvc() (PanelServices, *testServiceState) {
-	state := &testServiceState{}
-	svc := PanelServices{
-		Width:  120,
-		Height: 40,
-		Manager: func(string) SessionManager {
-			return nil
-		},
-		Resolved:    func(string) config.ResolvedSettings { return config.ResolvedSettings{} },
-		GHClient:    func() *github.Client { return nil },
-		PRCache:     func(string, string) *prCacheEntry { return nil },
-		ReviewCache: func(string, string) *reviewDiffEntry { return nil },
-		ClosePanel: func() {
-			state.closed = true
-		},
-		OpenInLaunch: func(*agent.Session, string) bool {
-			state.openInLaunchCalled = true
-			return state.openInLaunchResult
-		},
-		OpenPlanEditor: func(*agent.Session, string) {},
-		OpenURL:        func(string) error { return nil },
-		SetError: func(msg string) {
-			state.errMsg = msg
-		},
-		MergePRCmd: func(string, string, bool) tea.Cmd { return nil },
-		StartPRDraftCmd: func(*agent.Session, string, bool) tea.Cmd {
-			return func() tea.Msg { return nil }
-		},
-		KillSessionCmd: func(*agent.Session, string) tea.Cmd {
-			state.killSessionCalled = true
-			return func() tea.Msg { return nil }
-		},
-		FetchReviewDiff: func(*agent.Session, string) tea.Cmd { return nil },
-		FeedbackTriage: func(string, string) map[string]*feedbackTriageEntry {
-			return nil
-		},
-		SetFeedbackVerdict: func(string, string, string, feedbackVerdict) {},
-		SetFeedbackNote:    func(string, string, string, string) {},
-		prDraftInFlightFor: func(string, string) bool { return false },
-		ValidationRuns:     func(string) *validationRunState { return nil },
-		TriggerValidationRerun: func(string, string, string, []config.ValidationCheck) tea.Cmd {
-			return nil
-		},
-	}
-	return svc, state
+// reviewTestApp returns an App seeded with empty caches plus a stub manager
+// factory so buildReviewDeps yields live, no-op-friendly handles. Tests mutate
+// app.* maps to inject behaviour, then call app.buildReviewDeps().
+func reviewTestApp() App {
+	app := NewApp()
+	app.width = 120
+	app.height = 40
+	return app
 }
 
-type testServiceState struct {
-	closed             bool
-	errMsg             string
-	openInLaunchCalled bool
-	openInLaunchResult bool
-	killSessionCalled  bool
+// runReviewCmd runs cmd (if non-nil) and returns the single message it yields,
+// or nil. tea.Batch results are flattened one level via runCmdAll.
+func runReviewCmd(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	return runCmdAll(t, cmd)
+}
+
+// cmdClosesPanel reports whether cmd yields a panelCloseMsg.
+func cmdClosesPanel(t *testing.T, cmd tea.Cmd) bool {
+	t.Helper()
+	_, found := findMsg[panelCloseMsg](runReviewCmd(t, cmd))
+	return found
+}
+
+// cmdSetsError returns the error text from a setErrorMsg in cmd's output, or "".
+func cmdSetsError(t *testing.T, cmd tea.Cmd) string {
+	t.Helper()
+	if m, ok := findMsg[setErrorMsg](runReviewCmd(t, cmd)); ok {
+		return m.text
+	}
+	return ""
 }
 
 // TestReviewPanelModel_TabSwitching verifies 1–3 and tab/shift+tab change activeTab.
 func TestReviewPanelModel_TabSwitching(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, _ := newTestSvc()
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
 	press := func(msg tea.KeyPressMsg) {
 		t.Helper()
-		_, _ = panel.Update(msg, svc)
+		_, _ = panel.Update(msg)
 	}
 
 	// Numeric keys jump directly.
@@ -119,11 +102,9 @@ func TestReviewPanelModel_TabSwitching(t *testing.T) {
 func TestReviewPanelModel_ChecksTab_JKMovesCursor(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, _ := newTestSvc()
 
-	app := NewApp()
-	app.validationRuns[sess.ID] = &validationRunState{
+	app := reviewTestApp()
+	app.validationRuns[cacheKey("", sess.ID)] = &validationRunState{
 		runID: 1,
 		checks: []config.ValidationCheck{
 			{Name: "A", Command: "echo a"},
@@ -136,24 +117,22 @@ func TestReviewPanelModel_ChecksTab_JKMovesCursor(t *testing.T) {
 			{state: checkRunning},
 		},
 	}
-	svc.ValidationRuns = func(sessID string) *validationRunState {
-		return app.validationRuns[sessID]
-	}
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
 	// Switch to Checks tab.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: '3', Text: "3"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: '3', Text: "3"})
 
 	// Press j twice.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if panel.checksCursor != 1 {
 		t.Errorf("after j: checksCursor = %d, want 1", panel.checksCursor)
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if panel.checksCursor != 2 {
 		t.Errorf("after j j: checksCursor = %d, want 2", panel.checksCursor)
 	}
 	// Press k.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	if panel.checksCursor != 1 {
 		t.Errorf("after k: checksCursor = %d, want 1", panel.checksCursor)
 	}
@@ -163,46 +142,33 @@ func TestReviewPanelModel_ChecksTab_JKMovesCursor(t *testing.T) {
 func TestReviewPanelModel_ChecksTab_RKeyTriggersRerun(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "/repo", 120, 40)
-	svc, _ := newTestSvc()
 
-	app := NewApp()
+	app := reviewTestApp()
 	app.resolvedCache["/repo"] = config.ResolvedSettings{
 		ValidationChecks: []config.ValidationCheck{
 			{Name: "Tests", Command: "echo test"},
 		},
 	}
-	app.validationRuns[sess.ID] = &validationRunState{
+	app.validationRuns[cacheKey("/repo", sess.ID)] = &validationRunState{
 		runID:   1,
 		checks:  []config.ValidationCheck{{Name: "Tests", Command: "echo test"}},
 		results: []validationCheckResult{{state: checkPassed}},
 	}
-	svc.ValidationRuns = func(sessID string) *validationRunState {
-		return app.validationRuns[sessID]
-	}
-	svc.TriggerValidationRerun = func(sessID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd {
-		run := app.validationRuns[sessID]
-		if run != nil {
-			run.runID++
-			for i := range run.results {
-				run.results[i] = validationCheckResult{state: checkRunning}
-			}
-		}
-		return func() tea.Msg { return nil }
-	}
+	panel := newReviewPanel(sess, "/repo", 120, 40, app.buildReviewDeps())
 
 	// Switch to Checks tab.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: '3', Text: "3"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: '3', Text: "3"})
 
-	priorRunID := app.validationRuns[sess.ID].runID
+	priorRunID := app.validationRuns[cacheKey("/repo", sess.ID)].runID
 
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'r', Text: "r"}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	if cmd == nil {
 		t.Fatal("r on Checks tab must return a non-nil cmd")
 	}
 
-	if app.validationRuns[sess.ID].runID <= priorRunID {
-		t.Errorf("runID should have incremented; got %d, prior %d", app.validationRuns[sess.ID].runID, priorRunID)
+	if app.validationRuns[cacheKey("/repo", sess.ID)].runID <= priorRunID {
+		t.Errorf("runID should have incremented; got %d, prior %d",
+			app.validationRuns[cacheKey("/repo", sess.ID)].runID, priorRunID)
 	}
 }
 
@@ -210,7 +176,7 @@ func TestReviewPanelModel_ChecksTab_RKeyTriggersRerun(t *testing.T) {
 // the correct runID updates the matching check result without touching others.
 func TestHandleValidationResult_MatchingRunID(t *testing.T) {
 	app := NewApp()
-	app.validationRuns["s1"] = &validationRunState{
+	app.validationRuns[cacheKey("", "s1")] = &validationRunState{
 		runID: 1,
 		checks: []config.ValidationCheck{
 			{Name: "A", Command: "echo a"},
@@ -232,7 +198,7 @@ func TestHandleValidationResult_MatchingRunID(t *testing.T) {
 	}
 	app.handleValidationCheckResult(msg)
 
-	run := app.validationRuns["s1"]
+	run := app.validationRuns[cacheKey("", "s1")]
 	if run.results[0].state != checkPassed {
 		t.Errorf("results[0].state = %v, want checkPassed", run.results[0].state)
 	}
@@ -245,7 +211,7 @@ func TestHandleValidationResult_MatchingRunID(t *testing.T) {
 // runID is silently discarded.
 func TestHandleValidationResult_StaleRunID(t *testing.T) {
 	app := NewApp()
-	app.validationRuns["s1"] = &validationRunState{
+	app.validationRuns[cacheKey("", "s1")] = &validationRunState{
 		runID:  2,
 		checks: []config.ValidationCheck{{Name: "A", Command: "echo a"}},
 		results: []validationCheckResult{
@@ -261,7 +227,7 @@ func TestHandleValidationResult_StaleRunID(t *testing.T) {
 	}
 	app.handleValidationCheckResult(msg)
 
-	run := app.validationRuns["s1"]
+	run := app.validationRuns[cacheKey("", "s1")]
 	if run.results[0].state != checkRunning {
 		t.Errorf("stale result should be discarded; results[0].state = %v, want checkRunning", run.results[0].state)
 	}
@@ -271,7 +237,8 @@ func TestHandleValidationResult_StaleRunID(t *testing.T) {
 // initialises checksCursor and checksScroll to 0.
 func TestReviewPanelModel_ChecksFieldsZeroValue(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
-	panel := newReviewPanel(sess, "", 120, 40)
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 	if panel.checksCursor != 0 {
 		t.Errorf("checksCursor = %d, want 0", panel.checksCursor)
 	}
@@ -284,7 +251,8 @@ func TestReviewPanelModel_ChecksFieldsZeroValue(t *testing.T) {
 // activeTab to 0 (Tasks tab). Zero-value initialisation covers this, but the
 // test pins the contract so a future refactor can't silently break it.
 func TestReviewPanelModel_DefaultTab(t *testing.T) {
-	panel := newReviewPanel(nil, "", 80, 40)
+	app := reviewTestApp()
+	panel := newReviewPanel(nil, "", 80, 40, app.buildReviewDeps())
 	if panel.activeTab != 0 {
 		t.Errorf("activeTab = %d, want 0 (Tasks)", panel.activeTab)
 	}
@@ -302,27 +270,28 @@ func TestReviewPanelModel_NoDiffViewport(t *testing.T) {
 	if _, found := v.FieldByName("diffCacheByTask"); found {
 		t.Error("reviewPanelModel must not have a diffCacheByTask field")
 	}
-	panel := newReviewPanel(nil, "", 80, 40)
+	app := reviewTestApp()
+	panel := newReviewPanel(nil, "", 80, 40, app.buildReviewDeps())
 	type refresher interface {
-		RefreshDiffViewport(PanelServices)
+		RefreshDiffViewport()
 	}
 	if _, ok := any(panel).(refresher); ok {
 		t.Error("reviewPanelModel must not implement RefreshDiffViewport")
 	}
 }
 
-// TestReviewPanelModel_EscCloses verifies that pressing esc invokes
-// svc.ClosePanel() and otherwise leaves session lifecycle untouched.
+// TestReviewPanelModel_EscCloses verifies that pressing esc emits a
+// panelCloseMsg and otherwise leaves session lifecycle untouched.
 func TestReviewPanelModel_EscCloses(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 
-	if !state.closed {
-		t.Fatal("expected ClosePanel to fire on esc")
+	if !cmdClosesPanel(t, cmd) {
+		t.Fatal("expected panelCloseMsg on esc")
 	}
 	if sess.LifecyclePhase() != agent.LifecycleInReview {
 		t.Errorf("esc must preserve InReview phase, got %v", sess.LifecyclePhase())
@@ -334,13 +303,13 @@ func TestReviewPanelModel_EscCloses(t *testing.T) {
 func TestReviewPanelModel_DKeyDefers(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'd', Text: "d"}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
 
-	if !state.closed {
-		t.Fatal("expected ClosePanel to fire on d")
+	if !cmdClosesPanel(t, cmd) {
+		t.Fatal("expected panelCloseMsg on d")
 	}
 	if sess.LifecyclePhase() != agent.LifecycleReadyForReview {
 		t.Errorf("d must transition to ReadyForReview, got %v", sess.LifecyclePhase())
@@ -348,23 +317,27 @@ func TestReviewPanelModel_DKeyDefers(t *testing.T) {
 }
 
 // TestReviewPanelModel_TKeyClosesEvenOnFailure verifies the 't' key always
-// closes the panel and surfaces an error when the session has no agents.
-// Mirrors pre-refactor behaviour: 't' is exit-the-panel-intent regardless
-// of whether the open succeeds.
+// closes the panel and requests the agent terminal with a fallback error.
+// Mirrors pre-refactor behaviour: 't' is exit-the-panel-intent regardless of
+// whether the open succeeds.
 func TestReviewPanelModel_TKeyClosesEvenOnFailure(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
-	state.openInLaunchResult = false
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 't', Text: "t"}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	msgs := runReviewCmd(t, cmd)
 
-	if !state.closed {
-		t.Fatal("expected ClosePanel even on open failure")
+	if _, ok := findMsg[panelCloseMsg](msgs); !ok {
+		t.Fatal("expected panelCloseMsg even on open failure")
 	}
-	if state.errMsg == "" {
-		t.Error("expected error surfaced when session has no agents")
+	req, ok := findMsg[openAgentTerminalRequestMsg](msgs)
+	if !ok {
+		t.Fatal("expected openAgentTerminalRequestMsg")
+	}
+	if req.fallbackError == "" {
+		t.Error("expected fallbackError set so App surfaces an error when no agents")
 	}
 }
 
@@ -373,25 +346,21 @@ func TestReviewPanelModel_TKeyClosesEvenOnFailure(t *testing.T) {
 func TestReviewPanelModel_CKeyMarksComplete(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
-	// Wire Manager to return a non-nil SessionManager so the panel reaches the
-	// kill path. The actual manager pointer is not exercised here because
-	// KillSessionCmd is stubbed.
-	svc.Manager = func(string) SessionManager {
-		return &agent.Manager{}
-	}
+	repo := "/repo"
+	app := reviewTestApp()
+	// Non-nil manager so the panel reaches the kill path; the fake records the
+	// kill call.
+	fake := newFakeManager(repo, sess)
+	app.managers[repo] = fake
+	panel := newReviewPanel(sess, repo, 120, 40, app.buildReviewDeps())
 
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'c', Text: "c"}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
 
-	if !state.closed {
-		t.Fatal("expected ClosePanel on c")
+	if !cmdClosesPanel(t, cmd) {
+		t.Fatal("expected panelCloseMsg on c")
 	}
 	if sess.LifecyclePhase() != agent.LifecycleComplete {
 		t.Errorf("c must transition to Complete, got %v", sess.LifecyclePhase())
-	}
-	if !state.killSessionCalled {
-		t.Error("expected KillSessionCmd to be invoked")
 	}
 	if cmd == nil {
 		t.Error("expected a cmd batch (close + kill); got nil")
@@ -403,7 +372,6 @@ func TestReviewPanelModel_CKeyMarksComplete(t *testing.T) {
 func TestReviewPanelModel_TaskCursorMovesWithJK(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{
 			{Index: 1, Text: "task one"},
@@ -411,21 +379,22 @@ func TestReviewPanelModel_TaskCursorMovesWithJK(t *testing.T) {
 			{Index: 3, Text: "task three"},
 		},
 	}
-	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
+	app := reviewTestApp()
+	app.reviewDiffCache[cacheKey("", sess.ID)] = entry
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
 	if got := panel.TaskCursor(); got != 0 {
 		t.Fatalf("cursor starts at 0, got %d", got)
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if got := panel.TaskCursor(); got != 1 {
 		t.Errorf("after j, cursor=%d, want 1", got)
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if got := panel.TaskCursor(); got != 2 {
 		t.Errorf("after second j, cursor=%d, want 2", got)
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	if got := panel.TaskCursor(); got != 1 {
 		t.Errorf("after k, cursor=%d, want 1", got)
 	}
@@ -434,21 +403,21 @@ func TestReviewPanelModel_TaskCursorMovesWithJK(t *testing.T) {
 func TestReviewPanelModel_TaskCursorClampsAtTopAndBottom(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 1}, {Index: 2}},
 	}
-	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
+	app := reviewTestApp()
+	app.reviewDiffCache[cacheKey("", sess.ID)] = entry
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
 	// k at top is a no-op.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	if got := panel.TaskCursor(); got != 0 {
 		t.Errorf("k at top moved cursor to %d, want 0", got)
 	}
 	// j past last clamps.
 	for range 5 {
-		_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+		_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	}
 	if got := panel.TaskCursor(); got != reviewTaskCount(entry)-1 {
 		t.Errorf("over-scroll cursor=%d, want %d", got, reviewTaskCount(entry)-1)
@@ -458,20 +427,20 @@ func TestReviewPanelModel_TaskCursorClampsAtTopAndBottom(t *testing.T) {
 func TestReviewPanelModel_FKey_TogglesUserFlag(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 7, Text: "task one"}},
 	}
-	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
+	app := reviewTestApp()
+	app.reviewDiffCache[cacheKey("", sess.ID)] = entry
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'f', Text: "f"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
 	rec := entry.verdicts[7]
 	if rec == nil || !rec.userFlagged {
 		t.Fatalf("expected verdict[7].userFlagged=true, got %+v", rec)
 	}
 	// Toggle off.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'f', Text: "f"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
 	if entry.verdicts[7].userFlagged {
 		t.Error("second f should toggle userFlagged back to false")
 	}
@@ -479,9 +448,9 @@ func TestReviewPanelModel_FKey_TogglesUserFlag(t *testing.T) {
 
 func TestReviewPanelModel_FKey_NoCache_NoOp(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, _ := newTestSvc() // ReviewCache returns nil
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'f', Text: "f"}, svc)
+	app := reviewTestApp() // ReviewCache returns nil (empty map)
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'f', Text: "f"})
 	if cmd != nil {
 		t.Errorf("f without cache produced cmd %T, want nil", cmd())
 	}
@@ -490,17 +459,17 @@ func TestReviewPanelModel_FKey_NoCache_NoOp(t *testing.T) {
 func TestReviewPanelModel_BKey_NoFlags_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 1}},
 	}
-	svc, state := newTestSvc()
-	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'b', Text: "b"}, svc)
-	if cmd != nil {
-		t.Errorf("b without flagged tasks should return nil cmd, got %T", cmd())
+	app := reviewTestApp()
+	app.reviewDiffCache[cacheKey("", sess.ID)] = entry
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
+	if _, ok := findMsg[reviewReworkRequestMsg](runReviewCmd(t, cmd)); ok {
+		t.Error("b without flagged tasks should not emit a rework request")
 	}
-	if state.errMsg == "" {
+	if cmdSetsError(t, cmd) == "" {
 		t.Error("expected error message when no tasks are flagged")
 	}
 }
@@ -508,16 +477,16 @@ func TestReviewPanelModel_BKey_NoFlags_SetsError(t *testing.T) {
 func TestReviewPanelModel_BKey_WithFlag_EmitsReworkMsg(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "/repoB", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 1, Text: "task one"}},
 		verdicts: map[int]*taskVerdictRecord{
 			1: {state: verdictPending, userFlagged: true},
 		},
 	}
-	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'b', Text: "b"}, svc)
+	app := reviewTestApp()
+	app.reviewDiffCache[cacheKey("/repoB", sess.ID)] = entry
+	panel := newReviewPanel(sess, "/repoB", 120, 40, app.buildReviewDeps())
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
 	if cmd == nil {
 		t.Fatal("expected rework cmd")
 	}
@@ -541,7 +510,6 @@ func TestReviewPanelModel_BKey_WithFlag_EmitsReworkMsg(t *testing.T) {
 func TestReviewPanelModel_EnterEmitsDiffMsg(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
 	rawDiff := "diff --git a/a.go b/a.go\nindex 1234567..abcdefg 100644\n--- a/a.go\n+++ b/a.go\n@@ -1,3 +1,4 @@\n package main\n \n+// marker\n func A() {}\n"
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{{Index: 3, Text: "Add tab-switching keys"}},
@@ -551,10 +519,11 @@ func TestReviewPanelModel_EnterEmitsDiffMsg(t *testing.T) {
 		}},
 		verdicts: map[int]*taskVerdictRecord{3: {state: verdictPending}},
 	}
-	svc, state := newTestSvc()
-	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
+	app := reviewTestApp()
+	app.reviewDiffCache[cacheKey("", sess.ID)] = entry
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
-	_, cmd := panel.Update(keyNamed(tea.KeyEnter), svc)
+	_, cmd := panel.Update(keyNamed(tea.KeyEnter))
 
 	if cmd == nil {
 		t.Fatal("enter on task with rawDiff must return a cmd")
@@ -570,7 +539,7 @@ func TestReviewPanelModel_EnterEmitsDiffMsg(t *testing.T) {
 	if diffMsg.taskLabel != "[3] Add tab-switching keys" {
 		t.Errorf("taskLabel = %q, want %q", diffMsg.taskLabel, "[3] Add tab-switching keys")
 	}
-	if state.closed {
+	if _, closed := findMsg[panelCloseMsg](msgs); closed {
 		t.Error("enter must not close the review panel")
 	}
 }
@@ -580,16 +549,16 @@ func TestReviewPanelModel_EnterEmitsDiffMsg(t *testing.T) {
 func TestReviewPanelModel_EnterNoopOnEmptyDiff(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks:    []agent.PlanTask{{Index: 1, Text: "task one"}},
 		groups:   []taskReviewGroup{{taskIndex: 1, rawDiff: ""}},
 		verdicts: map[int]*taskVerdictRecord{1: {state: verdictPending}},
 	}
-	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
+	app := reviewTestApp()
+	app.reviewDiffCache[cacheKey("", sess.ID)] = entry
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
-	_, cmd := panel.Update(keyNamed(tea.KeyEnter), svc)
+	_, cmd := panel.Update(keyNamed(tea.KeyEnter))
 	if cmd != nil {
 		t.Errorf("enter on task with no rawDiff must be a no-op, got cmd %T", cmd())
 	}
@@ -599,15 +568,12 @@ func TestReviewPanelModel_EnterNoopOnEmptyDiff(t *testing.T) {
 func TestReviewPanelModel_SpaceIsNoOp(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: ' ', Text: " "}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
 	if cmd != nil {
 		t.Errorf("space should be a no-op, got cmd %T", cmd())
-	}
-	if state.closed {
-		t.Error("space must not close the panel")
 	}
 }
 
@@ -618,11 +584,10 @@ func TestReviewPanelModel_SpaceIsNoOp(t *testing.T) {
 func TestReviewPanelModel_ClickWithTabBarOffset(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	// Panel width 120; DashboardTopY defaults to 0 in newTestSvc.
+	// Panel width 120; dashboardTopY defaults to 0.
 	// renderReviewHeader returns 3 lines for this session (title+prompt+divider) → headerH=3.
 	// Tab bar adds 2 lines → paneTop should be 5.
 	// listHeaderLines=2 → first task row at Y=7.
-	panel := newReviewPanel(sess, "", 120, 40)
 	entry := &reviewDiffEntry{
 		tasks: []agent.PlanTask{
 			{Index: 1, Text: "task one"},
@@ -633,18 +598,19 @@ func TestReviewPanelModel_ClickWithTabBarOffset(t *testing.T) {
 			2: {state: verdictPending},
 		},
 	}
-	svc, _ := newTestSvc()
-	svc.ReviewCache = func(string, string) *reviewDiffEntry { return entry }
+	app := reviewTestApp()
+	app.reviewDiffCache[cacheKey("", sess.ID)] = entry
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
 	// Move cursor to row 1 first so we can verify the click brings it back to 0.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if panel.TaskCursor() != 1 {
 		t.Fatalf("precondition: cursor should be 1 after j, got %d", panel.TaskCursor())
 	}
 
 	// Click at the first task row: Y=7 (headerH=3 + tabBarH=2 + listHeaderLines=2).
 	click := tea.MouseClickMsg{Button: tea.MouseLeft, X: 30, Y: 7}
-	_, _ = panel.Update(click, svc)
+	_, _ = panel.Update(click)
 
 	if panel.TaskCursor() != 0 {
 		t.Errorf("click at Y=7 should move cursor to row 0, got %d (tab bar offset missing?)", panel.TaskCursor())
@@ -657,8 +623,8 @@ func TestReviewPanelModel_FormerScrollKeys_AreNoOp(t *testing.T) {
 	// cursor or close the panel.
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
 	keys := []tea.KeyPressMsg{
 		{Code: tea.KeyPgDown},
@@ -669,16 +635,13 @@ func TestReviewPanelModel_FormerScrollKeys_AreNoOp(t *testing.T) {
 		{Code: 'G', Text: "G"},
 	}
 	for _, k := range keys {
-		_, cmd := panel.Update(k, svc)
+		_, cmd := panel.Update(k)
 		if cmd != nil {
 			t.Errorf("formerly-scroll key %v produced cmd %T, want nil", k, cmd())
 		}
 	}
 	if panel.TaskCursor() != 0 {
 		t.Errorf("taskCursor = %d after keys, want 0", panel.TaskCursor())
-	}
-	if state.closed {
-		t.Error("these keys must not close the panel")
 	}
 }
 
@@ -688,9 +651,9 @@ func TestReviewPanelModel_QKey_NoPlan_DoesNotOpenSpec(t *testing.T) {
 	if sess.HasPlan() {
 		t.Skip("test prereq: session should not have a plan")
 	}
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, _ := newTestSvc()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"}, svc)
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
+	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
 	if panel.specOverlay {
 		t.Error("? opened spec overlay without a plan present")
 	}
@@ -707,9 +670,9 @@ func TestReviewPanelModel_QKey_WithPlan_OpensSpec(t *testing.T) {
 	if !sess.HasPlan() {
 		t.Fatal("test prereq: HasPlan should be true after writing plan.md")
 	}
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, _ := newTestSvc()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"}, svc)
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
+	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
 	if !panel.specOverlay {
 		t.Error("? should have opened spec overlay")
 	}
@@ -722,35 +685,35 @@ func TestReviewPanelModel_SpecOverlay_Keys(t *testing.T) {
 	if err := writePlanForTest(planDir, sess, "# Goal\n"); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, _ := newTestSvc()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"}, svc)
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
+	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
 	if !panel.specOverlay {
 		t.Fatal("test prereq: spec overlay should be open")
 	}
 
 	// pgdown advances scroll.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgDown}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
 	if panel.specOverlayScroll <= 0 {
 		t.Errorf("specOverlayScroll = %d after pgdown, want > 0", panel.specOverlayScroll)
 	}
 	// pgup back to 0 (clamped).
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgUp}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
 	if panel.specOverlayScroll != 0 {
 		t.Errorf("specOverlayScroll = %d after pgup, want 0 (clamp)", panel.specOverlayScroll)
 	}
 	// G jumps to bottom.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'G', Text: "G"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'G', Text: "G"})
 	if panel.specOverlayScroll != 9999 {
 		t.Errorf("specOverlayScroll = %d after G, want 9999", panel.specOverlayScroll)
 	}
 	// g jumps to top.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'g', Text: "g"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'g', Text: "g"})
 	if panel.specOverlayScroll != 0 {
 		t.Errorf("specOverlayScroll = %d after g, want 0", panel.specOverlayScroll)
 	}
 	// esc closes the overlay.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	if panel.specOverlay {
 		t.Error("esc should close spec overlay")
 	}
@@ -766,14 +729,14 @@ func TestReviewPanelModel_SpecOverlay_OtherKeys_AreSwallowed(t *testing.T) {
 		t.Fatalf("write plan: %v", err)
 	}
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"}, svc)
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
+	_, _ = panel.Update(tea.KeyPressMsg{Code: '?', Text: "?"})
 
 	// 'd' in main mode would defer the panel — must NOT do that while spec
 	// overlay is open.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'd', Text: "d"}, svc)
-	if state.closed {
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'd', Text: "d"})
+	if cmdClosesPanel(t, cmd) {
 		t.Error("'d' while spec overlay open closed the panel — should be swallowed")
 	}
 	if sess.LifecyclePhase() != agent.LifecycleInReview {
@@ -787,51 +750,48 @@ func TestReviewPanelModel_SpecOverlay_OtherKeys_AreSwallowed(t *testing.T) {
 func TestReviewPanelModel_PKey_WithCachedPR_OpensURL(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
+	app := reviewTestApp()
+	app.prCache[cacheKey("", sess.ID)] = &prCacheEntry{pr: &github.PRState{URL: "https://example.com/pr/1"}}
+
 	var openedURL string
-	svc.PRCache = func(string, string) *prCacheEntry {
-		return &prCacheEntry{pr: &github.PRState{URL: "https://example.com/pr/1"}}
-	}
-	svc.OpenURL = func(u string) error {
-		openedURL = u
-		return nil
-	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"}, svc)
+	openURL = func(u string) error { openedURL = u; return nil }
+	t.Cleanup(restoreOpenURL())
+
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+	msgs := runReviewCmd(t, cmd)
+
 	if openedURL != "https://example.com/pr/1" {
-		t.Errorf("OpenURL got %q, want %q", openedURL, "https://example.com/pr/1")
+		t.Errorf("openURL got %q, want %q", openedURL, "https://example.com/pr/1")
 	}
 	if sess.LifecyclePhase() != agent.LifecycleShipping {
 		t.Errorf("p with existing PR should transition to Shipping, got %v", sess.LifecyclePhase())
 	}
-	if !state.closed {
+	if _, closed := findMsg[panelCloseMsg](msgs); !closed {
 		t.Error("p with existing PR should close the panel")
 	}
 }
 
 func TestReviewPanelModel_PKey_NoPR_NoGHClient_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
-	svc.GHClient = func() *github.Client { return nil }
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"}, svc)
-	if cmd != nil {
-		t.Errorf("p with no PR and no GH client should return nil cmd, got %T", cmd())
+	app := reviewTestApp() // ghClient is nil
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+	if _, ok := findMsg[startPRDraftRequestMsg](runReviewCmd(t, cmd)); ok {
+		t.Error("p with no GH client should not request a PR draft")
 	}
-	if state.errMsg == "" {
+	if cmdSetsError(t, cmd) == "" {
 		t.Error("expected error when GitHub auth missing")
 	}
 }
 
 func TestReviewPanelModel_EKey_NoIDECommand_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTestWithPath("s1", "fix-auth", t.TempDir())
-	panel := newReviewPanel(sess, "/repo", 120, 40)
-	svc, state := newTestSvc()
-	svc.Resolved = func(string) config.ResolvedSettings {
-		return config.ResolvedSettings{IDECommand: ""}
-	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'e', Text: "e"}, svc)
-	if state.errMsg == "" {
+	app := reviewTestApp()
+	app.resolvedCache["/repo"] = config.ResolvedSettings{IDECommand: ""}
+	panel := newReviewPanel(sess, "/repo", 120, 40, app.buildReviewDeps())
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'e', Text: "e"})
+	if cmdSetsError(t, cmd) == "" {
 		t.Error("expected error when IDE command not configured")
 	}
 }
@@ -839,23 +799,21 @@ func TestReviewPanelModel_EKey_NoIDECommand_SetsError(t *testing.T) {
 func TestReviewPanelModel_UnknownKey_NoOp(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "fix-auth")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "", 120, 40)
-	svc, state := newTestSvc()
+	app := reviewTestApp()
+	panel := newReviewPanel(sess, "", 120, 40, app.buildReviewDeps())
 
 	before := struct {
 		cursor int
 		spec   bool
-		closed bool
-		errMsg string
 		phase  agent.LifecyclePhase
-	}{panel.TaskCursor(), panel.specOverlay, state.closed, state.errMsg, sess.LifecyclePhase()}
+	}{panel.TaskCursor(), panel.specOverlay, sess.LifecyclePhase()}
 
 	for _, k := range []tea.KeyPressMsg{
 		{Code: 'z', Text: "z"},
 		{Code: 'x', Text: "x"},
 		{Code: 'w', Mod: tea.ModCtrl},
 	} {
-		_, cmd := panel.Update(k, svc)
+		_, cmd := panel.Update(k)
 		if cmd != nil {
 			t.Errorf("unknown key %v produced cmd %T, want nil", k, cmd())
 		}
@@ -864,10 +822,8 @@ func TestReviewPanelModel_UnknownKey_NoOp(t *testing.T) {
 	after := struct {
 		cursor int
 		spec   bool
-		closed bool
-		errMsg string
 		phase  agent.LifecyclePhase
-	}{panel.TaskCursor(), panel.specOverlay, state.closed, state.errMsg, sess.LifecyclePhase()}
+	}{panel.TaskCursor(), panel.specOverlay, sess.LifecyclePhase()}
 
 	if before != after {
 		t.Errorf("unknown keys changed state: before=%+v after=%+v", before, after)
@@ -875,52 +831,42 @@ func TestReviewPanelModel_UnknownKey_NoOp(t *testing.T) {
 }
 
 // TestReviewPanel_PKey_UsesPinnedRepoPath_NotFirstMatch verifies that pressing
-// 'p' (draft PR) passes the panel's pinned repoPath to StartPRDraftCmd, not
-// the first-match repoPath from ManagerFor — the multi-repo collision fix.
+// 'p' (draft PR) emits a startPRDraftRequestMsg carrying the panel's pinned
+// repoPath, not a first-match repoPath — the multi-repo collision fix.
 func TestReviewPanel_PKey_UsesPinnedRepoPath_NotFirstMatch(t *testing.T) {
 	sess := agent.NewSessionForTest("session-1", "my-task")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "/repoB", 120, 40)
-	svc, _ := newTestSvc()
+	app := reviewTestApp()
+	app.ghClient = new(github.Client) // non-nil so the panel reaches the draft path
+	panel := newReviewPanel(sess, "/repoB", 120, 40, app.buildReviewDeps())
 
-	var recordedRepoPath string
-	svc.StartPRDraftCmd = func(_ *agent.Session, repoPath string, _ bool) tea.Cmd {
-		recordedRepoPath = repoPath
-		return func() tea.Msg { return nil }
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+	req, ok := findMsg[startPRDraftRequestMsg](runReviewCmd(t, cmd))
+	if !ok {
+		t.Fatal("expected startPRDraftRequestMsg")
 	}
-	// non-nil GHClient so the code passes the auth check and reaches StartPRDraftCmd
-	svc.GHClient = func() *github.Client { return new(github.Client) }
-	svc.PRCache = func(string, string) *prCacheEntry { return nil }
-
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"}, svc)
-
-	if recordedRepoPath != "/repoB" {
-		t.Errorf("StartPRDraftCmd received repoPath=%q, want /repoB (pinned)", recordedRepoPath)
+	if req.repoPath != "/repoB" {
+		t.Errorf("startPRDraftRequestMsg repoPath=%q, want /repoB (pinned)", req.repoPath)
 	}
 }
 
 // TestReviewPanel_CKey_UsesPinnedManager verifies that pressing 'c' (mark
 // complete) resolves the manager via the panel's pinned repoPath, not the
-// first-match lookup.
+// first-match lookup. The kill cmd only fires when the pinned repo has a
+// manager, so a kill-result msg confirms the pinned lookup succeeded.
 func TestReviewPanel_CKey_UsesPinnedManager(t *testing.T) {
 	sess := agent.NewSessionForTest("session-1", "my-task")
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	panel := newReviewPanel(sess, "/repoB", 120, 40)
-	svc, state := newTestSvc()
+	repo := "/repoB"
+	app := reviewTestApp()
+	fake := newFakeManager(repo, sess)
+	app.managers[repo] = fake
+	panel := newReviewPanel(sess, repo, 120, 40, app.buildReviewDeps())
 
-	var managerCalledWith string
-	svc.Manager = func(repoPath string) SessionManager {
-		managerCalledWith = repoPath
-		return &agent.Manager{} // non-nil so kill path is taken
-	}
-
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'c', Text: "c"}, svc)
-
-	if managerCalledWith != "/repoB" {
-		t.Errorf("Manager called with %q, want /repoB (pinned)", managerCalledWith)
-	}
-	if !state.killSessionCalled {
-		t.Error("expected KillSessionCmd to be invoked on non-nil manager")
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	msgs := runReviewCmd(t, cmd)
+	if _, ok := findMsg[killResultMsg](msgs); !ok {
+		t.Error("expected killResultMsg — manager must resolve via pinned repoPath")
 	}
 }
 
@@ -932,4 +878,11 @@ func writePlanForTest(planDir string, sess *agent.Session, content string) error
 		return err
 	}
 	return os.WriteFile(filepath.Join(planDir, "plan.md"), []byte(content), 0o644)
+}
+
+// restoreOpenURL captures the current openURL and returns a cleanup that
+// restores it, so tests that swap openURL don't leak across cases.
+func restoreOpenURL() func() {
+	orig := openURL
+	return func() { openURL = orig }
 }

--- a/internal/tui/shippingpanel_model.go
+++ b/internal/tui/shippingpanel_model.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/devenjarvis/refrain/internal/agent"
 	"github.com/devenjarvis/refrain/internal/github"
 )
@@ -19,7 +20,22 @@ type shippingPanelModel struct {
 	detailScroll   int
 	feedbackNote   feedbackNoteModal
 
+	// deps carries the App-level reference handles the panel reaches through
+	// for lookups and cmd factories. Bound once at construction (§3 fold).
+	deps shippingDeps
+
 	width, height int
+}
+
+// shippingDeps holds the reference-typed App handles the shipping panel needs.
+// Bound at construction to the App's maps/pointers (never to App itself) so the
+// closures stay live across App value-copies (App.Update is a value receiver).
+type shippingDeps struct {
+	PRCache            func(repoPath, sessionID string) *prCacheEntry
+	FeedbackTriage     func(repoPath, sessionID string) map[string]*feedbackTriageEntry
+	SetFeedbackVerdict func(repoPath, sessionID, itemKey string, v feedbackVerdict)
+	SetFeedbackNote    func(repoPath, sessionID, itemKey, note string)
+	MergePRCmd         func(sessionID, repoPath string, force bool) tea.Cmd
 }
 
 // feedbackVerdict is the user's disposition on a single feedback item.
@@ -92,7 +108,7 @@ func feedbackItemKey(item feedbackItem) string {
 // multi-repo session-ID collisions from routing operations to the wrong repo.
 // The nested feedbackNote modal is initialised but inactive until the user
 // presses 'n'.
-func newShippingPanel(sess *agent.Session, repoPath string, width, height int) *shippingPanelModel {
+func newShippingPanel(sess *agent.Session, repoPath string, width, height int, deps shippingDeps) *shippingPanelModel {
 	note := newFeedbackNoteModal()
 	note.SetSize(width, height+1)
 	return &shippingPanelModel{
@@ -101,6 +117,7 @@ func newShippingPanel(sess *agent.Session, repoPath string, width, height int) *
 		feedbackNote: note,
 		width:        width,
 		height:       height,
+		deps:         deps,
 	}
 }
 

--- a/internal/tui/shippingpanel_update.go
+++ b/internal/tui/shippingpanel_update.go
@@ -13,24 +13,21 @@ type shippingFeedbackRequestMsg struct {
 
 // feedbackNoteSubmitMsg is emitted by the embedded feedbackNoteModal when the
 // user saves a note (enter). It is owned and handled here (§4): the shipping
-// panel persists the note via svc.SetFeedbackNote one Update cycle after the
+// panel persists the note via deps.SetFeedbackNote one Update cycle after the
 // modal closes.
 type feedbackNoteSubmitMsg struct {
 	itemKey string
 	note    string
 }
 
-// closeShippingPanel invokes svc.ClosePanel(). Returns nil for inline
-// `return m, closeShippingPanel(svc)`.
-func closeShippingPanel(svc PanelServices) tea.Cmd {
-	if svc.ClosePanel != nil {
-		svc.ClosePanel()
-	}
-	return nil
+// closeShippingPanel returns a tea.Cmd yielding panelCloseMsg. Returns the cmd
+// for inline `return m, closeShippingPanel()`.
+func closeShippingPanel() tea.Cmd {
+	return func() tea.Msg { return panelCloseMsg{} }
 }
 
 // Update dispatches the shipping panel's key handling.
-func (m *shippingPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel, tea.Cmd) {
+func (m *shippingPanelModel) Update(msg tea.Msg) (PanelModel, tea.Cmd) {
 	if m == nil || m.session == nil {
 		return m, nil
 	}
@@ -39,26 +36,26 @@ func (m *shippingPanelModel) Update(msg tea.Msg, svc PanelServices) (PanelModel,
 		m.SetSize(msg.Width, msg.Height-1)
 		return m, nil
 	case feedbackNoteSubmitMsg:
-		if svc.SetFeedbackNote != nil {
-			svc.SetFeedbackNote(m.repoPath, m.session.ID, msg.itemKey, msg.note)
+		if m.deps.SetFeedbackNote != nil {
+			m.deps.SetFeedbackNote(m.repoPath, m.session.ID, msg.itemKey, msg.note)
 		}
 		return m, nil
 	case tea.KeyPressMsg:
-		return m.handleKey(msg, svc)
+		return m.handleKey(msg)
 	}
 	return m, nil
 }
 
 // handleKey is the per-key dispatch. The nested feedback-note modal
 // intercepts all keys when active.
-func (m *shippingPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (PanelModel, tea.Cmd) {
+func (m *shippingPanelModel) handleKey(msg tea.KeyPressMsg) (PanelModel, tea.Cmd) {
 	if m.feedbackNote.Active() {
 		var cmd tea.Cmd
 		m.feedbackNote, cmd = m.feedbackNote.Update(msg)
 		return m, cmd
 	}
 
-	entry := svc.PRCache(m.repoPath, m.session.ID)
+	entry := m.deps.PRCache(m.repoPath, m.session.ID)
 	items := feedbackItems(entryThreads(entry))
 	halfPane := m.height / 4
 	if halfPane < 1 {
@@ -91,26 +88,26 @@ func (m *shippingPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (
 			m.detailScroll = 0
 		}
 	case "a":
-		if len(items) > 0 && m.feedbackCursor < len(items) && svc.SetFeedbackVerdict != nil {
+		if len(items) > 0 && m.feedbackCursor < len(items) && m.deps.SetFeedbackVerdict != nil {
 			key := feedbackItemKey(items[m.feedbackCursor])
-			svc.SetFeedbackVerdict(m.repoPath, m.session.ID, key, feedbackApproved)
+			m.deps.SetFeedbackVerdict(m.repoPath, m.session.ID, key, feedbackApproved)
 		}
 	case "x":
-		if len(items) > 0 && m.feedbackCursor < len(items) && svc.SetFeedbackVerdict != nil {
+		if len(items) > 0 && m.feedbackCursor < len(items) && m.deps.SetFeedbackVerdict != nil {
 			key := feedbackItemKey(items[m.feedbackCursor])
-			svc.SetFeedbackVerdict(m.repoPath, m.session.ID, key, feedbackDisagreed)
+			m.deps.SetFeedbackVerdict(m.repoPath, m.session.ID, key, feedbackDisagreed)
 		}
 	case "u":
-		if len(items) > 0 && m.feedbackCursor < len(items) && svc.SetFeedbackVerdict != nil {
+		if len(items) > 0 && m.feedbackCursor < len(items) && m.deps.SetFeedbackVerdict != nil {
 			key := feedbackItemKey(items[m.feedbackCursor])
-			svc.SetFeedbackVerdict(m.repoPath, m.session.ID, key, feedbackNeutral)
+			m.deps.SetFeedbackVerdict(m.repoPath, m.session.ID, key, feedbackNeutral)
 		}
 	case "n":
 		if len(items) > 0 && m.feedbackCursor < len(items) {
 			item := items[m.feedbackCursor]
 			key := feedbackItemKey(item)
 			existing := ""
-			if triage := svc.FeedbackTriage(m.repoPath, m.session.ID); triage != nil {
+			if triage := m.deps.FeedbackTriage(m.repoPath, m.session.ID); triage != nil {
 				if e := triage[key]; e != nil {
 					existing = e.Note
 				}
@@ -118,35 +115,35 @@ func (m *shippingPanelModel) handleKey(msg tea.KeyPressMsg, svc PanelServices) (
 			return m, m.feedbackNote.Open(key, existing)
 		}
 	case "esc":
-		return m, closeShippingPanel(svc)
+		return m, closeShippingPanel()
 	case "t":
 		sess := m.session
 		repoPath := m.repoPath
-		closeShippingPanel(svc)
-		if !svc.OpenInLaunch(sess, repoPath) {
-			svc.SetError("session has no agents to open")
-		}
-		return m, nil
+		return m, tea.Batch(
+			closeShippingPanel(),
+			func() tea.Msg {
+				return openAgentTerminalRequestMsg{
+					session:       sess,
+					repoPath:      repoPath,
+					fallbackError: "session has no agents to open",
+				}
+			},
+		)
 	case "p":
 		if entry != nil && entry.pr != nil && entry.pr.URL != "" {
-			if err := svc.OpenURL(entry.pr.URL); err != nil {
-				svc.SetError(err.Error())
-			}
-		} else {
-			svc.SetError("no PR URL available")
+			return m, openURLRequestCmd(entry.pr.URL)
 		}
+		return m, setErrorCmd("no PR URL available")
 	case "m":
 		if !isMergeReady(entry) {
-			svc.SetError("not ready to merge — use M to force")
-			return m, nil
+			return m, setErrorCmd("not ready to merge — use M to force")
 		}
-		return m, svc.MergePRCmd(m.session.ID, m.repoPath, false)
+		return m, m.deps.MergePRCmd(m.session.ID, m.repoPath, false)
 	case "M":
 		if entry == nil || entry.pr == nil {
-			svc.SetError("no PR found")
-			return m, nil
+			return m, setErrorCmd("no PR found")
 		}
-		return m, svc.MergePRCmd(m.session.ID, m.repoPath, true)
+		return m, m.deps.MergePRCmd(m.session.ID, m.repoPath, true)
 	case "r":
 		sessID := m.session.ID
 		repoPath := m.repoPath

--- a/internal/tui/shippingpanel_view.go
+++ b/internal/tui/shippingpanel_view.go
@@ -13,12 +13,12 @@ import (
 
 // View renders the shipping panel. Modal precedence: if the feedback-note
 // modal is active, render it overlaid; otherwise render the panel proper.
-func (m *shippingPanelModel) View(svc PanelServices) string {
+func (m *shippingPanelModel) View() string {
 	if m == nil || m.session == nil {
 		return ""
 	}
-	entry := svc.PRCache(m.repoPath, m.session.ID)
-	triage := svc.FeedbackTriage(m.repoPath, m.session.ID)
+	entry := m.deps.PRCache(m.repoPath, m.session.ID)
+	triage := m.deps.FeedbackTriage(m.repoPath, m.session.ID)
 	return renderShippingPanel(m.session, entry, m.width, m.height, m.feedbackCursor, m.detailScroll, triage)
 }
 

--- a/internal/tui/shippingpanelmodel_test.go
+++ b/internal/tui/shippingpanelmodel_test.go
@@ -9,37 +9,29 @@ import (
 	"github.com/devenjarvis/refrain/internal/github"
 )
 
-// newTestShippingSvc returns a stub PanelServices for shipping-panel tests
-// plus a state value the test can inspect after Update.
-func newTestShippingSvc() (PanelServices, *testShippingSvcState) {
+// testShippingSvcState records the side effects a shipping-panel test wants to
+// assert on. Post-§3-fold (panel.go), reference-typed handles are injected via
+// shippingDeps at construction and recorded here; the scalar effects that used
+// to run through service closures (close, error, open-URL, open-in-launch) now
+// flow as messages the panel returns, so those are asserted on the emitted
+// tea.Cmd via runCmdAll/findMsg rather than recorded here.
+type testShippingSvcState struct {
+	pr             *prCacheEntry
+	triage         map[string]*feedbackTriageEntry
+	mergeRequested bool
+	mergeForce     bool
+}
+
+// newTestShippingDeps returns a stub shippingDeps for shipping-panel tests plus
+// a state value the test can inspect after Update. The PR cache and feedback
+// triage map are read through the deps closures; verdict/note setters and the
+// merge cmd record into state.
+func newTestShippingDeps() (shippingDeps, *testShippingSvcState) {
 	state := &testShippingSvcState{
 		triage: map[string]*feedbackTriageEntry{},
 	}
-	svc := PanelServices{
-		Width:  120,
-		Height: 40,
-		Manager: func(string) SessionManager {
-			return nil
-		},
+	deps := shippingDeps{
 		PRCache: func(string, string) *prCacheEntry { return state.pr },
-		ClosePanel: func() {
-			state.closed = true
-		},
-		OpenInLaunch: func(*agent.Session, string) bool {
-			return state.openInLaunchResult
-		},
-		SetError: func(msg string) {
-			state.errMsg = msg
-		},
-		OpenURL: func(string) error {
-			state.openedURL = true
-			return nil
-		},
-		MergePRCmd: func(sessionID, repoPath string, force bool) tea.Cmd {
-			state.mergeRequested = true
-			state.mergeForce = force
-			return func() tea.Msg { return nil }
-		},
 		FeedbackTriage: func(string, string) map[string]*feedbackTriageEntry {
 			return state.triage
 		},
@@ -55,30 +47,46 @@ func newTestShippingSvc() (PanelServices, *testShippingSvcState) {
 			}
 			state.triage[key].Note = note
 		},
+		MergePRCmd: func(sessionID, repoPath string, force bool) tea.Cmd {
+			state.mergeRequested = true
+			state.mergeForce = force
+			return func() tea.Msg { return mergePRMsg{sessionID: sessionID, repoPath: repoPath} }
+		},
 	}
-	return svc, state
+	return deps, state
 }
 
-type testShippingSvcState struct {
-	pr                 *prCacheEntry
-	triage             map[string]*feedbackTriageEntry
-	closed             bool
-	errMsg             string
-	openedURL          bool
-	openInLaunchResult bool
-	mergeRequested     bool
-	mergeForce         bool
+// cmdClosesShipping reports whether cmd yields a panelCloseMsg.
+func cmdClosesShipping(t *testing.T, cmd tea.Cmd) bool {
+	t.Helper()
+	if cmd == nil {
+		return false
+	}
+	_, ok := findMsg[panelCloseMsg](runCmdAll(t, cmd))
+	return ok
 }
 
-// TestShippingPanelModel_EscCloses verifies esc closes the panel.
+// cmdShippingError returns the error text from a setErrorMsg in cmd's output, or "".
+func cmdShippingError(t *testing.T, cmd tea.Cmd) string {
+	t.Helper()
+	if cmd == nil {
+		return ""
+	}
+	if m, ok := findMsg[setErrorMsg](runCmdAll(t, cmd)); ok {
+		return m.text
+	}
+	return ""
+}
+
+// TestShippingPanelModel_EscCloses verifies esc emits panelCloseMsg.
 func TestShippingPanelModel_EscCloses(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, _ := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
 
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape}, svc)
-	if !state.closed {
-		t.Fatal("expected ClosePanel on esc")
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if !cmdClosesShipping(t, cmd) {
+		t.Fatal("expected panelCloseMsg on esc")
 	}
 }
 
@@ -86,15 +94,15 @@ func TestShippingPanelModel_EscCloses(t *testing.T) {
 // error and does not call MergePRCmd when the PR isn't merge-ready.
 func TestShippingPanelModel_MergeBlockedWhenNotReady(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, state := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
 	// No PR entry => not merge-ready.
 
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'm', Text: "m"}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
 	if state.mergeRequested {
 		t.Error("expected merge to be blocked when PR not ready")
 	}
-	if state.errMsg == "" {
+	if cmdShippingError(t, cmd) == "" {
 		t.Error("expected error to be surfaced when not ready")
 	}
 }
@@ -103,11 +111,12 @@ func TestShippingPanelModel_MergeBlockedWhenNotReady(t *testing.T) {
 // gate and calls MergePRCmd with force=true.
 func TestShippingPanelModel_ForceMergeBypasses(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, state := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
 	state.pr = &prCacheEntry{pr: &github.PRState{Number: 1}}
 
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'M', Text: "M"}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'M', Text: "M"})
+	_ = runCmdAll(t, cmd)
 	if !state.mergeRequested {
 		t.Fatal("expected force-merge to be requested")
 	}
@@ -116,26 +125,26 @@ func TestShippingPanelModel_ForceMergeBypasses(t *testing.T) {
 	}
 }
 
-// TestShippingPanelModel_PKeyOpensPRURL verifies 'p' calls svc.OpenURL when
-// a URL is cached.
+// TestShippingPanelModel_PKeyOpensPRURL verifies 'p' emits an open-URL request
+// when a URL is cached.
 func TestShippingPanelModel_PKeyOpensPRURL(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, state := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
 	state.pr = &prCacheEntry{pr: &github.PRState{URL: "https://example/pr/1"}}
 
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"}, svc)
-	if !state.openedURL {
-		t.Error("expected OpenURL invoked when PR URL is cached")
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+	if _, ok := findMsg[openURLResultMsg](runCmdAll(t, cmd)); !ok {
+		t.Error("expected an open-URL request when PR URL is cached")
 	}
 }
 
-// shippingPanelWithFeedback returns a panel + svc + state where the cache has
-// two feedback items so cursor/verdict/note keys can be exercised.
-func shippingPanelWithFeedback() (*shippingPanelModel, PanelServices, *testShippingSvcState) {
+// shippingPanelWithFeedback returns a panel + deps + state where the cache has
+// three feedback items so cursor/verdict/note keys can be exercised.
+func shippingPanelWithFeedback() (*shippingPanelModel, shippingDeps, *testShippingSvcState) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, state := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
 	state.pr = &prCacheEntry{
 		pr: &github.PRState{Number: 1, URL: "https://example/pr/1"},
 		threads: []github.ReviewThread{
@@ -150,28 +159,28 @@ func shippingPanelWithFeedback() (*shippingPanelModel, PanelServices, *testShipp
 			},
 		},
 	}
-	return panel, svc, state
+	return panel, deps, state
 }
 
 func TestShippingPanelModel_JK_MovesFeedbackCursor(t *testing.T) {
-	panel, svc, _ := shippingPanelWithFeedback()
+	panel, _, _ := shippingPanelWithFeedback()
 	if panel.FeedbackCursor() != 0 {
 		t.Fatalf("test prereq: cursor=%d, want 0", panel.FeedbackCursor())
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if panel.FeedbackCursor() != 1 {
 		t.Errorf("after j cursor=%d, want 1", panel.FeedbackCursor())
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	if panel.FeedbackCursor() != 0 {
 		t.Errorf("after k cursor=%d, want 0", panel.FeedbackCursor())
 	}
 }
 
 func TestShippingPanelModel_JK_ClampsAtBounds(t *testing.T) {
-	panel, svc, _ := shippingPanelWithFeedback()
+	panel, _, _ := shippingPanelWithFeedback()
 	for range 10 {
-		_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+		_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	}
 	// 3 items in fixture (1 body + 2 inlines) — cursor should clamp at index 2.
 	if panel.FeedbackCursor() != 2 {
@@ -179,7 +188,7 @@ func TestShippingPanelModel_JK_ClampsAtBounds(t *testing.T) {
 	}
 	// k below 0 clamps.
 	for range 10 {
-		_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"}, svc)
+		_, _ = panel.Update(tea.KeyPressMsg{Code: 'k', Text: "k"})
 	}
 	if panel.FeedbackCursor() != 0 {
 		t.Errorf("under-scroll cursor=%d, want 0", panel.FeedbackCursor())
@@ -187,57 +196,57 @@ func TestShippingPanelModel_JK_ClampsAtBounds(t *testing.T) {
 }
 
 func TestShippingPanelModel_JK_ResetsDetailScroll(t *testing.T) {
-	panel, svc, _ := shippingPanelWithFeedback()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgDown}, svc)
+	panel, _, _ := shippingPanelWithFeedback()
+	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
 	if panel.DetailScroll() == 0 {
 		t.Fatal("test prereq: detailScroll should be > 0 after pgdown")
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if panel.DetailScroll() != 0 {
 		t.Errorf("j should reset detailScroll, got %d", panel.DetailScroll())
 	}
 }
 
 func TestShippingPanelModel_PgDownPgUp_ScrollDetail(t *testing.T) {
-	panel, svc, _ := shippingPanelWithFeedback()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgDown}, svc)
+	panel, _, _ := shippingPanelWithFeedback()
+	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
 	if panel.DetailScroll() == 0 {
 		t.Errorf("detailScroll = 0 after pgdown, want > 0")
 	}
 	first := panel.DetailScroll()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgUp}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
 	if panel.DetailScroll() >= first {
 		t.Errorf("pgup did not reduce detailScroll: was %d, now %d", first, panel.DetailScroll())
 	}
 }
 
 func TestShippingPanelModel_PgUp_ClampsAtZero(t *testing.T) {
-	panel, svc, _ := shippingPanelWithFeedback()
+	panel, _, _ := shippingPanelWithFeedback()
 	if panel.DetailScroll() != 0 {
 		t.Fatal("test prereq: detailScroll should start 0")
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgUp}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyPgUp})
 	if panel.DetailScroll() != 0 {
 		t.Errorf("pgup at top should clamp to 0, got %d", panel.DetailScroll())
 	}
 }
 
 func TestShippingPanelModel_CtrlD_CtrlU_HalfPageScroll(t *testing.T) {
-	panel, svc, _ := shippingPanelWithFeedback()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}, svc)
+	panel, _, _ := shippingPanelWithFeedback()
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
 	if panel.DetailScroll() == 0 {
 		t.Errorf("ctrl+d did not advance detailScroll")
 	}
 	pre := panel.DetailScroll()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl})
 	if panel.DetailScroll() >= pre {
 		t.Errorf("ctrl+u did not reduce detailScroll: pre=%d post=%d", pre, panel.DetailScroll())
 	}
 }
 
 func TestShippingPanelModel_AKeyApprovesCursorItem(t *testing.T) {
-	panel, svc, state := shippingPanelWithFeedback()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'a', Text: "a"}, svc)
+	panel, _, state := shippingPanelWithFeedback()
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
 	// Cursor starts at 0 → the thread body item → key "thread:alice".
 	got := state.triage["thread:alice"]
 	if got == nil || got.Verdict != feedbackApproved {
@@ -246,8 +255,8 @@ func TestShippingPanelModel_AKeyApprovesCursorItem(t *testing.T) {
 }
 
 func TestShippingPanelModel_XKeyDisagrees(t *testing.T) {
-	panel, svc, state := shippingPanelWithFeedback()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'x', Text: "x"}, svc)
+	panel, _, state := shippingPanelWithFeedback()
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
 	got := state.triage["thread:alice"]
 	if got == nil || got.Verdict != feedbackDisagreed {
 		t.Errorf("verdict = %+v, want disagreed", got)
@@ -255,9 +264,9 @@ func TestShippingPanelModel_XKeyDisagrees(t *testing.T) {
 }
 
 func TestShippingPanelModel_UKeyResetsToNeutral(t *testing.T) {
-	panel, svc, state := shippingPanelWithFeedback()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'a', Text: "a"}, svc)
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'u', Text: "u"}, svc)
+	panel, _, state := shippingPanelWithFeedback()
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'u', Text: "u"})
 	got := state.triage["thread:alice"]
 	if got == nil || got.Verdict != feedbackNeutral {
 		t.Errorf("verdict after 'a' then 'u' = %+v, want neutral", got)
@@ -268,10 +277,10 @@ func TestShippingPanelModel_AXU_NoItems_NoOp(t *testing.T) {
 	// Without any feedback items, the verdict keys must be no-ops, not
 	// crashes or off-by-one writes.
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, state := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
 	for _, k := range []rune{'a', 'x', 'u'} {
-		_, _ = panel.Update(tea.KeyPressMsg{Code: k, Text: string(k)}, svc)
+		_, _ = panel.Update(tea.KeyPressMsg{Code: k, Text: string(k)})
 	}
 	if len(state.triage) != 0 {
 		t.Errorf("verdict keys should not have written into triage on empty list, got %d entries", len(state.triage))
@@ -279,11 +288,11 @@ func TestShippingPanelModel_AXU_NoItems_NoOp(t *testing.T) {
 }
 
 func TestShippingPanelModel_NKey_OpensFeedbackNoteModal(t *testing.T) {
-	panel, svc, _ := shippingPanelWithFeedback()
+	panel, _, _ := shippingPanelWithFeedback()
 	if panel.NoteActive() {
 		t.Fatal("test prereq: note modal should start inactive")
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
 	if !panel.NoteActive() {
 		t.Error("n should open feedback note modal")
 	}
@@ -291,29 +300,29 @@ func TestShippingPanelModel_NKey_OpensFeedbackNoteModal(t *testing.T) {
 
 func TestShippingPanelModel_NKey_NoItems_DoesNotOpenModal(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, _ := newTestShippingSvc()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"}, svc)
+	deps, _ := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
 	if panel.NoteActive() {
 		t.Error("n with no items should not open the note modal")
 	}
 }
 
 func TestShippingPanelModel_NoteModalInterceptsKeys(t *testing.T) {
-	panel, svc, state := shippingPanelWithFeedback()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"}, svc) // open
+	panel, _, _ := shippingPanelWithFeedback()
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"}) // open
 	if !panel.NoteActive() {
 		t.Fatal("test prereq: note modal should be open")
 	}
 	// Typing 'j' should reach the textarea, NOT advance the feedback cursor.
 	cursorBefore := panel.FeedbackCursor()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'j', Text: "j"})
 	if panel.FeedbackCursor() != cursorBefore {
 		t.Error("j while note modal active moved feedback cursor")
 	}
 	// Esc cancels and does NOT close the shipping panel.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape}, svc)
-	if state.closed {
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmdClosesShipping(t, cmd) {
 		t.Error("esc inside note modal closed the shipping panel")
 	}
 	if panel.NoteActive() {
@@ -322,12 +331,12 @@ func TestShippingPanelModel_NoteModalInterceptsKeys(t *testing.T) {
 }
 
 func TestShippingPanelModel_NoteModalEnter_SavesNote(t *testing.T) {
-	panel, svc, state := shippingPanelWithFeedback()
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"}, svc)
+	panel, _, state := shippingPanelWithFeedback()
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
 	panel.feedbackNote.ta.SetValue("important note")
 	// Enter closes the modal synchronously and emits a feedbackNoteSubmitMsg;
 	// the note persists one Update cycle later when that msg is handled.
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: tea.KeyEnter}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if panel.NoteActive() {
 		t.Error("enter should close the modal")
 	}
@@ -338,7 +347,7 @@ func TestShippingPanelModel_NoteModalEnter_SavesNote(t *testing.T) {
 	if !ok {
 		t.Fatalf("enter cmd yielded %T, want feedbackNoteSubmitMsg", cmd())
 	}
-	_, _ = panel.Update(submit, svc)
+	_, _ = panel.Update(submit)
 	got := state.triage["thread:alice"]
 	if got == nil || got.Note != "important note" {
 		t.Errorf("triage note = %+v, want %q", got, "important note")
@@ -346,81 +355,95 @@ func TestShippingPanelModel_NoteModalEnter_SavesNote(t *testing.T) {
 }
 
 func TestShippingPanelModel_TKey_OpensInLaunch(t *testing.T) {
-	panel, svc, state := shippingPanelWithFeedback()
-	state.openInLaunchResult = true
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 't', Text: "t"}, svc)
-	if !state.closed {
+	panel, _, _ := shippingPanelWithFeedback()
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	msgs := runCmdAll(t, cmd)
+	if _, ok := findMsg[panelCloseMsg](msgs); !ok {
 		t.Error("t should close the shipping panel")
 	}
-	if state.errMsg != "" {
-		t.Errorf("t with successful OpenInLaunch should not error, got %q", state.errMsg)
+	req, ok := findMsg[openAgentTerminalRequestMsg](msgs)
+	if !ok {
+		t.Fatal("t should request the agent terminal")
+	}
+	if req.fallbackError == "" {
+		t.Error("t should carry a fallbackError so App surfaces an error when no agents")
 	}
 }
 
 func TestShippingPanelModel_TKey_OpenFail_SetsError(t *testing.T) {
-	panel, svc, state := shippingPanelWithFeedback()
-	state.openInLaunchResult = false
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 't', Text: "t"}, svc)
-	if !state.closed {
+	// 't' is exit-the-panel intent: it always closes and requests the terminal
+	// with a fallbackError. The launch-failure path (no agents) is applied by
+	// App.Update's handler, not the panel — here we assert the panel hands off
+	// the fallbackError so that path can fire.
+	panel, _, _ := shippingPanelWithFeedback()
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	msgs := runCmdAll(t, cmd)
+	if _, ok := findMsg[panelCloseMsg](msgs); !ok {
 		t.Error("t should close even when launch fails")
 	}
-	if state.errMsg == "" {
-		t.Error("t with failed OpenInLaunch should surface an error")
+	req, ok := findMsg[openAgentTerminalRequestMsg](msgs)
+	if !ok {
+		t.Fatal("t should request the agent terminal")
+	}
+	if req.fallbackError == "" {
+		t.Error("t with failed OpenInLaunch should surface an error via fallbackError")
 	}
 }
 
 func TestShippingPanelModel_PKey_NoURL_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, _ := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
 	// No PR entry => no URL.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"}, svc)
-	if state.errMsg == "" {
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'p', Text: "p"})
+	msgs := runCmdAll(t, cmd)
+	if _, ok := findMsg[setErrorMsg](msgs); !ok {
 		t.Error("p without a PR URL should surface an error")
 	}
-	if state.openedURL {
-		t.Error("p without a PR URL should not call OpenURL")
+	if _, ok := findMsg[openURLResultMsg](msgs); ok {
+		t.Error("p without a PR URL should not open a URL")
 	}
 }
 
 func TestShippingPanelModel_MergeReady_CallsMergeCmd(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, state := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
 	state.pr = &prCacheEntry{
 		pr:      &github.PRState{Number: 1, MergeableState: "clean"},
 		checks:  &github.CheckStatus{State: "success", Total: 3},
 		reviews: &github.ReviewStatus{State: "approved"},
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'm', Text: "m"}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	_ = runCmdAll(t, cmd)
 	if !state.mergeRequested {
 		t.Error("m should call MergePRCmd when ready")
 	}
 	if state.mergeForce {
 		t.Error("m should pass force=false")
 	}
-	if state.errMsg != "" {
-		t.Errorf("m when ready should not error, got %q", state.errMsg)
+	if cmdShippingError(t, cmd) != "" {
+		t.Errorf("m when ready should not error, got %q", cmdShippingError(t, cmd))
 	}
 }
 
 func TestShippingPanelModel_ForceMerge_NoPR_SetsError(t *testing.T) {
 	sess := agent.NewSessionForTest("s1", "ship")
-	panel := newShippingPanel(sess, "", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, state := newTestShippingDeps()
+	panel := newShippingPanel(sess, "", 120, 40, deps)
 	// No PR entry.
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'M', Text: "M"}, svc)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'M', Text: "M"})
 	if state.mergeRequested {
 		t.Error("force-merge without a PR should not call MergePRCmd")
 	}
-	if state.errMsg == "" {
+	if cmdShippingError(t, cmd) == "" {
 		t.Error("expected error when force-merging with no PR")
 	}
 }
 
 func TestShippingPanelModel_RKey_EmitsFeedbackRequestMsg(t *testing.T) {
-	panel, svc, _ := shippingPanelWithFeedback()
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'r', Text: "r"}, svc)
+	panel, _, _ := shippingPanelWithFeedback()
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	if cmd == nil {
 		t.Fatal("expected cmd from r")
 	}
@@ -434,21 +457,19 @@ func TestShippingPanelModel_RKey_EmitsFeedbackRequestMsg(t *testing.T) {
 }
 
 func TestShippingPanelModel_UnknownKey_NoOp(t *testing.T) {
-	panel, svc, state := shippingPanelWithFeedback()
+	panel, _, state := shippingPanelWithFeedback()
 	before := struct {
 		cursor int
 		scroll int
-		closed bool
-		err    string
 		merge  bool
-	}{panel.FeedbackCursor(), panel.DetailScroll(), state.closed, state.errMsg, state.mergeRequested}
+	}{panel.FeedbackCursor(), panel.DetailScroll(), state.mergeRequested}
 
 	for _, k := range []tea.KeyPressMsg{
 		{Code: 'z', Text: "z"},
 		{Code: 'q', Text: "q"},
 		{Code: 'w', Mod: tea.ModCtrl},
 	} {
-		_, cmd := panel.Update(k, svc)
+		_, cmd := panel.Update(k)
 		if cmd != nil {
 			t.Errorf("unknown key %v produced cmd %T, want nil", k, cmd())
 		}
@@ -457,10 +478,8 @@ func TestShippingPanelModel_UnknownKey_NoOp(t *testing.T) {
 	after := struct {
 		cursor int
 		scroll int
-		closed bool
-		err    string
 		merge  bool
-	}{panel.FeedbackCursor(), panel.DetailScroll(), state.closed, state.errMsg, state.mergeRequested}
+	}{panel.FeedbackCursor(), panel.DetailScroll(), state.mergeRequested}
 	if before != after {
 		t.Errorf("unknown keys changed state: before=%+v after=%+v", before, after)
 	}
@@ -470,21 +489,21 @@ func TestShippingPanelModel_UnknownKey_NoOp(t *testing.T) {
 // panel's pinned repoPath to MergePRCmd, not a first-match lookup.
 func TestShippingPanel_MergeKey_UsesPinnedRepoPath(t *testing.T) {
 	sess := agent.NewSessionForTest("session-1", "ship")
-	panel := newShippingPanel(sess, "/repoB", 120, 40)
-	svc, state := newTestShippingSvc()
+	deps, state := newTestShippingDeps()
 	var recordedRepoPath string
-	svc.MergePRCmd = func(sessionID, repoPath string, force bool) tea.Cmd {
+	deps.MergePRCmd = func(sessionID, repoPath string, force bool) tea.Cmd {
 		state.mergeRequested = true
 		state.mergeForce = force
 		recordedRepoPath = repoPath
 		return func() tea.Msg { return nil }
 	}
+	panel := newShippingPanel(sess, "/repoB", 120, 40, deps)
 	state.pr = &prCacheEntry{
 		pr:      &github.PRState{Number: 1, MergeableState: "clean"},
 		checks:  &github.CheckStatus{State: "success", Total: 1},
 		reviews: &github.ReviewStatus{State: "approved"},
 	}
-	_, _ = panel.Update(tea.KeyPressMsg{Code: 'm', Text: "m"}, svc)
+	_, _ = panel.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
 	if !state.mergeRequested {
 		t.Fatal("m should call MergePRCmd when ready")
 	}
@@ -497,9 +516,9 @@ func TestShippingPanel_MergeKey_UsesPinnedRepoPath(t *testing.T) {
 // panel's pinned repoPath in the emitted shippingFeedbackRequestMsg.
 func TestShippingPanel_FeedbackKey_EmitsRepoPath(t *testing.T) {
 	sess := agent.NewSessionForTest("session-1", "ship")
-	panel := newShippingPanel(sess, "/repoB", 120, 40)
-	svc, _ := newTestShippingSvc()
-	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'r', Text: "r"}, svc)
+	deps, _ := newTestShippingDeps()
+	panel := newShippingPanel(sess, "/repoB", 120, 40, deps)
+	_, cmd := panel.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
 	if cmd == nil {
 		t.Fatal("expected cmd from r")
 	}

--- a/internal/tui/update_keys.go
+++ b/internal/tui/update_keys.go
@@ -342,7 +342,7 @@ func (a App) handleKeysReviewPanel(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 	if snapshot == nil {
 		return a, nil, false
 	}
-	updated, cmd := snapshot.Update(msg, a.panelServices())
+	updated, cmd := snapshot.Update(msg)
 	if rp, ok := updated.(*reviewPanelModel); ok {
 		a.modals.CompareAndSetReview(snapshot, rp)
 	}
@@ -356,7 +356,7 @@ func (a App) handleKeysShippingPanel(msg tea.KeyPressMsg) (App, tea.Cmd, bool) {
 	if snapshot == nil {
 		return a, nil, false
 	}
-	updated, cmd := snapshot.Update(msg, a.panelServices())
+	updated, cmd := snapshot.Update(msg)
 	if sp, ok := updated.(*shippingPanelModel); ok {
 		a.modals.CompareAndSetShipping(snapshot, sp)
 	}
@@ -830,7 +830,8 @@ func (a App) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	// focusReview: delegate left-pane row clicks to the panel.
 	if rp := a.modals.Review(); rp != nil {
 		before := rp.TaskCursor()
-		rp.handleClick(msg, a.panelServices())
+		rp.SetDashboardTopY(dashboardTopY)
+		rp.handleClick(msg)
 		if rp.TaskCursor() != before {
 			return a, nil
 		}
@@ -1149,7 +1150,7 @@ func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
 	item := reviewItems[idx]
 	sess := item.session
 	sess.SetLifecyclePhase(agent.LifecycleInReview)
-	a.openReview(newReviewPanel(sess, item.repoPath, a.width, a.height))
+	a.openReviewPanel(sess, item.repoPath)
 	if _, ok := a.reviewDiffCache[cacheKey(item.repoPath, sess.ID)]; !ok {
 		return a, tea.Batch(
 			a.fetchReviewDiffCmd(sess, item.repoPath),
@@ -1157,7 +1158,7 @@ func (a App) handlePipelineOpenReview() (App, tea.Cmd, bool) {
 		), true
 	}
 	// Diff already cached; start validation if not already running.
-	if a.validationRuns[sess.ID] == nil {
+	if a.validationRuns[cacheKey(item.repoPath, sess.ID)] == nil {
 		return a, a.startValidationChecksCmd(sess, item.repoPath), true
 	}
 	return a, nil, true

--- a/internal/tui/update_pr.go
+++ b/internal/tui/update_pr.go
@@ -19,6 +19,7 @@ func (a App) handlePRDraftReady(msg prDraftReadyMsg) (tea.Model, tea.Cmd) {
 	a.prDraftInFlight = false
 	a.prDraftSessionID = ""
 	a.prDraftRepoPath = ""
+	a.syncReviewDrafting()
 	if msg.err != nil {
 		a.setError("PR draft failed: " + msg.err.Error())
 		return a, nil
@@ -546,15 +547,14 @@ func entryThreads(entry *prCacheEntry) []github.ReviewThread {
 	return entry.threads
 }
 
-// setFeedbackVerdict lazily allocates the per-session triage map and sets the
-// verdict on the item with the given key. For feedbackNeutral with an empty
-// note, the entry is deleted to keep the map clean.
-func (a *App) mergePRCmd(sessionID, repoPath string) tea.Cmd {
-	return a.mergePRCmdWithMode(sessionID, repoPath, false)
-}
-
-func (a *App) forceMergePRCmd(sessionID, repoPath string) tea.Cmd {
-	return a.mergePRCmdWithMode(sessionID, repoPath, true)
+// mergePRCmdFor returns the shipping panel's MergePRCmd dep. mergePRCmdWithMode
+// reads only reference-typed App state (ghClient, prCache, resolvedCache) and
+// builds an async cmd without mutating App scalars, so capturing a value copy
+// of App at construction is safe (those maps/pointer are shared, not copied).
+func (a App) mergePRCmdFor() func(sessionID, repoPath string, force bool) tea.Cmd {
+	return func(sessionID, repoPath string, force bool) tea.Cmd {
+		return a.mergePRCmdWithMode(sessionID, repoPath, force)
+	}
 }
 
 func (a *App) mergePRCmdWithMode(sessionID, repoPath string, force bool) tea.Cmd {

--- a/internal/tui/update_review.go
+++ b/internal/tui/update_review.go
@@ -81,7 +81,7 @@ func (a App) handleReviewVerdict(msg reviewVerdictMsg) (tea.Model, tea.Cmd) {
 // up the validationRunState by sessionID, verifies the runID matches (dropping
 // stale results), then updates the result at checkIndex.
 func (a *App) handleValidationCheckResult(msg validationCheckResultMsg) {
-	run := a.validationRuns[msg.sessionID]
+	run := a.validationRuns[cacheKey(msg.repoPath, msg.sessionID)]
 	if run == nil || run.runID != msg.runID {
 		return
 	}
@@ -167,15 +167,15 @@ func reviewTaskCount(entry *reviewDiffEntry) int {
 	return n
 }
 
-// setFeedbackVerdict records a triage verdict for one feedback item, scoped by
-// (repoPath, sessID) so two repos with overlapping session counters don't share
-// the same triage map.
-func (a *App) setFeedbackVerdict(repoPath, sessID, itemKey string, v feedbackVerdict) {
+// setFeedbackVerdictOn applies a triage verdict to the given triage map. It is
+// a free function over the map (not a method) so the shipping panel can bind it
+// at construction and stay live across App value-copies (§3 fold).
+func setFeedbackVerdictOn(triage map[string]map[string]*feedbackTriageEntry, repoPath, sessID, itemKey string, v feedbackVerdict) {
 	key := cacheKey(repoPath, sessID)
-	if a.feedbackTriage[key] == nil {
-		a.feedbackTriage[key] = make(map[string]*feedbackTriageEntry)
+	if triage[key] == nil {
+		triage[key] = make(map[string]*feedbackTriageEntry)
 	}
-	m := a.feedbackTriage[key]
+	m := triage[key]
 	if v == feedbackNeutral {
 		if e := m[itemKey]; e == nil || strings.TrimSpace(e.Note) == "" {
 			delete(m, itemKey)
@@ -188,16 +188,15 @@ func (a *App) setFeedbackVerdict(repoPath, sessID, itemKey string, v feedbackVer
 	m[itemKey].Verdict = v
 }
 
-// setFeedbackNote lazily allocates the per-session triage map and sets the
-// note on the item. If the resulting entry is neutral with an empty note, it
-// is deleted. Keyed by (repoPath, sessID) for the same reason as
-// setFeedbackVerdict.
-func (a *App) setFeedbackNote(repoPath, sessID, itemKey, note string) {
+// setFeedbackNoteOn applies a note to the given triage map. If the resulting
+// entry is neutral with an empty note, it is deleted. Free function over the
+// map for the same reason as setFeedbackVerdictOn.
+func setFeedbackNoteOn(triage map[string]map[string]*feedbackTriageEntry, repoPath, sessID, itemKey, note string) {
 	key := cacheKey(repoPath, sessID)
-	if a.feedbackTriage[key] == nil {
-		a.feedbackTriage[key] = make(map[string]*feedbackTriageEntry)
+	if triage[key] == nil {
+		triage[key] = make(map[string]*feedbackTriageEntry)
 	}
-	m := a.feedbackTriage[key]
+	m := triage[key]
 	if m[itemKey] == nil {
 		if note == "" {
 			return
@@ -212,15 +211,14 @@ func (a *App) setFeedbackNote(repoPath, sessID, itemKey, note string) {
 }
 
 // handleFeedbackNoteSubmit forwards a feedbackNoteSubmitMsg to the active
-// shipping panel so it can persist the note via svc.SetFeedbackNote. Mirrors
-// the snapshot-and-restore pattern of handleKeysShippingPanel; the message is
-// otherwise local to the shipping panel.
+// shipping panel so it can persist the note via its injected SetFeedbackNote
+// dep. The message is otherwise local to the shipping panel.
 func (a App) handleFeedbackNoteSubmit(msg feedbackNoteSubmitMsg) (tea.Model, tea.Cmd) {
 	snapshot := a.modals.Shipping()
 	if snapshot == nil {
 		return a, nil
 	}
-	updated, cmd := snapshot.Update(msg, a.panelServices())
+	updated, cmd := snapshot.Update(msg)
 	if sp, ok := updated.(*shippingPanelModel); ok {
 		a.modals.CompareAndSetShipping(snapshot, sp)
 	}
@@ -809,13 +807,24 @@ func runValidationCheckCmd(sessionID, repoPath, worktreePath string, checkIndex,
 
 // triggerValidationRun creates or replaces the validationRuns entry for
 // sessionID, increments the runID, sets all results to checkRunning, and
-// returns a batched tea.Cmd with one runValidationCheckCmd per check.
+// returns a batched tea.Cmd with one runValidationCheckCmd per check. Thin
+// wrapper over triggerValidationRunOn for App callers.
 func triggerValidationRun(a *App, sessionID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd {
+	return triggerValidationRunOn(a.managers, a.validationRuns, sessionID, repoPath, worktreePath, checks)
+}
+
+// triggerValidationRunOn creates or replaces the validationRuns entry, keyed in
+// the given runs map. It is a free function over the map (not a method) so the
+// review panel can bind it at construction and stay live across App value-copies
+// (§3 fold). The managers param is accepted for signature symmetry with the
+// other deps factories; it is currently unused but kept so the binding site
+// reads uniformly.
+func triggerValidationRunOn(_ map[string]SessionManager, runs map[string]*validationRunState, sessionID, repoPath, worktreePath string, checks []config.ValidationCheck) tea.Cmd {
 	if len(checks) == 0 {
 		return nil
 	}
 
-	prior := a.validationRuns[sessionID]
+	prior := runs[cacheKey(repoPath, sessionID)]
 	runID := 1
 	if prior != nil {
 		runID = prior.runID + 1
@@ -826,7 +835,7 @@ func triggerValidationRun(a *App, sessionID, repoPath, worktreePath string, chec
 		results[i] = validationCheckResult{state: checkRunning}
 	}
 
-	a.validationRuns[sessionID] = &validationRunState{
+	runs[cacheKey(repoPath, sessionID)] = &validationRunState{
 		checks:  checks,
 		results: results,
 		runID:   runID,
@@ -837,6 +846,41 @@ func triggerValidationRun(a *App, sessionID, repoPath, worktreePath string, chec
 		cmds[i] = runValidationCheckCmd(sessionID, repoPath, worktreePath, i, runID, ch.Command)
 	}
 	return tea.Batch(cmds...)
+}
+
+// killSessionCmdFor returns a closure matching the panel's KillSessionCmd dep.
+// It writes the closingAgents/closingSessions maps (bound here, not to App) and
+// returns a killResultMsg-producing tea.Cmd. Mirrors the former
+// panelServices.KillSessionCmd closure.
+func killSessionCmdFor(
+	managers map[string]SessionManager,
+	closingAgents, closingSessions map[string]bool,
+) func(sess *agent.Session, repoPath string) tea.Cmd {
+	return func(sess *agent.Session, repoPath string) tea.Cmd {
+		if repoPath == "" {
+			return nil
+		}
+		mgr := managers[repoPath]
+		if mgr == nil {
+			return nil
+		}
+		var agentIDs []string
+		for _, ag := range sess.Agents() {
+			agentIDs = append(agentIDs, ag.ID)
+			closingAgents[agentCacheKey(repoPath, ag.ID)] = true
+		}
+		sessID := sess.ID
+		closingSessions[cacheKey(repoPath, sessID)] = true
+		return func() tea.Msg {
+			return killResultMsg{
+				scope:     killScopeSession,
+				repoPath:  repoPath,
+				sessionID: sessID,
+				agentIDs:  agentIDs,
+				err:       filterNotFound(mgr.KillSession(sessID)),
+			}
+		}
+	}
 }
 
 // ensureGitignore adds .refrain/ to .gitignore in the given path if not already present.


### PR DESCRIPTION
## Summary

Phase 5b of the `internal/tui` → CONVENTIONS.md migration, in one PR.

**Fix: `validationRuns` repo-keying bug.** `App.validationRuns` was keyed by bare `sessionID`, so two repos hosting a session with the same ID collided, and stale entries leaked (it was absent from `cleanStaleCaches`). It is now keyed by `cacheKey(repoPath, sessionID)` at every read/write site (matching `prCache`/`reviewDiffCache`/`feedbackTriage`), `repoPath` is threaded through `validationCheckResultMsg` and the validation cmd chain, and it is cleaned alongside the other composite-keyed caches. Guarded by a two-repo regression test that fails under bare-ID keying.

**Refactor: fold review + shipping panels into the §3 Component contract.** The panels no longer take a per-tick `PanelServices` value; `PanelServices` and `App.panelServices()` are deleted.
- `PanelModel.Update/View` drop the `svc` arg (`Update(tea.Msg) (PanelModel, tea.Cmd)`, `View() string`).
- Reference-typed handles are injected at construction via `reviewDeps`/`shippingDeps`, bound in `buildReviewDeps`/`buildShippingDeps` to App's maps/pointers (not to the `App` value) so they stay live across App value-copies (`App.Update` is a value receiver).
- Panel→App scalar mutations now flow as messages applied centrally by `App.Update`: `panelCloseMsg`, `setErrorMsg`, `startPRDraftRequestMsg`, `openAgentTerminalRequestMsg`, `openURLResultMsg`.
- Live render scalars are pushed into panel fields via `SetDashboardTopY`/`SetDrafting`, kept in sync by `syncReviewDrafting` (including the `prDraftReady` clear path and the dashboard `p` path).
- Panels keep **pointer receivers** (they are nil-able pointer fields in `Modals`); §3 conformance is by Update/View shape, not receiver kind.

Per-session domain caches (`reviewDiffCache`/`validationRuns`/`feedbackTriage`) deliberately stay on `App` per §1. Dissolving the `update_*.go` mechanical splits and thinning `App.Update` to pure routing is deferred to Phase 5c.

## Test plan

- `go build ./...`, `gofumpt -l .` (clean), `go vet ./...`, `golangci-lint run` — all clean
- `go test -race ./...` — green (21 pkgs); includes the new `TestValidationRuns_RepoKeyedNoCollision` (two-repo, no collision + stale-cache cleanup) and `TestReviewPanel_DraftingClearedOnDraftReady` (footer reset round-trip)
- `go test -tags e2e -timeout 300s ./internal/e2e/` — green (review/shipping panels open, render, merge, address-feedback, run validation checks)
- `grep -rn "PanelServices\|panelServices()" internal/tui` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)