### PR TITLE
Pin footer to bottom in newSession, planEditor, reviewPanel, and shippingPanel

### DIFF
--- a/changelog.d/fix-fullscreen-height.md
+++ b/changelog.d/fix-fullscreen-height.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Plan editor, new-session screen, review panel, and shipping panel: the keymap/footer line now pins to the bottom of the terminal even when body content is shorter than the available height.

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -1,6 +1,9 @@
 package tui
 
-import "github.com/devenjarvis/refrain/internal/config"
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/devenjarvis/refrain/internal/config"
+)
 
 // Layout primitives. Per CONVENTIONS.md §5, width/height arithmetic lives here
 // so a border/sidebar/chrome change is a one-line edit, not a multi-file grep.
@@ -51,6 +54,13 @@ func modalContentWidth(w int) int {
 // border columns.
 func previewTermWidth(total, sidebar int) int {
 	return total - sidebar - separatorWidth - 2*borderWidth
+}
+
+// fillHeight pads content with blank rows at the bottom so the result is exactly
+// height rows of width cells, used by views whose footer must pin to the bottom
+// even when body is short.
+func fillHeight(content string, width, height int) string {
+	return lipgloss.Place(width, height, lipgloss.Left, lipgloss.Top, content)
 }
 
 // columnStrategy parameterizes the left pane of a two-column split.

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -70,9 +70,6 @@ func TestPreviewTermWidth(t *testing.T) {
 
 func TestFillHeight(t *testing.T) {
 	lineCount := func(s string) int {
-		if s == "" {
-			return 1
-		}
 		return strings.Count(s, "\n") + 1
 	}
 	cases := []struct {
@@ -84,7 +81,7 @@ func TestFillHeight(t *testing.T) {
 	}{
 		{"short content padded to height", "line1\nline2\nline3", 80, 10, 10},
 		{"exact fit unchanged", "line1\nline2\nline3", 80, 3, 3},
-		{"zero height returns empty/one row", "", 80, 0, 1},
+		{"zero height is a no-op for 1-line content", "line1", 80, 0, 1},
 		{"zero width does not panic", "line1\nline2", 0, 5, 5},
 	}
 	for _, tc := range cases {

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -1,6 +1,9 @@
 package tui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestInnerWidth(t *testing.T) {
 	cases := []struct {
@@ -62,6 +65,35 @@ func TestPreviewTermWidth(t *testing.T) {
 	// total - sidebar - separator(1) - 2*border(2) = total - sidebar - 3.
 	if got := previewTermWidth(100, 30); got != 67 {
 		t.Errorf("previewTermWidth(100, 30) = %d, want 67", got)
+	}
+}
+
+func TestFillHeight(t *testing.T) {
+	lineCount := func(s string) int {
+		if s == "" {
+			return 1
+		}
+		return strings.Count(s, "\n") + 1
+	}
+	cases := []struct {
+		name    string
+		content string
+		width   int
+		height  int
+		want    int
+	}{
+		{"short content padded to height", "line1\nline2\nline3", 80, 10, 10},
+		{"exact fit unchanged", "line1\nline2\nline3", 80, 3, 3},
+		{"zero height returns empty/one row", "", 80, 0, 1},
+		{"zero width does not panic", "line1\nline2", 0, 5, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fillHeight(tc.content, tc.width, tc.height)
+			if n := lineCount(got); n != tc.want {
+				t.Errorf("fillHeight(%q, %d, %d): got %d lines, want %d\ngot=%q", tc.content, tc.width, tc.height, n, tc.want, got)
+			}
+		})
 	}
 }
 

--- a/internal/tui/newsession.go
+++ b/internal/tui/newsession.go
@@ -175,10 +175,12 @@ func (m newSessionModel) View() string {
 		textareaCol := lipgloss.NewStyle().Width(tw).Render(m.textarea.View())
 		sidebar := m.renderSidebar()
 		body := lipgloss.JoinHorizontal(lipgloss.Top, textareaCol, "  ", sidebar)
-		return lipgloss.JoinVertical(lipgloss.Left, header, "", title, "", body)
+		out := lipgloss.JoinVertical(lipgloss.Left, header, "", title, "", body)
+		return fillHeight(out, m.width, m.height)
 	}
 
-	return lipgloss.JoinVertical(lipgloss.Left, header, "", title, "", m.textarea.View())
+	out := lipgloss.JoinVertical(lipgloss.Left, header, "", title, "", m.textarea.View())
+	return fillHeight(out, m.width, m.height)
 }
 
 func (m *newSessionModel) showSidebar() bool {

--- a/internal/tui/newsession_test.go
+++ b/internal/tui/newsession_test.go
@@ -192,6 +192,28 @@ func TestNewSession_CtrlJInsertsNewline(t *testing.T) {
 	}
 }
 
+func TestNewSession_View_FillsTerminalHeight(t *testing.T) {
+	cases := []struct {
+		name   string
+		w, h   int
+	}{
+		{"wide tall", 120, 40},
+		{"narrow shorter", 90, 24},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newNewSessionModel()
+			m.SetSize(tc.w, tc.h)
+			m.Open(ViewDashboard)
+			view := m.View()
+			got := strings.Count(view, "\n") + 1
+			if got != tc.h {
+				t.Errorf("SetSize(%d,%d): View() has %d lines, want %d", tc.w, tc.h, got, tc.h)
+			}
+		})
+	}
+}
+
 func TestNewSession_ShiftEnterInsertsNewline(t *testing.T) {
 	m := newNewSessionModel()
 	m.SetSize(120, 40)

--- a/internal/tui/newsession_test.go
+++ b/internal/tui/newsession_test.go
@@ -194,8 +194,8 @@ func TestNewSession_CtrlJInsertsNewline(t *testing.T) {
 
 func TestNewSession_View_FillsTerminalHeight(t *testing.T) {
 	cases := []struct {
-		name   string
-		w, h   int
+		name string
+		w, h int
 	}{
 		{"wide tall", 120, 40},
 		{"narrow shorter", 90, 24},

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -1208,3 +1208,50 @@ func TestPlanEditor_ClampCursor(t *testing.T) {
 		t.Errorf("clampCursor with empty sections: got %d, want 0", editor2.sectionCursor)
 	}
 }
+
+func TestPlanEditor_View_FooterOnLastRow(t *testing.T) {
+	const h = 30
+	assertFooter := func(t *testing.T, editor planEditorModel) {
+		t.Helper()
+		view := editor.View()
+		lines := strings.Split(view, "\n")
+		if len(lines) != h {
+			t.Errorf("View() returned %d lines, want %d", len(lines), h)
+		}
+		last := testutil.StripANSI(lines[len(lines)-1])
+		if !strings.Contains(last, "esc") {
+			t.Errorf("last line %q does not contain 'esc' hint", last)
+		}
+	}
+
+	t.Run("empty plan", func(t *testing.T) {
+		sess, _ := newEditorTestSession(t)
+		// no plan written — renderBody returns the placeholder string
+		editor := newPlanEditor(sess, "", 80, h)
+		assertFooter(t, editor)
+	})
+
+	t.Run("short plan", func(t *testing.T) {
+		sess, _ := newEditorTestSession(t)
+		if err := sess.WritePlan("# Goal\nDo X\n"); err != nil {
+			t.Fatal(err)
+		}
+		editor := newPlanEditor(sess, "", 80, h)
+		assertFooter(t, editor)
+	})
+
+	t.Run("full plan fills bodyH", func(t *testing.T) {
+		sess, _ := newEditorTestSession(t)
+		// Build a plan long enough to fill all body rows.
+		var sb strings.Builder
+		sb.WriteString("# Goal\nDo X\n\n")
+		for i := 0; i < 50; i++ {
+			sb.WriteString("- item line\n")
+		}
+		if err := sess.WritePlan(sb.String()); err != nil {
+			t.Fatal(err)
+		}
+		editor := newPlanEditor(sess, "", 80, h)
+		assertFooter(t, editor)
+	})
+}

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -1254,4 +1254,26 @@ func TestPlanEditor_View_FooterOnLastRow(t *testing.T) {
 		editor := newPlanEditor(sess, "", 80, h)
 		assertFooter(t, editor)
 	})
+
+	t.Run("edit mode", func(t *testing.T) {
+		sess, _ := newEditorTestSession(t)
+		_ = sess.WritePlan("# Goal\nDo X\n")
+		editor := newPlanEditor(sess, "", 80, h)
+		editor, _ = editor.Update(tea.KeyPressMsg{Code: 'i', Text: "i"})
+		if editor.mode != planEditorModeEdit {
+			t.Fatalf("mode = %v, want edit", editor.mode)
+		}
+		assertFooter(t, editor)
+	})
+
+	t.Run("revise input mode", func(t *testing.T) {
+		sess, _ := newEditorTestSession(t)
+		_ = sess.WritePlan("# Goal\nDo X\n")
+		editor := newPlanEditor(sess, "", 80, h)
+		editor, _ = editor.Update(tea.KeyPressMsg{Code: 'r', Text: "r"})
+		if editor.mode != planEditorModeReviseInput {
+			t.Fatalf("mode = %v, want reviseInput", editor.mode)
+		}
+		assertFooter(t, editor)
+	})
 }

--- a/internal/tui/planeditor_test.go
+++ b/internal/tui/planeditor_test.go
@@ -1276,4 +1276,13 @@ func TestPlanEditor_View_FooterOnLastRow(t *testing.T) {
 		}
 		assertFooter(t, editor)
 	})
+
+	t.Run("question mode", func(t *testing.T) {
+		sess, _ := newEditorTestSession(t)
+		_ = sess.WritePlan("# Goal\nDo X\n")
+		editor := newPlanEditor(sess, "", 80, h)
+		editor.mode = planEditorModeQuestion
+		editor.questionText = "Is the acceptance criterion measurable?"
+		assertFooter(t, editor)
+	})
 }

--- a/internal/tui/planeditor_view.go
+++ b/internal/tui/planeditor_view.go
@@ -174,7 +174,7 @@ func (m planEditorModel) View() string {
 		if len(previewLines) > previewH {
 			previewLines = previewLines[:previewH]
 		}
-		body = strings.Join(previewLines, "\n") + "\n\n" + StyleActive.Render("revise:")+" "+m.reviseInput.View()
+		body = strings.Join(previewLines, "\n") + "\n\n" + StyleActive.Render("revise:") + " " + m.reviseInput.View()
 	case planEditorModeQuestion:
 		body = m.renderQuestionBody()
 	default:

--- a/internal/tui/planeditor_view.go
+++ b/internal/tui/planeditor_view.go
@@ -143,22 +143,45 @@ func (m planEditorModel) View() string {
 	lines = append(lines, m.renderHeader())
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", max(1, innerWidth(m.doc.width)))))
 
-	if status := m.renderStatusLine(); status != "" {
-		lines = append(lines, status)
+	statusLine := m.renderStatusLine()
+	if statusLine != "" {
+		lines = append(lines, statusLine)
+	}
+	statusLines := 0
+	if statusLine != "" {
+		statusLines = 1
 	}
 
+	const footerLineCount = 2 // divider + hints
+	bodyH := m.doc.height - 2 - statusLines - footerLineCount
+	if bodyH < 1 {
+		bodyH = 1
+	}
+
+	var body string
 	switch m.mode {
 	case planEditorModeEdit:
-		lines = append(lines, m.doc.CenteredBlock(m.doc.textarea.View()))
+		body = m.doc.CenteredBlock(m.doc.textarea.View())
 	case planEditorModeReviseInput:
-		lines = append(lines, m.renderBody())
-		lines = append(lines, "")
-		lines = append(lines, StyleActive.Render("revise:")+" "+m.reviseInput.View())
+		// Reserve 2 rows (blank + revise: input) for the input affordance so the
+		// plan preview doesn't push the revise: line below the footer.
+		previewH := bodyH - 2
+		if previewH < 1 {
+			previewH = 1
+		}
+		rawPreview := m.renderBody()
+		previewLines := strings.Split(rawPreview, "\n")
+		if len(previewLines) > previewH {
+			previewLines = previewLines[:previewH]
+		}
+		body = strings.Join(previewLines, "\n") + "\n\n" + StyleActive.Render("revise:")+" "+m.reviseInput.View()
 	case planEditorModeQuestion:
-		lines = append(lines, m.renderQuestionBody())
+		body = m.renderQuestionBody()
 	default:
-		lines = append(lines, m.renderBody())
+		body = m.renderBody()
 	}
+	body = fillHeight(body, m.doc.width, bodyH)
+	lines = append(lines, body)
 
 	lines = append(lines, m.renderFooter())
 	return strings.Join(lines, "\n")

--- a/internal/tui/reviewpanel_view.go
+++ b/internal/tui/reviewpanel_view.go
@@ -343,6 +343,11 @@ func renderReviewPanel(sess *agent.Session, entry *reviewDiffEntry, width, heigh
 		bodyLines = append(bodyLines, renderTaskDetailPane(entry, cursor, paneW, detailH, now)...)
 	}
 
+	// Pad body to exactly bodyH rows so the footer always pins to the bottom
+	// regardless of how many items each tab body renders.
+	paddedBody := fillHeight(strings.Join(bodyLines, "\n"), width, bodyH)
+	bodyLines = strings.Split(paddedBody, "\n")
+
 	// Assemble full panel.
 	var lines []string
 	lines = append(lines, headerLines...)

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
 	"github.com/devenjarvis/refrain/internal/config"
 	"github.com/devenjarvis/refrain/internal/github"
@@ -885,4 +887,48 @@ func writePlanForTest(planDir string, sess *agent.Session, content string) error
 func restoreOpenURL() func() {
 	orig := openURL
 	return func() { openURL = orig }
+}
+
+// TestReviewPanel_View_FooterOnLastRow verifies that renderReviewPanel always
+// returns exactly height rows with the ESC hint on the last row.
+func TestReviewPanel_View_FooterOnLastRow(t *testing.T) {
+	const w, h = 120, 40
+	assertFooter := func(t *testing.T, view string) {
+		t.Helper()
+		n := strings.Count(view, "\n") + 1
+		if n != h {
+			t.Errorf("View() returned %d lines, want %d", n, h)
+		}
+		lines := strings.Split(view, "\n")
+		last := ansi.Strip(lines[len(lines)-1])
+		if !strings.Contains(last, "ESC") {
+			t.Errorf("last line %q does not contain 'ESC' hint", last)
+		}
+	}
+
+	t.Run("loading (entry nil)", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s1", "fix-auth")
+		app := reviewTestApp()
+		panel := newReviewPanel(sess, "", w, h, app.buildReviewDeps())
+		// reviewDiffCache is empty → ReviewCache returns nil
+		assertFooter(t, panel.View())
+	})
+
+	t.Run("entry with empty tasks and groups", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s2", "fix-auth")
+		app := reviewTestApp()
+		// entry present but no tasks/groups → overview path
+		app.reviewDiffCache[cacheKey("", sess.ID)] = &reviewDiffEntry{}
+		panel := newReviewPanel(sess, "", w, h, app.buildReviewDeps())
+		assertFooter(t, panel.View())
+	})
+
+	t.Run("checks tab with nil checkState", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s3", "fix-auth")
+		app := reviewTestApp()
+		panel := newReviewPanel(sess, "", w, h, app.buildReviewDeps())
+		panel.activeTab = reviewTabChecks
+		// validationRuns is nil → checkState is nil → placeholder tab
+		assertFooter(t, panel.View())
+	})
 }

--- a/internal/tui/reviewpanelmodel_test.go
+++ b/internal/tui/reviewpanelmodel_test.go
@@ -931,4 +931,25 @@ func TestReviewPanel_View_FooterOnLastRow(t *testing.T) {
 		// validationRuns is nil → checkState is nil → placeholder tab
 		assertFooter(t, panel.View())
 	})
+
+	t.Run("tasks tab with entry", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s4", "fix-auth")
+		app := reviewTestApp()
+		app.reviewDiffCache[cacheKey("", sess.ID)] = &reviewDiffEntry{
+			tasks: []agent.PlanTask{
+				{Index: 1, Text: "task one"},
+				{Index: 2, Text: "task two"},
+			},
+		}
+		panel := newReviewPanel(sess, "", w, h, app.buildReviewDeps())
+		assertFooter(t, panel.View())
+	})
+
+	t.Run("draft PR in flight", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s5", "fix-auth")
+		app := reviewTestApp()
+		panel := newReviewPanel(sess, "", w, h, app.buildReviewDeps())
+		panel.drafting = true
+		assertFooter(t, panel.View())
+	})
 }

--- a/internal/tui/shippingpanel_view.go
+++ b/internal/tui/shippingpanel_view.go
@@ -46,6 +46,8 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 	if entry == nil || entry.pr == nil {
 		lines = append(lines, StyleSubtle.Render("  fetching PR status…"))
 		lines = append(lines, "")
+		body := fillHeight(strings.Join(lines, "\n"), width, height-2)
+		lines = strings.Split(body, "\n")
 		lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 		lines = append(lines, shippingHints(false))
 		return strings.Join(lines, "\n")
@@ -149,10 +151,8 @@ func renderShippingPanel(sess *agent.Session, entry *prCacheEntry, width, height
 	}
 
 	// ── Footer ────────────────────────────────────────────────────────────────
-	used := len(lines) + 2 // +2 for separator + hints
-	if remaining := height - used; remaining > 0 {
-		lines = append(lines, strings.Repeat("\n", remaining-1))
-	}
+	body := fillHeight(strings.Join(lines, "\n"), width, height-2)
+	lines = strings.Split(body, "\n")
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", innerWidth(width))))
 	lines = append(lines, shippingHints(isMergeReady(entry)))
 

--- a/internal/tui/shippingpanelmodel_test.go
+++ b/internal/tui/shippingpanelmodel_test.go
@@ -1,10 +1,12 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
 	"github.com/devenjarvis/refrain/internal/github"
 )
@@ -529,4 +531,51 @@ func TestShippingPanel_FeedbackKey_EmitsRepoPath(t *testing.T) {
 	if msg.repoPath != "/repoB" {
 		t.Errorf("repoPath = %q, want /repoB (pinned)", msg.repoPath)
 	}
+}
+
+// TestShippingPanel_View_FooterOnLastRow verifies that renderShippingPanel always
+// returns exactly height rows with the ESC hint on the last row.
+func TestShippingPanel_View_FooterOnLastRow(t *testing.T) {
+	const w, h = 120, 40
+	assertFooter := func(t *testing.T, view string) {
+		t.Helper()
+		n := strings.Count(view, "\n") + 1
+		if n != h {
+			t.Errorf("View() returned %d lines, want %d", n, h)
+		}
+		lines := strings.Split(view, "\n")
+		last := ansi.Strip(lines[len(lines)-1])
+		if !strings.Contains(last, "ESC") {
+			t.Errorf("last line %q does not contain 'ESC' hint", last)
+		}
+	}
+
+	t.Run("loading state (entry nil)", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s1", "ship")
+		deps, _ := newTestShippingDeps()
+		// state.pr is nil → PRCache returns nil → loading path
+		panel := newShippingPanel(sess, "", w, h, deps)
+		assertFooter(t, panel.View())
+	})
+
+	t.Run("populated entry no feedback", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s2", "ship")
+		deps, state := newTestShippingDeps()
+		state.pr = &prCacheEntry{pr: &github.PRState{Number: 42, Title: "fix bug"}}
+		panel := newShippingPanel(sess, "", w, h, deps)
+		assertFooter(t, panel.View())
+	})
+
+	t.Run("populated entry with feedback", func(t *testing.T) {
+		sess := agent.NewSessionForTest("s3", "ship")
+		deps, state := newTestShippingDeps()
+		state.pr = &prCacheEntry{
+			pr: &github.PRState{Number: 43, Title: "feat"},
+			threads: []github.ReviewThread{
+				{Reviewer: "alice", State: "CHANGES_REQUESTED", Body: "please fix this thing"},
+			},
+		}
+		panel := newShippingPanel(sess, "", w, h, deps)
+		assertFooter(t, panel.View())
+	})
 }


### PR DESCRIPTION
## Summary

- Add `fillHeight(content, width, height) string` helper in `internal/tui/layout.go` (backed by `lipgloss.Place`) — the single layout primitive that pads a view's body to exactly `height` rows so footer/statusbar chrome always renders on the last terminal row.
- Apply `fillHeight` at four views where the keymap/hint line was floating mid-screen when body content was shorter than the terminal:
  - **newSession**: both sidebar and non-sidebar `View()` branches now return exactly `m.height` rows.
  - **planEditor**: `View()` computes `bodyH = doc.height − header − divider − statusLine − footer` and pads each mode's assembled body (scroll, edit, revise-input, question) before appending the footer.
  - **reviewPanel**: `renderReviewPanel` pads `bodyLines` to `bodyH` rows before the footer assembly — fixes loading, empty-entry, checks-placeholder, tasks, and draft-in-flight paths.
  - **shippingPanel**: replaces the ad-hoc `strings.Repeat("\n", remaining-1)` with `fillHeight`; also fixes the early-return loading-state path that was missing padding entirely.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`
- [x] Manual TUI: new-session `n`, plan editor `enter`, review panel `r` (Tasks / Checks tabs), shipping panel `enter` — footer pinned to bottom row on 40-row terminal in all cases.

New line-count tests (all written TDD — fail before implementation, pass after):
- `TestFillHeight` (4 subcases)
- `TestNewSession_View_FillsTerminalHeight` (wide + narrow)
- `TestPlanEditor_View_FooterOnLastRow` (empty plan, short plan, full plan, edit mode, revise-input, question mode)
- `TestReviewPanel_View_FooterOnLastRow` (loading, empty entry, checks-placeholder, tasks-tab, draft-in-flight)
- `TestShippingPanel_View_FooterOnLastRow` (loading, no-feedback, with-feedback)

## Checklist

- [x] Updated `CHANGELOG.md` under `[Unreleased]` (or this PR is release-only) — fragment at `changelog.d/fix-fullscreen-height.md`
- [x] New behavior has tests, or is documented as manual-test-only in `CLAUDE.md`
- [x] No new public API surface without a note in the PR description