### PR TITLE
Update default model to Claude Opus 4.8

### DIFF
--- a/changelog.d/model-fields-as-dropdowns.md
+++ b/changelog.d/model-fields-as-dropdowns.md
@@ -1,3 +1,3 @@
 ### Changed
 
-- The Plan Model and Agent Model fields in the global and per-repo config forms are now dropdowns populated with the current Claude model IDs (`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`), cycled with `←`/`→`. Agent Model also offers a blank option meaning "claude default" so it can be left unset. Users who need a model not in the list can still edit `~/.config/refrain/settings.json` (or `.refrain/settings.json`) directly.
+- The Plan Model and Agent Model fields in the global and per-repo config forms are now dropdowns populated with the current Claude model IDs (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`), cycled with `←`/`→`. Agent Model also offers a blank option meaning "claude default" so it can be left unset. Users who need a model not in the list can still edit `~/.config/refrain/settings.json` (or `.refrain/settings.json`) directly.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -543,8 +543,8 @@ func TestBuildSpawnArgs_AgentModel(t *testing.T) {
 	}{
 		{
 			name:     "model prepended for default claude program",
-			cfg:      Config{AgentModel: "claude-opus-4-7", BypassPermissions: true, Task: "do stuff"},
-			wantArgs: []string{"--model", "claude-opus-4-7", "--dangerously-skip-permissions", "do stuff"},
+			cfg:      Config{AgentModel: "claude-opus-4-8", BypassPermissions: true, Task: "do stuff"},
+			wantArgs: []string{"--model", "claude-opus-4-8", "--dangerously-skip-permissions", "do stuff"},
 		},
 		{
 			name:     "empty model no flag",
@@ -553,7 +553,7 @@ func TestBuildSpawnArgs_AgentModel(t *testing.T) {
 		},
 		{
 			name:     "model ignored for non-claude program",
-			cfg:      Config{AgentProgram: "bash", AgentModel: "claude-opus-4-7", Task: "hi"},
+			cfg:      Config{AgentProgram: "bash", AgentModel: "claude-opus-4-8", Task: "hi"},
 			wantArgs: []string{"hi"},
 		},
 		{
@@ -618,12 +618,12 @@ func TestBuildSpawnArgs_BuildSystemPrompt(t *testing.T) {
 		{
 			name: "model and prompt both prepend, model first",
 			cfg: Config{
-				AgentModel:        "claude-opus-4-7",
+				AgentModel:        "claude-opus-4-8",
 				BuildSystemPrompt: "p",
 				Task:              "t",
 			},
 			wantArgs: []string{
-				"--model", "claude-opus-4-7",
+				"--model", "claude-opus-4-8",
 				"--append-system-prompt", "p",
 				"t",
 			},
@@ -678,11 +678,11 @@ func TestBuildResumeArgs_BuildSystemPrompt(t *testing.T) {
 		{
 			name: "model and prompt both prepend on resume, model first",
 			cfg: Config{
-				AgentModel:        "claude-opus-4-7",
+				AgentModel:        "claude-opus-4-8",
 				BuildSystemPrompt: "p",
 			},
 			sid:      "sid",
-			wantArgs: []string{"--model", "claude-opus-4-7", "--append-system-prompt", "p", "--resume", "sid"},
+			wantArgs: []string{"--model", "claude-opus-4-8", "--append-system-prompt", "p", "--resume", "sid"},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/agent/detach_resume_test.go
+++ b/internal/agent/detach_resume_test.go
@@ -374,13 +374,13 @@ func TestBuildResumeArgs(t *testing.T) {
 		},
 		{
 			name:     "agent model prepended for claude",
-			cfg:      Config{AgentModel: "claude-opus-4-7", BypassPermissions: true, Task: "do stuff"},
+			cfg:      Config{AgentModel: "claude-opus-4-8", BypassPermissions: true, Task: "do stuff"},
 			sessID:   "uuid-123",
-			wantArgs: []string{"--model", "claude-opus-4-7", "--dangerously-skip-permissions", "--resume", "uuid-123", "do stuff"},
+			wantArgs: []string{"--model", "claude-opus-4-8", "--dangerously-skip-permissions", "--resume", "uuid-123", "do stuff"},
 		},
 		{
 			name:     "agent model ignored for non-claude program",
-			cfg:      Config{AgentProgram: "bash", AgentModel: "claude-opus-4-7", BypassPermissions: true},
+			cfg:      Config{AgentProgram: "bash", AgentModel: "claude-opus-4-8", BypassPermissions: true},
 			sessID:   "uuid-456",
 			wantArgs: []string{"--dangerously-skip-permissions", "--resume", "uuid-456"},
 		},

--- a/internal/agent/planner_test.go
+++ b/internal/agent/planner_test.go
@@ -474,12 +474,12 @@ func TestDefaultPlanDrafter_EmptyModelFallsBackToDefault(t *testing.T) {
 }
 
 func TestDefaultPlanDrafter_NonEmptyModelPreserved(t *testing.T) {
-	d, ok := DefaultPlanDrafter("claude-opus-4-7").(*defaultPlanDrafter)
+	d, ok := DefaultPlanDrafter("claude-opus-4-8").(*defaultPlanDrafter)
 	if !ok {
-		t.Fatalf("DefaultPlanDrafter(\"claude-opus-4-7\") not *defaultPlanDrafter")
+		t.Fatalf("DefaultPlanDrafter(\"claude-opus-4-8\") not *defaultPlanDrafter")
 	}
-	if d.Model() != "claude-opus-4-7" {
-		t.Errorf("Model() = %q, want claude-opus-4-7", d.Model())
+	if d.Model() != "claude-opus-4-8" {
+		t.Errorf("Model() = %q, want claude-opus-4-8", d.Model())
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -94,7 +94,7 @@ NEVER squash commits, NEVER amend a previous commit to add new task work, and NE
 // dropdowns for fields that pass `--model` to a real subprocess (e.g. the
 // plan drafter). The first entry is the form's default selection.
 var KnownModels = []string{
-	"claude-opus-4-7",
+	"claude-opus-4-8",
 	"claude-sonnet-4-6",
 	"claude-haiku-4-5-20251001",
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/devenjarvis/refrain/internal/config"
@@ -691,5 +692,17 @@ func TestResolve_ValidationChecks_DefaultEmpty(t *testing.T) {
 	r := config.Resolve(nil, nil)
 	if len(r.ValidationChecks) != 0 {
 		t.Errorf("ValidationChecks: got %d entries, want 0", len(r.ValidationChecks))
+	}
+}
+
+func TestKnownModels_Contents(t *testing.T) {
+	if !slices.Contains(config.KnownModels, "claude-opus-4-8") {
+		t.Error("KnownModels does not contain claude-opus-4-8")
+	}
+	if slices.Contains(config.KnownModels, "claude-opus-4-7") {
+		t.Error("KnownModels still contains stale claude-opus-4-7")
+	}
+	if config.KnownModels[0] != "claude-opus-4-8" {
+		t.Errorf("KnownModels[0] = %q, want claude-opus-4-8 (Opus must be first)", config.KnownModels[0])
 	}
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -541,14 +541,14 @@ func TestResolve_Models_Defaults(t *testing.T) {
 func TestResolve_Models_GlobalOverride(t *testing.T) {
 	g := &config.GlobalSettings{
 		PlanModel:  strPtr("claude-haiku-4-5"),
-		AgentModel: strPtr("claude-opus-4-7"),
+		AgentModel: strPtr("claude-opus-4-8"),
 	}
 	r := config.Resolve(g, nil)
 	if r.PlanModel != "claude-haiku-4-5" {
 		t.Errorf("PlanModel = %q, want claude-haiku-4-5", r.PlanModel)
 	}
-	if r.AgentModel != "claude-opus-4-7" {
-		t.Errorf("AgentModel = %q, want claude-opus-4-7", r.AgentModel)
+	if r.AgentModel != "claude-opus-4-8" {
+		t.Errorf("AgentModel = %q, want claude-opus-4-8", r.AgentModel)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Update KnownModels default to use `claude-opus-4-8` instead of `claude-opus-4-7` (latest Opus model)
- Add test coverage verifying `claude-opus-4-8` is present and `claude-opus-4-7` is absent in model configuration
- Update test fixtures to reflect the new default model version

This ensures refrain defaults to the latest available Claude Opus model.

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `gofmt -l .` (clean)
- [ ] `golangci-lint run ./...`
- [ ] `go test -race ./...`
- [ ] Manual TUI:

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description