### PR TITLE
Add design-system registry and DESIGN.md

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -17,6 +17,8 @@ components:
     in: cmd
   tui:
     in: internal/tui
+  tui_theme:
+    in: internal/tui/theme
   tui_diff:
     in: internal/tui/diff
   tui_mdrender:
@@ -85,15 +87,21 @@ deps:
       - hook
       - state
       - vt
+      - tui_theme
       - tui_diff
       - tui_mdrender
       - tui_mdtextarea
+  tui_theme:
+    anyVendorDeps: true
+    mayDependOn: []
   tui_diff:
     mayDependOn:
       - diffmodel
+      - tui_theme
   tui_mdrender:
     anyVendorDeps: true
-    mayDependOn: []
+    mayDependOn:
+      - tui_theme
   tui_mdtestutil:
     anyVendorDeps: true
     mayDependOn: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # CLAUDE.md
 
 > **Architecture & code conventions:** see [`CONVENTIONS.md`](CONVENTIONS.md). This file describes *what the system does*; `CONVENTIONS.md` describes *how the code must be structured* (component architecture, message/render rules, layering). Read it before writing or changing code.
+>
+> **Design system / visual tokens:** see [`DESIGN.md`](DESIGN.md). Colors, glyphs, borders, spacing, and animation palettes live in one registry (`internal/tui/theme`). Never hardcode a hex or glyph rune — reference a token.
 
 ## Project
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -147,7 +147,7 @@ go func() { a.session.merged = client.MergePR(id) == nil }()
 
 **Styles**
 
-- Styles come from **one theme/style registry**. Don't scatter `lipgloss.NewStyle().Foreground(...)` literals at call sites; reference named styles so the palette changes in one place.
+- Styles come from **one theme/style registry**: `internal/tui/theme`. Don't scatter `lipgloss.NewStyle().Foreground(...)` literals, raw hex colors, or glyph runes at call sites; reference the named tokens so the palette changes in one place. The registry is a leaf package (no internal deps) so the `diff` and `mdrender` subpackages consume the same tokens. See [`DESIGN.md`](DESIGN.md) for the token catalog and role guidance.
 - Color/accent semantics (e.g. the `StatusWaiting` accent) are defined once and reused, not re-picked per component.
 
 ---

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,222 @@
+# DESIGN.md — Refrain's design system
+
+This is the visual-vocabulary reference for Refrain's TUI: colors, glyphs,
+borders, spacing, and animation. It is written for both human contributors and
+Claude agents. `CLAUDE.md` says *what* the product does; `CONVENTIONS.md` says
+*how* the code is structured; this file says *how it should look* and where the
+tokens live.
+
+## Source of truth
+
+Token **values** live in code, in the leaf package
+[`internal/tui/theme`](internal/tui/theme). This document is the navigable map
+and rationale — when a value and this doc disagree, the code wins, and this doc
+should be corrected. The registry is a leaf package with **no internal
+dependencies**, so it can be imported by the top-level `internal/tui` package
+*and* by the `internal/tui/diff` and `internal/tui/mdrender` subpackages without
+violating the layering rules in `.go-arch-lint.yml`.
+
+## How to use it (the rule)
+
+**Never hardcode a hex color, glyph rune, border, or padding value at a call
+site.** Reference a token instead.
+
+- Subpackages and new code: `import "github.com/devenjarvis/refrain/internal/tui/theme"`
+  and reference `theme.ColorPrimary`, `theme.GlyphSuccess`, `theme.BorderModal()`,
+  `theme.PadModal`, etc.
+- Inside the top-level `tui` package, the color roles and composed `Style*`
+  objects are also available unqualified (e.g. `ColorPrimary`, `StyleHeading`)
+  via the thin bridge in `internal/tui/theme.go`; those aliases point straight
+  at the registry, which remains the single source of truth.
+- If you need a color/glyph that has no token, **add a role** to the registry
+  and a row to this doc — do not inline a literal. See *Adding or changing a
+  token* below.
+
+This is the mechanical enforcement of `CONVENTIONS.md` §5 ("Styles come from one
+theme/style registry").
+
+## Color roles
+
+Roles are semantic, not hue-named: pick the role that matches the *meaning*, and
+the palette can be retuned in one place. (`internal/tui/theme/colors.go`.)
+
+### Surfaces & text
+
+| Role | Hex | Use when… |
+|---|---|---|
+| `ColorBg` | `#111827` | the base application surface |
+| `ColorSurfaceRaised` | `#1F2937` | a raised surface above the base (status bar, chips) |
+| `ColorText` | `#F9FAFB` | primary, high-contrast body/title text |
+| `ColorTextProse` | `#D1D5DB` | long-form prose (markdown body); deliberately dimmer than `ColorText` to cut glare |
+| `ColorMuted` | `#6B7280` | de-emphasized text, separators, borders, gutters |
+| `ColorMutedLight` | `#9CA3AF` | secondary de-emphasized text, one step brighter than `ColorMuted` |
+| `ColorHairline` | `#374151` | thin dividers / horizontal rules |
+
+### Brand accents
+
+| Role | Hex | Use when… |
+|---|---|---|
+| `ColorPrimary` | `#7C3AED` | primary accent: titles, primary borders, markdown H1 |
+| `ColorSecondary` | `#06B6D4` | secondary accent: links, active state, hunk headers, markdown H2 |
+| `ColorPrimaryLight` | `#A78BFA` | lighter purple accent: markdown H5, bullets, list numbers |
+
+### Status roles (agent run-state)
+
+| Role | Hex | Use when… |
+|---|---|---|
+| `ColorSuccess` | `#10B981` | success / pass / additions / checked boxes |
+| `ColorWarning` | `#F59E0B` | warnings / concerns |
+| `ColorError` | `#EF4444` | errors / failures / deletions |
+| `ColorWaiting` | `#D946EF` | an agent is blocked on input (permission prompt) |
+
+### Pipeline-stage accents (lifecycle column)
+
+| Role | Hex | Use when… |
+|---|---|---|
+| `ColorBuilding` | `#7ec8e3` | identifying the BUILDING stage |
+| `ColorReviewing` | `#9b7fdb` | identifying the REVIEWING stage |
+| `ColorShipping` | `#5ab58a` | identifying the SHIPPING stage |
+
+### Wellness break overlay
+
+| Role | Hex | Use when… |
+|---|---|---|
+| `ColorBreakTitle` | `#38BDF8` | the break-overlay title (also `BreatheColors[0]`) |
+| `ColorBreakAccent` | `#34D399` | the break-overlay resume cue (also `BreatheColors[2]`) |
+
+### Diff backgrounds
+
+Diff add/del **foregrounds** reuse `ColorSuccess`/`ColorError`. The four
+backgrounds are distinct because normal vs. word-diff emphasis is load-bearing.
+
+| Role | Hex | Use when… |
+|---|---|---|
+| `ColorDiffAddBg` | `#0a2e1f` | row background for added lines |
+| `ColorDiffDelBg` | `#2e0a14` | row background for deleted lines |
+| `ColorDiffAddBgEmph` | `#165c3f` | intra-line emphasis background, additions |
+| `ColorDiffDelBgEmph` | `#5c1629` | intra-line emphasis background, deletions |
+
+### Markdown code
+
+| Role | Hex | Use when… |
+|---|---|---|
+| `ColorCodeFg` | `#FBBF24` | inline-code and fenced-fallback code foreground |
+| `ColorCodeBg` | `#1A1D23` | fenced code-block background |
+| `ColorInlineCodeBg` | adaptive `{Dark:#2D2D2D, Light:#E8E8E8}` | inline-code background (the only adaptive token) |
+
+Markdown heading colors are not separate roles — they map through
+`theme.MarkdownHeadingColor(level)` onto the roles above (H1→Primary,
+H2→Secondary, H3→Success, H4→Warning, H5→PrimaryLight, H6→MutedLight).
+
+## Two parallel color systems: status vs. stage
+
+Refrain runs **two** color axes that must stay visually distinct:
+
+- **Status roles** (`ColorSuccess`/`ColorWarning`/`ColorError`/`ColorWaiting`)
+  encode an agent's *run-state* and appear as badges and glyphs. They are punchy,
+  saturated hues.
+- **Pipeline-stage accents** (`ColorBuilding`/`ColorReviewing`/`ColorShipping`)
+  encode *which lifecycle column* a session is in and appear as section
+  headings/chrome. They are deliberately desaturated pastels.
+
+They co-occur — a SHIPPING section can contain a success badge — so do **not**
+unify them. Note one near-adjacency: `ColorReviewing` (`#9b7fdb`) and
+`ColorPrimaryLight` (`#A78BFA`) are both light purple but semantically distinct
+(stage accent vs. markdown bullet). Don't "fix" one to match the other.
+
+## Glyph & icon set
+
+Every single-rune marker the TUI emits is a token in
+`internal/tui/theme/glyphs.go`. Reference the constant; don't paste the rune.
+
+| Token | Glyph | Meaning | Emitted by |
+|---|---|---|---|
+| `GlyphError` | `✗` | error / fail | `sessionFocusStatus`, `sessionStatusGlyph`, `verdictBadge`, `checkBadge`, `checkSymbolFor` |
+| `GlyphSuccess` | `✓` | success / pass | same set |
+| `GlyphWaiting` | `⏸` | waiting on input | `sessionFocusStatus`, `sessionStatusGlyph` |
+| `GlyphQuestion` | `?` | may need input | `sessionFocusStatus`, `sessionStatusGlyph`, `checkSymbolFor` |
+| `GlyphActive` | `●` | actively running | `sessionStatusGlyph`, `focusLaunchTabDot` |
+| `GlyphIdle` | `○` | idle / pending | `sessionStatusGlyph`, `focusLaunchTabDot`, `checkSymbolFor` |
+| `GlyphCross` | `×` | closed / done tab | `focusLaunchTabDot` |
+| `GlyphPending` | `⋯` | pending verdict | `verdictBadge`, `checkBadge` |
+| `GlyphFlagged` | `⚑` | flagged for rework | `verdictBadge` |
+| `GlyphConcerns` | `!` | verdict: concerns | `verdictBadge` |
+| `GlyphNoDiff` | `⊘` | verdict: no diff | `verdictBadge` |
+| `GlyphBranch` | `⎇` | git branch label | `renderBranchLabel` |
+| `GlyphStripe` | `▎` | card status stripe | `renderFocusSessionCard` |
+| `GlyphCursor` | `▍` | selected-row cursor | diff tree |
+| `GlyphCaret` | `›` | inline list cursor | checks list |
+| `GlyphArrow` | `→` | stacked-PR chain sep | `prIndicator` |
+| `GlyphFolderOpen` / `GlyphFolderClosed` | `▾` / `▸` | diff-tree folder | diff tree |
+| `GlyphCheckboxDone` / `GlyphCheckboxTodo` | `✓` / `☐` | markdown task box | mdrender |
+| `GlyphFenceBar` | `│` | fenced-line / quote bar | mdrender |
+| `GlyphRuleThin` / `GlyphRuleHeavy` | `─` / `━` | horizontal rule | mdrender |
+
+## Spinner & animation
+
+- `SpinnerBraille` — the braille spinner frame set; `theme.SpinnerFrame(now)`
+  derives the current frame from the model's tick timestamp (no clock read at
+  render time, per `CONVENTIONS.md` §5), keeping every running row in sync.
+- `BreatheColors` — the four-hue calm cycle for the wellness break overlay's
+  breathing animation. Entries 0 and 2 are `ColorBreakTitle`/`ColorBreakAccent`;
+  the indigo/rose hues exist only for this cycle.
+- `CompleteColors` — warm pulse tones shown once the focus timer is up.
+
+Animation palettes are ordered sequences a renderer cycles through frame by
+frame; they are not single-role tokens.
+
+## Borders & chrome
+
+Border *shape and color* are design decisions and live as constructors in
+`internal/tui/theme/borders.go`; *sizing* (Width/Height/Padding) is the caller's.
+
+- `BorderModal()` — rounded primary-accent border for centered overlay boxes
+  (repo-config, repo-checks, global-settings, note modals). Combine with
+  `PadModal`.
+- `BorderPaneLeft()` — muted normal border on the right edge only, for the left
+  pane of a two-column split (file-browser, branch-picker, repo-picker).
+
+Width/height *arithmetic* (border, sidebar, separator, modal-chrome math) is a
+separate concern and lives in `internal/tui/layout.go` as pure helpers
+(`innerWidth`, `modalContentWidth`, `splitColumns`, …). Layout math goes there;
+fixed design constants go in the registry.
+
+## Spacing scale
+
+`internal/tui/theme/spacing.go`. Padding pairs are `{vertical, horizontal}` to
+match `lipgloss.Padding(v, h)`.
+
+| Token | Value | Use |
+|---|---|---|
+| `PadModal` | `{1, 2}` | modal box inner padding |
+| `PadStatusBar` | `{0, 1}` | status bar inner padding |
+| `PadCell` | `{0, 1}` | dashboard pipeline-cell inner padding |
+| `IndentTree` | `2` | per-depth indent of the diff file tree |
+| `LabelWidth` | `22` | fixed width of a form field label |
+
+## NO_COLOR & color profiles
+
+Every color token is gated by `initColor` (and `initAdaptive`), which honor the
+`NO_COLOR` convention: when `NO_COLOR` is set to any value, tokens degrade to the
+terminal's default color. Because the `diff` and `mdrender` subpackages now build
+their styles from the registry, they honor `NO_COLOR` too (they did not before —
+a deliberate improvement). One color path is **not** ours: chroma's
+`terminal256` syntax highlighting in fenced code blocks and diffs is governed by
+chroma's own style, not these tokens.
+
+Render tests force a TrueColor profile so token output is deterministic. To smoke
+the degraded path, run the TUI with `NO_COLOR=1`.
+
+## Adding or changing a token
+
+1. Add or edit the role in the relevant `internal/tui/theme/*.go` file, with a
+   godoc comment explaining when to use it.
+2. If it's a color used by the top-level `tui` package unqualified, add an alias
+   in `internal/tui/theme.go`.
+3. Add or update the row in this doc.
+4. Keep the build green: `go build ./...`, `go test -race ./...`, `go vet ./...`,
+   `gofmt -w .`, `golangci-lint run`, `go-arch-lint check`.
+5. Add a `changelog.d/` fragment.
+6. Any **visual** change (a retuned hue, a swapped glyph) must be deliberate and
+   called out in the PR — the design system exists to make drift visible, not to
+   smuggle it in.

--- a/changelog.d/add-design-system.md
+++ b/changelog.d/add-design-system.md
@@ -1,0 +1,7 @@
+### Added
+
+- Design system: a new leaf package `internal/tui/theme` is the single registry for every visual token — color roles, glyphs, spinner/animation palettes, border styles, and spacing — and a new `DESIGN.md` documents the role catalog for contributors and agents. The `diff` and `mdrender` subpackages now consume the same tokens instead of redeclaring their own colors.
+
+### Changed
+
+- Consolidated ~48 scattered hex color literals into ~26 semantic role tokens, collapsing exact duplicates and centralizing glyphs, animation palettes, and the two-pane/modal border styles. The `diff` and `mdrender` subpackages now honor `NO_COLOR` (they previously rendered colors regardless). No intended change to the default-profile appearance.

--- a/internal/tui/branchpicker.go
+++ b/internal/tui/branchpicker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/refrain/internal/git"
 	"github.com/devenjarvis/refrain/internal/github"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // branchPickerItem represents a single entry in the branch picker.
@@ -231,11 +232,9 @@ func (m branchPickerModel) View() string {
 	left := m.renderList(leftWidth)
 	right := m.renderDetails(rightWidth)
 
-	leftStyle := lipgloss.NewStyle().
+	leftStyle := theme.BorderPaneLeft().
 		Width(leftWidth).
-		Height(m.height).
-		Border(lipgloss.NormalBorder(), false, true, false, false).
-		BorderForeground(ColorMuted)
+		Height(m.height)
 
 	rightStyle := lipgloss.NewStyle().
 		Width(rightWidth).

--- a/internal/tui/configform.go
+++ b/internal/tui/configform.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/refrain/internal/config"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // fieldKind distinguishes toggle fields from text input fields.
@@ -215,8 +216,8 @@ func (f configForm) View() string {
 		return StyleSubtle.Render("No settings available")
 	}
 
-	labelStyle := lipgloss.NewStyle().Width(22).Foreground(ColorText)
-	focusedLabelStyle := StyleActive.Bold(true).Width(22)
+	labelStyle := lipgloss.NewStyle().Width(theme.LabelWidth).Foreground(ColorText)
+	focusedLabelStyle := StyleActive.Bold(true).Width(theme.LabelWidth)
 	toggleOn := StyleSuccess.Render("[x]")
 	toggleOff := StyleSubtle.Render("[ ]")
 

--- a/internal/tui/dashboard_view.go
+++ b/internal/tui/dashboard_view.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/devenjarvis/refrain/internal/agent"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 	"github.com/devenjarvis/refrain/internal/vt"
 )
 
@@ -177,17 +178,17 @@ func (items listItems) sessionFocusStatus(sess *agent.Session) string {
 		}
 	}
 	if hasError {
-		return StyleError.Render("✗ error")
+		return StyleError.Render(theme.GlyphError + " error")
 	}
 	if waitingCount > 0 {
-		badge := fmt.Sprintf("⏸ %d waiting", waitingCount)
+		badge := fmt.Sprintf("%s %d waiting", theme.GlyphWaiting, waitingCount)
 		if firstWaitingReason != "" {
 			badge += " — " + truncateVisible(firstWaitingReason, 40)
 		}
 		return StyleWaiting.Render(badge)
 	}
 	if idleAskingCount > 0 {
-		return StyleWarning.Render(fmt.Sprintf("? %d idle — may need input", idleAskingCount))
+		return StyleWarning.Render(fmt.Sprintf("%s %d idle — may need input", theme.GlyphQuestion, idleAskingCount))
 	}
 	// Progress bar takes priority over the idle/reviewable badge so it
 	// stays visible while the agent pauses between tasks. Once all tasks
@@ -297,17 +298,17 @@ func (items listItems) sessionStatusGlyph(sess *agent.Session) (glyph string, co
 	}
 	switch {
 	case hasError:
-		return "✗", ColorError
+		return theme.GlyphError, ColorError
 	case hasWaiting:
-		return "⏸", ColorWaiting
+		return theme.GlyphWaiting, ColorWaiting
 	case hasIdleAsking:
-		return "?", ColorWarning
+		return theme.GlyphQuestion, ColorWarning
 	case sess.IsReviewable() || !sess.DoneAt().IsZero():
-		return "✓", ColorSuccess
+		return theme.GlyphSuccess, ColorSuccess
 	case hasActive:
-		return "●", ColorSecondary
+		return theme.GlyphActive, ColorSecondary
 	default:
-		return "○", ColorMuted
+		return theme.GlyphIdle, ColorMuted
 	}
 }
 
@@ -325,7 +326,7 @@ func (d dashboardModel) renderFocusSessionCard(props dashboardProps, sess *agent
 	if selected {
 		stripeColor = ColorSecondary
 	}
-	stripe := lipgloss.NewStyle().Foreground(stripeColor).Render("▎")
+	stripe := lipgloss.NewStyle().Foreground(stripeColor).Render(theme.GlyphStripe)
 	const indent = "   "
 	const stripeIndentWidth = 4 // stripe (1) + 3 spaces
 
@@ -491,7 +492,7 @@ func renderBranchLabel(branch string) string {
 	if branch == "" {
 		return ""
 	}
-	return StyleSubtle.Render("⎇ " + branch)
+	return StyleSubtle.Render(theme.GlyphBranch + " " + branch)
 }
 
 // planningStatusBadge renders the right-aligned status badge for a Planning
@@ -774,7 +775,7 @@ func (d dashboardModel) renderPipelineWidget(props dashboardProps, width int) st
 		cnt := lipgloss.NewStyle().Foreground(color).Bold(true).Render(fmt.Sprintf("%d", count))
 		lbl := StyleSubtle.Render(truncateVisible(label, cellWidth-2))
 		inner := fmt.Sprintf("%s\n%s", lbl, cnt)
-		style := lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(0, 1).Width(cellWidth)
+		style := lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(theme.PadCell[0], theme.PadCell[1]).Width(cellWidth)
 		if highlight {
 			style = style.BorderForeground(color)
 		}
@@ -794,11 +795,11 @@ func (d dashboardModel) renderPipelineWidget(props dashboardProps, width int) st
 func focusLaunchTabDot(ag *agent.Agent) string {
 	switch ag.Status() {
 	case agent.StatusActive, agent.StatusWaiting:
-		return "●"
+		return theme.GlyphActive
 	case agent.StatusError, agent.StatusDone:
-		return "×"
+		return theme.GlyphCross
 	default:
-		return "○"
+		return theme.GlyphIdle
 	}
 }
 
@@ -917,22 +918,12 @@ var breatheFramesCompact = [12][3]string{
 	{"   · · · ", "  · · ·  ", " · · ·   "},
 }
 
-// breatheColors cycles through calm hues. The longer cycle gives the user
-// something to gently track without becoming repetitive.
-var breatheColors = [4]lipgloss.Color{
-	"#38BDF8", // sky blue
-	"#818CF8", // indigo
-	"#34D399", // emerald
-	"#F472B6", // rose — adds variety on every other breath
-}
-
-// completeColors pulse warm tones once the timer is up so the screen reads
-// unmistakably as "done" without auto-advancing the user back to work.
-var completeColors = [3]lipgloss.Color{
-	"#F59E0B", // amber
-	"#FBBF24", // gold
-	"#FACC15", // yellow
-}
+// breatheColors and completeColors are the wellness-overlay animation palettes,
+// sourced from the design-system registry (internal/tui/theme).
+var (
+	breatheColors  = theme.BreatheColors
+	completeColors = theme.CompleteColors
+)
 
 // generateBreatheFrames builds a smooth concentric breath cycle. The first
 // half of the cycle inhales (radius grows), the second half exhales. A

--- a/internal/tui/diff/render.go
+++ b/internal/tui/diff/render.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sergi/go-diff/diffmatchpatch"
 
 	"github.com/devenjarvis/refrain/internal/diffmodel"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // SideBySideMinWidth is the terminal-width threshold (inclusive) above which
@@ -112,15 +113,18 @@ func (r *Renderer) Render(width int, sideBySide bool) string {
 
 // ── styles ───────────────────────────────────────────────────────────────────
 
+// Diff colors come from the design-system registry (internal/tui/theme). These
+// package-private names are shared with tree.go; add/del foregrounds reuse the
+// success/error roles, and the four backgrounds are the dedicated diff tokens.
 var (
-	colAdd         = lipgloss.Color("#10B981")
-	colDel         = lipgloss.Color("#EF4444")
-	colMuted       = lipgloss.Color("#6B7280")
-	colSecondary   = lipgloss.Color("#06B6D4")
-	colAddBg       = lipgloss.Color("#0a2e1f")
-	colDelBg       = lipgloss.Color("#2e0a14")
-	colAddBgBright = lipgloss.Color("#165c3f")
-	colDelBgBright = lipgloss.Color("#5c1629")
+	colAdd         = theme.ColorSuccess
+	colDel         = theme.ColorError
+	colMuted       = theme.ColorMuted
+	colSecondary   = theme.ColorSecondary
+	colAddBg       = theme.ColorDiffAddBg
+	colDelBg       = theme.ColorDiffDelBg
+	colAddBgBright = theme.ColorDiffAddBgEmph
+	colDelBgBright = theme.ColorDiffDelBgEmph
 
 	styleAddRow    = lipgloss.NewStyle().Background(colAddBg)
 	styleDelRow    = lipgloss.NewStyle().Background(colDelBg)

--- a/internal/tui/diff/tree.go
+++ b/internal/tui/diff/tree.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/devenjarvis/refrain/internal/diffmodel"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // FileSelectedMsg is emitted when the user selects a file leaf in the tree.
@@ -284,7 +285,7 @@ func (t *Tree) View(width, height int) string {
 var (
 	treeStyleCursor    = lipgloss.NewStyle().Bold(true).Foreground(colSecondary)
 	treeStyleNormal    = lipgloss.NewStyle().Foreground(colMuted)
-	treeStyleFile      = lipgloss.NewStyle().Foreground(lipgloss.Color("#F9FAFB"))
+	treeStyleFile      = lipgloss.NewStyle().Foreground(theme.ColorText)
 	treeStyleFileDim   = lipgloss.NewStyle().Foreground(colMuted)
 	treeStyleAddCount  = lipgloss.NewStyle().Foreground(colAdd)
 	treeStyleDelCount  = lipgloss.NewStyle().Foreground(colDel)
@@ -301,7 +302,7 @@ func depthOf(path string) int {
 }
 
 func (t *Tree) renderNode(n *diffmodel.FileNode, isCursor bool, width int) string {
-	indent := strings.Repeat("  ", depthOf(n.Path))
+	indent := strings.Repeat(" ", theme.IndentTree*depthOf(n.Path))
 	var body string
 	if n.IsLeaf {
 		label := n.Name
@@ -315,14 +316,14 @@ func (t *Tree) renderNode(n *diffmodel.FileNode, isCursor bool, width int) strin
 	} else {
 		var glyph string
 		if t.expanded[n.Path] {
-			glyph = "▾ "
+			glyph = theme.GlyphFolderOpen + " "
 		} else {
-			glyph = "▸ "
+			glyph = theme.GlyphFolderClosed + " "
 		}
 		body = indent + treeStyleFolderTag.Render(glyph) + n.Name
 	}
 	if isCursor {
-		body = treeStyleCursor.Render("▍ ") + body
+		body = treeStyleCursor.Render(theme.GlyphCursor+" ") + body
 	} else {
 		body = treeStyleNormal.Render("  ") + body
 	}

--- a/internal/tui/feedbacknotemodal.go
+++ b/internal/tui/feedbacknotemodal.go
@@ -7,6 +7,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	xlipgloss "charm.land/lipgloss/v2"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // feedbackNoteModal is a centered textarea overlay for attaching a guidance
@@ -116,9 +118,7 @@ func (m feedbackNoteModal) View() string {
 		"",
 		footer,
 	)
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ColorPrimary).
+	return theme.BorderModal().
 		Padding(0, 1).
 		Width(w).
 		Render(body)

--- a/internal/tui/filebrowser.go
+++ b/internal/tui/filebrowser.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/refrain/internal/git"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // fileBrowserSelectMsg is emitted when the user selects a git repo directory.
@@ -157,11 +158,9 @@ func (m fileBrowserModel) View() string {
 	left := m.renderDirList(leftWidth)
 	right := m.renderDetails(rightWidth)
 
-	leftStyle := lipgloss.NewStyle().
+	leftStyle := theme.BorderPaneLeft().
 		Width(leftWidth).
-		Height(m.height).
-		Border(lipgloss.NormalBorder(), false, true, false, false).
-		BorderForeground(ColorMuted)
+		Height(m.height)
 
 	rightStyle := lipgloss.NewStyle().
 		Width(rightWidth).

--- a/internal/tui/mdrender/render.go
+++ b/internal/tui/mdrender/render.go
@@ -29,6 +29,8 @@ import (
 	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // LineKind labels what role a source line plays in the markdown stream.
@@ -138,7 +140,7 @@ func (r *Renderer) StyleName() string { return r.styleName }
 func (r *Renderer) HeadingUnderline(level, headingWidth, maxWidth int) string {
 	if level == 1 {
 		color := styleH1.GetForeground()
-		return lipgloss.NewStyle().Foreground(color).Render(strings.Repeat("━", maxWidth))
+		return lipgloss.NewStyle().Foreground(color).Render(strings.Repeat(theme.GlyphRuleHeavy, maxWidth))
 	}
 	// H2: thin rule no wider than the heading text.
 	w := headingWidth
@@ -148,7 +150,7 @@ func (r *Renderer) HeadingUnderline(level, headingWidth, maxWidth int) string {
 	if w < 1 {
 		w = 1
 	}
-	return lipgloss.NewStyle().Foreground(colMuted).Render(strings.Repeat("─", w))
+	return lipgloss.NewStyle().Foreground(colMuted).Render(strings.Repeat(theme.GlyphRuleThin, w))
 }
 
 // RenderLines is the full-buffer pass: parse, wrap, style, and return the
@@ -187,7 +189,7 @@ func (r *Renderer) RenderLines(plan string, width int) []string {
 			wrapWidth = width - 2
 		}
 		segments := wrapPlain(line, wrapWidth)
-		fenceBar := styleFenceBar.Render("│") + " "
+		fenceBar := styleFenceBar.Render(theme.GlyphFenceBar) + " "
 		if len(segments) == 0 {
 			styled := r.styleSegmentWithFence("", ctx, false, 0, wrapWidth)
 			if isFenceContent {
@@ -347,14 +349,14 @@ func (r *Renderer) styleSegmentWithFence(
 		if w < 1 {
 			w = ansi.StringWidth(segment)
 		}
-		return styleHR.Render(strings.Repeat("─", w))
+		return styleHR.Render(strings.Repeat(theme.GlyphRuleThin, w))
 	case LineBlockquote:
 		depth := parent.BlockquoteDepth
 		if depth < 1 {
 			depth = 1
 		}
 		barStyle := lipgloss.NewStyle().Foreground(colQuote)
-		bar := barStyle.Render(strings.Repeat("│", depth)) + " "
+		bar := barStyle.Render(strings.Repeat(theme.GlyphFenceBar, depth)) + " "
 		if isContinuation {
 			// Align continuation text under the body column.
 			indent := strings.Repeat(" ", depth+1)
@@ -606,35 +608,31 @@ func splitLines(s string) []string {
 
 // ── styles ───────────────────────────────────────────────────────────────────
 
+// Markdown colors come from the design-system registry (internal/tui/theme).
+// Heading levels map through theme.MarkdownHeadingColor; the remaining roles
+// reuse shared tokens (collapsing what were byte-identical duplicates).
 var (
-	colHeading1 = lipgloss.Color("#7C3AED") // primary purple — matches ColorPrimary
-	colHeading2 = lipgloss.Color("#06B6D4") // cyan — matches ColorSecondary
-	colHeading3 = lipgloss.Color("#10B981") // green — matches ColorSuccess
-	colHeading4 = lipgloss.Color("#F59E0B") // amber — matches ColorWarning
-	colHeading5 = lipgloss.Color("#A78BFA") // light purple
-	colHeading6 = lipgloss.Color("#9CA3AF") // light gray
+	colMuted        = theme.ColorMuted
+	colCodeFG       = theme.ColorCodeFg
+	colCodeBg       = theme.ColorCodeBg
+	colLink         = theme.ColorSecondary
+	colQuote        = theme.ColorMutedLight
+	colHR           = theme.ColorHairline
+	colBullet       = theme.ColorPrimaryLight
+	colListNum      = theme.ColorPrimaryLight
+	colCheckboxDone = theme.ColorSuccess
+	colParagraph    = theme.ColorTextProse
 
-	colMuted        = lipgloss.Color("#6B7280")
-	colCodeFG       = lipgloss.Color("#FBBF24") // amber for inline code
-	colCodeBg       = lipgloss.Color("#1A1D23") // subtle dark background for code blocks
-	colLink         = lipgloss.Color("#06B6D4")
-	colQuote        = lipgloss.Color("#9CA3AF")
-	colHR           = lipgloss.Color("#374151")
-	colBullet       = lipgloss.Color("#A78BFA")
-	colListNum      = lipgloss.Color("#A78BFA")
-	colCheckboxDone = lipgloss.Color("#10B981") // success green
-	colParagraph    = lipgloss.Color("#D1D5DB") // softer white for prose
-
-	styleH1 = lipgloss.NewStyle().Foreground(colHeading1).Bold(true)
-	styleH2 = lipgloss.NewStyle().Foreground(colHeading2).Bold(true)
-	styleH3 = lipgloss.NewStyle().Foreground(colHeading3).Bold(true)
-	styleH4 = lipgloss.NewStyle().Foreground(colHeading4).Bold(true)
-	styleH5 = lipgloss.NewStyle().Foreground(colHeading5).Bold(true)
-	styleH6 = lipgloss.NewStyle().Foreground(colHeading6).Bold(true)
+	styleH1 = lipgloss.NewStyle().Foreground(theme.MarkdownHeadingColor(1)).Bold(true)
+	styleH2 = lipgloss.NewStyle().Foreground(theme.MarkdownHeadingColor(2)).Bold(true)
+	styleH3 = lipgloss.NewStyle().Foreground(theme.MarkdownHeadingColor(3)).Bold(true)
+	styleH4 = lipgloss.NewStyle().Foreground(theme.MarkdownHeadingColor(4)).Bold(true)
+	styleH5 = lipgloss.NewStyle().Foreground(theme.MarkdownHeadingColor(5)).Bold(true)
+	styleH6 = lipgloss.NewStyle().Foreground(theme.MarkdownHeadingColor(6)).Bold(true)
 
 	styleBold       = lipgloss.NewStyle().Bold(true)
 	styleItalic     = lipgloss.NewStyle().Italic(true)
-	styleInlineCode = lipgloss.NewStyle().Foreground(colCodeFG).Background(lipgloss.AdaptiveColor{Dark: "#2D2D2D", Light: "#E8E8E8"})
+	styleInlineCode = lipgloss.NewStyle().Foreground(colCodeFG).Background(theme.ColorInlineCodeBg)
 	styleLink       = lipgloss.NewStyle().Foreground(colLink).Underline(true)
 	styleHR         = lipgloss.NewStyle().Foreground(colHR)
 	styleBullet     = lipgloss.NewStyle().Foreground(colBullet).Bold(true)
@@ -725,12 +723,12 @@ func styleListSegment(segment string, ctx LineCtx, isContinuation bool) string {
 		if ctx.CheckboxChecked {
 			for _, pfx := range []string{"[x] ", "[X] "} {
 				if strings.HasPrefix(body, pfx) {
-					glyph := lipgloss.NewStyle().Foreground(colCheckboxDone).Render("✓")
+					glyph := lipgloss.NewStyle().Foreground(colCheckboxDone).Render(theme.GlyphCheckboxDone)
 					return prefix + glyph + " " + styleInline(body[4:])
 				}
 			}
 		} else if strings.HasPrefix(body, "[ ] ") {
-			glyph := lipgloss.NewStyle().Foreground(colMuted).Render("☐")
+			glyph := lipgloss.NewStyle().Foreground(colMuted).Render(theme.GlyphCheckboxTodo)
 			return prefix + glyph + " " + styleInline(body[4:])
 		}
 	}

--- a/internal/tui/pr.go
+++ b/internal/tui/pr.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/refrain/internal/github"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // rowStatePhrase returns a human-readable badge for a session's shipping row.
@@ -113,16 +114,16 @@ func checkSymbolFor(checks *github.CheckStatus) string {
 	var style lipgloss.Style
 	switch checks.State {
 	case "success":
-		sym = "\u2713"
+		sym = theme.GlyphSuccess
 		style = StyleSuccess
 	case "failure":
-		sym = "\u2717"
+		sym = theme.GlyphError
 		style = StyleError
 	case "pending":
-		sym = "\u25cb"
+		sym = theme.GlyphIdle
 		style = StyleWarning
 	default:
-		sym = "?"
+		sym = theme.GlyphQuestion
 		style = StyleSubtle
 	}
 	return style.Render(sym)
@@ -152,7 +153,7 @@ func prIndicator(entry *prCacheEntry) string {
 
 	// Stacked: emit base-first chain. entry.stack is ordered immediate-parent
 	// (index 0) to root, so reversing gives root-to-head order.
-	sep := StyleSubtle.Render(" \u2192 ")
+	sep := StyleSubtle.Render(" " + theme.GlyphArrow + " ")
 	var parts []string
 	for i := len(entry.stack) - 1; i >= 0; i-- {
 		base := entry.stack[i]

--- a/internal/tui/repopicker.go
+++ b/internal/tui/repopicker.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/devenjarvis/refrain/internal/config"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // repoPickerAddRepoIdx is the sentinel value stored in repoPickerModel.filtered
@@ -216,11 +217,9 @@ func (m repoPickerModel) View() string {
 	left := m.renderList(leftWidth)
 	right := m.renderDetails(rightWidth)
 
-	leftStyle := lipgloss.NewStyle().
+	leftStyle := theme.BorderPaneLeft().
 		Width(leftWidth).
-		Height(m.height).
-		Border(lipgloss.NormalBorder(), false, true, false, false).
-		BorderForeground(ColorMuted)
+		Height(m.height)
 
 	rightStyle := lipgloss.NewStyle().
 		Width(rightWidth).

--- a/internal/tui/reviewpanel_test.go
+++ b/internal/tui/reviewpanel_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devenjarvis/refrain/internal/agent"
 	"github.com/devenjarvis/refrain/internal/config"
 	"github.com/devenjarvis/refrain/internal/git"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // TestRenderReviewHeader_TwoLineIntentCap checks that a long prompt is capped to
@@ -833,7 +834,7 @@ func TestReviewTaskCount(t *testing.T) {
 // TestVerdictBadge verifies the icon, label, and style returned for each verdict state.
 func TestVerdictBadge(t *testing.T) {
 	spinnerChars := map[string]bool{}
-	for _, f := range spinnerFrames {
+	for _, f := range theme.SpinnerBraille {
 		spinnerChars[f] = true
 	}
 

--- a/internal/tui/reviewpanel_view.go
+++ b/internal/tui/reviewpanel_view.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devenjarvis/refrain/internal/config"
 	"github.com/devenjarvis/refrain/internal/git"
 	"github.com/devenjarvis/refrain/internal/tui/mdrender"
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
 // reviewDetailMaxMeasure is the maximum content column width for the right detail
@@ -28,48 +29,45 @@ func detailContentMeasure(paneWidth, maxMeasure int) (measure, leftPad int) {
 	return mdrender.ContentMeasure(paneWidth, maxMeasure)
 }
 
-// spinnerFrames is the braille spinner sequence used while a verdict is running.
-var spinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
-
 // reviewSpinnerFrame returns the spinner character for the given render clock.
 // now is the model's tick-refreshed timestamp (§5: no clock read at render
-// time); deriving the frame from it keeps all running rows in sync.
+// time); deriving the frame from it keeps all running rows in sync. The frame
+// set and derivation live in the design-system registry (theme.SpinnerFrame).
 func reviewSpinnerFrame(now time.Time) string {
-	frame := int(now.UnixMilli()/100) % len(spinnerFrames)
-	return spinnerFrames[frame]
+	return theme.SpinnerFrame(now)
 }
 
 // verdictBadge returns the icon, label, and lipgloss style for a task verdict record.
 // rec may be nil (treated as verdictPending). now drives the running-state spinner.
 func verdictBadge(rec *taskVerdictRecord, now time.Time) (icon, label string, style lipgloss.Style) {
 	if rec == nil {
-		return "⋯", "Pending", StyleSubtle
+		return theme.GlyphPending, "Pending", StyleSubtle
 	}
 	// User flag wins over the AI verdict: the human reviewer is explicitly
 	// asking for rework on this task.
 	if rec.userFlagged {
-		return "⚑", "flagged", StyleWarning
+		return theme.GlyphFlagged, "flagged", StyleWarning
 	}
 	switch rec.state {
 	case verdictPending:
-		return "⋯", "Pending", StyleSubtle
+		return theme.GlyphPending, "Pending", StyleSubtle
 	case verdictRunning:
 		return reviewSpinnerFrame(now), "Reviewing…", StyleAccent
 	case verdictDone:
 		switch rec.verdict.Kind {
 		case agent.VerdictPass:
-			return "✓", "pass", StyleSuccess
+			return theme.GlyphSuccess, "pass", StyleSuccess
 		case agent.VerdictConcerns:
-			return "!", "concerns", StyleWarning
+			return theme.GlyphConcerns, "concerns", StyleWarning
 		case agent.VerdictFail:
-			return "✗", "fail", StyleError
+			return theme.GlyphError, "fail", StyleError
 		}
 	case verdictErr:
-		return "✗", "error", StyleError
+		return theme.GlyphError, "error", StyleError
 	case verdictNoDiff:
-		return "⊘", "no diff found", StyleSubtle
+		return theme.GlyphNoDiff, "no diff found", StyleSubtle
 	}
-	return "⋯", "Pending", StyleSubtle
+	return theme.GlyphPending, "Pending", StyleSubtle
 }
 
 // checkBadge returns the icon and lipgloss style for a validation check result.
@@ -78,17 +76,17 @@ func verdictBadge(rec *taskVerdictRecord, now time.Time) (icon, label string, st
 func checkBadge(result validationCheckResult, now time.Time) (icon string, style lipgloss.Style) {
 	switch result.state {
 	case checkPending:
-		return "⋯", StyleSubtle
+		return theme.GlyphPending, StyleSubtle
 	case checkRunning:
 		return reviewSpinnerFrame(now), StyleAccent
 	case checkPassed:
-		return "✓", StyleSuccess
+		return theme.GlyphSuccess, StyleSuccess
 	case checkFailed:
-		return "✗", StyleError
+		return theme.GlyphError, StyleError
 	case checkError:
-		return "✗", StyleError
+		return theme.GlyphError, StyleError
 	}
-	return "⋯", StyleSubtle
+	return theme.GlyphPending, StyleSubtle
 }
 
 // renderChecksTab renders the Checks tab body: a compact check list on top and
@@ -129,7 +127,7 @@ func renderChecksTab(cs *checksTabState, width, height int, now time.Time) []str
 		cursor := " "
 		nameStyle := StyleSubtle
 		if i == cs.cursor {
-			cursor = "›"
+			cursor = theme.GlyphCaret
 			nameStyle = lipgloss.NewStyle()
 		}
 

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,37 +1,45 @@
 package tui
 
 import (
-	"os"
-
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/devenjarvis/refrain/internal/tui/theme"
 )
 
-var noColor = os.Getenv("NO_COLOR") != ""
+// This file is the tui package's bridge to the design-system registry in
+// internal/tui/theme. The registry is the single source of truth for token
+// VALUES; the aliases below let tui code reference roles unqualified, and the
+// Style* objects compose those roles into the lipgloss styles this package
+// renders. Subpackages (diff, mdrender) import the theme package directly.
+// See DESIGN.md for the role catalog.
 
+// Color-role aliases. Values live in internal/tui/theme; never redefine a hex
+// here — add the role there.
 var (
-	ColorPrimary   = initColor("#7C3AED")
-	ColorSecondary = initColor("#06B6D4")
-	ColorSuccess   = initColor("#10B981")
-	ColorWarning   = initColor("#F59E0B")
-	ColorError     = initColor("#EF4444")
-	ColorMuted     = initColor("#6B7280")
-	ColorText      = initColor("#F9FAFB")
-	ColorBg        = initColor("#111827")
+	ColorPrimary       = theme.ColorPrimary
+	ColorSecondary     = theme.ColorSecondary
+	ColorPrimaryLight  = theme.ColorPrimaryLight
+	ColorSuccess       = theme.ColorSuccess
+	ColorWarning       = theme.ColorWarning
+	ColorError         = theme.ColorError
+	ColorWaiting       = theme.ColorWaiting
+	ColorMuted         = theme.ColorMuted
+	ColorMutedLight    = theme.ColorMutedLight
+	ColorText          = theme.ColorText
+	ColorTextProse     = theme.ColorTextProse
+	ColorBg            = theme.ColorBg
+	ColorSurfaceRaised = theme.ColorSurfaceRaised
+	ColorHairline      = theme.ColorHairline
+	ColorBuilding      = theme.ColorBuilding
+	ColorReviewing     = theme.ColorReviewing
+	ColorShipping      = theme.ColorShipping
+	ColorBreakTitle    = theme.ColorBreakTitle
+	ColorBreakAccent   = theme.ColorBreakAccent
+)
 
-	// ColorWaiting is the accent for agents in StatusWaiting (permission
-	// prompts, input blocks); surfaced as a status badge in the dashboard.
-	ColorWaiting = initColor("#D946EF")
-
-	// Pipeline-section accents: the colors that identify the BUILDING,
-	// REVIEWING, and SHIPPING stages across the dashboard and panels.
-	ColorBuilding  = initColor("#7ec8e3")
-	ColorReviewing = initColor("#9b7fdb")
-	ColorShipping  = initColor("#5ab58a")
-
-	// Break-overlay accents: the wellness break overlay's title and resume cue.
-	ColorBreakTitle  = initColor("#38BDF8")
-	ColorBreakAccent = initColor("#34D399")
-
+// Composed styles. These are tui-presentation compositions built from the
+// color roles above; subpackages build their own from the registry directly.
+var (
 	StyleTitle = lipgloss.NewStyle().
 			Bold(true).
 			Foreground(ColorPrimary)
@@ -85,25 +93,16 @@ var (
 
 	StyleStatusBar = lipgloss.NewStyle().
 			Foreground(ColorText).
-			Background(initColor("#1F2937")).
-			Padding(0, 1)
+			Background(ColorSurfaceRaised).
+			Padding(theme.PadStatusBar[0], theme.PadStatusBar[1])
 )
 
-func initColor(hex string) lipgloss.Color {
-	if noColor {
-		return lipgloss.Color("")
-	}
-	return lipgloss.Color(hex)
-}
-
-// modalBoxStyle is the canonical centered-overlay box: a rounded primary
-// border with 1×2 padding at the given width. Shared by the repo-config,
+// modalBoxStyle is the canonical centered-overlay box: a rounded primary border
+// with PadModal padding at the given width. Shared by the repo-config,
 // repo-checks, and global-settings modals so they render identically.
 func modalBoxStyle(width int) lipgloss.Style {
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ColorPrimary).
-		Padding(1, 2).
+	return theme.BorderModal().
+		Padding(theme.PadModal[0], theme.PadModal[1]).
 		Width(width)
 }
 

--- a/internal/tui/theme/animation.go
+++ b/internal/tui/theme/animation.go
@@ -1,0 +1,27 @@
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+// Animation palettes are ordered color sequences (not single roles): a renderer
+// cycles through them frame by frame, driven by the model's tick timestamp.
+
+// BreatheColors cycles calm hues for the wellness break overlay's breathing
+// animation. The first and third entries are the break-overlay accents
+// (ColorBreakTitle, ColorBreakAccent); the indigo and rose hues exist solely
+// for this cycle and are not standalone roles.
+var BreatheColors = [4]lipgloss.Color{
+	ColorBreakTitle,      // sky blue
+	initColor("#818CF8"), // indigo
+	ColorBreakAccent,     // emerald
+	initColor("#F472B6"), // rose
+}
+
+// CompleteColors pulse warm tones once the focus timer is up so the screen
+// reads unmistakably as "done" without auto-advancing back to work. The gold
+// entry coincides numerically with ColorCodeFg but is semantically unrelated;
+// kept separate so the animation is not coupled to markdown styling.
+var CompleteColors = [3]lipgloss.Color{
+	ColorWarning,         // amber
+	initColor("#FBBF24"), // gold
+	initColor("#FACC15"), // yellow
+}

--- a/internal/tui/theme/borders.go
+++ b/internal/tui/theme/borders.go
@@ -1,0 +1,25 @@
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+// Border-style constructors. Each returns a fresh lipgloss.Style so callers can
+// chain Width/Height/Padding without mutating shared state. Color and border
+// shape are the design-system decision; sizing is the caller's.
+
+// BorderModal is the canonical centered-overlay box: a rounded primary border.
+// Callers add Width/Padding (see PadModal). Shared by the repo-config,
+// repo-checks, global-settings, and note modals so overlays render identically.
+func BorderModal() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorPrimary)
+}
+
+// BorderPaneLeft is the left pane of a two-column split: a muted normal border
+// drawn only on the right edge, separating it from the right pane. Shared by the
+// file-browser, branch-picker, and repo-picker.
+func BorderPaneLeft() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder(), false, true, false, false).
+		BorderForeground(ColorMuted)
+}

--- a/internal/tui/theme/colors.go
+++ b/internal/tui/theme/colors.go
@@ -1,0 +1,152 @@
+// Package theme is Refrain's design-system registry: the single source of truth
+// for every color, glyph, border, spacing, and animation token used across the
+// TUI. It has no internal dependencies, so the leaf rendering subpackages
+// (internal/tui/diff, internal/tui/mdrender) can consume the same tokens as the
+// top-level internal/tui package without violating the layering rules in
+// .go-arch-lint.yml.
+//
+// See DESIGN.md at the repo root for the role catalog and usage guidance. The
+// rule for contributors and agents alike: never hardcode a hex, glyph, border,
+// or padding value — add or reference a token here.
+package theme
+
+import (
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// noColor mirrors the NO_COLOR convention: when the env var is set (to any
+// value), every token degrades to the terminal's default color. It is read once
+// at package init.
+var noColor = os.Getenv("NO_COLOR") != ""
+
+// initColor gates a hex color behind NO_COLOR. A blank lipgloss.Color renders
+// with the terminal default, so styles built from it carry no ANSI color.
+func initColor(hex string) lipgloss.Color {
+	if noColor {
+		return lipgloss.Color("")
+	}
+	return lipgloss.Color(hex)
+}
+
+// initAdaptive gates a light/dark adaptive color behind NO_COLOR.
+func initAdaptive(dark, light string) lipgloss.TerminalColor {
+	if noColor {
+		return lipgloss.Color("")
+	}
+	return lipgloss.AdaptiveColor{Dark: dark, Light: light}
+}
+
+// Color roles. Identifiers are organized by role; the value comments give the
+// raw hex. Collapsed near-duplicates (e.g. markdown headings that were
+// byte-identical to brand accents) are noted at their canonical role below.
+var (
+	// ── Surfaces & text ────────────────────────────────────────────────────
+
+	// ColorBg is the base application surface.
+	ColorBg = initColor("#111827")
+	// ColorSurfaceRaised is a raised surface (status bar, chips) above the base.
+	ColorSurfaceRaised = initColor("#1F2937")
+	// ColorText is primary, high-contrast body/title text.
+	ColorText = initColor("#F9FAFB")
+	// ColorTextProse is softer prose text, deliberately dimmer than ColorText
+	// to reduce glare across long markdown reading.
+	ColorTextProse = initColor("#D1D5DB")
+	// ColorMuted is de-emphasized text, separators, borders, and gutters.
+	ColorMuted = initColor("#6B7280")
+	// ColorMutedLight is secondary de-emphasized text one step brighter than
+	// ColorMuted (markdown blockquotes and H6 collapse here).
+	ColorMutedLight = initColor("#9CA3AF")
+	// ColorHairline is the thin divider/rule color.
+	ColorHairline = initColor("#374151")
+
+	// ── Brand accents ──────────────────────────────────────────────────────
+
+	// ColorPrimary is the primary brand accent (titles, primary borders; md H1).
+	ColorPrimary = initColor("#7C3AED")
+	// ColorSecondary is the secondary accent (links, active, hunk headers; md H2).
+	ColorSecondary = initColor("#06B6D4")
+	// ColorPrimaryLight is a lighter purple accent (md H5, bullets, list numbers).
+	ColorPrimaryLight = initColor("#A78BFA")
+
+	// ── Status roles (agent run-state) ─────────────────────────────────────
+
+	// ColorSuccess marks success/pass/additions (md H3, checkboxes).
+	ColorSuccess = initColor("#10B981")
+	// ColorWarning marks warnings/concerns (md H4).
+	ColorWarning = initColor("#F59E0B")
+	// ColorError marks errors/failures/deletions.
+	ColorError = initColor("#EF4444")
+	// ColorWaiting accents agents in StatusWaiting (permission prompts, input
+	// blocks). Kept distinct from status colors so waiting reads unambiguously.
+	ColorWaiting = initColor("#D946EF")
+
+	// ── Pipeline-stage accents (lifecycle column) ──────────────────────────
+	// These encode WHICH stage a session is in and are intentionally kept
+	// separate from the status roles above: a SHIPPING section can contain a
+	// success badge, so the two axes must stay visually distinct. They are
+	// desaturated pastels versus the punchy status hues.
+
+	// ColorBuilding identifies the BUILDING stage.
+	ColorBuilding = initColor("#7ec8e3")
+	// ColorReviewing identifies the REVIEWING stage. Note it is a near-neighbor
+	// of ColorPrimaryLight (both light purple) but semantically distinct; do not
+	// "fix" one to match the other.
+	ColorReviewing = initColor("#9b7fdb")
+	// ColorShipping identifies the SHIPPING stage.
+	ColorShipping = initColor("#5ab58a")
+
+	// ── Wellness break overlay ─────────────────────────────────────────────
+
+	// ColorBreakTitle is the break-overlay title; also the first BreatheColors
+	// hue.
+	ColorBreakTitle = initColor("#38BDF8")
+	// ColorBreakAccent is the break-overlay resume cue; also the third
+	// BreatheColors hue.
+	ColorBreakAccent = initColor("#34D399")
+
+	// ── Diff backgrounds ───────────────────────────────────────────────────
+	// Diff add/del FOREGROUNDS reuse ColorSuccess/ColorError. The four
+	// backgrounds stay distinct: normal vs. word-diff emphasis is load-bearing.
+
+	// ColorDiffAddBg is the row background for added lines.
+	ColorDiffAddBg = initColor("#0a2e1f")
+	// ColorDiffDelBg is the row background for deleted lines.
+	ColorDiffDelBg = initColor("#2e0a14")
+	// ColorDiffAddBgEmph is the intra-line emphasis background for additions.
+	ColorDiffAddBgEmph = initColor("#165c3f")
+	// ColorDiffDelBgEmph is the intra-line emphasis background for deletions.
+	ColorDiffDelBgEmph = initColor("#5c1629")
+
+	// ── Markdown code ──────────────────────────────────────────────────────
+
+	// ColorCodeFg is inline-code and fenced-fallback code foreground.
+	ColorCodeFg = initColor("#FBBF24")
+	// ColorCodeBg is the fenced code-block background.
+	ColorCodeBg = initColor("#1A1D23")
+	// ColorInlineCodeBg is the inline-code background; the only adaptive token.
+	ColorInlineCodeBg = initAdaptive("#2D2D2D", "#E8E8E8")
+)
+
+// MarkdownHeadingColor maps a markdown heading level (1–6) onto a color role.
+// Levels beyond 6 fall back to the H1 accent. This is the documented token for
+// the heading scale; callers should not redeclare per-level heading colors.
+func MarkdownHeadingColor(level int) lipgloss.Color {
+	switch level {
+	case 1:
+		return ColorPrimary
+	case 2:
+		return ColorSecondary
+	case 3:
+		return ColorSuccess
+	case 4:
+		return ColorWarning
+	case 5:
+		return ColorPrimaryLight
+	case 6:
+		return ColorMutedLight
+	default:
+		return ColorPrimary
+	}
+}

--- a/internal/tui/theme/glyphs.go
+++ b/internal/tui/theme/glyphs.go
@@ -1,0 +1,52 @@
+package theme
+
+import "time"
+
+// Glyph tokens. Every single-rune marker the TUI emits lives here so the icon
+// language stays consistent and a glyph swap is a one-line edit. Group by role.
+const (
+	// ── Status badges / session glyphs ─────────────────────────────────────
+
+	GlyphError    = "✗" // error / fail (U+2717)
+	GlyphSuccess  = "✓" // success / pass (U+2713)
+	GlyphWaiting  = "⏸" // waiting on input / permission
+	GlyphQuestion = "?" // may need input
+	GlyphActive   = "●" // actively running
+	GlyphIdle     = "○" // idle / pending (U+25CB)
+	GlyphCross    = "×" // closed / done agent tab
+
+	// ── Verdict / check badges ─────────────────────────────────────────────
+
+	GlyphPending  = "⋯" // pending verdict
+	GlyphFlagged  = "⚑" // user-flagged for rework
+	GlyphConcerns = "!" // verdict: concerns
+	GlyphNoDiff   = "⊘" // verdict: no diff found
+
+	// ── Navigation / chrome ────────────────────────────────────────────────
+
+	GlyphBranch       = "⎇" // git branch label
+	GlyphStripe       = "▎" // session-card status stripe
+	GlyphCursor       = "▍" // selected-row cursor bar
+	GlyphCaret        = "›" // inline list cursor
+	GlyphArrow        = "→" // stacked-PR chain separator
+	GlyphFolderOpen   = "▾" // expanded diff-tree folder
+	GlyphFolderClosed = "▸" // collapsed diff-tree folder
+
+	// ── Markdown ───────────────────────────────────────────────────────────
+
+	GlyphCheckboxDone = "✓" // checked task checkbox
+	GlyphCheckboxTodo = "☐" // unchecked task checkbox
+	GlyphFenceBar     = "│" // prefix bar on fenced lines
+	GlyphRuleThin     = "─" // thin horizontal rule
+	GlyphRuleHeavy    = "━" // heavy horizontal rule
+)
+
+// SpinnerBraille is the braille spinner sequence shown while work is running.
+var SpinnerBraille = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
+
+// SpinnerFrame returns the spinner glyph for the given render clock. now is the
+// model's tick-refreshed timestamp (no clock read at render time); deriving the
+// frame from it keeps all running rows in sync.
+func SpinnerFrame(now time.Time) string {
+	return SpinnerBraille[int(now.UnixMilli()/100)%len(SpinnerBraille)]
+}

--- a/internal/tui/theme/spacing.go
+++ b/internal/tui/theme/spacing.go
@@ -1,0 +1,23 @@
+package theme
+
+// Spacing tokens. These codify the magic padding/indent numbers that were
+// previously inlined as literals, so a spacing change is a one-line edit. Width
+// *arithmetic* (border/sidebar/chrome math) stays in internal/tui/layout.go;
+// these are the fixed design-system constants those helpers and styles consume.
+
+// Padding pairs are {vertical, horizontal}, matching lipgloss.Padding(v, h).
+var (
+	// PadModal is the inner padding of a modal box.
+	PadModal = [2]int{1, 2}
+	// PadStatusBar is the status bar's inner padding.
+	PadStatusBar = [2]int{0, 1}
+	// PadCell is the dashboard checks-cell inner padding.
+	PadCell = [2]int{0, 1}
+)
+
+const (
+	// IndentTree is the per-depth indent (in cells) of the diff file tree.
+	IndentTree = 2
+	// LabelWidth is the fixed column width of a form field label.
+	LabelWidth = 22
+)

--- a/internal/tui/theme/theme_test.go
+++ b/internal/tui/theme/theme_test.go
@@ -1,0 +1,86 @@
+package theme
+
+import (
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TestInitColorNoColor verifies the NO_COLOR gate: when noColor is set, a hex
+// degrades to the empty (terminal-default) color; otherwise it passes through.
+func TestInitColorNoColor(t *testing.T) {
+	orig := noColor
+	defer func() { noColor = orig }()
+
+	noColor = true
+	if got := initColor("#FFFFFF"); got != lipgloss.Color("") {
+		t.Errorf("initColor with NO_COLOR = %q, want empty", got)
+	}
+	if got := initAdaptive("#2D2D2D", "#E8E8E8"); got != lipgloss.Color("") {
+		t.Errorf("initAdaptive with NO_COLOR = %v, want empty Color", got)
+	}
+
+	noColor = false
+	if got := initColor("#FFFFFF"); got != lipgloss.Color("#FFFFFF") {
+		t.Errorf("initColor = %q, want #FFFFFF", got)
+	}
+	if _, ok := initAdaptive("#2D2D2D", "#E8E8E8").(lipgloss.AdaptiveColor); !ok {
+		t.Errorf("initAdaptive without NO_COLOR is not an AdaptiveColor")
+	}
+}
+
+// TestMarkdownHeadingColor pins the level→role mapping so the heading scale
+// stays in sync with the brand/status roles it borrows.
+func TestMarkdownHeadingColor(t *testing.T) {
+	cases := map[int]lipgloss.Color{
+		1: ColorPrimary,
+		2: ColorSecondary,
+		3: ColorSuccess,
+		4: ColorWarning,
+		5: ColorPrimaryLight,
+		6: ColorMutedLight,
+		7: ColorPrimary, // out of range falls back to H1
+	}
+	for level, want := range cases {
+		if got := MarkdownHeadingColor(level); got != want {
+			t.Errorf("MarkdownHeadingColor(%d) = %q, want %q", level, got, want)
+		}
+	}
+}
+
+// TestGlyphsNonEmpty guards against an accidentally blanked glyph token, which
+// would silently drop a status/icon marker from the UI.
+func TestGlyphsNonEmpty(t *testing.T) {
+	glyphs := []string{
+		GlyphError, GlyphSuccess, GlyphWaiting, GlyphQuestion, GlyphActive,
+		GlyphIdle, GlyphCross, GlyphPending, GlyphFlagged, GlyphConcerns,
+		GlyphNoDiff, GlyphBranch, GlyphStripe, GlyphCursor, GlyphCaret,
+		GlyphArrow, GlyphFolderOpen, GlyphFolderClosed, GlyphCheckboxDone,
+		GlyphCheckboxTodo, GlyphFenceBar, GlyphRuleThin, GlyphRuleHeavy,
+	}
+	for i, g := range glyphs {
+		if g == "" {
+			t.Errorf("glyph at index %d is empty", i)
+		}
+	}
+}
+
+// TestSpinnerFrame returns a frame from the braille set and advances over time.
+func TestSpinnerFrame(t *testing.T) {
+	base := time.UnixMilli(0)
+	in := func(s string) bool {
+		for _, f := range SpinnerBraille {
+			if f == s {
+				return true
+			}
+		}
+		return false
+	}
+	if got := SpinnerFrame(base); !in(got) {
+		t.Errorf("SpinnerFrame returned %q, not in SpinnerBraille", got)
+	}
+	if SpinnerFrame(base) == SpinnerFrame(base.Add(100*time.Millisecond)) {
+		t.Errorf("SpinnerFrame did not advance across a 100ms tick")
+	}
+}


### PR DESCRIPTION
Introduce internal/tui/theme, a leaf package (no internal deps) that is
the single source of truth for every visual token: semantic color roles,
glyphs, spinner/animation palettes, border styles, and spacing. Because
it has no internal dependencies, the diff and mdrender subpackages can
consume the same tokens as the top-level tui package without violating
the layering rules in .go-arch-lint.yml.

Consolidate ~48 scattered hex literals into ~26 role tokens (collapsing
exact duplicates), and centralize the previously-inlined glyphs,
animation palettes, two-pane/modal borders, and spacing constants. The
diff and mdrender subpackages now build their styles from the registry
and therefore honor NO_COLOR, which they did not before. No intended
change to the default-profile appearance: the render tests pass with
byte-identical output.

Document the system in a new DESIGN.md (role catalog, status-vs-stage
distinction, glyph/spinner/border/spacing reference, NO_COLOR notes),
linked from CLAUDE.md and CONVENTIONS.md §5.

https://claude.ai/code/session_01YB1MNdPw1HnMxAzzCA3k2H