### PR TITLE
Prefer remote-tracking ref for new session worktree

### DIFF
--- a/changelog.d/fix-worktree-prefer-remote-ref.md
+++ b/changelog.d/fix-worktree-prefer-remote-ref.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- New session worktrees now branch off `origin/<baseBranch>` whenever that
+  remote-tracking ref exists locally, even when the in-line `git fetch` fails
+  (offline, auth error, or broken URL). Previously a fetch error caused refrain
+  to silently use whichever branch the user had checked out in the main
+  worktree, producing sessions that started from a stale or unrelated commit.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1217,13 +1217,15 @@ func (m *Manager) createSessionWorktree(cfg Config) (*Session, error) {
 		}
 	}
 
-	// Best-effort: update base branch from remote so the worktree
-	// starts from the latest code. If offline, fall back to local HEAD.
+	// Cut the worktree from origin/<baseBranch> whenever the remote ref exists
+	// locally — falling back to local HEAD would inherit whatever branch the
+	// user happens to have checked out in the main worktree.
+	// Best-effort fetch + fast-forward local ref so a subsequent diff
+	// against baseBranch is fresh; ignore the error.
+	_ = git.UpdateBaseBranch(m.repoPath, baseBranch)
 	startPoint := ""
-	if baseBranch != "" {
-		if err := git.UpdateBaseBranch(m.repoPath, baseBranch); err == nil {
-			startPoint = "origin/" + baseBranch
-		}
+	if baseBranch != "" && git.HasRemoteBranch(m.repoPath, baseBranch) {
+		startPoint = "origin/" + baseBranch
 	}
 
 	wt, err := git.CreateWorktree(m.repoPath, name, config.ExpandBranchPrefix(settings.BranchPrefix), settings.WorktreeDir, baseBranch, startPoint)

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1043,6 +1043,83 @@ func setupTestRepoWithRemote(t *testing.T) string {
 	return work
 }
 
+// TestCreateSession_BranchesOffFreshRemoteMain verifies that when a commit is
+// pushed to origin/main between the last local sync and session creation,
+// the new worktree starts from that new commit (not from the stale local ref).
+func TestCreateSession_BranchesOffFreshRemoteMain(t *testing.T) {
+	work := setupTestRepoWithRemote(t)
+
+	bareURL, err := git.GetRemoteURL(work)
+	if err != nil {
+		t.Fatalf("GetRemoteURL: %v", err)
+	}
+
+	// Push fresh.txt via a sibling clone so origin/main is ahead of work.
+	tmp := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "clone", bareURL, "."},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = tmp
+		if out, err2 := cmd.CombinedOutput(); err2 != nil {
+			t.Fatalf("setup sibling %v: %v\n%s", args, err2, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "fresh.txt"), []byte("fresh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var pushSHA string
+	for _, args := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "out-of-band push"},
+		{"git", "push", "origin", "main"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = tmp
+		if out, err2 := cmd.CombinedOutput(); err2 != nil {
+			t.Fatalf("sibling push %v: %v\n%s", args, err2, out)
+		}
+	}
+	shaCmd := exec.Command("git", "rev-parse", "HEAD")
+	shaCmd.Dir = tmp
+	shaBytes, err := shaCmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse sibling HEAD: %v", err)
+	}
+	pushSHA = strings.TrimSpace(string(shaBytes))
+
+	mgr := NewManager(work, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	sess, _, err := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err != nil {
+		t.Fatalf("CreateSessionWithCommand: %v", err)
+	}
+
+	gotRevCmd := exec.Command("git", "rev-parse", "HEAD")
+	gotRevCmd.Dir = sess.Worktree.Path
+	gotBytes, err := gotRevCmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD in worktree: %v", err)
+	}
+	gotSHA := strings.TrimSpace(string(gotBytes))
+
+	if gotSHA != pushSHA {
+		t.Errorf("worktree HEAD = %s, want %s (the out-of-band push SHA)", gotSHA, pushSHA)
+	}
+
+	// Belt-and-suspenders: the file from the new commit should be present.
+	if _, err := os.Stat(filepath.Join(sess.Worktree.Path, "fresh.txt")); os.IsNotExist(err) {
+		t.Error("fresh.txt not present in worktree; worktree did not start from the pushed commit")
+	}
+}
+
 // TestCreateSession_BranchesOffRemoteDefault verifies that a new session's
 // worktree is created from the remote default branch (origin/main) even when
 // the user has a different branch checked out locally in the main worktree.

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -6,11 +6,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/devenjarvis/refrain/internal/git"
 	"github.com/devenjarvis/refrain/internal/planner"
 )
 
@@ -1069,5 +1071,107 @@ func TestCreateSession_BranchesOffRemoteDefault(t *testing.T) {
 
 	if got := sess.Worktree.BaseBranch; got != "main" {
 		t.Errorf("Worktree.BaseBranch = %q, want %q (must use remote default, not local HEAD)", got, "main")
+	}
+}
+
+// TestCreateSession_PrefersCachedOriginRef_WhenFetchFails verifies that when
+// a fetch fails (e.g. offline or broken URL), the new worktree still starts
+// from the last-known refs/remotes/origin/<baseBranch> rather than falling
+// back to local HEAD.
+func TestCreateSession_PrefersCachedOriginRef_WhenFetchFails(t *testing.T) {
+	work := setupTestRepoWithRemote(t)
+
+	bareURL, err := git.GetRemoteURL(work)
+	if err != nil {
+		t.Fatalf("GetRemoteURL: %v", err)
+	}
+
+	// Push a new commit via a sibling clone so origin/main moves forward.
+	tmp := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "clone", bareURL, "."},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = tmp
+		if out, err2 := cmd.CombinedOutput(); err2 != nil {
+			t.Fatalf("setup sibling %v: %v\n%s", args, err2, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "extra.txt"), []byte("extra\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "out-of-band push"},
+		{"git", "push", "origin", "main"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = tmp
+		if out, err2 := cmd.CombinedOutput(); err2 != nil {
+			t.Fatalf("sibling push %v: %v\n%s", args, err2, out)
+		}
+	}
+
+	// Fetch in work so refs/remotes/origin/main has the new commit locally,
+	// without fast-forwarding the local main branch.
+	fetchCmd := exec.Command("git", "fetch", "origin", "main")
+	fetchCmd.Dir = work
+	if out, err2 := fetchCmd.CombinedOutput(); err2 != nil {
+		t.Fatalf("git fetch: %v\n%s", err2, out)
+	}
+
+	// Record what refs/remotes/origin/main points to — this is what we expect
+	// the new worktree's HEAD to be.
+	revCmd := exec.Command("git", "rev-parse", "refs/remotes/origin/main")
+	revCmd.Dir = work
+	wantSHABytes, err := revCmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse refs/remotes/origin/main: %v", err)
+	}
+	wantSHA := strings.TrimSpace(string(wantSHABytes))
+
+	// Verify local main is still behind (fetch doesn't fast-forward the local branch).
+	localRevCmd := exec.Command("git", "rev-parse", "main")
+	localRevCmd.Dir = work
+	localSHABytes, err := localRevCmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse main: %v", err)
+	}
+	localSHA := strings.TrimSpace(string(localSHABytes))
+	if wantSHA == localSHA {
+		t.Fatal("expected local main to be behind origin/main after fetch; test setup is wrong")
+	}
+
+	// Break origin so the next fetch (inside createSessionWorktree) fails.
+	breakCmd := exec.Command("git", "remote", "set-url", "origin", "/nonexistent")
+	breakCmd.Dir = work
+	if out, err2 := breakCmd.CombinedOutput(); err2 != nil {
+		t.Fatalf("set-url: %v\n%s", err2, out)
+	}
+
+	mgr := NewManager(work, defaultTestSettings())
+	defer mgr.Shutdown()
+
+	sess, _, err := mgr.CreateSessionWithCommand(
+		Config{Task: "test", Rows: 24, Cols: 80},
+		func(name string) *exec.Cmd { return exec.Command("bash", "-c", "sleep 5") },
+	)
+	if err != nil {
+		t.Fatalf("CreateSessionWithCommand: %v", err)
+	}
+
+	gotRevCmd := exec.Command("git", "rev-parse", "HEAD")
+	gotRevCmd.Dir = sess.Worktree.Path
+	gotSHABytes, err := gotRevCmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD in worktree: %v", err)
+	}
+	gotSHA := strings.TrimSpace(string(gotSHABytes))
+
+	if gotSHA != wantSHA {
+		t.Errorf("worktree HEAD = %s, want %s (cached origin/main); got local main SHA instead", gotSHA, wantSHA)
 	}
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -416,6 +416,71 @@ func TestUpdateBaseBranch_NoRemote(t *testing.T) {
 	}
 }
 
+func TestHasRemoteBranch(t *testing.T) {
+	t.Run("exists after clone", func(t *testing.T) {
+		work, _ := initTestRepoWithRemote(t)
+		if !git.HasRemoteBranch(work, "main") {
+			t.Error("HasRemoteBranch(work, \"main\") = false, want true")
+		}
+	})
+
+	t.Run("never fetched branch", func(t *testing.T) {
+		work, _ := initTestRepoWithRemote(t)
+		if git.HasRemoteBranch(work, "never-existed") {
+			t.Error("HasRemoteBranch(work, \"never-existed\") = true, want false")
+		}
+	})
+
+	t.Run("no origin remote", func(t *testing.T) {
+		repo := initTestRepo(t)
+		if git.HasRemoteBranch(repo, "main") {
+			t.Error("HasRemoteBranch(repo, \"main\") = true for repo with no remote, want false")
+		}
+	})
+
+	t.Run("branch with slash on origin", func(t *testing.T) {
+		work, bare := initTestRepoWithRemote(t)
+		// Create and push a branch with a slash in its name via a sibling clone.
+		tmp := t.TempDir()
+		for _, args := range [][]string{
+			{"git", "clone", bare, "."},
+			{"git", "config", "user.email", "test@test.com"},
+			{"git", "config", "user.name", "Test"},
+			{"git", "config", "commit.gpgsign", "false"},
+			{"git", "checkout", "-b", "feature/sub"},
+		} {
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = tmp
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("setup tmp %v: %v\n%s", args, err, out)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(tmp, "sub.txt"), []byte("sub\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{
+			{"git", "add", "."},
+			{"git", "commit", "-m", "feature/sub commit"},
+			{"git", "push", "origin", "feature/sub"},
+		} {
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Dir = tmp
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("push tmp %v: %v\n%s", args, err, out)
+			}
+		}
+		// Fetch into work so refs/remotes/origin/feature/sub exists locally.
+		cmd := exec.Command("git", "fetch", "origin", "feature/sub")
+		cmd.Dir = work
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("fetch feature/sub: %v\n%s", err, out)
+		}
+		if !git.HasRemoteBranch(work, "feature/sub") {
+			t.Error("HasRemoteBranch(work, \"feature/sub\") = false, want true")
+		}
+	})
+}
+
 func TestAttachWorktree(t *testing.T) {
 	repo := initTestRepo(t)
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -109,6 +109,12 @@ func UpdateBaseBranch(repoPath, branch string) error {
 	return nil
 }
 
+// HasRemoteBranch reports whether refs/remotes/origin/<branch> resolves locally.
+func HasRemoteBranch(repoPath, branch string) bool {
+	_, err := runGit(repoPath, "rev-parse", "--verify", "refs/remotes/origin/"+branch)
+	return err == nil
+}
+
 // CreateWorktree creates a new git worktree for the named agent.
 // branchPrefix and worktreeDir control naming and placement; pass empty
 // strings to use defaults ("refrain/" and ".refrain/worktrees").


### PR DESCRIPTION
## Summary

- Added `git.HasRemoteBranch` helper to check whether `refs/remotes/origin/<branch>` exists locally via `git rev-parse --verify`, handling missing branches and repos without an origin
- Modified `createSessionWorktree` to always prefer `origin/<baseBranch>` as the worktree start point instead of silently falling back to local HEAD on fetch failures
- With this change, cached remote-tracking refs are used even when fetch encounters transient failures (offline, broken remote), ensuring the session branches from the latest known remote state
- Added regression test `TestCreateSession_BranchesOffFreshRemoteMain` verifying that commits pushed to origin land in newly created sessions
- Updated changelog

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...` (including new session worktree test)
- [ ] Manual TUI: Create session and verify it branches from origin/main

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [x] New behavior has tests (`TestCreateSession_BranchesOffFreshRemoteMain`)
- [x] No new public API surface without a note (git.HasRemoteBranch is a helper utility)