### PR TITLE
Replace gofumpt with standard gofmt in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] `go build ./...`
 - [ ] `go vet ./...`
-- [ ] `gofumpt -l .` (clean)
+- [ ] `gofmt -l .` (clean)
 - [ ] `golangci-lint run ./...`
 - [ ] `go test -race ./...`
 - [ ] Manual TUI:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,8 @@ jobs:
           version: v2.1
           install-mode: goinstall
 
-      - name: Check formatting (gofumpt)
-        run: |
-          go install mvdan.cc/gofumpt@latest
-          test -z "$(gofumpt -l .)"
+      - name: Check formatting (gofmt)
+        run: test -z "$(gofmt -l .)"
 
   e2e:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,11 +40,7 @@ linters:
 
 formatters:
   enable:
-    - gofumpt
-
-  settings:
-    gofumpt:
-      extra-rules: true
+    - gofmt
 
 issues:
   max-issues-per-linter: 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ go test ./...               # unit tests
 go test -race ./...         # with race detector (required before commit)
 go vet ./...                # static analysis
 golangci-lint run           # lint (uses .golangci.yml)
-gofumpt -w .                # format all Go files
+gofmt -w .                  # format all Go files
 ./refrain doctor              # validate environment + hook pipeline round-trip
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ go test ./...               # run all tests
 go test -race ./...         # run with race detector
 go vet ./...                # static analysis
 golangci-lint run           # lint (config in .golangci.yml)
-gofumpt -w .                # format all Go files
+gofmt -w .                  # format all Go files
 ```
 
 Always run `go test -race ./...` before opening a PR. Refrain runs several goroutines per agent (PTY/VT/git) and the race detector has caught real bugs here.
@@ -57,7 +57,7 @@ gremlins unleash --diff origin/main .
 2. Keep PRs focused — one concern per PR.
 3. Add or update tests. Bug fixes should include a regression test where practical.
 4. Update `CHANGELOG.md` under `[Unreleased]`.
-5. Run locally before pushing: `go test -race ./... && go vet ./... && golangci-lint run && gofumpt -l .` (the last should print nothing).
+5. Run locally before pushing: `go test -race ./... && go vet ./... && golangci-lint run && gofmt -l .` (the last should print nothing).
 6. Open a PR. The template prompts for summary and test plan.
 
 ## Commit messages

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -210,7 +210,7 @@ Run before every commit / in every PR:
 
 - [ ] `go test -race ./...` passes (required — not optional).
 - [ ] `go vet ./...` clean.
-- [ ] `gofumpt -w .` applied.
+- [ ] `gofmt -w .` applied.
 - [ ] `golangci-lint run` clean.
 - [ ] Changelog fragment added under `changelog.d/` (`### Added` / `### Fixed` / …).
 - [ ] No new field added to a model without a clear single owner (§6).

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ go build -o refrain .         # build
 go test -race ./...         # run unit tests with the race detector (required before committing)
 go vet ./...                # static analysis
 golangci-lint run           # lint (config in .golangci.yml)
-gofumpt -w .                # format
+gofmt -w .                  # format
 ./refrain doctor              # validate environment + hook pipeline round-trip
 ```
 

--- a/changelog.d/change-gofmt-instead-of-gofumpt.md
+++ b/changelog.d/change-gofmt-instead-of-gofumpt.md
@@ -1,0 +1,3 @@
+### Changed
+
+- CI, golangci-lint config, and developer docs now use standard `gofmt` instead of `gofumpt`; contributors no longer need a separate formatter install.


### PR DESCRIPTION
## Summary

- Simplify CI tooling by replacing `gofumpt` with the standard `gofmt` formatter
- Reduces tool dependencies while maintaining code formatting consistency
- `gofmt` is built into Go and has lower onboarding friction for contributors
- Updated documentation and CI configuration to reflect the change

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [ ] Manual TUI:

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only)
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description